### PR TITLE
Anna ilmoituskomponentille sen vaatimat kaksi parametria

### DIFF
--- a/src/cljs/harja/views/ilmoituksen_tiedot.cljs
+++ b/src/cljs/harja/views/ilmoituksen_tiedot.cljs
@@ -60,17 +60,20 @@
    [:div.kuittaukset
     [:h3 "Kuittaukset"]
     [:div
-     (if-let [uusi-kuittaus (:uusi-kuittaus ilmoitus)]
-       [kuittaukset/uusi-kuittaus e! uusi-kuittaus]
-       (when (oikeudet/voi-kirjoittaa? oikeudet/ilmoitukset-ilmoitukset
-                                       (:id @nav/valittu-urakka))
+     ;; Tilannekuvanäkymässä ei voi tehdä kuittauksia, mutta tätä komponenttia käytetään
+     ;; näyttämään ilmoituksen tarkempia tietoja. Tällöin e! on nil
+     (when e!
+       (if-let [uusi-kuittaus (:uusi-kuittaus ilmoitus)]
+         [kuittaukset/uusi-kuittaus e! uusi-kuittaus]
+         (when (oikeudet/voi-kirjoittaa? oikeudet/ilmoitukset-ilmoitukset
+                                         (:id @nav/valittu-urakka))
 
-         (if (:ilmoitusid ilmoitus)
-           [:button.nappi-ensisijainen
-            {:class "uusi-kuittaus-nappi"
-             :on-click #(e! (v/->AvaaUusiKuittaus))}
-            (ikonit/livicon-plus) " Uusi kuittaus"]
-           [yleiset/vihje "Liidosta tuoduille ilmoituksille ei voi tehdä uusia kuittauksia"])))
+           (if (:ilmoitusid ilmoitus)
+             [:button.nappi-ensisijainen
+              {:class    "uusi-kuittaus-nappi"
+               :on-click #(e! (v/->AvaaUusiKuittaus))}
+              (ikonit/livicon-plus) " Uusi kuittaus"]
+             [yleiset/vihje "Liidosta tuoduille ilmoituksille ei voi tehdä uusia kuittauksia"]))))
 
      (when-not (empty? (:kuittaukset ilmoitus))
        [:div

--- a/src/cljs/harja/views/kartta/popupit.cljs
+++ b/src/cljs/harja/views/kartta/popupit.cljs
@@ -39,12 +39,13 @@
     [:h2 [:b otsikko]]
 
     [:table.otsikot-ja-arvot
-     (for [[nimi arvo] nimi-arvo-parit]
-       (when-not (nil? arvo)
-         ^{:key (str nimi arvo)}
-         [:tr
-          [:td.otsikko [:b nimi]]
-          [:td.arvo arvo]]))]
+     [:tbody
+      (for [[nimi arvo] nimi-arvo-parit]
+        (when-not (nil? arvo)
+          ^{:key (str nimi arvo)}
+          [:tr
+           [:td.otsikko [:b nimi]]
+           [:td.arvo arvo]]))]]
 
     (when linkki
       [:a.arvolistaus-linkki.klikattava
@@ -121,7 +122,7 @@
                                                                                   (.preventDefault e)
                                                                                   (modal/piilota!))}
                                           "Takaisin tilannekuvaan"]}
-                               [ilmoituksen-tiedot/ilmoitus (dissoc tapahtuma :type :alue)]))}}))))
+                               [ilmoituksen-tiedot/ilmoitus nil (dissoc tapahtuma :type :alue)]))}}))))
 
 (defmethod nayta-popup :suljettu-tieosuus-klikattu [tapahtuma]
   (kartta/nayta-popup! (geometrian-koordinaatti tapahtuma)


### PR DESCRIPTION
Ilmoituskomponentti ottaa nykyään kaksi parametria. Tilannekuva
välittää vain jälkimmäisestä, joten päivitetty komponenttia
käsittelemään tilanne, jossa ensimmäinen parametri on nil.

Korjattu myös react warning popupin luomisessa, tablen sisällön
pitää olla tbodyn sisällä.
