### PR TITLE
HAR-2776 Toteuma API:n sopimus vaihtoehtoiseksi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ tuotanto_test.sh
 .labyrintti-salasana
 .turi-salasana
 .hipchat-token
+opt/sonic/7.6.2/sonic-client.jar
+opt/sonic/7.6.2/sonic-crypto.jar
+opt/sonic/7.6.2/sonic-xmessage.jar

--- a/resources/api/documentation/harja-api-versiohistoria.md
+++ b/resources/api/documentation/harja-api-versiohistoria.md
@@ -2,6 +2,8 @@
 <b>Julkaistu: 27.7.2016</b>
 
 <b>Versiohistoria:</b>
+- Versionumero: 0.2.5. Julkaistu 8.8.2016:
+    - Sopimusnumero on muutettu vaihtoehtoiseksi toteumille. Jos sopimusnumeroa ei ole annettu, tehdään kirjaus automaattisesti urakan pääsopimukselle. 
 - Versionumero: 0.2.4. Julkaistu 27.7.2016:
     - Varusterajapinnat päivitetty. Jatkossa varusteiden ja laitteiden teknisten arvojen parsinta tehdään Harjan puolella. Samalla mahdollistettu usean varustetoteuman sekä yksittäisen varustetoteuman sisällä usean toimenpiteen kirjaaminen kerralla.
 - Versionumero: 0.2.3. Julkaistu 15.7.2016:

--- a/resources/api/schemas/entities/toteuma.schema.json
+++ b/resources/api/schemas/entities/toteuma.schema.json
@@ -13,8 +13,7 @@
     },
     "sopimusId": {
       "id": "urn:harja/toteumat/0/toteuma/sopimusId",
-      "type": "integer",
-      "required": true
+      "type": "integer"
     },
     "alkanut": {
       "id": "urn:harja/toteumat/0/toteuma/alkanut",

--- a/src/clj/harja/kyselyt/sopimukset.sql
+++ b/src/clj/harja/kyselyt/sopimukset.sql
@@ -36,3 +36,8 @@ WHERE urakka_sampoid = :urakka_sampo_id;
 SELECT EXISTS(SELECT id
               FROM sopimus
               WHERE urakka = :urakka_id AND id = :sopimus_id);
+
+-- name: hae-urakan-paasopimus
+SELECT id
+FROM sopimus
+WHERE urakka = 1 AND paasopimus = 1;

--- a/src/clj/harja/kyselyt/sopimukset.sql
+++ b/src/clj/harja/kyselyt/sopimukset.sql
@@ -40,4 +40,4 @@ SELECT EXISTS(SELECT id
 -- name: hae-urakan-paasopimus
 SELECT id
 FROM sopimus
-WHERE urakka = 1 AND paasopimus = 1;
+WHERE urakka = :urakka AND paasopimus IS NULL;

--- a/src/clj/harja/palvelin/integraatiot/api/toteuma.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/toteuma.clj
@@ -6,6 +6,7 @@
             [harja.palvelin.integraatiot.api.tyokalut.kutsukasittely :refer [kasittele-kutsu]]
             [harja.kyselyt.materiaalit :as materiaalit]
             [harja.kyselyt.toteumat :as toteumat]
+            [harja.kyselyt.sopimukset :as sopimukset]
             [harja.palvelin.integraatiot.api.tyokalut.liitteet :refer [dekoodaa-base64]]
             [harja.palvelin.integraatiot.api.tyokalut.json :refer [aika-string->java-sql-date]]
             [harja.palvelin.integraatiot.api.tyokalut.virheet :as virheet]
@@ -21,45 +22,54 @@
             #(get-in % [toteumatyyppi-yksikko :toteuma :sopimusId])
             (toteumatyyppi-monikko data)))))
 
