### PR TITLE
HAR-2788 turvallisuusraportin korjaus

### DIFF
--- a/src/clj/harja/palvelin/raportointi/raportit/turvallisuuspoikkeamat.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/turvallisuuspoikkeamat.clj
@@ -168,10 +168,10 @@
                                                     (c/from-sql-time %2)) turpot))
               (when (not (empty? turpot))
                 (if urakoittain?
-                  (rivi "Yhteensä" "" "" "" "" ""
+                  (rivi "Yhteensä" "" "" ""  ""
                         (reduce + 0 (keep :sairaalavuorokaudet turpot))
                         (reduce + 0 (keep :sairauspoissaolopaivat turpot)))
-                  (rivi "Yhteensä" "" "" "" ""
+                  (rivi "Yhteensä" "" "" ""
                         (reduce + 0 (keep :sairaalavuorokaudet turpot))
                         (reduce + 0 (keep :sairauspoissaolopaivat turpot))))))))
 

--- a/test/clj/harja/palvelin/raportointi/testiapurit.clj
+++ b/test/clj/harja/palvelin/raportointi/testiapurit.clj
@@ -1,0 +1,76 @@
+(ns harja.palvelin.raportointi.testiapurit
+  (:require  [clojure.test :as t :refer [is]]
+             [clojure.core.match :refer [match]]))
+
+(defn tarkista-raportti [vastaus nimi]
+  (match vastaus
+         ([:raportti {:nimi nimi}
+           & elementit] :seq)
+         elementit
+         :else (is false (str "Raportti ei ole oikean muotoinen! saatiin: " (pr-str vastaus)))))
+
+(defn tarkista-taulukko-otsikko [taulukko otsikko]
+  (let [taulukon-otsikko (:otsikko (second taulukko))]
+    (is (= taulukon-otsikko otsikko)
+        (str "Taulukon otsikko ei täsmää! " taulukon-otsikko " != " otsikko))))
+
+(defn tarkista-taulukko-yhteensa [taulukko numero-sarake]
+  (let [rivit (nth taulukko 3)
+        laskettu-summa (reduce + 0 (keep #(nth % numero-sarake) (butlast rivit)))
+        raportoitu-summa (nth (last rivit) numero-sarake)]
+    (is (== laskettu-summa raportoitu-summa)
+        (str "Laskettu ja raportoitu yhteensä summa ei täsmää: "
+             laskettu-summa " != " raportoitu-summa))))
+
+(defn tarkista-taulukko-sarakkeet [taulukko & sarakkeet]
+  (let [taulukon-sarakkeet (nth taulukko 2)]
+    (is (= (count taulukon-sarakkeet) (count sarakkeet))
+        (str "Taulukossa on eri määrä sarakkeita. "
+             (count taulukon-sarakkeet) " != " (count sarakkeet)))
+    (dorun
+     (map (fn [taulukon-sarake sarake]
+            (let [taulukon-sarake* (select-keys taulukon-sarake (keys sarake))]
+                 (is (= taulukon-sarake* sarake)
+                     (str "Taulukon sarake ei täsmää vaadittuun: "
+                          (pr-str taulukon-sarake) " != "
+                          (pr-str sarake)))))
+          taulukon-sarakkeet sarakkeet))))
+
+(defn tarkista-taulukko-rivit [taulukko & rivit]
+  (let [taulukon-rivit (nth taulukko 3)]
+    (is (= (count taulukon-rivit) (count rivit))
+        (str "Taulukossa eri määrä rivejä. "
+             (count taulukon-rivit) " != " (count rivit)))
+    (dorun
+     (map (fn [taulukon-rivi rivi]
+            (if (fn? rivi)
+              (is (rivi taulukon-rivi)
+                  (str "Taulukon rivi ei tyydytä annettua predikaattia, rivi: "
+                       (pr-str taulukon-rivi) ", predikaatti: " rivi))
+              (is (= taulukon-rivi rivi)
+                  (str "Taulukon rivi ei täsmää vaadittuun: "
+                       (pr-str taulukon-rivi) " != "
+                       (pr-str rivi)))))
+          taulukon-rivit rivit))))
+
+(defn tarkista-taulukko-kaikki-rivit [taulukko rivi-pred-fn]
+  (dorun
+   (map-indexed (fn [i taulukon-rivi]
+                  (is (rivi-pred-fn taulukon-rivi)
+                      (str "Taulukon rivi " i " ei täsmää predikaattiin: "
+                           (pr-str taulukon-rivi))))
+                (nth taulukko 3))))
+
+(defmacro elementti [raportti elementin-match]
+  `(let [loytynyt-elementti#
+         (some (fn [elementti#]
+                 (match elementti#
+                        ~elementin-match elementti#
+                        :else nil))
+               (drop 2 ~raportti))]
+     (is (not (nil? loytynyt-elementti#))
+         (str "Elementtiä matcherilla ei löytynyt: " ~(pr-str elementin-match)))
+     loytynyt-elementti#))
+
+(defmacro taulukko-otsikolla [raportti otsikko]
+  `(elementti ~raportti [:taulukko {:otsikko ~otsikko} sarakkeet# rivit#]))

--- a/test/clj/harja/palvelin/raportointi/turvallisuusraportti_test.clj
+++ b/test/clj/harja/palvelin/raportointi/turvallisuusraportti_test.clj
@@ -11,7 +11,10 @@
             [clj-time.coerce :as c]
             [harja.palvelin.komponentit.pdf-vienti :as pdf-vienti]
             [harja.palvelin.raportointi :as raportointi]
-            [harja.palvelin.palvelut.raportit :as raportit]))
+            [harja.palvelin.palvelut.raportit :as raportit]
+            [clojure.core.match :refer [match]]
+            [clojure.string :as str]
+            [harja.palvelin.raportointi.testiapurit :as apurit]))
 
 (defn jarjestelma-fixture [testit]
   (alter-var-root #'jarjestelma
@@ -37,6 +40,7 @@
                       jarjestelma-fixture
                       urakkatieto-fixture))
 
+
 (deftest raportin-suoritus-urakalle-toimii
   (let [vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
                                 :suorita-raportti
@@ -49,92 +53,15 @@
                                               :hoitoluokat #{1 2 3 4 5 6 8 7}
                                               :urakkatyyppi "hoito"}})]
     (is (vector? vastaus))
