### PR TITLE
Har 2783 ykshint raportit

### DIFF
--- a/src/clj/harja/palvelin/raportointi/raportit/yksikkohintaiset_tyot_kuukausittain.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/yksikkohintaiset_tyot_kuukausittain.clj
@@ -164,9 +164,12 @@
                                (mapv (fn [rivi]
                                        {:otsikko (pvm/kuukausi-ja-vuosi-valilyonnilla (c/to-date rivi))
                                         :leveys 5
-                                        :otsikkorivi-luokka "grid-kk-sarake"})
+                                        :otsikkorivi-luokka "grid-kk-sarake"
+                                        :fmt :numero})
                                      listattavat-pvmt)
-                               {:leveys 7 :otsikko "Mää\u00ADrä yh\u00ADteen\u00ADsä"}
+                               {:leveys 7
+                                :otsikko "Mää\u00ADrä yh\u00ADteen\u00ADsä"
+                                :fmt :numero}
                                (when (and (= konteksti :urakka)
                                           aikavali-kasittaa-hoitokauden?)
                                  [{:leveys 5 :otsikko "Tot-%" :fmt :prosentti}

--- a/src/clj/harja/palvelin/raportointi/raportit/yksikkohintaiset_tyot_kuukausittain.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/yksikkohintaiset_tyot_kuukausittain.clj
@@ -173,22 +173,30 @@
                                   {:leveys 10 :otsikko "Suun\u00ADni\u00ADtel\u00ADtu määrä hoi\u00ADto\u00ADkau\u00ADdella"
                                    :fmt :numero}])]))
       (mapv (fn [rivi]
-              (flatten (keep identity [(when urakoittain?
-                                         (or (:urakka_nimi rivi) "-"))
-                                       (or (:nimi rivi) "-")
-                                       (or (:yksikko rivi) "-")
-                                       (mapv (fn [pvm]
-                                               (or
-                                                 (get rivi (pvm/kuukausi-ja-vuosi-valilyonnilla (c/to-date pvm)))
-                                                 0))
-                                             listattavat-pvmt)
-                                       (or (:toteutunut_maara rivi) 0)
-                                       (when (and (= konteksti :urakka)
-                                                  aikavali-kasittaa-hoitokauden?)
-                                         [(let [formatoitu (:toteumaprosentti rivi)]
-                                            (if-not (str/blank? formatoitu) formatoitu "-"))
-                                          (let [formatoitu (:suunniteltu_maara rivi)]
-                                            (if-not (str/blank? formatoitu) formatoitu "Ei suunnitelmaa"))])])))
+              (keep identity (concat [(when urakoittain?
+                                        (or (:urakka_nimi rivi) "-"))
+                                      (or (:nimi rivi) "-")
+                                      (or (:yksikko rivi) "-")]
+                                     (mapv (fn [pvm]
+                                             (or
+                                               (get rivi (pvm/kuukausi-ja-vuosi-valilyonnilla (c/to-date pvm)))
+                                               0))
+                                           listattavat-pvmt)
+                                     [(or (:toteutunut_maara rivi) 0)]
+                                     (when (and (= konteksti :urakka)
+                                                aikavali-kasittaa-hoitokauden?)
+                                       [(let [formatoitu (:toteumaprosentti rivi)]
+                                          (if (not (or (nil? formatoitu)
+                                                       (and (or (string? formatoitu) (coll? formatoitu))
+                                                            (empty? formatoitu))))
+                                            formatoitu
+                                            [:info "-"]))
+                                        (let [formatoitu (:suunniteltu_maara rivi)]
+                                          (if (not (or (nil? formatoitu)
+                                                       (and (or (string? formatoitu) (coll? formatoitu))
+                                                            (empty? formatoitu))))
+                                            formatoitu
+                                            [:info "Ei suunnitelmaa"]))]))))
             naytettavat-rivit)]
      (yks-hint-tyot/suunnitelutietojen-nayttamisilmoitus konteksti alkupvm loppupvm suunnittelutiedot)]))
 

--- a/test/clj/harja/palvelin/raportointi/yksikkohintaiset_tyot_kuukausittain_test.clj
+++ b/test/clj/harja/palvelin/raportointi/yksikkohintaiset_tyot_kuukausittain_test.clj
@@ -79,42 +79,55 @@
                         :otsikko "Yk­sik­kö"}
                        {:leveys             5
                         :otsikko            "10 / 15"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "11 / 15"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "12 / 15"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "01 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "02 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "03 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "04 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "05 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "06 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "07 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "08 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "09 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys  7
-                        :otsikko "Mää­rä yh­teen­sä"})
+                        :otsikko "Mää­rä yh­teen­sä"
+                        :fmt :numero})
                      ['("Pensaiden täydennysistutus"
                         "m2"
                         0
@@ -187,42 +200,55 @@
                         :otsikko "Yk­sik­kö"}
                        {:leveys             5
                         :otsikko            "10 / 15"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "11 / 15"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "12 / 15"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "01 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "02 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "03 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "04 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "05 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "06 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "07 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "08 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "09 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys  7
-                        :otsikko "Mää­rä yh­teen­sä"})
+                        :otsikko "Mää­rä yh­teen­sä"
+                        :fmt :numero})
                      ['("Pensaiden täydennysistutus"
                         "m2"
                         0
@@ -293,42 +319,55 @@
                         :otsikko "Yk­sik­kö"}
                        {:leveys             5
                         :otsikko            "10 / 15"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "11 / 15"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "12 / 15"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "01 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "02 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "03 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "04 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "05 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "06 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "07 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "08 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys             5
                         :otsikko            "09 / 16"
-                        :otsikkorivi-luokka "grid-kk-sarake"}
+                        :otsikkorivi-luokka "grid-kk-sarake"
+                        :fmt :numero}
                        {:leveys  7
-                        :otsikko "Mää­rä yh­teen­sä"})
+                        :otsikko "Mää­rä yh­teen­sä"
+                        :fmt :numero})
                      ['("Pensaiden täydennysistutus"
                         "m2"
                         0


### PR DESCRIPTION
Raporttia ei saatu suoritettua, koska soluun yritettiin laittaa virheviesti, mutta formatter odotti numeroa. Lisätty uuden skeeman mukaiset virheviestit ( [:info "foobar"] ), poistettu flatten, ja lisätty kahteen soluun puuttuvat formatterit.
