### PR TITLE
HAR-2630: Näytä ed. sillantarkastus popupissa

### DIFF
--- a/src/cljs/harja/views/urakka/laadunseuranta/siltatarkastukset.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/siltatarkastukset.cljs
@@ -62,7 +62,10 @@
   (reset! muokattava-tarkastus tarkastus))
 
 (defn tarkastuksen-tekija-ja-aika [silta-tai-tarkastus]
-  (let [tarkastuksia? (> (count @st/valitun-sillan-tarkastukset) 0)
+  (let [tarkastuksia? (or (> (count @st/valitun-sillan-tarkastukset) 0)
+                          ;; popup tarvii tätä vaikkei silta olisi valittuna
+                          (and (:tarkastusaika silta-tai-tarkastus)
+                               (:tarkastaja silta-tai-tarkastus)))
         aika (if (:tarkastusaika silta-tai-tarkastus)
                (pvm/pvm (:tarkastusaika silta-tai-tarkastus))
                "Ei tietoa tarkastusajasta")


### PR DESCRIPTION
Tämä taski väljentää ehtoa, milloin sillan edellisen tarkastuksen aika voidaan näyttää, lopettamalla vaatimus siitä että jonkin sillan pitää olla valittu.

Jos siltaa ei ollut valittu, mutta urakan tasolla klikattiin jotakin siltaa niin että sillan popup aukenee (mutta silta ei vielä tule "valituksi") , sillan tiedot näyttävä popup ei kyennyt kertomaan edellisen tarkastuksen ajankohtaa, koska oletti että tietoatomissa st/valitun-sillan-tarkastukset olisi aina sisältöä.
