### PR TITLE
Kommentoi pois liuoussuolaus frontiltakin

### DIFF
--- a/src/cljc/harja/domain/tilannekuva.cljc
+++ b/src/cljc/harja/domain/tilannekuva.cljc
@@ -74,7 +74,10 @@
   [l-ja-p-alueiden-puhdistus "l- ja p-alueiden puhdistus"
    "L- ja P-alueiden puhdistus"]
   [muu "muu" "Muu"]
-  [liuossuolaus "liuossuolaus" "Liuossuolaus"]
+  ;; Liuossuolausta ei ymmärtääkseni enää seurata, mutta kesälomien takia tässä on korjauksen
+  ;; hetkellä pieni informaatiouupelo. Nämä rivit voi poistaa tulevaisuudessa, jos lukija
+  ;; kokee tietävänsä asian varmaksi.
+  ;; [liuossuolaus "liuossuolaus" "Liuossuolaus"]
   [aurausviitoitus-ja-kinostimet "aurausviitoitus ja kinostimet"
    "Aurausviitoitus ja kinostimet"]
   [lumensiirto "lumensiirto" "Lumensiirto"]
@@ -91,7 +94,10 @@
               tma-laite]
    :talvi [auraus-ja-sohjonpoisto
            suolaus
-           liuossuolaus
+           ;; Liuossuolausta ei ymmärtääkseni enää seurata, mutta kesälomien takia tässä on korjauksen
+           ;; hetkellä pieni informaatiouupelo. Nämä rivit voi poistaa tulevaisuudessa, jos lukija
+           ;; kokee tietävänsä asian varmaksi.
+           ;;liuossuolaus
            pistehiekoitus
            linjahiekoitus
            pinnan-tasaus

--- a/src/cljc/harja/ui/kartta/asioiden_ulkoasu.cljc
+++ b/src/cljc/harja/ui/kartta/asioiden_ulkoasu.cljc
@@ -147,15 +147,24 @@
    #{"AURAUS JA SOHJONPOISTO" "PINNAN TASAUS" "PISTEHIEKOITUS"} auraus-tasaus-ja-kolmas
    #{"AURAUS JA SOHJONPOISTO" "PINNAN TASAUS" "LINJAHIEKOITUS"} auraus-tasaus-ja-kolmas
    #{"AURAUS JA SOHJONPOISTO" "PINNAN TASAUS" "SUOLAUS"}        auraus-tasaus-ja-kolmas
-   #{"AURAUS JA SOHJONPOISTO" "PINNAN TASAUS" "LIUOSSUOLAUS"}   auraus-tasaus-ja-kolmas
+   ;; Liuossuolausta ei ymmärtääkseni enää seurata, mutta kesälomien takia tässä on korjauksen
+   ;; hetkellä pieni informaatiouupelo. Nämä rivit voi poistaa tulevaisuudessa, jos lukija
+   ;; kokee tietävänsä asian varmaksi.
+   ;;#{"AURAUS JA SOHJONPOISTO" "PINNAN TASAUS" "LIUOSSUOLAUS"}   auraus-tasaus-ja-kolmas
    #{"AURAUS JA SOHJONPOISTO" "PISTEHIEKOITUS"}                 auraus-ja-hiekoitus
    #{"AURAUS JA SOHJONPOISTO" "LINJAHIEKOITUS"}                 auraus-ja-hiekoitus
    #{"AURAUS JA SOHJONPOISTO" "SUOLAUS"}                        auraus-ja-suolaus
-   #{"AURAUS JA SOHJONPOISTO" "LIUOSSUOLAUS"}                   auraus-ja-suolaus
+   ;; Liuossuolausta ei ymmärtääkseni enää seurata, mutta kesälomien takia tässä on korjauksen
+   ;; hetkellä pieni informaatiouupelo. Nämä rivit voi poistaa tulevaisuudessa, jos lukija
+   ;; kokee tietävänsä asian varmaksi.
+   ;;#{"AURAUS JA SOHJONPOISTO" "LIUOSSUOLAUS"}                   auraus-ja-suolaus
    ;; tilannekuva/talvihoito
    #{"AURAUS JA SOHJONPOISTO"}                                  [(viiva-mustalla-rajalla puhtaat/oranssi) "oranssi"]
    #{"SUOLAUS"}                                                 [(viiva-mustalla-rajalla puhtaat/syaani) "syaani"]
-   #{"LIUOSSUOLAUS"}                                            [(viiva-mustalla-rajalla puhtaat/tummansininen) "tummansininen"]
+   ;; Liuossuolausta ei ymmärtääkseni enää seurata, mutta kesälomien takia tässä on korjauksen
+   ;; hetkellä pieni informaatiouupelo. Nämä rivit voi poistaa tulevaisuudessa, jos lukija
+   ;; kokee tietävänsä asian varmaksi.
+   ;;#{"LIUOSSUOLAUS"}                                            [(viiva-mustalla-rajalla puhtaat/tummansininen) "tummansininen"]
    #{"PISTEHIEKOITUS"}                                          [(viiva-mustalla-rajalla puhtaat/pinkki) "pinkki"]
    #{"LINJAHIEKOITUS"}                                          [(viiva-mustalla-rajalla puhtaat/magenta) "magenta"]
    #{"PINNAN TASAUS"}                                           [(viiva-mustalla-rajalla puhtaat/violetti) "violetti"]

--- a/src/cljc/harja/ui/kartta/esitettavat_asiat.cljc
+++ b/src/cljc/harja/ui/kartta/esitettavat_asiat.cljc
@@ -330,7 +330,10 @@
 (def tehtavien-nimet
   {"AURAUS JA SOHJONPOISTO"          "Auraus tai sohjonpoisto"
    "SUOLAUS"                         "Suolaus"
-   "LIUOSSUOLAUS"                    "Liuossuolaus"
+   ;; Liuossuolausta ei ymmärtääkseni enää seurata, mutta kesälomien takia tässä on korjauksen
+   ;; hetkellä pieni informaatiouupelo. Nämä rivit voi poistaa tulevaisuudessa, jos lukija
+   ;; kokee tietävänsä asian varmaksi.
+   ;;"LIUOSSUOLAUS"                    "Liuossuolaus"
    "PISTEHIEKOITUS"                  "Pistehiekoitus"
    "LINJAHIEKOITUS"                  "Linjahiekoitus"
    "PINNAN TASAUS"                   "Pinnan tasaus"

--- a/src/cljs/harja/tiedot/tilannekuva/tilannekuva.cljs
+++ b/src/cljs/harja/tiedot/tilannekuva/tilannekuva.cljs
@@ -82,7 +82,10 @@ hakutiheys-historiakuva 1200000)
              tk/linjahiekoitus false
              tk/lumivallien-madaltaminen false
              tk/sulamisveden-haittojen-torjunta false
-             tk/liuossuolaus false
+             ;; Liuossuolausta ei ymmärtääkseni enää seurata, mutta kesälomien takia tässä on korjauksen
+             ;; hetkellä pieni informaatiouupelo. Nämä rivit voi poistaa tulevaisuudessa, jos lukija
+             ;; kokee tietävänsä asian varmaksi.
+             ;;tk/liuossuolaus false
              tk/aurausviitoitus-ja-kinostimet false
              tk/lumensiirto false
              tk/paannejaan-poisto false


### PR DESCRIPTION
HAR-2533 yhteydessä oli lisätty uusia seurattavia toimenpiteitä,
ja täten päivitetty suoritettavatehtava enumia. Tästä enumista
oli pudotettu pois lioussuolaus, ja tämän takia työkoneiden haku
tilannekuvaan epäonnistui kokonaan, jos lioussuolaus oli valittuna.

Selvittelyn jälkeen todettiin, että lioussuolaus on ehkä poistettu
tarkoituksella. Ismolta tulleessa "Harja tehtävä luetteloiden kommentit"
viestissä oli liitteenä excel, jossa oli mainittu vain suolaus, ei
liuossuolausta. Ilmeisesti APIn kautta ei työkoneille ole ollut
mahdollista raportoida työkoneelle liuossuolausta ikinä, eikä
liuossuolaus toimenpiteelle ole liitetty linkkiä saman nimiseen
enumiin. Asia kannattanee vielä varmistaa Mikolta/Jarilta kunhan palaavat
lomilta, mutta selvittelyn jälkeen voimme olla liuossuolauksen poistoon
suhteellisen luottavaisia.

Poistettu kommentilla, koska jos liuossuolaus tarvitaan sittenkin
- joka on hyvin mahdollista, toimenpidelista elää paljon - pitää
  se muistaa palauttaa aika moneen paikkaan.
