### PR TITLE
HAR-2898 Palauta latauspalkki tilannekuvaan

### DIFF
--- a/src/cljs/harja/tiedot/navigaatio.cljs
+++ b/src/cljs/harja/tiedot/navigaatio.cljs
@@ -68,10 +68,6 @@
 ;; :L (korkeampi täysleveä)
 (def kartan-kokovalinta "Kartan koko" (atom :S))
 
-(def kartta-nakyvissa? "Kartta ei piilotettu" (reaction (let [koko @kartan-kokovalinta]
-                                                          (and (not= :S koko)
-                                                               (not= :hidden koko)))))
-
 (defn vaihda-kartan-koko! [uusi-koko]
   (let [vanha-koko @kartan-kokovalinta]
     (when uusi-koko
@@ -151,7 +147,6 @@
 ;; jos haluat palauttaa kartan edelliseen kokoon, säilö edellinen koko tähän (esim. Valitse kartalta -toiminto)
 (def kartan-edellinen-koko (atom nil))
 
-
 (def kartan-koko
   "Kartan laskettu koko riippuu kartan kokovalinnasta sekä kartan pakotteista."
   (reaction (let [valittu-koko @kartan-kokovalinta
@@ -168,6 +163,13 @@
                       (and (= sivu :urakat)
                            (not v-ur)) :XL
                       :default valittu-koko)))))
+
+(def kartta-nakyvissa?
+  "Kartta ei piilotettu"
+  (reaction (let [koko @kartan-koko]
+              (and (not= :S koko)
+                   (not= :hidden koko)))))
+
 
 (def kartan-kontrollit-nakyvissa?
   (reaction

--- a/src/cljs/harja/views/kartta.cljs
+++ b/src/cljs/harja/views/kartta.cljs
@@ -644,15 +644,10 @@ tyyppi ja sijainti. Kun kaappaaminen lopetetaan, suljetaan myös annettu kanava.
                                 :layer "taustakartta"}]}]))))
 
 (defn kartan-edistyminen [kuvataso geometriataso]
-  (let [taso (if (and kuvataso (not= 0 (:ladataan kuvataso))) kuvataso geometriataso)
-        ladattu (:ladattu taso)
-        ladataan (:ladataan taso)
-        ;; Näytetään jo edistymispalkki vaikka lataustilanne olisi esim 0/1
-        [ladattu ladataan] (if (and (= ladattu 0) (not= ladataan 0))
-                             [(inc ladattu) (inc ladataan)]
-                             [ladattu ladataan])]
-    (when (and taso (not= 0 ladattu ladataan) @nav/kartta-nakyvissa?)
-     [:div.kartta-progress {:style {:width (str (* 100.0 (/ ladattu ladataan)) "%")}}])))
+  (let [ladattu (+ (:ladattu kuvataso) (:ladattu geometriataso))
+        ladataan (+ (:ladataan kuvataso) (:ladattu geometriataso))]
+    (when (and @nav/kartta-nakyvissa? (pos? ladataan))
+      [:div.kartta-progress {:style {:width (str (* 100.0 (/ ladattu ladataan)) "%")}}])))
 
 (defn kartta []
   [:div.karttacontainer


### PR DESCRIPTION
**Päättele kartan näkyvyys sen koosta**
Virheellisesti pääteltiin että kartta EI ole näkyvissä, koska
kokovalinta oli :S vaikka tilannekuva pakottaa koon :XL, muutettu
kartta-nakyvissa? reaktio riippumaan kartan koosta, ei kartan kokovalinnasta.

**Yksinkertaista kartan edistymisen näyttämistä**
