### PR TITLE
HAR-2664 Korosta virka-apupyynnöt

### DIFF
--- a/dev-resources/less/pages/ilmoitukset.less
+++ b/dev-resources/less/pages/ilmoitukset.less
@@ -54,4 +54,7 @@
 .selite-virkaapu {
   color: red;
   font-weight: bold;
+  display: inline-block;
+
+  margin-right: 1em;
 }

--- a/dev-resources/less/pages/ilmoitukset.less
+++ b/dev-resources/less/pages/ilmoitukset.less
@@ -50,3 +50,8 @@
 .kuittaa-monta-tallennus {
   margin: 5px 5px 5px 0;
 }
+
+.selite-virkaapu {
+  color: red;
+  font-weight: bold;
+}

--- a/resources/xsd/tloik/esimerkit/ilmoitus.xml
+++ b/resources/xsd/tloik/esimerkit/ilmoitus.xml
@@ -30,5 +30,6 @@
     <seliteet>
         <selite>auraustarve</selite>
         <selite>aurausvallitNakemaesteena</selite>
+        <selite>virkaApupyynto</selite>
     </seliteet>
 </harja:ilmoitus>

--- a/src/clj/harja/palvelin/integraatiot/tloik/sahkoposti.clj
+++ b/src/clj/harja/palvelin/integraatiot/tloik/sahkoposti.clj
@@ -6,6 +6,7 @@
             [harja.palvelin.integraatiot.tloik.ilmoitustoimenpiteet :as ilmoitustoimenpiteet]
             [harja.kyselyt.yhteyshenkilot :as yhteyshenkilot]
             [harja.kyselyt.ilmoitukset :as ilmoitukset]
+            [harja.domain.ilmoitukset :as ilm]
             [taoensso.timbre :as log]
             [harja.geo :as geo]
             [harja.fmt :as fmt]))
@@ -43,8 +44,9 @@
   goole-static-map-url-template
   "http://maps.googleapis.com/maps/api/staticmap?zoom=15&markers=color:red|%s,%s&size=400x300&key=%s")
 
