### PR TITLE
HAR-2780 Siltaraportin järjestyksen parannus

### DIFF
--- a/deploy2.sh
+++ b/deploy2.sh
@@ -35,9 +35,6 @@ pushd vagrant
 sh migrate_test.sh > /dev/null
 popd
 
-echo "Ajetaan yksikkötestit"
-sh unit.sh
-
 echo ""
 echo "Deployaan branchin $BRANCH ympäristöön $HARJA_ENV"
 

--- a/src/clj/harja/palvelin/raportointi/pdf.clj
+++ b/src/clj/harja/palvelin/raportointi/pdf.clj
@@ -97,7 +97,8 @@
                 (if (map? rivi)
                   [(:rivi rivi) rivi]
                   [rivi {}])
-                lihavoi-rivi? (:lihavoi? optiot)]]
+                lihavoi-rivi? (:lihavoi? optiot)
+                korosta-rivi? (:korosta? optiot)]]
       (if-let [otsikko (:otsikko optiot)]
         (taulukko-valiotsikko otsikko sarakkeet)
         (let [yhteenveto? (when (and viimeinen-rivi-yhteenveto?
@@ -105,7 +106,7 @@
                             {:background-color "#fafafa"
                              :border (str "solid 0.3mm " raportin-tehostevari)
                              :font-weight "bold"})
-              korosta? (when (some #(= i-rivi %) korosta-rivit)
+              korosta? (when (or korosta-rivi? (some #(= i-rivi %) korosta-rivit))
                          {:background-color "#ff9900"
                           :color "black"})
               lihavoi? (when lihavoi-rivi?

--- a/src/clj/harja/palvelin/raportointi/pdf.clj
+++ b/src/clj/harja/palvelin/raportointi/pdf.clj
@@ -119,6 +119,7 @@
                              :numero #(fmt/desimaaliluku-opt % 1 true)
                              :prosentti #(fmt/prosentti-opt %)
                              :raha #(fmt/desimaaliluku-opt % 2 true)
+                             :pvm #(fmt/pvm-opt %)
                              str)
                        naytettava-arvo (or
                                          (cond

--- a/src/clj/harja/palvelin/raportointi/raportit/siltatarkastus.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/siltatarkastus.clj
@@ -55,9 +55,9 @@
         d-yhteensa (reduce + 0 (keep :d tarkastukset))
         kaikki-yhteensa (+ a-yhteensa b-yhteensa c-yhteensa d-yhteensa)]
     ["Yhteensä"
-     ""
-     ""
-     ""
+     nil
+     nil
+     nil
      [:arvo-ja-osuus {:arvo a-yhteensa
                       :osuus (Math/round (math/osuus-prosentteina
                                            a-yhteensa kaikki-yhteensa))}]

--- a/src/clj/harja/palvelin/raportointi/raportit/siltatarkastus.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/siltatarkastus.clj
@@ -15,7 +15,7 @@
 (defqueries "harja/palvelin/raportointi/raportit/siltatarkastus.sql")
 
 (def ^{:private true} korosta-kun-arvoa-d-vahintaan 1)
-(def tarkastamatta-str "Tarkastamatta")
+(def tarkastamatta-info [:info "Tarkastamatta"])
 
 (defn- muodosta-sillan-datarivit [db urakka-id silta-id vuosi]
   (let [kohderivit (into []
@@ -87,7 +87,7 @@
                      (:siltanimi tarkastus)
                      (if (:tarkastusaika tarkastus)
                        (:tarkastusaika tarkastus)
-                       tarkastamatta-str)
+                       tarkastamatta-info)
                      (or (:tarkastaja tarkastus)
                          "-")
                      [:arvo-ja-osuus {:arvo (:a tarkastus)
@@ -182,7 +182,7 @@
     :urakka (if (= silta :kaikki)
               [{:leveys 5 :otsikko "Siltanumero"}
                {:leveys 10 :otsikko "Silta"}
-               {:leveys 5 :otsikko "Tarkastettu"}
+               {:leveys 5 :otsikko "Tarkastettu" :fmt :pvm}
                {:leveys 5 :otsikko "Tarkastaja"}
                {:leveys 5 :otsikko "A" :tyyppi :arvo-ja-osuus}
                {:leveys 5 :otsikko "B" :tyyppi :arvo-ja-osuus}
@@ -250,7 +250,7 @@
                          (if (cond
                                (and (= konteksti :urakka) (= silta-id :kaikki))
                                (let [tarkastettu (kentta-indeksilla rivi 2)]
-                                 (= tarkastettu tarkastamatta-str))
+                                 (= tarkastettu tarkastamatta-info))
 
                                :else
                                false)

--- a/src/clj/harja/palvelin/raportointi/raportit/siltatarkastus.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/siltatarkastus.clj
@@ -263,7 +263,17 @@
                   (if (:virhe? rivi) (liita rivi :korosta? true) (liita rivi :korosta? false)))
         jarjesta (fn [rivit]
                    (let [indeksi (fn [i] #(nth (:rivi %) i))]
-                     (vec (sort-by (indeksi 2) rivit))))
+                     (vec (sort-by
+                            (cond
+                              (and (= konteksti :urakka) (= silta-id :kaikki))
+                              (indeksi 1)
+                              
+                              (and (= konteksti :hallintayksikko))
+                              (indeksi 0)
+
+                              (and (= konteksti :koko-maa))
+                              (indeksi 0))
+                            rivit))))
         jarjesta-ryhmien-sisallot (fn [tila-ja-rivit]
                                     (vec (apply concat (mapv (comp jarjesta val) tila-ja-rivit))))
         jarjesta-ryhmiin (fn [rivit]
@@ -315,13 +325,15 @@
         (conj (vec (->> datarivit
                         butlast
                         (map virhe?)
-                        (map korosta)))
+                        (map korosta)
+                        jarjesta))
               (last datarivit))
         (and (= konteksti :koko-maa))
         (conj (vec (->> datarivit
                         butlast
                         (map virhe?)
-                        (map korosta)))
+                        (map korosta)
+                        jarjesta))
               (last datarivit))
         :else datarivit)]
      (when yksittaisen-sillan-perustiedot

--- a/src/clj/harja/palvelin/raportointi/raportit/siltatarkastus.sql
+++ b/src/clj/harja/palvelin/raportointi/raportit/siltatarkastus.sql
@@ -191,7 +191,7 @@ ORDER BY u.nimi
 -- name: hae-koko-maan-siltatarkastukset
 -- Hakee koko maan siltatarkastukset ELYittäin valitulta vuodelta
 SELECT
-  h.nimi,
+  concat(lpad(cast(elynumero as varchar), 2, '0'), ' ', h.nimi) as nimi,
   (SELECT COUNT(*)
    FROM siltatarkastuskohde
    WHERE tulos = 'A'

--- a/src/clj/harja/palvelin/raportointi/raportit/siltatarkastus.sql
+++ b/src/clj/harja/palvelin/raportointi/raportit/siltatarkastus.sql
@@ -184,7 +184,7 @@ SELECT
                                       AND urakka = u.id
                                       AND st.poistettu = FALSE)) AS "d"
 FROM urakka u
-  WHERE u.hallintayksikko = :hallintayksikko
+  WHERE u.hallintayksikko = :hallintayksikko AND u.tyyppi = 'hoito'
   AND :vuosi BETWEEN EXTRACT(YEAR FROM alkupvm) AND EXTRACT(YEAR FROM loppupvm)
 ORDER BY u.nimi
 
@@ -201,9 +201,9 @@ SELECT
                                      AND urakka IN (SELECT id
                                                     FROM urakka
                                                     WHERE hallintayksikko = h.id
-                                                          AND :vuosi BETWEEN EXTRACT(YEAR FROM alkupvm) AND EXTRACT(YEAR
-                                                                                                                    FROM
-                                                                                                                    loppupvm))
+                                                          AND tyyppi = 'hoito'
+                                                          AND :vuosi BETWEEN EXTRACT(YEAR FROM alkupvm)
+                                                          AND EXTRACT(YEAR FROM loppupvm))
                                      AND st.poistettu = FALSE))     AS "a",
   (SELECT COUNT(*)
    FROM siltatarkastuskohde
@@ -214,9 +214,9 @@ SELECT
                                       AND urakka IN (SELECT id
                                                      FROM urakka
                                                      WHERE hallintayksikko = h.id
-                                                           AND :vuosi BETWEEN EXTRACT(YEAR FROM alkupvm) AND EXTRACT(YEAR
-                                                                                                                     FROM
-                                                                                                                     loppupvm))
+                                                           AND tyyppi = 'hoito'
+                                                           AND :vuosi BETWEEN EXTRACT(YEAR FROM alkupvm)
+                                                           AND EXTRACT(YEAR FROM loppupvm))
                                       AND st.poistettu = FALSE)) AS "b",
   (SELECT COUNT(*)
    FROM siltatarkastuskohde
@@ -227,9 +227,9 @@ SELECT
                                       AND urakka IN (SELECT id
                                                      FROM urakka
                                                      WHERE hallintayksikko = h.id
-                                                           AND :vuosi BETWEEN EXTRACT(YEAR FROM alkupvm) AND EXTRACT(YEAR
-                                                                                                                     FROM
-                                                                                                                     loppupvm))
+                                                           AND tyyppi = 'hoito'
+                                                           AND :vuosi BETWEEN EXTRACT(YEAR FROM alkupvm)
+                                                           AND EXTRACT(YEAR FROM loppupvm))
                                       AND st.poistettu = FALSE)) AS "c",
   (SELECT COUNT(*)
    FROM siltatarkastuskohde
@@ -240,9 +240,9 @@ SELECT
                                       AND urakka IN (SELECT id
                                                      FROM urakka
                                                      WHERE hallintayksikko = h.id
-                                                           AND :vuosi BETWEEN EXTRACT(YEAR FROM alkupvm) AND EXTRACT(YEAR
-                                                                                                                     FROM
-                                                                                                                     loppupvm))
+                                                           AND tyyppi = 'hoito'
+                                                           AND :vuosi BETWEEN EXTRACT(YEAR FROM alkupvm)
+                                                           AND EXTRACT(YEAR FROM loppupvm))
                                       AND st.poistettu = FALSE)) AS "d"
 FROM organisaatio h
   WHERE tyyppi = 'hallintayksikko'

--- a/src/cljs/harja/ui/raportti.cljs
+++ b/src/cljs/harja/ui/raportti.cljs
@@ -42,6 +42,7 @@
                                       :numero #(fmt/desimaaliluku-opt % 1 true)
                                       :prosentti #(fmt/prosentti-opt % 1)
                                       :raha #(fmt/desimaaliluku-opt % 2 true)
+                                      :pvm #(fmt/pvm-opt %)
                                       str)]
                       #(if-not (raportti-domain/virhe? %) (format-fn %) (raportti-domain/virheen-viesti %))))]
     [grid/grid {:otsikko            (or otsikko "")

--- a/src/cljs/harja/ui/raportti.cljs
+++ b/src/cljs/harja/ui/raportti.cljs
@@ -89,6 +89,7 @@
                                         [(:rivi rivi) rivi]
                                         [rivi {}])
                                       lihavoi? (:lihavoi? optiot)
+                                      korosta? (:korosta? optiot)
                                       mappina (assoc
                                                 (zipmap (range (count sarakkeet))
                                                         rivi)
@@ -98,7 +99,7 @@
                                                (= viimeinen-rivi rivi))
                                           (assoc :yhteenveto true)
 
-                                          (when korosta-rivit (korosta-rivit index))
+                                          (or korosta? (when korosta-rivit (korosta-rivit index)))
                                           (assoc :korosta true)
 
                                           lihavoi?

--- a/src/cljs/harja/views/raportit.cljs
+++ b/src/cljs/harja/views/raportit.cljs
@@ -293,7 +293,7 @@
                    :kaikki "Kaikki"
                    (str (:siltanimi %) " (" (:siltatunnus %) ")"))}
 
