### PR TITLE
HAR-1990_sorateiden_hoitoluokat

### DIFF
--- a/asetukset.edn
+++ b/asetukset.edn
@@ -76,33 +76,33 @@
 
  :geometriapaivitykset {:tuontivali         60
 
-                        ;; :tieosoiteverkon-shapefile                 "file://shp/Tieosoiteverkko/PTK_tieosoiteverkko.shp"
-                        ;; :tieosoiteverkon-alk-osoite                "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTK_tieosoiteverkko.shz"
-                        ;; :tieosoiteverkon-alk-tuontikohde           "./shp/Tieosoiteverkko/PTK_tieosoiteverkko.shz"
+                        :tieosoiteverkon-shapefile                 "file://shp/Tieosoiteverkko/PTK_tieosoiteverkko.shp"
+                        :tieosoiteverkon-alk-osoite                "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTK_tieosoiteverkko.shz"
+                        :tieosoiteverkon-alk-tuontikohde           "./shp/Tieosoiteverkko/PTK_tieosoiteverkko.shz"
 
-                        ;; :pohjavesialueen-shapefile                 "file://shp/Pohjavesialueet/PTV_tl141.shp"
-                        ;; :pohjavesialueen-alk-osoite                "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTV_tl141.shz"
-                        ;; :pohjavesialueen-alk-tuontikohde           "./shp/Pohjavesialueet/PTV_tl141.shz"
+                        :pohjavesialueen-shapefile                 "file://shp/Pohjavesialueet/PTV_tl141.shp"
+                        :pohjavesialueen-alk-osoite                "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTV_tl141.shz"
+                        :pohjavesialueen-alk-tuontikohde           "./shp/Pohjavesialueet/PTV_tl141.shz"
 
-                        ;; :talvihoidon-hoitoluokkien-shapefile       "file://shp/Talvihoitoluokat/PTV_tl132.shp"
-                        ;; :talvihoidon-hoitoluokkien-alk-osoite      "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTV_tl132.shz"
-                        ;; :talvihoidon-hoitoluokkien-alk-tuontikohde "./shp/Talvihoitoluokat/PTV_tl132.shz"
+                        :talvihoidon-hoitoluokkien-shapefile       "file://shp/Talvihoitoluokat/PTV_tl132.shp"
+                        :talvihoidon-hoitoluokkien-alk-osoite      "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTV_tl132.shz"
+                        :talvihoidon-hoitoluokkien-alk-tuontikohde "./shp/Talvihoitoluokat/PTV_tl132.shz"
 
                         :soratien-hoitoluokkien-shapefile          "file://shp/Soratieluokat/PTV_tl149.shp"
-                        ;; :soratien-hoitoluokkien-alk-osoite         "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTV_tl149.shz"
-                        ;; :soratien-hoitoluokkien-alk-tuontikohde    "./shp/Soratieluokat/PTV_tl149.shz"
+                        :soratien-hoitoluokkien-alk-osoite         "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTV_tl149.shz"
+                        :soratien-hoitoluokkien-alk-tuontikohde    "./shp/Soratieluokat/PTV_tl149.shz"
 
-                        ;; :siltojen-shapefile                        "file://shp/Sillat/PTV_silta.shp"
-                        ;; :siltojen-alk-osoite                       "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTV_silta.shz"
-                        ;; :siltojen-alk-tuontikohde                  "./shp/Sillat/PTV_silta.shz"
+                        :siltojen-shapefile                        "file://shp/Sillat/PTV_silta.shp"
+                        :siltojen-alk-osoite                       "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTV_silta.shz"
+                        :siltojen-alk-tuontikohde                  "./shp/Sillat/PTV_silta.shz"
 
-                        ;; :urakoiden-shapefile                       "file://shp/Hoitourakat/PTV_Hoitourakat10_2015.shx"
-                        ;; :urakoiden-alk-osoite                      "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTV_Hoitourakat10_2015.shz"
-                        ;; :urakoiden-alk-tuontikohde                 "./shp/Hoitourakat/PTV_Hoitourakat10_2015.shz"
+                        :urakoiden-shapefile                       "file://shp/Hoitourakat/PTV_Hoitourakat10_2015.shx"
+                        :urakoiden-alk-osoite                      "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTV_Hoitourakat10_2015.shz"
+                        :urakoiden-alk-tuontikohde                 "./shp/Hoitourakat/PTV_Hoitourakat10_2015.shz"
 
-                        ;; :ely-alueiden-shapefile                    "file://shp/ELYt/ULKOISET_Elyt_infra.shp"
-                        ;; :ely-alueiden-alk-osoite                   "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/ULKOISET_Elyt_infra.shz"
-                        ;; :ely-alueiden-alk-tuontikohde              "./shp/ELYt/ULKOISET_Elyt_infra.shz"
+                        :ely-alueiden-shapefile                    "file://shp/ELYt/ULKOISET_Elyt_infra.shp"
+                        :ely-alueiden-alk-osoite                   "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/ULKOISET_Elyt_infra.shz"
+                        :ely-alueiden-alk-tuontikohde              "./shp/ELYt/ULKOISET_Elyt_infra.shz"
                         }
 
  :yha                  {:url                                       "https://harja-test.solitaservices.fi/harja/integraatiotesti/yha/"}

