### PR TITLE
HAR-3083 Varmista, että yks. hint. töiden suunnittelu tallentaa kaikki rivit

### DIFF
--- a/src/cljs/harja/views/urakka/suunnittelu/kokonaishintaiset_tyot.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/kokonaishintaiset_tyot.cljs
@@ -246,7 +246,7 @@
               :voi-poistaa? (constantly false)
               :muokkaa-footer (fn [g]
                                 [:div.kok-hint-muokkaa-footer
-                                 [raksiboksi {:teksti "Tallenna tulevillekin hoitokausille"
+                                 [raksiboksi {:teksti "Monista kaikki yo. tiedot tulevillekin hoitokausille"
                                               :toiminto #(swap! tuleville? not)
                                               :info-teksti  [:div.raksiboksin-info (ikonit/livicon-warning-sign) "Tulevilla hoitokausilla eri tietoa, jonka tallennus ylikirjoittaa."]
                                               :nayta-infoteksti? (and @tuleville? @varoita-ylikirjoituksesta?)}

--- a/src/cljs/harja/views/urakka/suunnittelu/materiaalit.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/materiaalit.cljs
@@ -154,7 +154,7 @@
 
 
           (when voi-muokata?
-            [raksiboksi {:teksti "Tallenna tulevillekin hoitokausille"
+            [raksiboksi {:teksti "Monista kaikki yo. tiedot tulevillekin hoitokausille"
                          :toiminto #(swap! tuleville? not)
                          :info-teksti [:div.raksiboksin-info (ikonit/livicon-warning-sign) "Tulevilla hoitokausilla eri tietoa, jonka tallennus ylikirjoittaa."]
                          :nayta-infoteksti? (and @tuleville? @varoita-ylikirjoituksesta?)}

--- a/src/cljs/harja/views/urakka/suunnittelu/yksikkohintaiset_tyot.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/yksikkohintaiset_tyot.cljs
@@ -29,8 +29,7 @@
             (into []
                   (if @tuleville?
                     (u/rivit-tulevillekin-kausille ur uudet-tyot valittu-hoitokausi)
-                    uudet-tyot
-                    ))
+                    uudet-tyot))
             res (<! (yks-hint-tyot/tallenna-urakan-yksikkohintaiset-tyot ur sopimusnumero muuttuneet))
             prosessoidut-tyorivit (s/prosessoi-tyorivit ur res)]
         (reset! tyot prosessoidut-tyorivit)
@@ -175,6 +174,7 @@
            :tallenna (if (oikeudet/voi-kirjoittaa? oikeudet/urakat-suunnittelu-yksikkohintaisettyot (:id ur))
                        #(tallenna-tyot ur @u/valittu-sopimusnumero @u/valittu-hoitokausi urakan-yks-hint-tyot %)
                        :ei-mahdollinen)
+           :tallenna-vain-muokatut false
            :tallennus-ei-mahdollinen-tooltip (oikeudet/oikeuden-puute-kuvaus
                                               :kirjoitus
                                               oikeudet/urakat-suunnittelu-yksikkohintaisettyot)

--- a/src/cljs/harja/views/urakka/suunnittelu/yksikkohintaiset_tyot.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/yksikkohintaiset_tyot.cljs
@@ -186,7 +186,7 @@
                                  (ryhmittele-hinnoitellut @tyorivit))
            :piilota-toiminnot? true
            :muokkaa-footer (fn [g]
-                             [raksiboksi {:teksti "Tallenna tulevillekin hoitokausille"
+                             [raksiboksi {:teksti "Monista kaikki yo. tiedot tulevillekin hoitokausille"
                                           :toiminto #(swap! tuleville? not)
                                           :info-teksti [:div.raksiboksin-info (ikonit/livicon-warning-sign) "Tulevilla hoitokausilla eri tietoa, jonka tallennus ylikirjoittaa."]
                                           :nayta-infoteksti? @varoita-ylikirjoituksesta?}


### PR DESCRIPTION
Näin siksi, että tuleville hoitokausille tallennus tallentaa aina kaikki rivit, ei vain muokattuja
