### PR TITLE
HAR-3271 korjaa IE valintabugi

### DIFF
--- a/src/cljs/harja/tiedot/ilmoitukset.cljs
+++ b/src/cljs/harja/tiedot/ilmoitukset.cljs
@@ -25,12 +25,13 @@
 ;; Valinnat jotka riippuvat ulkoisista atomeista
 (defonce valinnat
          (reaction
-           {:hallintayksikko (:id @nav/valittu-hallintayksikko)
-            :urakka (:id @nav/valittu-urakka)
-            :valitun-urakan-hoitokaudet @u/valitun-urakan-hoitokaudet
-            :urakoitsija (:id @nav/valittu-urakoitsija)
-            :urakkatyyppi (:arvo @nav/valittu-urakkatyyppi)
-            :hoitokausi @u/valittu-hoitokausi}))
+          {:voi-hakea? true
+           :hallintayksikko (:id @nav/valittu-hallintayksikko)
+           :urakka (:id @nav/valittu-urakka)
+           :valitun-urakan-hoitokaudet @u/valitun-urakan-hoitokaudet
+           :urakoitsija (:id @nav/valittu-urakoitsija)
+           :urakkatyyppi (:arvo @nav/valittu-urakkatyyppi)
+           :hoitokausi @u/valittu-hoitokausi}))
 
 
 (def ^{:const true}
@@ -50,7 +51,6 @@ tila-filtterit [:kuittaamaton :vastaanotettu :aloitettu :lopetettu])
                            :hakuehto ""
                            :selite [nil ""]
                            :vain-myohassa? false
-                           :aloituskuittauksen-ajankohta :kaikki}
                            :aloituskuittauksen-ajankohta :kaikki
                            :ilmoittaja-nimi ""
                            :ilmoittaja-puhelin ""}
@@ -116,15 +116,18 @@ tila-filtterit [:kuittaamaton :vastaanotettu :aloitettu :lopetettu])
   "Ajastaa uuden ilmoitushaun. Jos ilmoitushaku on jo ajastettu, se perutaan ja uusi ajastetaan."
   ([app] (hae app 300))
   ([app timeout] (hae app timeout false))