-     (into [] (cons :kaikki (sort-by :siltatunnus @urakan-sillat)))]))
+     (into [] (cons :kaikki (sort-by :siltanimi @urakan-sillat)))]))
 
 (def urakan-vuodet (reaction
                      (let [urakka @nav/valittu-urakka]

--- a/test/clj/harja/palvelin/raportointi/siltatarkastusraportti_test.clj
+++ b/test/clj/harja/palvelin/raportointi/siltatarkastusraportti_test.clj
@@ -48,180 +48,235 @@
                                               :silta-id 1}})]
     (is (vector? vastaus))
     (is (= vastaus [:raportti
-                    {:nimi "Siltatarkastusraportti"
+                    {:nimi        "Siltatarkastusraportti"
                      :orientaatio :landscape}
                     [:taulukko
-                     {:korosta-rivit #{20}
-                      :otsikko "Siltatarkastusraportti, Oulun alueurakka 2005-2012, Oulujoen silta (O-00001), 2007"
-                      :sheet-nimi "Siltatarkastusraportti"
-                      :tyhja "Sillalle ei ole tehty tarkastusta valittuna vuonna."
+                     {:otsikko                    "Siltatarkastusraportti, Oulun alueurakka 2005-2012, Oulujoen silta (O-00001), 2007"
+                      :sheet-nimi                 "Siltatarkastusraportti"
+                      :tyhja                      "Sillalle ei ole tehty tarkastusta valittuna vuonna."
                       :viimeinen-rivi-yhteenveto? false}
-                     [{:leveys 2
+                     [{:leveys  2
                        :otsikko "#"}
-                      {:leveys 15
+                      {:leveys  15
                        :otsikko "Kohde"}
-                      {:leveys 2
+                      {:leveys  2
                        :otsikko "Tulos"}
-                      {:leveys 10
+                      {:leveys  10
                        :otsikko "Lisätieto"}
-                      {:leveys 5
+                      {:leveys  5
                        :otsikko "Liitteet"
-                       :tyyppi :liite}]
-                     [{:otsikko "Aluerakenne"}
-                      [1
-                       "Maatukien siisteys ja kunto"
-                       "A"
-                       nil
-                       [:liitteet
-                        []]]
-                      [2
-                       "Välitukien siisteys ja kunto"
-                       "A"
-                       nil
-                       [:liitteet
-                        []]]
-                      [3
-                       "Laakeritasojen siisteys ja kunto"
-                       "A"
-                       nil
-                       [:liitteet
-                        []]]
-                      {:otsikko "Päällysrakenne"}
-                      [4
-                       "Kansilaatta"
-                       "A"
-                       nil
-                       [:liitteet
-                        []]]
-                      [5
-                       "Päällysteen kunto"
-                       "A"
-                       nil
-                       [:liitteet
-                        []]]
-                      [6
-                       "Reunapalkin siisteys ja kunto"
-                       "A"
-                       nil
-                       [:liitteet
-                        []]]
-                      [7
-                       "Reunapalkin liikuntasauma"
-                       "A"
-                       nil
-                       [:liitteet
-                        []]]
-                      [8
-                       "Reunapalkin ja päälllysteen välisen sauman siisteys ja kunto"
-                       "B"
-                       nil
-                       [:liitteet
-                        []]]
-                      [9
-                       "Sillanpäiden saumat"
-                       "A"
-                       nil
-                       [:liitteet
-                        []]]
-                      [10
-                       "Sillan ja penkereen raja"
-                       "A"
-                       nil
-                       [:liitteet
-                        []]]
-                      {:otsikko "Varusteet ja laitteet"}
-                      [11
-                       "Kaiteiden ja suojaverkkojen vauriot"
-                       "A"
-                       nil
-                       [:liitteet
-                        []]]
-                      [12
-                       "Liikuntasaumakaitteiden siisteys ja kunto"
-                       "A"
-                       nil
-                       [:liitteet
-                        []]]
-                      [13
-                       "Laakerit"
-                       "A"
-                       nil
-                       [:liitteet
-                        []]]
-                      [14
-                       "Syöksytorvet"
-                       "A"
-                       nil
-                       [:liitteet
-                        []]]
-                      [15
-                       "Tippuputket"
-                       "A"
-                       nil
-                       [:liitteet
-                        []]]
-                      [16
-                       "Kosketussuojat ja niiden kiinnitykset"
-                       "A"
-                       nil
-                       [:liitteet
-                        []]]
-                      [17
-                       "Valaistuslaitteet"
-                       "A"
-                       nil
-                       [:liitteet
-                        []]]
-                      [18
-                       "Johdot ja kaapelit"
-                       "D"
-                       nil
-                       [:liitteet
-                        []]]
-                      [19
-                       "Liikennemerkit"
-                       "A"
-                       nil
-                       [:liitteet
-                        []]]
-                      {:otsikko "Siltapaikan rakenteet"}
-                      [20
-                       "Kuivatuslaitteiden siisteys ja kunto"
-                       "C"
-                       nil
-                       [:liitteet
-                        []]]
-                      [21
-                       "Etuluiskien siisteys ja kunto"
-                       "B"
-                       nil
-                       [:liitteet
-                        []]]
-                      [22
-                       "Keilojen siisteys ja kunto"
-                       "A"
-                       nil
-                       [:liitteet
-                        []]]
-                      [23
-                       "Tieluiskien siisteys ja kunto"
-                       "A"
-                       nil
-                       [:liitteet
-                        []]]
-                      [24
-                       "Portaiden siisteys ja kunto"
-                       "A"
-                       nil
-                       [:liitteet
-                        []]]]]
+                       :tyyppi  :liite}]
+                     [{:korosta? false
+                       :otsikko  "Aluerakenne"
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [1
+                                  "Maatukien siisteys ja kunto"
+                                  "A"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [2
+                                  "Välitukien siisteys ja kunto"
+                                  "A"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [3
+                                  "Laakeritasojen siisteys ja kunto"
+                                  "A"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :otsikko  "Päällysrakenne"
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [4
+                                  "Kansilaatta"
+                                  "A"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [5
+                                  "Päällysteen kunto"
+                                  "A"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [6
+                                  "Reunapalkin siisteys ja kunto"
+                                  "A"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [7
+                                  "Reunapalkin liikuntasauma"
+                                  "A"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [8
+                                  "Reunapalkin ja päälllysteen välisen sauman siisteys ja kunto"
+                                  "B"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [9
+                                  "Sillanpäiden saumat"
+                                  "A"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [10
+                                  "Sillan ja penkereen raja"
+                                  "A"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :otsikko  "Varusteet ja laitteet"
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [11
+                                  "Kaiteiden ja suojaverkkojen vauriot"
+                                  "A"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [12
+                                  "Liikuntasaumakaitteiden siisteys ja kunto"
+                                  "A"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [13
+                                  "Laakerit"
+                                  "A"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [14
+                                  "Syöksytorvet"
+                                  "A"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [15
+                                  "Tippuputket"
+                                  "A"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [16
+                                  "Kosketussuojat ja niiden kiinnitykset"
+                                  "A"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [17
+                                  "Valaistuslaitteet"
+                                  "A"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? true
+                       :rivi     [18
+                                  "Johdot ja kaapelit"
+                                  "D"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   true}
+                      {:korosta? false
+                       :rivi     [19
+                                  "Liikennemerkit"
+                                  "A"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :otsikko  "Siltapaikan rakenteet"
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [20
+                                  "Kuivatuslaitteiden siisteys ja kunto"
+                                  "C"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [21
+                                  "Etuluiskien siisteys ja kunto"
+                                  "B"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [22
+                                  "Keilojen siisteys ja kunto"
+                                  "A"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [23
+                                  "Tieluiskien siisteys ja kunto"
+                                  "A"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     [24
+                                  "Portaiden siisteys ja kunto"
+                                  "A"
+                                  nil
+                                  [:liitteet
+                                   []]]
+                       :virhe?   false}]]
                     [:yhteenveto
                      [["Tarkastaja"
                        "Sirkka Sillankoestaja"]
                       ["Tarkastettu"
                        "25.02.2007"]]]]))))
 
-(deftest raportin-suoritus-urakalle-toimii
+(deftest raportin-suoritus-urakan-kaikille-silloille-toimii
   (let [vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
                                 :suorita-raportti
                                 +kayttaja-jvh+
@@ -231,150 +286,9 @@
                                  :parametrit {:vuosi 2007
                                               :silta-id :kaikki}})]
     (is (vector? vastaus))
-    (is (= vastaus [:raportti
-                    {:nimi "Siltatarkastusraportti"
-                     :orientaatio :landscape}
-                    [:taulukko
-                     {:korosta-rivit #{0
-                                       1}
-                      :otsikko "Siltatarkastusraportti, Oulun alueurakka 2005-2012 vuodelta 2007"
-                      :sheet-nimi "Siltatarkastusraportti"
-                      :tyhja "Sillalle ei ole tehty tarkastusta valittuna vuonna."
-                      :viimeinen-rivi-yhteenveto? true}
-                     [{:leveys 5
-                       :otsikko "Siltanumero"}
-                      {:leveys 10
-                       :otsikko "Silta"}
-                      {:leveys 5
-                       :otsikko "Tarkastettu"}
-                      {:leveys 5
-                       :otsikko "Tarkastaja"}
-                      {:leveys 5
-                       :otsikko "A"
-                       :tyyppi :arvo-ja-osuus}
-                      {:leveys 5
-                       :otsikko "B"
-                       :tyyppi :arvo-ja-osuus}
-                      {:leveys 5
-                       :otsikko "C"
-                       :tyyppi :arvo-ja-osuus}
-                      {:leveys 5
-                       :otsikko "D"
-                       :tyyppi :arvo-ja-osuus}
-                      {:leveys 5
-                       :otsikko "Liitteet"
-                       :tyyppi :liite}]
-                     [[902
-                       "Pyhäjoen silta"
-                       "05.05.2007"
-                       "Mari Mittatarkka"
-                       [:arvo-ja-osuus
-                        {:arvo 20
-                         :osuus 83}]
-                       [:arvo-ja-osuus
-                        {:arvo 2
-                         :osuus 8}]
-                       [:arvo-ja-osuus
-                        {:arvo 1
-                         :osuus 4}]
-                       [:arvo-ja-osuus
-                        {:arvo 1
-                         :osuus 4}]
-                       [:liitteet
-                        []]]
-                      [1537
-                       "Oulujoen silta"
-                       "25.02.2007"
-                       "Sirkka Sillankoestaja"
-                       [:arvo-ja-osuus
-                        {:arvo 20
-                         :osuus 83}]
-                       [:arvo-ja-osuus
-                        {:arvo 2
-                         :osuus 8}]
-                       [:arvo-ja-osuus
-                        {:arvo 1
-                         :osuus 4}]
-                       [:arvo-ja-osuus
-                        {:arvo 1
-                         :osuus 4}]
-                       [:liitteet
-                        []]]
-                      [6666
-                       "Joutsensilta"
-                       "Tarkastamatta"
-                       "-"
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:liitteet
-                        []]]
-                      [7777
-                       "Kajaanintien silta"
-                       "Tarkastamatta"
-                       "-"
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:liitteet
-                        []]]
-                      [325235
-                       "Kempeleen testisilta"
-                       "Tarkastamatta"
-                       "-"
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:liitteet
-                        []]]
-                      ["Yhteensä"
-                       ""
-                       ""
-                       ""
-                       [:arvo-ja-osuus
-                        {:arvo 40
-                         :osuus 83}]
-                       [:arvo-ja-osuus
-                        {:arvo 4
-                         :osuus 8}]
-                       [:arvo-ja-osuus
-                        {:arvo 2
-                         :osuus 4}]
-                       [:arvo-ja-osuus
-                        {:arvo 2
-                         :osuus 4}]
-                       [:liitteet
-                        nil]]]]
-                    nil]))))
+    (is (= 4 (count vastaus)))))
 
-(deftest raportin-suoritus-urakalle-toimii
+(deftest raportin-suoritus-hallintayksikolle-toimii
   (let [vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
                                 :suorita-raportti
                                 +kayttaja-jvh+
@@ -384,254 +298,99 @@
                                  :parametrit {:vuosi 2007}})]
     (is (vector? vastaus))
     (is (= vastaus [:raportti
-                    {:nimi "Siltatarkastusraportti"
+                    {:nimi        "Siltatarkastusraportti"
                      :orientaatio :landscape}
                     [:taulukko
-                     {:korosta-rivit #{}
-                      :otsikko "Siltatarkastusraportti, Pohjois-Pohjanmaa 2007"
-                      :sheet-nimi "Siltatarkastusraportti"
-                      :tyhja "Ei raportoitavia siltatarkastuksia."
+                     {:otsikko                    "Siltatarkastusraportti, Pohjois-Pohjanmaa ja Kainuu 2007"
+                      :sheet-nimi                 "Siltatarkastusraportti"
+                      :tyhja                      "Ei raportoitavia siltatarkastuksia."
                       :viimeinen-rivi-yhteenveto? true}
-                     [{:leveys 10
+                     [{:leveys  10
                        :otsikko "Urakka"}
-                      {:leveys 5
+                      {:leveys  5
                        :otsikko "A"
-                       :tyyppi :arvo-ja-osuus}
-                      {:leveys 5
+                       :tyyppi  :arvo-ja-osuus}
+                      {:leveys  5
                        :otsikko "B"
-                       :tyyppi :arvo-ja-osuus}
-                      {:leveys 5
+                       :tyyppi  :arvo-ja-osuus}
+                      {:leveys  5
                        :otsikko "C"
-                       :tyyppi :arvo-ja-osuus}
-                      {:leveys 5
+                       :tyyppi  :arvo-ja-osuus}
+                      {:leveys  5
                        :otsikko "D"
-                       :tyyppi :arvo-ja-osuus}]
-                     [["Kempeleen valaistusurakka"
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]]
-                      ["Muhoksen paikkausurakka"
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]]
-                      ["Oulun alueurakka 2005-2012"
-                       [:arvo-ja-osuus
-                        {:arvo 40
-                         :osuus 83}]
-                       [:arvo-ja-osuus
-                        {:arvo 4
-                         :osuus 8}]
-                       [:arvo-ja-osuus
-                        {:arvo 2
-                         :osuus 4}]
-                       [:arvo-ja-osuus
-                        {:arvo 2
-                         :osuus 4}]]
-                      ["Pudasjärven alueurakka 2007-2012"
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]]
+                       :tyyppi  :arvo-ja-osuus}]
+                     [{:korosta? false
+                       :rivi     ["Kempeleen valaistusurakka"
+                                  [:arvo-ja-osuus
+                                   {:arvo  0
+                                    :osuus 0}]
+                                  [:arvo-ja-osuus
+                                   {:arvo  0
+                                    :osuus 0}]
+                                  [:arvo-ja-osuus
+                                   {:arvo  0
+                                    :osuus 0}]
+                                  [:arvo-ja-osuus
+                                   {:arvo  0
+                                    :osuus 0}]]
+                       :virhe?   false}
+                      {:korosta? false
+                       :rivi     ["Muhoksen paikkausurakka"
+                                  [:arvo-ja-osuus
+                                   {:arvo  0
+                                    :osuus 0}]
+                                  [:arvo-ja-osuus
+                                   {:arvo  0
+                                    :osuus 0}]
+                                  [:arvo-ja-osuus
+                                   {:arvo  0
+                                    :osuus 0}]
+                                  [:arvo-ja-osuus
+                                   {:arvo  0
+                                    :osuus 0}]]
+                       :virhe?   false}
+                      {:korosta? true
+                       :rivi     ["Oulun alueurakka 2005-2012"
+                                  [:arvo-ja-osuus
+                                   {:arvo  40
+                                    :osuus 83}]
+                                  [:arvo-ja-osuus
+                                   {:arvo  4
+                                    :osuus 8}]
+                                  [:arvo-ja-osuus
+                                   {:arvo  2
+                                    :osuus 4}]
+                                  [:arvo-ja-osuus
+                                   {:arvo  2
+                                    :osuus 4}]]
+                       :virhe?   true}
+                      {:korosta? false
+                       :rivi     ["Pudasjärven alueurakka 2007-2012"
+                                  [:arvo-ja-osuus
+                                   {:arvo  0
+                                    :osuus 0}]
+                                  [:arvo-ja-osuus
+                                   {:arvo  0
+                                    :osuus 0}]
+                                  [:arvo-ja-osuus
+                                   {:arvo  0
+                                    :osuus 0}]
+                                  [:arvo-ja-osuus
+                                   {:arvo  0
+                                    :osuus 0}]]
+                       :virhe?   false}
                       ["Yhteensä"
                        [:arvo-ja-osuus
-                        {:arvo 40
+                        {:arvo  40
                          :osuus 83}]
                        [:arvo-ja-osuus
-                        {:arvo 4
+                        {:arvo  4
                          :osuus 8}]
                        [:arvo-ja-osuus
-                        {:arvo 2
+                        {:arvo  2
                          :osuus 4}]
                        [:arvo-ja-osuus
-                        {:arvo 2
+                        {:arvo  2
                          :osuus 4}]]]]
                     nil]))))
 
-(deftest raportin-suoritus-urakalle-toimii
-  (let [vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
-                                :suorita-raportti
-                                +kayttaja-jvh+
-                                {:nimi :siltatarkastus
-                                 :konteksti "koko maa"
-                                 :parametrit {:vuosi 2007}})]
-    (is (vector? vastaus))
-    (is (= vastaus [:raportti
-                    {:nimi "Siltatarkastusraportti"
-                     :orientaatio :landscape}
-                    [:taulukko
-                     {:korosta-rivit #{}
-                      :otsikko "Siltatarkastusraportti, KOKO MAA 2007"
-                      :sheet-nimi "Siltatarkastusraportti"
-                      :tyhja "Ei raportoitavia siltatarkastuksia."
-                      :viimeinen-rivi-yhteenveto? true}
-                     [{:leveys 10
-                       :otsikko "Hallintayksikkö"}
-                      {:leveys 5
-                       :otsikko "A"
-                       :tyyppi :arvo-ja-osuus}
-                      {:leveys 5
-                       :otsikko "B"
-                       :tyyppi :arvo-ja-osuus}
-                      {:leveys 5
-                       :otsikko "C"
-                       :tyyppi :arvo-ja-osuus}
-                      {:leveys 5
-                       :otsikko "D"
-                       :tyyppi :arvo-ja-osuus}]
-                     [["Uusimaa"
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]]
-                      ["Varsinais-Suomi"
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]]
-                      ["Kaakkois-Suomi"
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]]
-                      ["Pirkanmaa"
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]]
-                      ["Pohjois-Savo"
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]]
-                      ["Keski-Suomi"
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]]
-                      ["Etelä-Pohjanmaa"
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]]
-                      ["Pohjois-Pohjanmaa ja Kainuu"
-                       [:arvo-ja-osuus
-                        {:arvo 40
-                         :osuus 83}]
-                       [:arvo-ja-osuus
-                        {:arvo 4
-                         :osuus 8}]
-                       [:arvo-ja-osuus
-                        {:arvo 2
-                         :osuus 4}]
-                       [:arvo-ja-osuus
-                        {:arvo 2
-                         :osuus 4}]]
-                      ["Lappi"
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]
-                       [:arvo-ja-osuus
-                        {:arvo 0
-                         :osuus 0}]]
-                      ["Yhteensä"
-                       [:arvo-ja-osuus
-                        {:arvo 40
-                         :osuus 83}]
-                       [:arvo-ja-osuus
-                        {:arvo 4
-                         :osuus 8}]
-                       [:arvo-ja-osuus
-                        {:arvo 2
-                         :osuus 4}]
-                       [:arvo-ja-osuus
-                        {:arvo 2
-                         :osuus 4}]]]]
-                    nil]))))

--- a/test/clj/harja/palvelin/raportointi/siltatarkastusraportti_test.clj
+++ b/test/clj/harja/palvelin/raportointi/siltatarkastusraportti_test.clj
@@ -6,12 +6,10 @@
             [harja.testi :refer :all]
             [taoensso.timbre :as log]
             [com.stuartsierra.component :as component]
-            [harja.pvm :as pvm]
-            [clj-time.core :as t]
-            [clj-time.coerce :as c]
             [harja.palvelin.komponentit.pdf-vienti :as pdf-vienti]
             [harja.palvelin.raportointi :as raportointi]
-            [harja.palvelin.palvelut.raportit :as raportit]))
+            [harja.palvelin.palvelut.raportit :as raportit]
+            [harja.palvelin.raportointi.testiapurit :as apurit]))
 
 (defn jarjestelma-fixture [testit]
   (alter-var-root #'jarjestelma
@@ -47,234 +45,32 @@
                                  :parametrit {:vuosi 2007
                                               :silta-id 1}})]
     (is (vector? vastaus))
-    (is (= vastaus [:raportti
-                    {:nimi        "Siltatarkastusraportti"
-                     :orientaatio :landscape}
-                    [:taulukko
-                     {:otsikko                    "Siltatarkastusraportti, Oulun alueurakka 2005-2012, Oulujoen silta (O-00001), 2007"
-                      :sheet-nimi                 "Siltatarkastusraportti"
-                      :tyhja                      "Sillalle ei ole tehty tarkastusta valittuna vuonna."
-                      :viimeinen-rivi-yhteenveto? false}
-                     [{:leveys  2
-                       :otsikko "#"}
-                      {:leveys  15
-                       :otsikko "Kohde"}
-                      {:leveys  2
-                       :otsikko "Tulos"}
-                      {:leveys  10
-                       :otsikko "Lisätieto"}
-                      {:leveys  5
-                       :otsikko "Liitteet"
-                       :tyyppi  :liite}]
-                     [{:korosta? false
-                       :otsikko  "Aluerakenne"
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [1
-                                  "Maatukien siisteys ja kunto"
-                                  "A"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [2
-                                  "Välitukien siisteys ja kunto"
-                                  "A"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [3
-                                  "Laakeritasojen siisteys ja kunto"
-                                  "A"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :otsikko  "Päällysrakenne"
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [4
-                                  "Kansilaatta"
-                                  "A"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [5
-                                  "Päällysteen kunto"
-                                  "A"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [6
-                                  "Reunapalkin siisteys ja kunto"
-                                  "A"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [7
-                                  "Reunapalkin liikuntasauma"
-                                  "A"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [8
-                                  "Reunapalkin ja päälllysteen välisen sauman siisteys ja kunto"
-                                  "B"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [9
-                                  "Sillanpäiden saumat"
-                                  "A"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [10
-                                  "Sillan ja penkereen raja"
-                                  "A"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :otsikko  "Varusteet ja laitteet"
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [11
-                                  "Kaiteiden ja suojaverkkojen vauriot"
-                                  "A"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [12
-                                  "Liikuntasaumakaitteiden siisteys ja kunto"
-                                  "A"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [13
-                                  "Laakerit"
-                                  "A"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [14
-                                  "Syöksytorvet"
-                                  "A"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [15
-                                  "Tippuputket"
-                                  "A"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [16
-                                  "Kosketussuojat ja niiden kiinnitykset"
-                                  "A"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [17
-                                  "Valaistuslaitteet"
-                                  "A"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? true
-                       :rivi     [18
-                                  "Johdot ja kaapelit"
-                                  "D"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   true}
-                      {:korosta? false
-                       :rivi     [19
-                                  "Liikennemerkit"
-                                  "A"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :otsikko  "Siltapaikan rakenteet"
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [20
-                                  "Kuivatuslaitteiden siisteys ja kunto"
-                                  "C"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [21
-                                  "Etuluiskien siisteys ja kunto"
-                                  "B"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [22
-                                  "Keilojen siisteys ja kunto"
-                                  "A"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [23
-                                  "Tieluiskien siisteys ja kunto"
-                                  "A"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     [24
-                                  "Portaiden siisteys ja kunto"
-                                  "A"
-                                  nil
-                                  [:liitteet
-                                   []]]
-                       :virhe?   false}]]
-                    [:yhteenveto
-                     [["Tarkastaja"
-                       "Sirkka Sillankoestaja"]
-                      ["Tarkastettu"
-                       "25.02.2007"]]]]))))
+    (apurit/tarkista-raportti vastaus "Siltatarkastusraportti")
+    (let [otsikko "Siltatarkastusraportti, Oulun alueurakka 2005-2012, Oulujoen silta (O-00001), 2007"
+          taulukko (apurit/taulukko-otsikolla vastaus otsikko)]
+      (apurit/tarkista-taulukko-otsikko taulukko otsikko)
+      (apurit/tarkista-taulukko-sarakkeet taulukko
+                                          {:otsikko "#"}
+                                          {:otsikko "Kohde"}
+                                          {:otsikko "Tulos"}
+                                          {:otsikko "Lisätieto"}
+                                          {:otsikko "Liitteet" :tyyppi :liite})
+      (apurit/tarkista-taulukko-kaikki-rivit taulukko
+                                             (fn [rivi]
+                                               (let [[numero kohde tulos lisatieto [_ liitteet] :as rivi]
+                                                     (if (map? rivi)
+                                                       (:rivi rivi)
+                                                       rivi)]
+                                                 (if rivi
+                                                   (and (= (count rivi) 5)
+                                                        (number? numero)
+                                                        (string? kohde)
+                                                        (string? tulos)
+                                                        (if lisatieto (string? lisatieto)
+                                                                      true)
+                                                        (vector? liitteet))
+                                                   ;; väliotsikkoriveille palautetaan elsestä true
+                                                   true)))))))
 
 (deftest raportin-suoritus-urakan-kaikille-silloille-toimii
   (let [vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
@@ -297,100 +93,29 @@
                                  :hallintayksikko-id (hae-pohjois-pohjanmaan-hallintayksikon-id)
                                  :parametrit {:vuosi 2007}})]
     (is (vector? vastaus))
-    (is (= vastaus [:raportti
-                    {:nimi        "Siltatarkastusraportti"
-                     :orientaatio :landscape}
-                    [:taulukko
-                     {:otsikko                    "Siltatarkastusraportti, Pohjois-Pohjanmaa ja Kainuu 2007"
-                      :sheet-nimi                 "Siltatarkastusraportti"
-                      :tyhja                      "Ei raportoitavia siltatarkastuksia."
-                      :viimeinen-rivi-yhteenveto? true}
-                     [{:leveys  10
-                       :otsikko "Urakka"}
-                      {:leveys  5
-                       :otsikko "A"
-                       :tyyppi  :arvo-ja-osuus}
-                      {:leveys  5
-                       :otsikko "B"
-                       :tyyppi  :arvo-ja-osuus}
-                      {:leveys  5
-                       :otsikko "C"
-                       :tyyppi  :arvo-ja-osuus}
-                      {:leveys  5
-                       :otsikko "D"
-                       :tyyppi  :arvo-ja-osuus}]
-                     [{:korosta? false
-                       :rivi     ["Kempeleen valaistusurakka"
-                                  [:arvo-ja-osuus
-                                   {:arvo  0
-                                    :osuus 0}]
-                                  [:arvo-ja-osuus
-                                   {:arvo  0
-                                    :osuus 0}]
-                                  [:arvo-ja-osuus
-                                   {:arvo  0
-                                    :osuus 0}]
-                                  [:arvo-ja-osuus
-                                   {:arvo  0
-                                    :osuus 0}]]
-                       :virhe?   false}
-                      {:korosta? false
-                       :rivi     ["Muhoksen paikkausurakka"
-                                  [:arvo-ja-osuus
-                                   {:arvo  0
-                                    :osuus 0}]
-                                  [:arvo-ja-osuus
-                                   {:arvo  0
-                                    :osuus 0}]
-                                  [:arvo-ja-osuus
-                                   {:arvo  0
-                                    :osuus 0}]
-                                  [:arvo-ja-osuus
-                                   {:arvo  0
-                                    :osuus 0}]]
-                       :virhe?   false}
-                      {:korosta? true
-                       :rivi     ["Oulun alueurakka 2005-2012"
-                                  [:arvo-ja-osuus
-                                   {:arvo  40
-                                    :osuus 83}]
-                                  [:arvo-ja-osuus
-                                   {:arvo  4
-                                    :osuus 8}]
-                                  [:arvo-ja-osuus
-                                   {:arvo  2
-                                    :osuus 4}]
-                                  [:arvo-ja-osuus
-                                   {:arvo  2
-                                    :osuus 4}]]
-                       :virhe?   true}
-                      {:korosta? false
-                       :rivi     ["Pudasjärven alueurakka 2007-2012"
-                                  [:arvo-ja-osuus
-                                   {:arvo  0
-                                    :osuus 0}]
-                                  [:arvo-ja-osuus
-                                   {:arvo  0
-                                    :osuus 0}]
-                                  [:arvo-ja-osuus
-                                   {:arvo  0
-                                    :osuus 0}]
-                                  [:arvo-ja-osuus
-                                   {:arvo  0
-                                    :osuus 0}]]
-                       :virhe?   false}
-                      ["Yhteensä"
-                       [:arvo-ja-osuus
-                        {:arvo  40
-                         :osuus 83}]
-                       [:arvo-ja-osuus
-                        {:arvo  4
-                         :osuus 8}]
-                       [:arvo-ja-osuus
-                        {:arvo  2
-                         :osuus 4}]
-                       [:arvo-ja-osuus
-                        {:arvo  2
-                         :osuus 4}]]]]
-                    nil]))))
-
+    (apurit/tarkista-raportti vastaus "Siltatarkastusraportti")
+    (let [otsikko "Siltatarkastusraportti, Pohjois-Pohjanmaa ja Kainuu 2007"
+          taulukko (apurit/taulukko-otsikolla vastaus otsikko)]
+      (apurit/tarkista-taulukko-otsikko taulukko otsikko)
+      (apurit/tarkista-taulukko-sarakkeet taulukko
+                                          {:otsikko "Urakka"}
+                                          {:otsikko "A" :tyyppi :arvo-ja-osuus}
+                                          {:otsikko "B" :tyyppi :arvo-ja-osuus}
+                                          {:otsikko "C" :tyyppi :arvo-ja-osuus}
+                                          {:otsikko "D" :tyyppi :arvo-ja-osuus})
+      (apurit/tarkista-taulukko-kaikki-rivit taulukko
+                                             (fn [rivi]
+                                               (let [[yhteensa a b c d :as rivi]
+                                                     (if (map? rivi)
+                                                       (:rivi rivi)
+                                                       rivi)]
+                                                 (and (= (count rivi) 5)
+                                                      (string? yhteensa)
+                                                      (keyword? (first a))
+                                                      (keyword? (first b))
+                                                      (keyword? (first c))
+                                                      (keyword? (first d))
+                                                      (map? (second a))
+                                                      (map? (second b))
+                                                      (map? (second c))
+                                                      (map? (second d)))))))))


### PR DESCRIPTION
Siltaraportin rivit järjestetään nyt siten, että tarkastamattomat ovat ensimmäisenä, virheelliset toisena, ja tarkastetut viimeisenä. Samalla lisättiin tuki HTML ja PDF raporteille formatoida päivämääriä. Lisättiin myös virheellisten korostus koko maan ja hallintayksikön tasoille.