-    (is (= vastaus [:raportti
-                    {:nimi "Turvallisuusraportti"}
-                    [:taulukko
-                     {:otsikko                    "Oulun alueurakka 2014-2019, Turvallisuusraportti ajalta 01.10.2014 - 01.10.2015"
-                      :sheet-nimi                 "Turvallisuusraportti"
-                      :viimeinen-rivi-yhteenveto? true}
-                     [{:otsikko "Tyyppi"}
-                      {:fmt     :numero
-                       :otsikko "Määrä"}]
-                     '(["Työtapaturma"
-                       1]
-                       ["Vaaratilanne"
-                        0]
-                       ["Turvallisuushavainto"
-                        0]
-                       ["Muu"
-                        0]
-                       ["Yksittäisiä ilmoituksia yhteensä"
-                        1])]
-                    nil
-                    [:pylvaat
-                     {:legend        ["Työtapaturmat"
-                                      "Vaaratilanteet"
-                                      "Turvallisuushavainnot"
-                                      "Muut"]
-                      :otsikko       "Turvallisuuspoikkeamat kuukausittain 01.10.2014-01.10.2015"
-                      :piilota-arvo? #{0}}
-                     [["2014/10"
-                       []]
-                      ["2014/11"
-                       []]
-                      ["2014/12"
-                       []]
-                      ["2015/01"
-                       []]
-                      ["2015/02"
-                       []]
-                      ["2015/03"
-                       []]
-                      ["2015/04"
-                       []]
-                      ["2015/05"
-                       []]
-                      ["2015/06"
-                       []]
-                      ["2015/07"
-                       []]
-                      ["2015/08"
-                       []]
-                      ["2015/09"
-                       []]
-                      ["2015/10"
-                       [1
-                        nil
-                        nil
-                        nil]]]]
-                    [:taulukko
-                     {:otsikko                    "Turvallisuuspoikkeamat listana: 1 kpl"
-                      :viimeinen-rivi-yhteenveto? true}
-                     [{:leveys  14
-                       :otsikko "Pvm"}
-                      {:leveys  24
-                       :otsikko "Tyyppi"}
-                      {:leveys  15
-                       :otsikko "Vakavuusaste"}
-                      {:leveys  14
-                       :otsikko "Ammatti"}
-                      {:fmt     :numero
-                       :leveys  9
-                       :otsikko "Sairaala­vuoro­kaudet"}
-                      {:fmt     :numero
-                       :leveys  9
-                       :otsikko "Sairaus­poissa­olo­päivät"}]
-                     '(["1.10.2015 0:20"
-                       "Ty­ö­ta­pa­tur­ma"
-                       "Vakava"
-                       "Porari"
-                       1
-                       7]
-                       ["Yhteensä"
-                        ""
-                        ""
-                        ""
-                        ""
-                        1
-                        7])]]))))
+    (apurit/tarkista-raportti vastaus "Turvallisuusraportti")
+    (let [otsikko (str "Oulun alueurakka 2014-2019, "
+                       "Turvallisuusraportti ajalta 01.10.2014 - 01.10.2015")
+          taulukko (apurit/elementti vastaus [:taulukko {:otsikko otsikko} _ _])]
+      (apurit/tarkista-taulukko-otsikko taulukko otsikko)
+      (apurit/tarkista-taulukko-sarakkeet taulukko
+                                          {:otsikko "Tyyppi"}
+                                          {:otsikko "Määrä" :fmt :numero})
+      (apurit/tarkista-taulukko-yhteensa taulukko 1))))
 
 
 (deftest raportin-suoritus-hallintayksikolle-toimii
@@ -149,92 +76,14 @@
                                               :hoitoluokat #{1 2 3 4 5 6 8 7}
                                               :urakkatyyppi "hoito"}})]
     (is (vector? vastaus))