--- a/asetukset.edn
+++ b/asetukset.edn
@@ -76,33 +76,33 @@
 
  :geometriapaivitykset {:tuontivali         60
 
-                        :tieosoiteverkon-shapefile                 "file://shp/Tieosoiteverkko/PTK_tieosoiteverkko.shp"
-                        :tieosoiteverkon-alk-osoite                "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTK_tieosoiteverkko.shz"
-                        :tieosoiteverkon-alk-tuontikohde           "./shp/Tieosoiteverkko/PTK_tieosoiteverkko.shz"
+                        ;; :tieosoiteverkon-shapefile                 "file://shp/Tieosoiteverkko/PTK_tieosoiteverkko.shp"
+                        ;; :tieosoiteverkon-alk-osoite                "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTK_tieosoiteverkko.shz"
+                        ;; :tieosoiteverkon-alk-tuontikohde           "./shp/Tieosoiteverkko/PTK_tieosoiteverkko.shz"
 
-                        :pohjavesialueen-shapefile                 "file://shp/Pohjavesialueet/PTV_tl141.shp"
-                        :pohjavesialueen-alk-osoite                "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTV_tl141.shz"
-                        :pohjavesialueen-alk-tuontikohde           "./shp/Pohjavesialueet/PTV_tl141.shz"
+                        ;; :pohjavesialueen-shapefile                 "file://shp/Pohjavesialueet/PTV_tl141.shp"
+                        ;; :pohjavesialueen-alk-osoite                "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTV_tl141.shz"
+                        ;; :pohjavesialueen-alk-tuontikohde           "./shp/Pohjavesialueet/PTV_tl141.shz"
 
-                        :talvihoidon-hoitoluokkien-shapefile       "file://shp/Talvihoitoluokat/PTV_tl132.shp"
-                        :talvihoidon-hoitoluokkien-alk-osoite      "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTV_tl132.shz"
-                        :talvihoidon-hoitoluokkien-alk-tuontikohde "./shp/Talvihoitoluokat/PTV_tl132.shz"
+                        ;; :talvihoidon-hoitoluokkien-shapefile       "file://shp/Talvihoitoluokat/PTV_tl132.shp"
+                        ;; :talvihoidon-hoitoluokkien-alk-osoite      "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTV_tl132.shz"
+                        ;; :talvihoidon-hoitoluokkien-alk-tuontikohde "./shp/Talvihoitoluokat/PTV_tl132.shz"
 
-                        :soratien-hoitoluokkien-shapefile          "file://shp/Soratieluokat/PTV_TIIRA_KP_SORATIELUOKKA.shp"
-                        :soratien-hoitoluokkien-alk-osoite         "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTV_TIIRA_KP_SORATIELUOKKA.shz"
-                        :soratien-hoitoluokkien-alk-tuontikohde    "./shp/Soratieluokat/PTV_TIIRA_KP_SORATIELUOKKA.shz"
+                        :soratien-hoitoluokkien-shapefile          "file://shp/Soratieluokat/PTV_tl149.shp"
+                        ;; :soratien-hoitoluokkien-alk-osoite         "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTV_tl149.shz"
+                        ;; :soratien-hoitoluokkien-alk-tuontikohde    "./shp/Soratieluokat/PTV_tl149.shz"
 
-                        :siltojen-shapefile                        "file://shp/Sillat/PTV_silta.shp"
-                        :siltojen-alk-osoite                       "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTV_silta.shz"
-                        :siltojen-alk-tuontikohde                  "./shp/Sillat/PTV_silta.shz"
+                        ;; :siltojen-shapefile                        "file://shp/Sillat/PTV_silta.shp"
+                        ;; :siltojen-alk-osoite                       "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTV_silta.shz"
+                        ;; :siltojen-alk-tuontikohde                  "./shp/Sillat/PTV_silta.shz"
 
-                        :urakoiden-shapefile                       "file://shp/Hoitourakat/PTV_Hoitourakat10_2015.shx"
-                        :urakoiden-alk-osoite                      "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTV_Hoitourakat10_2015.shz"
-                        :urakoiden-alk-tuontikohde                 "./shp/Hoitourakat/PTV_Hoitourakat10_2015.shz"
+                        ;; :urakoiden-shapefile                       "file://shp/Hoitourakat/PTV_Hoitourakat10_2015.shx"
+                        ;; :urakoiden-alk-osoite                      "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/PTV_Hoitourakat10_2015.shz"
+                        ;; :urakoiden-alk-tuontikohde                 "./shp/Hoitourakat/PTV_Hoitourakat10_2015.shz"
 
-                        :ely-alueiden-shapefile                    "file://shp/ELYt/ULKOISET_Elyt_infra.shp"
-                        :ely-alueiden-alk-osoite                   "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/ULKOISET_Elyt_infra.shz"
-                        :ely-alueiden-alk-tuontikohde              "./shp/ELYt/ULKOISET_Elyt_infra.shz"
+                        ;; :ely-alueiden-shapefile                    "file://shp/ELYt/ULKOISET_Elyt_infra.shp"
+                        ;; :ely-alueiden-alk-osoite                   "https://harja-test.solitaservices.fi/harja/integraatiotesti/alk/ULKOISET_Elyt_infra.shz"
+                        ;; :ely-alueiden-alk-tuontikohde              "./shp/ELYt/ULKOISET_Elyt_infra.shz"
                         }
 
  :yha                  {:url                                       "https://harja-test.solitaservices.fi/harja/integraatiotesti/yha/"}

