### PR TITLE
Lisää NewRelic transaction tracet

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -124,6 +124,9 @@
 
                  [com.cemerick/piggieback "0.2.1"]
                  [figwheel-sidecar "0.5.3"]
+
+                 ;; Performance metriikat
+                 [yleisradio/new-reliquary "1.0.0"]
                  ]
 
   :dev-dependencies [

--- a/src/clj/harja/palvelin/komponentit/http_palvelin.clj
+++ b/src/clj/harja/palvelin/komponentit/http_palvelin.clj
@@ -254,10 +254,6 @@ Valinnainen optiot parametri on mäppi, joka voi sisältää seuraavat keywordit
                       :tarkista-polku?   false
                       :ei-todennettava   ei-todennettava?})))
 
-(defn julkaise-palvelut [http & palveluiden-nimet-ja-funktiot]
-  (doseq [[nimi funktio] (partition 2 palveluiden-nimet-ja-funktiot)]
-    (julkaise-palvelu http nimi funktio)))
-
 (defn julkaise-palvelut [http & nimet-ja-palvelut]
   (doseq [[nimi palvelu-fn] (partition 2 nimet-ja-palvelut)]
     (julkaise-palvelu http nimi palvelu-fn)))

--- a/src/clj/harja/palvelin/komponentit/http_palvelin.clj
+++ b/src/clj/harja/palvelin/komponentit/http_palvelin.clj
@@ -18,7 +18,9 @@
             [harja.transit :as transit]
             [harja.domain.roolit]
 
-            [slingshot.slingshot :refer [try+ throw+]])
+            [slingshot.slingshot :refer [try+ throw+]]
+
+            [new-reliquary.core :as nr])
   (:import (java.text SimpleDateFormat)
            (java.io ByteArrayInputStream ByteArrayOutputStream)))
 
@@ -219,24 +221,30 @@ Valinnainen optiot parametri on mäppi, joka voi sisältää seuraavat keywordit
   HttpPalvelut
   (julkaise-palvelu [http-palvelin nimi palvelu-fn] (julkaise-palvelu http-palvelin nimi palvelu-fn nil))
   (julkaise-palvelu [http-palvelin nimi palvelu-fn optiot]
-    (if (:ring-kasittelija? optiot)
-      (swap! sessiottomat-kasittelijat conj {:nimi nimi
-                                             :fn   (if (= false (:tarkista-polku? optiot))
-                                                     palvelu-fn
-                                                     (ring-kasittelija nimi palvelu-fn))
-                                             :ei-todennettava (:ei-todennettava optiot)})
-      (let [ar (arityt palvelu-fn)
-            liikaa-parametreja (some #(when (or (= 0 %) (> % 2)) %) ar)]
-        (when liikaa-parametreja
-          (log/fatal "Palvelufunktiolla on oltava 1 parametri (GET: user) tai 2 parametria (POST: user payload), oli: " liikaa-parametreja))
-        (when (ar 2)
-          ;; POST metodi, kutsutaan kutsusta parsitulla EDN objektilla
-          (swap! kasittelijat
-                 conj {:nimi nimi :fn (transit-post-kasittelija nimi palvelu-fn optiot)}))
-        (when (ar 1)
-          ;; GET metodi, vain käyttäjätiedot parametrina
-          (swap! kasittelijat
-                 conj {:nimi nimi :fn (transit-get-kasittelija nimi palvelu-fn optiot)})))))
+    (let [ar (arityt palvelu-fn)
+          transaktio-fn (fn [& args]
+                          (nr/with-newrelic-transaction
+                            (or (:kategoria optiot) "Backend palvelut")
+                            (str nimi)
+                            {}
+                            #(apply palvelu-fn args)))]
+      (if (:ring-kasittelija? optiot)
+        (swap! sessiottomat-kasittelijat conj {:nimi nimi
+                                               :fn   (if (= false (:tarkista-polku? optiot))
+                                                       transaktio-fn
+                                                       (ring-kasittelija nimi transaktio-fn))
+                                               :ei-todennettava (:ei-todennettava optiot)})
+        (do
+          (when (some #(when (or (= 0 %) (> % 2)) %) ar)
+            (log/fatal "Palvelufunktiolla on oltava 1 parametri (GET: user) tai 2 parametria (POST: user payload), oli: " liikaa-parametreja))
+          (when (ar 2)
+            ;; POST metodi, kutsutaan kutsusta parsitulla EDN objektilla
+            (swap! kasittelijat
+                   conj {:nimi nimi :fn (transit-post-kasittelija nimi transaktio-fn optiot)}))
+          (when (ar 1)
+            ;; GET metodi, vain käyttäjätiedot parametrina
+            (swap! kasittelijat
+                   conj {:nimi nimi :fn (transit-get-kasittelija nimi transaktio-fn optiot)}))))))
 
   (poista-palvelu [this nimi]
     (swap! kasittelijat

--- a/src/clj/harja/palvelin/palvelut/raportit.clj
+++ b/src/clj/harja/palvelin/palvelut/raportit.clj
@@ -1,6 +1,6 @@
 (ns harja.palvelin.palvelut.raportit
   (:require [com.stuartsierra.component :as component]
-            [harja.palvelin.komponentit.http-palvelin :refer [julkaise-palvelut poista-palvelut]]
+            [harja.palvelin.komponentit.http-palvelin :refer [julkaise-palvelu poista-palvelut]]
             [harja.palvelin.komponentit.pdf-vienti :refer [rekisteroi-pdf-kasittelija! poista-pdf-kasittelija!] :as pdf-vienti]
             [harja.palvelin.raportointi :refer [hae-raportit suorita-raportti]]))
 
@@ -13,18 +13,19 @@
            pdf-vienti  :pdf-vienti
            :as         this}]
 
-    (julkaise-palvelut http
-                       :hae-raportit
-                       (fn [user]
-                         (reduce-kv (fn [acc nimi raportti]
-                                      ;; Otetaan suoritus fn ja koodi pois frontille lähetettävästä
-                                      (assoc acc nimi (dissoc raportti :suorita :koodi)))
-                                    {}
-                                    (hae-raportit raportointi)))
+    (julkaise-palvelu http
+                      :hae-raportit
+                      (fn [user]
+                        (reduce-kv (fn [acc nimi raportti]
+                                     ;; Otetaan suoritus fn ja koodi pois frontille lähetettävästä
+                                     (assoc acc nimi (dissoc raportti :suorita :koodi)))
+                                   {}
+                                   (hae-raportit raportointi))))
 
-                       :suorita-raportti
-                       (fn [user raportti]
-                         (suorita-raportti raportointi user raportti)))
+    (julkaise-palvelu http :suorita-raportti
+                      (fn [user raportti]
+                        (suorita-raportti raportointi user raportti))
+                      {:trace false})
 
     this)
 


### PR DESCRIPTION
Lisätty julkaise-palvelu new relic tracetus.
Lisäksi raporteissa on oma tracensa, jotta ne eivät näy geneerisenä "suorita-raportti" palvelun alla.