-    (is (= vastaus [:raportti
-                    {:nimi "Turvallisuusraportti"}
-                    [:taulukko
-                     {:otsikko                    "Pohjois-Pohjanmaa ja Kainuu, Turvallisuusraportti ajalta 01.10.2014 - 01.10.2015"
-                      :sheet-nimi                 "Turvallisuusraportti"
-                      :viimeinen-rivi-yhteenveto? true}
-                     [{:otsikko "Tyyppi"}
-                      {:fmt     :numero
-                       :otsikko "Määrä"}]
-                     '(["Työtapaturma"
-                       1]
-                       ["Vaaratilanne"
-                        0]
-                       ["Turvallisuushavainto"
-                        0]
-                       ["Muu"
-                        0]
-                       ["Yksittäisiä ilmoituksia yhteensä"
-                        1])]
-                    nil
-                    [:pylvaat
-                     {:legend        ["Työtapaturmat"
-                                      "Vaaratilanteet"
-                                      "Turvallisuushavainnot"
-                                      "Muut"]
-                      :otsikko       "Turvallisuuspoikkeamat kuukausittain 01.10.2014-01.10.2015"
-                      :piilota-arvo? #{0}}
-                     [["2014/10"
-                       []]
-                      ["2014/11"
-                       []]
-                      ["2014/12"
-                       []]
-                      ["2015/01"
-                       []]
-                      ["2015/02"
-                       []]
-                      ["2015/03"
-                       []]
-                      ["2015/04"
-                       []]
-                      ["2015/05"
-                       []]
-                      ["2015/06"
-                       []]
-                      ["2015/07"
-                       []]
-                      ["2015/08"
-                       []]
-                      ["2015/09"
-                       []]
-                      ["2015/10"
-                       [1
-                        nil
-                        nil
-                        nil]]]]
-                    [:taulukko
-                     {:otsikko                    "Turvallisuuspoikkeamat listana: 1 kpl"
-                      :viimeinen-rivi-yhteenveto? true}
-                     [{:leveys  14
-                       :otsikko "Pvm"}
-                      {:leveys  24
-                       :otsikko "Tyyppi"}
-                      {:leveys  15
-                       :otsikko "Vakavuusaste"}
-                      {:leveys  14
-                       :otsikko "Ammatti"}
-                      {:fmt     :numero
-                       :leveys  9
-                       :otsikko "Sairaala­vuoro­kaudet"}
-                      {:fmt     :numero
-                       :leveys  9
-                       :otsikko "Sairaus­poissa­olo­päivät"}]
-                     '(["1.10.2015 0:20"
-                       "Ty­ö­ta­pa­tur­ma"
-                       "Vakava"
-                       "Porari"
-                       1
-                       7]
-                       ["Yhteensä"
-                        ""
-                        ""
-                        ""
-                        ""
-                        1
-                        7])]]))))
+    (apurit/tarkista-raportti vastaus "Turvallisuusraportti")
+    (let [otsikko (str "Pohjois-Pohjanmaa ja Kainuu, "
+                       "Turvallisuusraportti ajalta 01.10.2014 - 01.10.2015")
+          taulukko (apurit/taulukko-otsikolla vastaus otsikko)]
+      (apurit/tarkista-taulukko-otsikko taulukko otsikko)
+      (apurit/tarkista-taulukko-sarakkeet taulukko
+                                          {:otsikko "Tyyppi"} {:otsikko "Määrä"})
+      (apurit/tarkista-taulukko-yhteensa taulukko 1))))
 
 (deftest raportin-suoritus-koko-maalle-toimii
   (let [vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
@@ -247,159 +96,37 @@
                                               :hoitoluokat #{1 2 3 4 5 6 8 7}
                                               :urakkatyyppi "hoito"}})]
     (is (vector? vastaus))
