### PR TITLE
Ota huomioon tyhjä merkkijono ilmoittajan nimellä ja puhelinnumerolla haettaessa ilmoituksia

### DIFF
--- a/src/clj/harja/palvelin/palvelut/ilmoitukset.clj
+++ b/src/clj/harja/palvelin/palvelut/ilmoitukset.clj
@@ -12,7 +12,8 @@
             [harja.pvm :as pvm]
             [clj-time.coerce :as c]
             [harja.domain.oikeudet :as oikeudet]
-            [clojure.java.jdbc :as jdbc])
+            [clojure.java.jdbc :as jdbc]
+            [clojure.string :as str])
   (:import (java.util Date)))
 
 (def ilmoitus-xf
@@ -153,9 +154,9 @@
                                       :selite_annettu selite-annettu?
                                       :selite selite
                                       :tr-numero tr-numero
-                                      :ilmoittaja-nimi (when ilmoittaja-nimi
+                                      :ilmoittaja-nimi (when-not (str/blank? ilmoittaja-nimi)
                                                          (str "%" ilmoittaja-nimi "%"))
-                                      :ilmoittaja-puhelin (when ilmoittaja-puhelin
+                                      :ilmoittaja-puhelin (when-not (str/blank? ilmoittaja-puhelin)
                                                             (str "%" ilmoittaja-puhelin "%"))
                                       :max-maara max-maara}))
             {:kuittaus :kuittaukset}))


### PR DESCRIPTION
Ota huomioon tyhjä merkkijono ilmoittajan nimellä ja puhelinnumerolla haettaessa
