### PR TITLE
HAR-2766 Hae tarkastusreitit kursorilla

### DIFF
--- a/src/cljc/harja/geo.cljc
+++ b/src/cljc/harja/geo.cljc
@@ -134,6 +134,13 @@
                                 sarakkeet)))))))
 
 #?(:clj
+   (defn muunna-reitti [{reitti :reitti :as rivi}]
+     (if reitti
+       (assoc rivi
+              :reitti (pg->clj reitti))
+       rivi)))
+
+#?(:clj
    (def wgs84-wkt "PROJCS[\"WGS 84 / Pseudo-Mercator\", \n  GEOGCS[\"WGS 84\", \n    DATUM[\"World Geodetic System 1984\", \n      SPHEROID[\"WGS 84\", 6378137.0, 298.257223563, AUTHORITY[\"EPSG\",\"7030\"]], \n      AUTHORITY[\"EPSG\",\"6326\"]], \n    PRIMEM[\"Greenwich\", 0.0, AUTHORITY[\"EPSG\",\"8901\"]], \n    UNIT[\"degree\", 0.017453292519943295], \n    AXIS[\"Geodetic longitude\", EAST], \n    AXIS[\"Geodetic latitude\", NORTH], \n    AUTHORITY[\"EPSG\",\"4326\"]], \n  PROJECTION[\"Popular Visualisation Pseudo Mercator\"], \n  PARAMETER[\"semi_minor\", 6378137.0], \n  PARAMETER[\"latitude_of_origin\", 0.0], \n  PARAMETER[\"central_meridian\", 0.0], \n  PARAMETER[\"scale_factor\", 1.0], \n  PARAMETER[\"false_easting\", 0.0], \n  PARAMETER[\"false_northing\", 0.0], \n  UNIT[\"m\", 1.0], \n  AXIS[\"Easting\", EAST], \n  AXIS[\"Northing\", NORTH], \n  AUTHORITY[\"EPSG\",\"3857\"]]"))
 
 #?(:clj


### PR DESCRIPTION
**Uusi haku tarkastusreiteille**
Haku, joka hakee tarkastuksen reitit karttapiirtoa varten, ei hae
kaikkea tietoja, jota listaus tarvitsee.

**Lisää muunna-reitti apuri**
Yleisesti käytetty row-fn

**Käytä uutta hakua tarkastusreittien piirrossa**
