### PR TITLE
HAR-3082 Ryhmittele tulevat urakat erilleen

### DIFF
--- a/src/cljs/harja/views/raportit.cljs
+++ b/src/cljs/harja/views/raportit.cljs
@@ -642,7 +642,8 @@
                           :ryhmittely     (let [nyt (pvm/nyt)]
                                             #(if (pvm/jalkeen? nyt (:loppupvm %))
                                               :paattyneet
-                                              :kaynnissa))
+                                              (when (pvm/jalkeen? nyt (:alkupvm %))
+                                                :kaynnissa)))
                           :ryhman-otsikko #(case %
                                             :kaynnissa "Käynnissä olevat urakat"
                                             :paattyneet "Päättyneet urakat")

--- a/src/cljs/harja/views/urakat.cljs
+++ b/src/cljs/harja/views/urakat.cljs
@@ -40,7 +40,18 @@
 
 (defn valitse-urakka []
   (let [urakkalista @nav/hallintayksikon-urakkalista
-        suodatettu-urakkalista @nav/suodatettu-urakkalista]
+        suodatettu-urakkalista @nav/suodatettu-urakkalista
+        nyt (pvm/nyt)
+        tulevia? (some #(pvm/ennen? nyt (:alkupvm %)) suodatettu-urakkalista)
+        kaynnissaolevia? (some #(and
+                                 (pvm/jalkeen? nyt (:alkupvm %))
+                                 (pvm/ennen? nyt (:loppupvm %))) suodatettu-urakkalista)
+        paattyneita? (some #(pvm/jalkeen? nyt (:loppupvm %)) suodatettu-urakkalista)
+        naytettavat-ryhmat (into []
+                                 (keep identity)
+                                 [(when tulevia? :tulevat)
+                                  (when kaynnissaolevia? :kaynnissa)
+                                  (when paattyneita? :paattyneet)])]
     [:div.row
      [:div.col-md-4
       (if (nil? urakkalista)
@@ -51,13 +62,12 @@
           ^{:key "ur-lista"}
           [suodatettu-lista {:format         :nimi :haku :nimi
                              :selection      nav/valittu-urakka
-                             :nayta-ryhmat   [:tulevat :kaynnissa :paattyneet]
-                             :ryhmittely     (let [nyt (pvm/nyt)]
-                                               #(if (pvm/ennen? nyt (:alkupvm %))
-                                                 :tulevat
-                                                 (if (pvm/jalkeen? nyt (:loppupvm %))
-                                                   :paattyneet
-                                                   :kaynnissa)))
+                             :nayta-ryhmat   naytettavat-ryhmat
+                             :ryhmittely     #(if (pvm/ennen? nyt (:alkupvm %))
+                                               :tulevat
+                                               (if (pvm/jalkeen? nyt (:loppupvm %))
+                                                 :paattyneet
+                                                 :kaynnissa))
                              :ryhman-otsikko #(case %
                                                :tulevat "Tulevat urakat"
                                                :kaynnissa "Käynnissä olevat urakat"

--- a/src/cljs/harja/views/urakat.cljs
+++ b/src/cljs/harja/views/urakat.cljs
@@ -51,12 +51,15 @@
           ^{:key "ur-lista"}
           [suodatettu-lista {:format         :nimi :haku :nimi
                              :selection      nav/valittu-urakka
-                             :nayta-ryhmat   [:kaynnissa :paattyneet]
+                             :nayta-ryhmat   [:tulevat :kaynnissa :paattyneet]
                              :ryhmittely     (let [nyt (pvm/nyt)]
-                                               #(if (pvm/jalkeen? nyt (:loppupvm %))
-                                                 :paattyneet
-                                                 :kaynnissa))
+                                               #(if (pvm/ennen? nyt (:alkupvm %))
+                                                 :tulevat
+                                                 (if (pvm/jalkeen? nyt (:loppupvm %))
+                                                   :paattyneet
+                                                   :kaynnissa)))
                              :ryhman-otsikko #(case %
+                                               :tulevat "Tulevat urakat"
                                                :kaynnissa "Käynnissä olevat urakat"
                                                :paattyneet "Päättyneet urakat")
                              :on-select      nav/valitse-urakka!


### PR DESCRIPTION
HAR-3082 Ryhmittele tulevat urakat erilleen

Ryhmittele urakkalistassa erilleen tulevat, käynnissä olevat ja päättyneet urakat.

Älä mahdollista raporttien tekoa urakoille jotka eivät vielä ole käynnissä.
