### PR TITLE
HAR-2840: Estä YHA:sta tulleiden kohteiden ajoradan ja kaistan muokkaus

### DIFF
--- a/src/cljs/harja/tiedot/urakka/yllapitokohteet.cljs
+++ b/src/cljs/harja/tiedot/urakka/yllapitokohteet.cljs
@@ -105,6 +105,8 @@
                    :tr-alkuetaisyys nil
                    :tr-loppuosa (:tr-loppuosa rivi)
                    :tr-loppuetaisyys (:tr-loppuetaisyys rivi)
+                   :tr-ajorata (:tr-ajorata rivi)
+                   :tr-kaista (:tr-kaista rivi)
                    :toimenpide ""}]
     (-> kohdeosat
         (assoc-in [key :tr-loppuosa] nil)

--- a/src/cljs/harja/views/urakka/yllapitokohteet.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet.cljs
@@ -288,8 +288,8 @@
                             [{:nimi :nimi}
                              {:nimi :tunnus}
                              {:nimi :tr-numero :muokattava? (constantly false)}
-                             {:nimi :tr-ajorata}
-                             {:nimi :tr-kaista}
+                             {:nimi :tr-ajorata :muokattava? (constantly false)}
+                             {:nimi :tr-kaista :muokattava? (constantly false)}
                              {:nimi :tr-alkuosa :muokattava? (fn [_ rivi]
                                                                (pos? rivi))
                               :validoi [(partial validoi-osa-olemassa osan-pituus kohde)]}
@@ -427,6 +427,12 @@
        kohde
        @osan-pituus])))
 
+(defn kohteen-vetolaatikko [_ _ _]
+  (fn [urakka kohteet-atom rivi]
+    (if @grid/gridia-muokataan?
+     [:span "Kohteen tierekisterikohteet ovat muokattavissa kohteen tallennuksen jälkeen."]
+     [yllapitokohdeosat-kohteelle urakka kohteet-atom rivi])))
+
 (defn yllapitokohteet [urakka kohteet-atom optiot]
   (let [tr-sijainnit (atom {})                              ;; onnistuneesti haetut TR-sijainnit
         tr-virheet (atom {})                                ;; virheelliset TR sijainnit
@@ -443,11 +449,9 @@
            :vetolaatikot
            (into {}
                  (map (juxt
-                       :id
-                       (fn [rivi]
-                         (if @grid/gridia-muokataan?
-                           [:span "Kohteen tierekisterikohteet ovat muokattavissa kohteen tallennuksen jälkeen."]
-                           [yllapitokohdeosat-kohteelle urakka kohteet-atom rivi]))))
+                        :id
+                        (fn [rivi]
+                          [kohteen-vetolaatikko urakka kohteet-atom rivi])))
                  @kohteet-atom)
            :tallenna @tallenna
            :muutos (fn [grid]
@@ -468,7 +472,8 @@
                     :tyyppi :string :leveys kohde-leveys}
                    {:otsikko "Tyyppi"
                     :nimi :yllapitokohdetyyppi :tyyppi :string :leveys yllapitokohdetyyppi-leveys
-                    :muokattava? (constantly false) :fmt #({:paallyste "Päällyste"
+                    :muokattava? (constantly false)
+                    :fmt #({:paallyste "Päällyste"
                                                             :sora "Sora"
                                                             :kevytliikenne "Kevytliikenne"} %)}]
                   (tierekisteriosoite-sarakkeet
@@ -476,8 +481,8 @@
                     [nil
                      nil
                      {:nimi :tr-numero :muokattava? (constantly (not (:yha-sidottu? optiot)))}
-                     {:nimi :tr-ajorata}
-                     {:nimi :tr-kaista}
+                     {:nimi :tr-ajorata :muokattava? (constantly (not (:yha-sidottu? optiot)))}
+                     {:nimi :tr-kaista :muokattava? (constantly (not (:yha-sidottu? optiot)))}
                      {:nimi :tr-alkuosa}
                      {:nimi :tr-alkuetaisyys}
                      {:nimi :tr-loppuosa}


### PR DESCRIPTION
YHAS:sta tulleille kohteille ei saa jatkossa muokata ajorataa tai kaistaa.

Korjaa samalla pääkohteiden muokkaamisen taulukossa