--- a/src/clj/harja/palvelin/integraatiot/paikkatietojarjestelma/tuonnit/soratien_hoitoluokat.clj
+++ b/src/clj/harja/palvelin/integraatiot/paikkatietojarjestelma/tuonnit/soratien_hoitoluokat.clj
@@ -8,18 +8,20 @@
 
 (defn vie-hoitoluokka-entry [db soratie]
   (if (:the_geom soratie)
-    (hoitoluokat/vie-hoitoluokkatauluun! db
-                                         (:ajorata soratie)
-                                         (:alkutieo soratie)
-                                         (:tienro soratie)
-                                         (:piirinro soratie)
-                                         (.intValue (:et_loppu soratie))
-                                         (:loppu_tieo soratie)
-                                         (.intValue (:et_alku soratie))
-                                         (:lopputieo soratie)
-                                         (:soratlk_ko soratie)
-                                         (.toString (:the_geom soratie))
-                                         "soratie")
+    (let [kokonaisluvuksi #(when % (.intValue %))]
+      (hoitoluokat/vie-hoitoluokkatauluun!
+        db
+        (kokonaisluvuksi (:ajorata soratie))
+        (kokonaisluvuksi (:aosa soratie))
+        (kokonaisluvuksi (:tie soratie))
+        (kokonaisluvuksi (:piirinro soratie))
+        (kokonaisluvuksi (:let soratie))
+        (kokonaisluvuksi (:losa soratie))
+        (kokonaisluvuksi (:aet soratie))
+        (kokonaisluvuksi (:osa soratie))
+        (kokonaisluvuksi (:soratielk soratie))
+        (.toString (:the_geom soratie))
+        "soratie"))
     (log/warn "Soratiehoitoluokkaa ei voida tuoda ilman geometriaa. Virheviesti: " (:loc_error soratie))))
 
 (defn vie-hoitoluokat-kantaan [db shapefile]

--- a/src/clj/harja/palvelin/integraatiot/paikkatietojarjestelma/tuonnit/soratien_hoitoluokat.clj
+++ b/src/clj/harja/palvelin/integraatiot/paikkatietojarjestelma/tuonnit/soratien_hoitoluokat.clj
@@ -8,7 +8,7 @@
 
 (defn vie-hoitoluokka-entry [db soratie]
   (if (:the_geom soratie)
-    (let [kokonaisluvuksi #(when % (.intValue %))]
+    (let [kokonaisluvuksi #(when % (int %))]
       (hoitoluokat/vie-hoitoluokkatauluun!
         db
         (kokonaisluvuksi (:ajorata soratie))
@@ -20,7 +20,7 @@
         (kokonaisluvuksi (:aet soratie))
         (kokonaisluvuksi (:osa soratie))
         (kokonaisluvuksi (:soratielk soratie))
-        (.toString (:the_geom soratie))
+        (str (:the_geom soratie))
         "soratie"))
     (log/warn "Soratiehoitoluokkaa ei voida tuoda ilman geometriaa. Virheviesti: " (:loc_error soratie))))
 


### PR DESCRIPTION
Sorateiden hoitoluokkien geometria-aineisto on päivitetty pois vanhasta TIIRA:n materiaalista käyttämään varsinaista Tierekisterin aineistoa.