-    (is (= vastaus [:raportti
-                    {:nimi "Turvallisuusraportti"}
-                    [:taulukko
-                     {:otsikko                    "KOKO MAA, Turvallisuusraportti ajalta 01.01.2014 - 31.12.2015"
-                      :sheet-nimi                 "Turvallisuusraportti"
-                      :viimeinen-rivi-yhteenveto? false}
-                     [{:otsikko "Hallintayksikkö"}
-                      {:fmt     :numero
-                       :otsikko "Työtapaturmat"}
-                      {:fmt     :numero
-                       :otsikko "Vaaratilanteet"}
-                      {:fmt     :numero
-                       :otsikko "Turvallisuushavainnot"}
-                      {:fmt     :numero
-                       :otsikko "Muut"}]
-                     '(["Uusimaa"
-                       0
-                       0
-                       0
-                       0]
-                       ["Varsinais-Suomi"
-                        0
-                        0
-                        0
-                        0]
-                       ["Kaakkois-Suomi"
-                        0
-                        0
-                        0
-                        0]
-                       ["Pirkanmaa"
-                        0
-                        0
-                        0
-                        0]
-                       ["Pohjois-Savo"
-                        0
-                        0
-                        0
-                        0]
-                       ["Keski-Suomi"
-                        0
-                        0
-                        0
-                        0]
-                       ["Etelä-Pohjanmaa"
-                        0
-                        0
-                        0
-                        0]
-                       ["Pohjois-Pohjanmaa ja Kainuu"
-                        2
-                        1
-                        3
-                        1]
-                       ["Lappi"
-                        0
-                        0
-                        0
-                        0])]
-                    [:taulukko
-                     {:otsikko "Turvallisuuspoikkeamat vakavuusasteittain"}
-                     [{:otsikko "Hallintayksikkö"}
-                      {:fmt     :numero
-                       :otsikko "Lievät"}
-                      {:fmt     :numero
-                       :otsikko "Vakavat"}]
-                     '(["Uusimaa"
-                       0
-                       0]
-                       ["Varsinais-Suomi"
-                        0
-                        0]
-                       ["Kaakkois-Suomi"
-                        0
-                        0]
-                       ["Pirkanmaa"
-                        0
-                        0]
-                       ["Pohjois-Savo"
-                        0
-                        0]
-                       ["Keski-Suomi"
-                        0
-                        0]
-                       ["Etelä-Pohjanmaa"
-                        0
-                        0]
-                       ["Pohjois-Pohjanmaa ja Kainuu"
-                        1
-                        4]
-                       ["Lappi"
-                        0
-                        0])]
-                    [:pylvaat
-                     {:legend        ["Työtapaturmat"
-                                      "Vaaratilanteet"
-                                      "Turvallisuushavainnot"
-                                      "Muut"]
-                      :otsikko       "Turvallisuuspoikkeamat kuukausittain 01.01.2014-31.12.2015"
-                      :piilota-arvo? #{0}}
-                     [["2014/01"
-                       []]
-                      ["2014/02"
-                       []]
-                      ["2014/03"
-                       []]
-                      ["2014/04"
-                       []]
-                      ["2014/05"
-                       []]
-                      ["2014/06"
-                       []]
-                      ["2014/07"
-                       []]
-                      ["2014/08"
-                       []]
-                      ["2014/09"
-                       []]
-                      ["2014/10"
-                       []]
-                      ["2014/11"
-                       []]
-                      ["2014/12"
-                       []]
-                      ["2015/01"
-                       []]
-                      ["2015/02"
-                       []]
-                      ["2015/03"
-                       []]
-                      ["2015/04"
-                       []]
-                      ["2015/05"
-                       []]
-                      ["2015/06"
-                       []]
-                      ["2015/07"
-                       []]
-                      ["2015/08"
-                       []]
-                      ["2015/09"
-                       []]
-                      ["2015/10"
-                       [2
-                        1
-                        1
-                        1]]
-                      ["2015/11"
-                       [nil
-                        nil
-                        2
-                        nil]]
-                      ["2015/12"
-                       []]]]
-                    nil]))))
+    (apurit/tarkista-raportti vastaus "Turvallisuusraportti")
+    (let [otsikko "KOKO MAA, Turvallisuusraportti ajalta 01.01.2014 - 31.12.2015"
+          taulukko (apurit/taulukko-otsikolla vastaus otsikko)]
+      (apurit/tarkista-taulukko-sarakkeet taulukko
+                                          {:otsikko "Hallintayksikkö"}
+                                          {:fmt     :numero
+                                           :otsikko "Työtapaturmat"}
+                                          {:fmt     :numero
+                                           :otsikko "Vaaratilanteet"}
+                                          {:fmt     :numero
+                                           :otsikko "Turvallisuushavainnot"}
+                                          {:fmt     :numero
+                                           :otsikko "Muut"})
+      (apurit/tarkista-taulukko-kaikki-rivit taulukko
+                                             (fn [[alue tyo vaara havainnot muut :as rivi]]
+                                               (and (= (count rivi) 5)
+                                                    (string? alue)
+                                                    (number? tyo)
+                                                    (number? vaara)
+                                                    (number? havainnot)
+                                                    (number? muut)))))
+    (let [vakavuus (apurit/taulukko-otsikolla vastaus "Turvallisuuspoikkeamat vakavuusasteittain")]
+      (apurit/tarkista-taulukko-sarakkeet vakavuus
+                                          {:otsikko "Hallintayksikkö"}
+                                          {:fmt     :numero
+                                           :otsikko "Lievät"}
+                                          {:fmt     :numero
+                                           :otsikko "Vakavat"})
+      (apurit/tarkista-taulukko-kaikki-rivit vakavuus
+                                             (fn [[hal lievat vakavat :as rivi]]
+                                               (and (= (count rivi) 3)
+                                                    (string? hal)
+                                                    (number? lievat)
+                                                    (number? vakavat)))))))


### PR DESCRIPTION
**Korjaa yhteensä rivi**

**Lisää testiapureita raporteille**

**Käytä uusia testiapureita suoran datan testaamisen**
Ei enää testata koko datan assertointia vaan varmistetaan raportin
muodollinen pätevyys.