-  ([{haku :ilmoitushaku-id :as app} timeout taustahaku?]
-    ;; Jos seuraava haku ollaan laukaisemassa, peru se
-   (when haku
-     (.clearTimeout js/window haku))
-   (-> app
-       (assoc :ilmoitushaku-id (.setTimeout js/window
-                                            (t/send-async! v/->HaeIlmoitukset)
-                                            timeout))
-       (assoc :taustahaku? taustahaku?))))
+  ([{valinnat :valinnat haku :ilmoitushaku-id :as app} timeout taustahaku?]
+   (if-not (:voi-hakea? valinnat)
+     app
+     (do
+       ;; Jos seuraava haku ollaan laukaisemassa, peru se
+       (when haku
+         (.clearTimeout js/window haku))
+       (-> app
+           (assoc :ilmoitushaku-id (.setTimeout js/window
+                                                (t/send-async! v/->HaeIlmoitukset)
+                                                timeout))
+           (assoc :taustahaku? taustahaku?))))))
 
 ;; Kaikki mitä UI voi ilmoitusnäkymässä tehdä, käsitellään täällä
 (extend-protocol t/Event
@@ -147,17 +150,18 @@ tila-filtterit [:kuittaamaton :vastaanotettu :aloitettu :lopetettu])
   (process-event [_ {valinnat :valinnat taustahaku? :taustahaku? :as app}]
     (let [tulos! (t/send-async! v/->IlmoitusHaku)]
       (go
-        (tulos!
-          {:ilmoitukset (<! (k/post! :hae-ilmoitukset
-                                     (-> valinnat
-                                         (update-in [:aikavali 0] #(and % (pvm/paivan-alussa %)))
-                                         (update-in [:aikavali 1] #(and % (pvm/paivan-lopussa %)))
-                                         ;; jos tyyppiä/tilaa ei valittu, ota kaikki
-                                         (update :tyypit
-                                                 #(if (empty? %) +ilmoitustyypit+ %))
-                                         (update :tilat
-                                                 #(if (empty? %) (into #{} tila-filtterit) %)))))
-           :taustahaku? taustahaku?})))
+        (let [haku (-> valinnat
+                       (update-in [:aikavali 0] #(and % (pvm/paivan-alussa %)))
+                       (update-in [:aikavali 1] #(and % (pvm/paivan-lopussa %)))
+                       ;; jos tyyppiä/tilaa ei valittu, ota kaikki
+                       (update :tyypit
+                               #(if (empty? %) +ilmoitustyypit+ %))
+                       (update :tilat
+                               #(if (empty? %) (into #{} tila-filtterit) %)))]
+          (log "---- HAETAAN: " (pr-str haku))
+          (tulos!
+           {:ilmoitukset (<! (k/post! :hae-ilmoitukset haku))
+            :taustahaku? taustahaku?}))))
     (if taustahaku?
       app
       (assoc app :ilmoitukset nil)))

--- a/src/cljs/harja/tiedot/ilmoitukset.cljs
+++ b/src/cljs/harja/tiedot/ilmoitukset.cljs
@@ -138,7 +138,6 @@ tila-filtterit [:kuittaamaton :vastaanotettu :aloitettu :lopetettu])
 
   v/YhdistaValinnat
   (process-event [{valinnat :valinnat :as e} app]
-    (log "   YHDISTETAAN " (pr-str valinnat))
     (hae
       ;; Kun näkymään tullaan ensimmäistä kertaa, aseta oletus aikaväliksi nykypäivästä 7 päivää taaksepäin
       (let [valinnat (if (get-in app [:valinnat :aikavali])
@@ -158,7 +157,6 @@ tila-filtterit [:kuittaamaton :vastaanotettu :aloitettu :lopetettu])
                                #(if (empty? %) +ilmoitustyypit+ %))
                        (update :tilat
                                #(if (empty? %) (into #{} tila-filtterit) %)))]
-          (log "---- HAETAAN: " (pr-str haku))
           (tulos!
            {:ilmoitukset (<! (k/post! :hae-ilmoitukset haku))
             :taustahaku? taustahaku?}))))

--- a/src/cljs/harja/tiedot/ilmoitukset.cljs
+++ b/src/cljs/harja/tiedot/ilmoitukset.cljs
@@ -51,6 +51,9 @@ tila-filtterit [:kuittaamaton :vastaanotettu :aloitettu :lopetettu])
                            :selite [nil ""]
                            :vain-myohassa? false
                            :aloituskuittauksen-ajankohta :kaikki}
+                           :aloituskuittauksen-ajankohta :kaikki
+                           :ilmoittaja-nimi ""
+                           :ilmoittaja-puhelin ""}
                 :kuittaa-monta nil}))
 
 (defn- jarjesta-ilmoitukset [tulos]

--- a/src/cljs/harja/tiedot/ilmoitukset.cljs
+++ b/src/cljs/harja/tiedot/ilmoitukset.cljs
@@ -132,6 +132,7 @@ tila-filtterit [:kuittaamaton :vastaanotettu :aloitettu :lopetettu])
 
   v/YhdistaValinnat
   (process-event [{valinnat :valinnat :as e} app]
+    (log "   YHDISTETAAN " (pr-str valinnat))
     (hae
       ;; Kun näkymään tullaan ensimmäistä kertaa, aseta oletus aikaväliksi nykypäivästä 7 päivää taaksepäin
       (let [valinnat (if (get-in app [:valinnat :aikavali])

--- a/src/cljs/harja/views/ilmoitukset.cljs
+++ b/src/cljs/harja/views/ilmoitukset.cljs
@@ -254,12 +254,10 @@
 
 (defn- ilmoitukset* [e! ilmoitukset]
   ;; Kun näkymään tullaan, yhdistetään navigaatiosta tulevat valinnat
-  (log "YHDISTÄ ALKUVALINNAT")
   (e! (v/->YhdistaValinnat @tiedot/valinnat))
 
   (komp/luo
    (komp/watcher tiedot/valinnat (fn [_ _ uusi]
-                                   (log "YHDISTÄ MUUTTUNEET VALINNAT")
                                    (e! (v/->YhdistaValinnat uusi))))
    (komp/sisaan #(notifikaatiot/pyyda-notifikaatiolupa))
    (komp/kuuntelija :ilmoitus-klikattu (fn [_ i] (e! (v/->ValitseIlmoitus i))))

--- a/src/cljs/harja/views/ilmoitukset.cljs
+++ b/src/cljs/harja/views/ilmoitukset.cljs
@@ -262,7 +262,6 @@
    (komp/sisaan #(notifikaatiot/pyyda-notifikaatiolupa))
    (komp/kuuntelija :ilmoitus-klikattu (fn [_ i] (e! (v/->ValitseIlmoitus i))))
    (fn [e! {valittu-ilmoitus :valittu-ilmoitus :as ilmoitukset}]
-     (log "ILMOITUKSET: " (pr-str ilmoitukset))
      [:span
       [kartta/kartan-paikka]
       (if valittu-ilmoitus


### PR DESCRIPTION
**Lokitusta**

**Lisää tyhjät arvot ilmoittajalle**
IE vaatii, että input kentän value ei ole NULL, joten lisätään tyhjät stringit.

**Älä hae ennen kuin valinnat on yhdistetty**