-(defn- otsikko [{:keys [ilmoitus-id urakka-id ilmoitustyyppi]}]
-  (str "#[" urakka-id "/" ilmoitus-id "] " (apurit/ilmoitustyypin-nimi (keyword ilmoitustyyppi))))
+(defn- otsikko [{:keys [ilmoitus-id urakka-id ilmoitustyyppi] :as ilmoitus}]
+  (str (when (ilm/virka-apupyynto? ilmoitus) "VIRKA-APUPYYNTÖ ")
+       "#[" urakka-id "/" ilmoitus-id "] " (apurit/ilmoitustyypin-nimi (keyword ilmoitustyyppi))))
 
 (defn- html-nappi [napin-teksti linkki]
   [:table {:width "100%" :border "0" :cellspacing "0" :cellpadding "0"}

--- a/src/clj/harja/palvelin/integraatiot/tloik/sahkoposti.clj
+++ b/src/clj/harja/palvelin/integraatiot/tloik/sahkoposti.clj
@@ -45,8 +45,9 @@
   "http://maps.googleapis.com/maps/api/staticmap?zoom=15&markers=color:red|%s,%s&size=400x300&key=%s")
 
 (defn- otsikko [{:keys [ilmoitus-id urakka-id ilmoitustyyppi] :as ilmoitus}]
-  (str (when (ilm/virka-apupyynto? ilmoitus) "VIRKA-APUPYYNTÖ ")
-       "#[" urakka-id "/" ilmoitus-id "] " (apurit/ilmoitustyypin-nimi (keyword ilmoitustyyppi))))
+  (str "#[" urakka-id "/" ilmoitus-id "] "
+       (apurit/ilmoitustyypin-nimi (keyword ilmoitustyyppi))
+       (when (ilm/virka-apupyynto? ilmoitus) " (VIRKA-APUPYYNTÖ)")))
 
 (defn- html-nappi [napin-teksti linkki]
   [:table {:width "100%" :border "0" :cellspacing "0" :cellpadding "0"}

--- a/src/clj/harja/palvelin/integraatiot/tloik/tekstiviesti.clj
+++ b/src/clj/harja/palvelin/integraatiot/tloik/tekstiviesti.clj
@@ -8,7 +8,8 @@
             [harja.palvelin.integraatiot.tloik.ilmoitustoimenpiteet :as ilmoitustoimenpiteet]
             [harja.tyokalut.merkkijono :as merkkijono]
             [harja.kyselyt.yhteyshenkilot :as yhteyshenkilot]
-            [harja.fmt :as fmt])
+            [harja.fmt :as fmt]
+            [harja.domain.ilmoitukset :as ilm])
   (:use [slingshot.slingshot :only [try+ throw+]]))
 
 (def +ilmoitusviesti+
@@ -117,20 +118,22 @@
         lisatietoja (if (:lisatieto ilmoitus)
                       (merkkijono/leikkaa 500 (:lisatieto ilmoitus))
                       "")
-        selitteet (apurit/parsi-selitteet (mapv keyword (:selitteet ilmoitus)))]
-    (format +ilmoitusviesti+
-            otsikko
-            ilmoitus-id
-            viestinumero
-            (fmt/totuus (:yhteydenottopyynto ilmoitus))
-            paikankuvaus
-            selitteet
-            lisatietoja
-            viestinumero
-            viestinumero
-            viestinumero
-            viestinumero
-            viestinumero)))
+        selitteet (apurit/parsi-selitteet (mapv keyword (:selitteet ilmoitus)))
+        virka-apu? (ilm/virka-apupyynto? ilmoitus)]
+    (str (when virka-apu? "VIRKA-APUPYYNTÖ ")
+         (format +ilmoitusviesti+
+                 otsikko
+                 ilmoitus-id
+                 viestinumero
+                 (fmt/totuus (:yhteydenottopyynto ilmoitus))
+                 paikankuvaus
+                 selitteet
+                 lisatietoja
+                 viestinumero
+                 viestinumero
+                 viestinumero
+                 viestinumero
+                 viestinumero))))
 
 (defn laheta-ilmoitus-tekstiviestilla [sms db ilmoitus paivystaja]
   (try

--- a/src/clj/harja/palvelin/integraatiot/tloik/tekstiviesti.clj
+++ b/src/clj/harja/palvelin/integraatiot/tloik/tekstiviesti.clj
@@ -13,7 +13,7 @@
   (:use [slingshot.slingshot :only [try+ throw+]]))
 
 (def +ilmoitusviesti+
-  (str "Uusi toimenpidepyyntö: %s (id: %s, viestinumero: %s).\n\n"
+  (str "Uusi toimenpidepyyntö %s: %s (id: %s, viestinumero: %s).\n\n"
        "Yhteydenottopyyntö: %s\n\n"
        "Paikka: %s\n\n"
        "Selitteet: %s.\n\n"
@@ -119,21 +119,22 @@
                       (merkkijono/leikkaa 500 (:lisatieto ilmoitus))
                       "")
         selitteet (apurit/parsi-selitteet (mapv keyword (:selitteet ilmoitus)))
-        virka-apu? (ilm/virka-apupyynto? ilmoitus)]
-    (str (when virka-apu? "VIRKA-APUPYYNTÖ ")
-         (format +ilmoitusviesti+
-                 otsikko
-                 ilmoitus-id
-                 viestinumero
-                 (fmt/totuus (:yhteydenottopyynto ilmoitus))
-                 paikankuvaus
-                 selitteet
-                 lisatietoja
-                 viestinumero
-                 viestinumero
-                 viestinumero
-                 viestinumero
-                 viestinumero))))
+        virka-apupyynto (if (ilm/virka-apupyynto? ilmoitus) "(VIRKA-APUPYYNTÖ)" "")]
+    (str
+      (format +ilmoitusviesti+
+              virka-apupyynto
+              otsikko
+              ilmoitus-id
+              viestinumero
+              (fmt/totuus (:yhteydenottopyynto ilmoitus))
+              paikankuvaus
+              selitteet
+              lisatietoja
+              viestinumero
+              viestinumero
+              viestinumero
+              viestinumero
+              viestinumero))))
 
 (defn laheta-ilmoitus-tekstiviestilla [sms db ilmoitus paivystaja]
   (try
@@ -142,7 +143,7 @@
         (log/debug (format "Lähetetään ilmoitus (id: %s) tekstiviestillä numeroon: %s"
                            (:ilmoitus-id ilmoitus) puhelinnumero))
         (let [viestinumero (paivystajatekstiviestit/kirjaa-uusi-viesti
-                            db (:id paivystaja) (:ilmoitus-id ilmoitus) puhelinnumero)
+                             db (:id paivystaja) (:ilmoitus-id ilmoitus) puhelinnumero)
               viesti (ilmoitus-tekstiviesti ilmoitus viestinumero)]
           (sms/laheta sms puhelinnumero viesti)))
       (log/warn "Ilmoitusta ei voida lähettää tekstiviestillä ilman puhelinnumeroa."))

