### PR TITLE
Har 2756 karttaselitenappi

### DIFF
--- a/src/cljc/harja/fmt.cljc
+++ b/src/cljc/harja/fmt.cljc
@@ -316,8 +316,8 @@
 
   Optiot mappi, jossa voi olla arvot:
   pisteet?      Näyttää kolme pistettä tekstin lopussa jos teksti katkeaa. Oletus false."
-  ([pituus merkkijono] (leikkaa-merkkijono pituus merkkijono {}))
-  ([pituus merkkijono {:keys [pisteet?] :as optiot}]
+  ([pituus merkkijono] (leikkaa-merkkijono pituus {} merkkijono))
+  ([pituus {:keys [pisteet?] :as optiot} merkkijono]
    (when merkkijono
      (let [tulos (subs merkkijono 0 (min (count merkkijono) pituus))]
        (if (and pisteet? (> (count merkkijono) pituus))

--- a/src/cljc/harja/fmt.cljc
+++ b/src/cljc/harja/fmt.cljc
@@ -324,6 +324,10 @@
          (str tulos "...")
          tulos)))))
 
+(defn left-pad
+  [minimi-pituus merkkijono]
+  (str (apply str (repeat (- minimi-pituus (count merkkijono)) " ")) merkkijono))
+
 (defn kuvaile-paivien-maara
   "Ottaa päivien määrää kuvaavan numeron, ja kuvailee sen tekstinä.
   - Jos päiviä on alle 7, näytetään päivien määrä

--- a/src/cljc/harja/fmt.cljc
+++ b/src/cljc/harja/fmt.cljc
@@ -316,8 +316,8 @@
 
   Optiot mappi, jossa voi olla arvot:
   pisteet?      Näyttää kolme pistettä tekstin lopussa jos teksti katkeaa. Oletus false."
-  ([merkkijono pituus] (leikkaa-merkkijono merkkijono pituus {}))
-  ([merkkijono pituus {:keys [pisteet?] :as optiot}]
+  ([pituus merkkijono] (leikkaa-merkkijono pituus merkkijono {}))
+  ([pituus merkkijono {:keys [pisteet?] :as optiot}]
    (when merkkijono
      (let [tulos (subs merkkijono 0 (min (count merkkijono) pituus))]
        (if (and pisteet? (> (count merkkijono) pituus))

--- a/src/cljc/harja/fmt.cljc
+++ b/src/cljc/harja/fmt.cljc
@@ -325,8 +325,9 @@
          tulos)))))
 
 (defn left-pad
-  [minimi-pituus merkkijono]
-  (str (apply str (repeat (- minimi-pituus (count merkkijono)) " ")) merkkijono))
+  [minimi-pituus sisalto]
+  (let [merkkijono (str sisalto)]
+    (str (apply str (repeat (- minimi-pituus (count merkkijono)) " ")) merkkijono)))
 
 (defn kuvaile-paivien-maara
   "Ottaa päivien määrää kuvaavan numeron, ja kuvailee sen tekstinä.

--- a/src/cljs/harja/ui/liitteet.cljs
+++ b/src/cljs/harja/ui/liitteet.cljs
@@ -135,7 +135,7 @@
             (ikonit/livicon-upload)
             (if @tiedosto
               (if grid?
-                (str "Vaihda " (fmt/leikkaa-merkkijono 25 (:nimi @tiedosto) {:pisteet? true}))
+                (str "Vaihda " (fmt/leikkaa-merkkijono 25 {:pisteet? true} (:nimi @tiedosto)))
                 "Vaihda liite")
               (or nappi-teksti "Lisää liite"))]
            [:input.upload

--- a/src/cljs/harja/ui/liitteet.cljs
+++ b/src/cljs/harja/ui/liitteet.cljs
@@ -135,7 +135,7 @@
             (ikonit/livicon-upload)
             (if @tiedosto
               (if grid?
-                (str "Vaihda " (fmt/leikkaa-merkkijono (:nimi @tiedosto) 25 {:pisteet? true}))
+                (str "Vaihda " (fmt/leikkaa-merkkijono 25 (:nimi @tiedosto) {:pisteet? true}))
                 "Vaihda liite")
               (or nappi-teksti "Lisää liite"))]
            [:input.upload

--- a/src/cljs/harja/views/hallinta/integraatioloki.cljs
+++ b/src/cljs/harja/views/hallinta/integraatioloki.cljs
@@ -39,7 +39,7 @@
   (let [sisalto (kartta-merkkijonoksi otsikko)
         max-pituus 30]
     (if (> (count sisalto) max-pituus)
-      [:div (str (fmt/leikkaa-merkkijono max-pituus sisalto {:pisteet? true}) " ")
+      [:div (str (fmt/leikkaa-merkkijono max-pituus {:pisteet? true} sisalto) " ")
        [:span.pull-right
         [:button.nappi-toissijainen.grid-lisaa
          {:on-click
@@ -53,7 +53,7 @@
         teksti lisatiedot]
     (if (> (count teksti) max-pituus)
       [:span
-       (str (fmt/leikkaa-merkkijono max-pituus lisatiedot {:pisteet? true}) " ")
+       (str (fmt/leikkaa-merkkijono max-pituus {:pisteet? true} lisatiedot) " ")
        [:button.nappi-toissijainen.grid-lisaa
         {:on-click
          (fn [e]
@@ -64,7 +64,7 @@
 (defn nayta-sisalto [sisalto]
   (let [max-pituus 30]
     (if (> (count sisalto) max-pituus)
-      [:div (str (fmt/leikkaa-merkkijono max-pituus sisalto {:pisteet? true}))
+      [:div (str (fmt/leikkaa-merkkijono max-pituus {:pisteet? true} sisalto))
        [:span.pull-right
         [:button.nappi-toissijainen.grid-lisaa
          {:on-click

--- a/src/cljs/harja/views/hallinta/integraatioloki.cljs
+++ b/src/cljs/harja/views/hallinta/integraatioloki.cljs
@@ -39,7 +39,7 @@
   (let [sisalto (kartta-merkkijonoksi otsikko)
         max-pituus 30]
     (if (> (count sisalto) max-pituus)
-      [:div (str (fmt/leikkaa-merkkijono sisalto max-pituus {:pisteet? true}) " ")
+      [:div (str (fmt/leikkaa-merkkijono max-pituus sisalto {:pisteet? true}) " ")
        [:span.pull-right
         [:button.nappi-toissijainen.grid-lisaa
          {:on-click
@@ -53,7 +53,7 @@
         teksti lisatiedot]
     (if (> (count teksti) max-pituus)
       [:span
-       (str (fmt/leikkaa-merkkijono lisatiedot max-pituus {:pisteet? true}) " ")
+       (str (fmt/leikkaa-merkkijono max-pituus lisatiedot {:pisteet? true}) " ")
        [:button.nappi-toissijainen.grid-lisaa
         {:on-click
          (fn [e]
@@ -64,7 +64,7 @@
 (defn nayta-sisalto [sisalto]
   (let [max-pituus 30]
     (if (> (count sisalto) max-pituus)
-      [:div (str (fmt/leikkaa-merkkijono sisalto max-pituus {:pisteet? true}))
+      [:div (str (fmt/leikkaa-merkkijono max-pituus sisalto {:pisteet? true}))
        [:span.pull-right
         [:button.nappi-toissijainen.grid-lisaa
          {:on-click
@@ -89,7 +89,7 @@
                             [:span.integraatioloki-varoitus (ikonit/circle-arrow-left) " Ulos"])}
             {:otsikko "Osoite" :nimi :osoite :leveys "30%"}
             {:otsikko     "Parametrit" :nimi :parametrit :leveys "20%" :tyyppi :komponentti
-             :komponentti #(fmt/leikkaa-merkkijono (kartta-merkkijonoksi (:parametrit %)) 50)}
+             :komponentti #(fmt/leikkaa-merkkijono 50 (kartta-merkkijonoksi (:parametrit %)))}
             {:otsikko     "Otsikko" :nimi :otsikko :leveys "30%" :tyyppi :komponentti
              :komponentti #(nayta-otsikko (:otsikko %))}
             {:otsikko "Siirtotyyppi" :nimi :siirtotyyppi :leveys "20%"}

--- a/src/cljs/harja/views/kartta.cljs
+++ b/src/cljs/harja/views/kartta.cljs
@@ -273,10 +273,11 @@
   (let [selitteet (reduce set/union
                           (keep #(when % (taso/selitteet %))
                                 (vals @tasot/geometriat-kartalle)))
+        lukumaara-str (fmt/left-pad 2 (count selitteet))
         varilaatikon-koko 20
         teksti (if @ikonien-selitykset-auki
-                 (str "Piilota (" (count selitteet) " kpl)")
-                 (str "Karttaselitteet (" (count selitteet) " kpl)"))]
+                 (str "Piilota | " lukumaara-str " kpl")
+                 (str "Karttaselitteet | " lukumaara-str " kpl"))]
     (if (and (not= :S @nav/kartan-koko)
              (not (empty? selitteet))
              @ikonien-selitykset-nakyvissa?)

--- a/src/cljs/harja/views/kartta.cljs
+++ b/src/cljs/harja/views/kartta.cljs
@@ -273,7 +273,10 @@
   (let [selitteet (reduce set/union
                           (keep #(when % (taso/selitteet %))
                                 (vals @tasot/geometriat-kartalle)))
-        varilaatikon-koko 20]
+        varilaatikon-koko 20
+        teksti (if @ikonien-selitykset-auki
+                 (str "Piilota (" (count selitteet) " kpl)")
+                 (str "Karttaselitteet (" (count selitteet) " kpl)"))]
     (if (and (not= :S @nav/kartan-koko)
              (not (empty? selitteet))
              @ikonien-selitykset-nakyvissa?)
@@ -331,12 +334,12 @@
            {:on-click (fn [event]
                         (reset! ikonien-selitykset-auki false)
                         (.stopPropagation event)
-                        (.preventDefault event))} "Sulje"]]
+                        (.preventDefault event))} teksti]]
          [:span.kartan-ikonien-selitykset-avaa.klikattava {:on-click (fn [event]
                                                                        (reset! ikonien-selitykset-auki true)
                                                                        (.stopPropagation event)
                                                                        (.preventDefault event))}
-          "Karttaselitteet"])])))
+          teksti])])))
 
 (def kartan-yleiset-kontrollit-sisalto (atom nil))
 


### PR DESCRIPTION
Yksinkertainen käytettävyysparannus, selitelaatikon napissa näkyy nyt, montako erilaista selitettä (eli monenko tyyppistä asiaa) kartalla on. Tuntuu varsinkin tilannekuvassa ihan kivalta, kun suodattimia vaihtelemalla näkee heti, että nyt suodattimet taisi löytää jotain uutta ja jännää.

Lisätty left-pad funktio, jotta tekstin pituus pysyy aina suunnilleen samana.

Muutettu leikkaa-merkkijono funktion parametrien järjestystä clojuremaisempaan suuntaan.