+
+(defn hae-sopimus-id [db urakka-id toteuma]
+  (let [sopimus-id (or (:sopimusId toteuma) (sopimukset/hae-urakan-paasopimus db urakka-id))]
+    (if sopimus-id
+      sopimus-id
+      (throw+ {:type virheet/+viallinen-kutsu+
+               :virheet [{:koodi virheet/+sopimusta-ei-loydy+
+                          :viesti (format "Urakalle (id: %s.) ei löydy sopimusta" urakka-id)}]}))))
+
 (defn paivita-toteuma [db urakka-id kirjaaja toteuma]
   (log/debug "Päivitetään vanha toteuma, jonka ulkoinen id on " (get-in toteuma [:tunniste :id]))
   (validointi/validoi-toteuman-pvm-vali (:alkanut toteuma) (:paattynyt toteuma))
   (validointi/tarkista-tehtavat db (:tehtavat toteuma))
-
-  (:id (toteumat/paivita-toteuma-ulkoisella-idlla<!
-         db
-         (aika-string->java-sql-date (:alkanut toteuma))
-         (aika-string->java-sql-date (:paattynyt toteuma))
-         (:id kirjaaja)
-         (get-in toteuma [:suorittaja :nimi])
-         (get-in toteuma [:suorittaja :ytunnus])
-         ""
-         (:toteumatyyppi toteuma)
-         (:reitti toteuma)
-         (:sopimusId toteuma)
-         (get-in toteuma [:tunniste :id])
-         urakka-id)))
+  (let [sopimus-id (hae-sopimus-id db urakka-id toteuma)]
+    (:id (toteumat/paivita-toteuma-ulkoisella-idlla<!
+           db
+           (aika-string->java-sql-date (:alkanut toteuma))
+           (aika-string->java-sql-date (:paattynyt toteuma))
+           (:id kirjaaja)
+           (get-in toteuma [:suorittaja :nimi])
+           (get-in toteuma [:suorittaja :ytunnus])
+           ""
+           (:toteumatyyppi toteuma)
+           (:reitti toteuma)
+           sopimus-id
+           (get-in toteuma [:tunniste :id])
+           urakka-id))))
 
 (defn luo-uusi-toteuma [db urakka-id kirjaaja toteuma]
   (log/debug "Luodaan uusi toteuma.")
   (validointi/validoi-toteuman-pvm-vali (:alkanut toteuma) (:paattynyt toteuma))
   (validointi/tarkista-tehtavat db (:tehtavat toteuma))
-
-  (:id (toteumat/luo-toteuma<!
-         db
-         urakka-id
-         (:sopimusId toteuma)
-         (aika-string->java-sql-date (:alkanut toteuma))
-         (aika-string->java-sql-date (:paattynyt toteuma))
-         (:toteumatyyppi toteuma)
-         (:id kirjaaja)
-         (get-in toteuma [:suorittaja :nimi])
-         (get-in toteuma [:suorittaja :ytunnus])
-         ""
-         (get-in toteuma [:tunniste :id])
-         (:reitti toteuma)
-         nil nil nil nil nil
-         "harja-api")))
+  (let [sopimus-id (hae-sopimus-id db urakka-id toteuma)]
+    (:id (toteumat/luo-toteuma<!
+           db
+           urakka-id
+           sopimus-id
+           (aika-string->java-sql-date (:alkanut toteuma))
+           (aika-string->java-sql-date (:paattynyt toteuma))
+           (:toteumatyyppi toteuma)
+           (:id kirjaaja)
+           (get-in toteuma [:suorittaja :nimi])
+           (get-in toteuma [:suorittaja :ytunnus])
+           ""
+           (get-in toteuma [:tunniste :id])
+           (:reitti toteuma)
+           nil nil nil nil nil
+           "harja-api"))))
 
 (defn paivita-tai-luo-uusi-toteuma [db urakka-id kirjaaja toteuma]
   (if (toteumat/onko-olemassa-ulkoisella-idlla? db (get-in toteuma [:tunniste :id]) (:id kirjaaja))
@@ -104,8 +114,8 @@
     (let [materiaali-nimi (:materiaali materiaali)
           materiaalikoodi-id (:id (first (materiaalit/hae-materiaalikoodin-id-nimella db materiaali-nimi)))]
       (if (nil? materiaalikoodi-id)
-        (throw+ {:type    virheet/+sisainen-kasittelyvirhe+
-                 :virheet [{:koodi  virheet/+tuntematon-materiaali+
+        (throw+ {:type virheet/+sisainen-kasittelyvirhe+
+                 :virheet [{:koodi virheet/+tuntematon-materiaali+
                             :viesti (format "Tuntematon materiaali: %s." materiaali-nimi)}]}))
       (toteumat/luo-toteuma-materiaali<!
         db

--- a/src/clj/harja/palvelin/integraatiot/api/toteuma.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/toteuma.clj
@@ -24,7 +24,7 @@
 
 
 (defn hae-sopimus-id [db urakka-id toteuma]
-  (let [sopimus-id (or (:sopimusId toteuma) (sopimukset/hae-urakan-paasopimus db urakka-id))]
+  (let [sopimus-id (or (:sopimusId toteuma) (:id (first (sopimukset/hae-urakan-paasopimus db urakka-id))))]
     (if sopimus-id
       sopimus-id
       (throw+ {:type virheet/+viallinen-kutsu+

--- a/src/clj/harja/palvelin/integraatiot/api/tyokalut/virheet.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/tyokalut/virheet.clj
@@ -31,6 +31,7 @@
 (def +puutteelliset-parametrit+ "puutteelliset-parametrit")
 (def +virheellinen-sijainti+ "virheellinen-sijainti")
 (def +virheellinen-paivamaara+ "virheellinen-paivamaara")
+(def +sopimusta-ei-loydy+ "sopimusta ei löydy")
 
 (defn heita-poikkeus [tyyppi virheet]
   (throw+

--- a/test/clj/harja/palvelin/integraatiot/api/reittitoteuman_kirjaus_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/reittitoteuman_kirjaus_test.clj
@@ -97,5 +97,5 @@
     (let [toteuma-id (ffirst (q (str "SELECT id FROM toteuma WHERE ulkoinen_id = " ulkoinen-id)))
           sopimus-id (ffirst (q (str "SELECT sopimus FROM toteuma WHERE ulkoinen_id = " ulkoinen-id)))
           reittipiste-idt (into [] (flatten (q (str "SELECT id FROM reittipiste WHERE toteuma = " toteuma-id))))]
-      (is (= 5 sopimus-id))
+      (is (= 5 sopimus-id) "Toteuma kirjattiin pääsopimukselle")
       (poista-reittitoteuma toteuma-id ulkoinen-id reittipiste-idt))))

--- a/test/clj/harja/palvelin/integraatiot/api/reittitoteuman_kirjaus_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/reittitoteuman_kirjaus_test.clj
@@ -17,6 +17,15 @@
 
 (use-fixtures :once jarjestelma-fixture)
 
+(defn poista-reittitoteuma [toteuma-id ulkoinen-id reittipiste-idt]
+  (doseq [reittipiste-id reittipiste-idt]
+    (u (str "DELETE FROM reitti_materiaali WHERE reittipiste = " reittipiste-id))
+    (u (str "DELETE FROM reitti_tehtava WHERE reittipiste = " reittipiste-id)))
+  (u (str "DELETE FROM reittipiste WHERE toteuma = " toteuma-id))
+  (u (str "DELETE FROM toteuma_materiaali WHERE toteuma = " toteuma-id))
+  (u (str "DELETE FROM toteuma_tehtava WHERE toteuma = " toteuma-id))
+  (u (str "DELETE FROM toteuma WHERE ulkoinen_id = " ulkoinen-id)))
+
 (deftest tallenna-yksittainen-reittitoteuma
   (let [ulkoinen-id (tyokalut/hae-vapaa-toteuma-ulkoinen-id)
         vastaus-lisays (api-tyokalut/post-kutsu ["/api/urakat/" urakka "/toteumat/reitti"] kayttaja portti
@@ -57,13 +66,7 @@
               (is (= (count reitti-materiaali-idt) 1))
               (is (= reitti-hoitoluokka 7)))) ; testidatassa on reittipisteen koordinaateille hoitoluokka
 
-          (doseq [reittipiste-id reittipiste-idt]
-            (u (str "DELETE FROM reitti_materiaali WHERE reittipiste = " reittipiste-id))
-            (u (str "DELETE FROM reitti_tehtava WHERE reittipiste = " reittipiste-id)))
-          (u (str "DELETE FROM reittipiste WHERE toteuma = " toteuma-id))
-          (u (str "DELETE FROM toteuma_materiaali WHERE toteuma = " toteuma-id))
-          (u (str "DELETE FROM toteuma_tehtava WHERE toteuma = " toteuma-id))
-          (u (str "DELETE FROM toteuma WHERE ulkoinen_id = " ulkoinen-id)))))))
+          (poista-reittitoteuma toteuma-id ulkoinen-id reittipiste-idt))))))
 
 
 (deftest tallenna-usea-reittitoteuma
@@ -82,3 +85,17 @@
       (is (= toteuma1-kannassa [ulkoinen-id-1 "8765432-1" "Tienpesijät Oy"])))
     (let [toteuma2-kannassa (first (q (str "SELECT ulkoinen_id, suorittajan_ytunnus, suorittajan_nimi FROM toteuma WHERE ulkoinen_id = " ulkoinen-id-2)))]
       (is (= toteuma2-kannassa [ulkoinen-id-2 "8765432-1" "Tienraivaajat Oy"])))))
+
+(deftest tarkista-toteuman-tallentaminen-paasopimukselle
+  (let [ulkoinen-id (tyokalut/hae-vapaa-toteuma-ulkoinen-id)
+        vastaus-lisays (api-tyokalut/post-kutsu ["/api/urakat/" urakka "/toteumat/reitti"] kayttaja portti
+                                                (-> "test/resurssit/api/reittitoteuma_yksittainen.json"
+                                                    slurp
+                                                    (.replace "__ID__" (str ulkoinen-id))
+                                                    (.replace "__SUORITTAJA_NIMI__" "Tienpesijät Oy")))]
+    (is (= 200 (:status vastaus-lisays)))
+    (let [toteuma-id (ffirst (q (str "SELECT id FROM toteuma WHERE ulkoinen_id = " ulkoinen-id)))
+          sopimus-id (ffirst (q (str "SELECT sopimus FROM toteuma WHERE ulkoinen_id = " ulkoinen-id)))
+          reittipiste-idt (into [] (flatten (q (str "SELECT id FROM reittipiste WHERE toteuma = " toteuma-id))))]
+      (is (= 5 sopimus-id))
+      (poista-reittitoteuma toteuma-id ulkoinen-id reittipiste-idt))))

--- a/test/resurssit/api/reittitoteuma_yksittainen_ilman_sopimusta.json
+++ b/test/resurssit/api/reittitoteuma_yksittainen_ilman_sopimusta.json
@@ -1,0 +1,76 @@
+{
+  "otsikko": {
+    "lahettaja": {
+      "jarjestelma": "Urakoitsijan järjestelmä",
+      "organisaatio": {
+        "nimi": "Urakoitsija",
+        "ytunnus": "1234567-8"
+      }
+    },
+    "viestintunniste": {
+      "id": 137023
+    },
+    "lahetysaika": "2016-01-30T12:00:00Z"
+  },
+  "reittitoteuma": {
+    "toteuma": {
+      "tunniste": {
+        "id": __ID__
+      },
+      "suorittaja": {
+        "nimi": "__SUORITTAJA_NIMI__",
+        "ytunnus": "8765432-1"
+      },
+      "alkanut": "2016-01-30T12:00:00Z",
+      "paattynyt": "2016-01-30T14:00:00Z",
+      "toteumatyyppi": "kokonaishintainen",
+      "tehtavat": [
+        {
+          "tehtava": {
+            "id": 1370,
+            "maara": {
+              "yksikko": "km",
+              "maara": 123
+            }
+          }
+        }
+      ],
+      "materiaalit": [
+        {
+          "materiaali": "Talvisuolaliuos NaCl",
+          "maara": {
+            "yksikko": "kg",
+            "maara": 4.62
+          }
+        }
+      ]
+    },
+    "reitti": [
+      {
+        "reittipiste": {
+          "aika": "2016-01-30T12:00:00Z",
+          "koordinaatit": {
+            "x": 429451.2124,
+            "y": 7199520.6102
+          },
+          "tehtavat": [
+            {
+              "tehtava": {
+                "id": 1370
+              }
+            }
+          ],
+          "materiaalit": [
+            {
+              "materiaali": "Talvisuolaliuos NaCl",
+              "maara": {
+                "yksikko": "kg",
+                "maara": 1.32
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Sopimus id on nyt merkitty vaihtoehtoiseksi toteuma rajapintoihin. Mikäli sopimusta ei ole annettu, kirjataan toteuma automaattisesti urakan pääsopimukselle. Jatkossa kuitenkin voidaan antaa sopimus ja tehdä kirjaus eksplisiittisesti tietylle sopimukselle.