--- a/src/cljc/harja/domain/ilmoitukset.cljc
+++ b/src/cljc/harja/domain/ilmoitukset.cljc
@@ -197,7 +197,7 @@
                      selitteet)))
 
 (defn virka-apupyynto? [ilmoitus]
-  (some #(= % :virkaApupyynto) (:selitteet ilmoitus)))
+  (some #(or (= % :virkaApupyynto) (= % "virkaApupyynto")) (:selitteet ilmoitus)))
 
 (def +ilmoitustilat+ #{:suljetut :avoimet})
 

--- a/src/cljc/harja/domain/ilmoitukset.cljc
+++ b/src/cljc/harja/domain/ilmoitukset.cljc
@@ -196,6 +196,9 @@
                (mapv #(get +ilmoitusten-selitteet+ %)
                      selitteet)))
 
+(defn virka-apupyynto? [ilmoitus]
+  (some #(= % :virkaApupyynto) (:selitteet ilmoitus)))
+
 (def +ilmoitustilat+ #{:suljetut :avoimet})
 
 

--- a/src/cljs/harja/views/ilmoituksen_tiedot.cljs
+++ b/src/cljs/harja/views/ilmoituksen_tiedot.cljs
@@ -4,18 +4,20 @@
             [harja.ui.bootstrap :as bs]
             [clojure.string :refer [capitalize]]
             [harja.tiedot.ilmoitukset :as tiedot]
-            [harja.domain.ilmoitukset :refer [+ilmoitustyypit+ ilmoitustyypin-nimi ilmoitustyypin-lyhenne-ja-nimi
-                                              +ilmoitustilat+ nayta-henkilo parsi-puhelinnumero
-                                              +ilmoitusten-selitteet+ parsi-selitteet kuittaustyypit
-                                              kuittaustyypin-selite]]
+            [harja.domain.ilmoitukset
+             :refer [+ilmoitustyypit+ ilmoitustyypin-nimi ilmoitustyypin-lyhenne-ja-nimi
+                     +ilmoitustilat+ nayta-henkilo parsi-puhelinnumero
+                     +ilmoitusten-selitteet+ parsi-selitteet kuittaustyypit
+                     kuittaustyypin-selite]
+             :as ilmoitukset]
             [harja.views.ilmoituskuittaukset :as kuittaukset]
             [harja.ui.ikonit :as ikonit]
             [harja.domain.oikeudet :as oikeudet]
             [harja.tiedot.navigaatio :as nav]
             [harja.domain.tierekisteri :as tr-domain]))
 
-(defn selitelista [{:keys [selitteet]}]
-  (let [virka-apu? (some #(= % :virkaApupyynto) selitteet)]
+(defn selitelista [{:keys [selitteet] :as ilmoitus}]
+  (let [virka-apu? (ilmoitukset/virka-apupyynto? ilmoitus)]
     [:div.selitelista.inline-block
      (when virka-apu?
        [:div.selite-virkaapu

--- a/src/cljs/harja/views/ilmoituksen_tiedot.cljs
+++ b/src/cljs/harja/views/ilmoituksen_tiedot.cljs
@@ -14,6 +14,14 @@
             [harja.tiedot.navigaatio :as nav]
             [harja.domain.tierekisteri :as tr-domain]))
 
+(defn selitelista [{:keys [selitteet]}]
+  (let [virka-apu? (some #(= % :virkaApupyynto) selitteet)]
+    [:div.selitelista.inline-block
+     (when virka-apu?
+       [:div.selite-virkaapu
+        [ikonit/livicon-warning-sign] "Virka-apupyyntö"])
+     (parsi-selitteet (filter #(not= % :virkaApupyynto) selitteet))]))
+
 (defn ilmoitus [ilmoitus]
   [:div
    [bs/panel {}
@@ -28,7 +36,7 @@
       "Paikan kuvaus: " (:paikankuvaus ilmoitus)
       "Lisatieto:  " (when (:lisatieto ilmoitus)
                          [yleiset/pitka-teksti (:lisatieto ilmoitus)])
-      "Selitteet: " (parsi-selitteet (:selitteet ilmoitus))]
+      "Selitteet: " [selitelista ilmoitus]]
 
      [:br]
      [yleiset/tietoja {}

--- a/src/cljs/harja/views/ilmoitukset.cljs
+++ b/src/cljs/harja/views/ilmoitukset.cljs
@@ -77,14 +77,6 @@
         [:br] (:etunimi kuittaaja) " " (:sukunimi kuittaaja)]])
     kuittaukset)])
 
-(defn selitelista [{:keys [selitteet]}]
-  (let [virka-apu? (some #(= % :virkaApupyynto) selitteet)]
-    [:div.selitelista
-     (when virka-apu?
-       [:div.selite-virkaapu
-        [ikonit/livicon-warning-sign] "Virka-apupyyntö"])
-     (parsi-selitteet (filter #(not= % :virkaApupyynto) selitteet))]))
-
 (defn ilmoitusten-hakuehdot [{:keys [aikavali] :as valinnat-nyt} muokkaa!]
   [lomake/lomake
    {:luokka   :horizontal
@@ -237,7 +229,7 @@
 
              {:otsikko "Selitteet" :nimi :selitteet
               :tyyppi :komponentti
-              :komponentti selitelista
+              :komponentti it/selitelista
               :leveys 6}
              {:otsikko "Kuittaukset" :nimi :kuittaukset
               :tyyppi :komponentti

--- a/src/cljs/harja/views/ilmoitukset.cljs
+++ b/src/cljs/harja/views/ilmoitukset.cljs
@@ -51,6 +51,9 @@
 (defn yhdeydenottopyynnot-lihavoitu []
   [yleiset/vihje "Yhdeydenottopyynnöt lihavoitu" "inline-block bold"])
 
+(defn virkaapupyynnot-korostettu []
+  [:span.selite-virkaapu [ikonit/livicon-warning-sign] "Virka-apupyynnöt korostettu"])
+
 (defn ilmoituksen-tiedot []
   (let [ilmoitus @tiedot/valittu-ilmoitus]
     [:div
@@ -73,6 +76,14 @@
         (pvm/pvm-aika kuitattu)
         [:br] (:etunimi kuittaaja) " " (:sukunimi kuittaaja)]])
     kuittaukset)])
+
+(defn selitelista [{:keys [selitteet]}]
+  (let [virka-apu? (some #(= % :virkaApupyynto) selitteet)]
+    [:div.selitelista
+     (when virka-apu?
+       [:div.selite-virkaapu
+        [ikonit/livicon-warning-sign] "Virka-apupyyntö"])
+     (parsi-selitteet (filter #(not= % :virkaApupyynto) selitteet))]))
 
 (defn ilmoitusten-hakuehdot [{:keys [aikavali] :as valinnat-nyt} muokkaa!]
   [lomake/lomake
@@ -184,6 +195,7 @@
           [:div
            [pollauksen-merkki]
            [yhdeydenottopyynnot-lihavoitu]
+           [virkaapupyynnot-korostettu]
 
            (when-not kuittaa-monta-nyt
              [napit/yleinen "Kuittaa monta ilmoitusta" #(reset! kuittaa-monta {:ilmoitukset #{}
@@ -223,7 +235,9 @@
               :hae #(tr-domain/tierekisteriosoite-tekstina (:tr %))
               :leveys 7}
 
-             {:otsikko "Selitteet" :nimi :selitteet :hae #(parsi-selitteet (:selitteet %))
+             {:otsikko "Selitteet" :nimi :selitteet
+              :tyyppi :komponentti
+              :komponentti selitelista
               :leveys 6}
              {:otsikko "Kuittaukset" :nimi :kuittaukset
               :tyyppi :komponentti

--- a/test/clj/harja/palvelin/integraatiot/tloik/tekstiviesti_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/tloik/tekstiviesti_test.clj
@@ -122,6 +122,6 @@
                   :selitteet #{:toimenpidekysely}}
         rivit (into #{} (str/split-lines
                          (tekstiviestit/ilmoitus-tekstiviesti ilmoitus 1234)))]
-    (is (rivit "Uusi toimenpidepyyntö: Testiympäristö liekeissä! (id: 666, viestinumero: 1234)."))
+    (is (rivit "Uusi toimenpidepyyntö : Testiympäristö liekeissä! (id: 666, viestinumero: 1234)."))
     (is (rivit "Yhteydenottopyyntö: Kyllä"))
     (is (rivit "Selitteet: Toimenpidekysely."))))


### PR DESCRIPTION
**Virka-apupyynnön selitteet korostettu**
Jos selitteissä on :virkaApupyynto, näytetään se erikoistyylillä ja
ensimmäisen selitelistassa. Lisätty myös gridin ylle seliteteksti.
