### PR TITLE
HAR-2992, HAR-2993: Laadunseurannan pikkufiksejä

### DIFF
--- a/dev-resources/less/styles.less
+++ b/dev-resources/less/styles.less
@@ -118,8 +118,9 @@ div.valilehti {
   width: 90px;
 }
 #testiharja {
-  color: black;
+  color: @vaara;
   font-size: .8 * @fontin-koko-leipateksti;
+  font-weight: bold;
   position: absolute;
   top: 3px;
   left: 48px;

--- a/laadunseuranta/clj-src/harja_laadunseuranta/tarkastukset.clj
+++ b/laadunseuranta/clj-src/harja_laadunseuranta/tarkastukset.clj
@@ -231,7 +231,7 @@
                                      :let (:aet paatepiste)}]
     (assoc tarkastus
                                         ;:sijainti (:geometria koko-tarkastuksen-tr-osoite)
-           :tarkastaja (:kayttajanimi kayttaja)
+           :tarkastaja (str (:etunimi kayttaja) " " (:sukunimi kayttaja))
            :tr_numero (:tie koko-tarkastuksen-tr-osoite)
            :tr_alkuosa (:aosa koko-tarkastuksen-tr-osoite)
            :tr_alkuetaisyys (:aet koko-tarkastuksen-tr-osoite)

--- a/src/cljc/harja/ui/kartta/esitettavat_asiat.cljc
+++ b/src/cljc/harja/ui/kartta/esitettavat_asiat.cljc
@@ -7,8 +7,6 @@
       [harja.domain.laadunseuranta.tarkastukset :as tarkastukset]
       [harja.domain.ilmoitukset :as ilmoitukset]
       [harja.geo :as geo]
-      [harja.ui.kartta.varit.puhtaat :as puhtaat]
-
       [harja.ui.kartta.asioiden-ulkoasu :as ulkoasu]))
 
 #?(:clj (defn log [& things]
@@ -248,7 +246,7 @@
 
 (def tarkastus-selitteet
   #{{:teksti "Tarkastus (ok)" :vari (:ok-tarkastus ulkoasu/viivojen-varit)}
-    {:teksti "Tarkastus (havaintoja)" :vari (:ei-ok-tarkastus ulkoasu/viivojen-varit)}})
+    {:teksti "Laadun\u00ADalitus" :vari (:ei-ok-tarkastus ulkoasu/viivojen-varit)}})
 
 (defmethod asia-kartalle :tarkastus [tarkastus valittu-fn?]
   (let [ikoni (ulkoasu/tarkastuksen-ikoni


### PR DESCRIPTION
HAR-2992: Korjaa tarkastajan nimi tarkastajakenttään
HAR-2993: Korjaa laadunalituksen karttaselite
