### PR TITLE
Kerää työkoneen reitti talteen

### DIFF
--- a/src/clj/harja/kyselyt/tilannekuva.sql
+++ b/src/clj/harja/kyselyt/tilannekuva.sql
@@ -312,6 +312,7 @@ SELECT
   t.vastaanotettu,
   t.tyokonetyyppi,
   t.sijainti,
+  ST_Simplify(t.reitti, :toleranssi) AS reitti,
   t.suunta,
   t.edellinensijainti,
   t.urakkaid,

--- a/src/clj/harja/kyselyt/tilannekuva.sql
+++ b/src/clj/harja/kyselyt/tilannekuva.sql
@@ -304,6 +304,7 @@ SELECT
   t.tyokoneid,
   t.jarjestelma,
   t.organisaatio,
+  t.alkanut,
   (SELECT nimi
    FROM organisaatio
    WHERE id = t.organisaatio) AS organisaationimi,

--- a/src/clj/harja/kyselyt/tyokoneseuranta.sql
+++ b/src/clj/harja/kyselyt/tyokoneseuranta.sql
@@ -65,4 +65,4 @@ WHERE urakkaid = :urakkaid
 -- name: poista-vanhentuneet-havainnot!
 -- Poistaa vanhentuneet havainnot työkoneseurannasta
 DELETE FROM tyokonehavainto
-WHERE vastaanotettu < NOW() - INTERVAL '2 hours'
+ WHERE date_trunc('day',alkanut) < current_date;

--- a/src/cljc/harja/ui/kartta/esitettavat_asiat.cljc
+++ b/src/cljc/harja/ui/kartta/esitettavat_asiat.cljc
@@ -479,20 +479,18 @@
 (defmethod asia-kartalle :tyokone [tyokone valittu-fn?]
   (let [selite-teksti (tehtavan-nimi (:tehtavat tyokone))
         [viivat nuolen-vari] (tehtavan-viivat-ja-nuolitiedosto
-                               (:tehtavat tyokone) (valittu-fn? tyokone))
-        paikka {:sijainti {:type (if (:reitti tyokone) :line :point)}}
-        paikka (if (:reitti tyokone)
-                 (assoc-in paikka [:sijainti :points] (:reitti tyokone))
-                 (assoc-in paikka [:sijainti :coordinates]
-                           (:sijainti tyokone)))]
+                              (:tehtavat tyokone) (valittu-fn? tyokone))
+        paikka (or (:reitti tyokone)
+                   {:type :point
+                    :coordinates (:sijainti tyokone)})]
     (assoc tyokone
-      :type :tyokone
-      :nimi (or (:nimi tyokone) (str/capitalize (name (:tyokonetyyppi tyokone))))
-      :selite {:teksti selite-teksti
-               :vari   (viivojen-varit-leveimmasta-kapeimpaan viivat)}
-      :alue (maarittele-feature paikka (valittu-fn? tyokone)
-                                (ulkoasu/tyokoneen-ikoni nuolen-vari (muunna-tyokoneen-suunta (:suunta tyokone)))
-                                viivat))))
+           :type :tyokone
+           :nimi (or (:nimi tyokone) (str/capitalize (name (:tyokonetyyppi tyokone))))
+           :selite {:teksti selite-teksti
+                    :vari   (viivojen-varit-leveimmasta-kapeimpaan viivat)}
+           :alue (maarittele-feature paikka (valittu-fn? tyokone)
+                                     (ulkoasu/tyokoneen-ikoni nuolen-vari (muunna-tyokoneen-suunta (:suunta tyokone)))
+                                     viivat))))
 
 (defmethod asia-kartalle :default [asia _]
   (warn "Kartalla esitettävillä asioilla pitää olla :tyyppi-kartalla avain!, "

--- a/src/cljs/harja/tiedot/tilannekuva/tilannekuva.cljs
+++ b/src/cljs/harja/tiedot/tilannekuva/tilannekuva.cljs
@@ -318,27 +318,6 @@ hakutiheys-historiakuva 1200000)
   (reaction
     (kasaa-parametrit @valittu-tila @nav/kartalla-nakyva-alue @suodattimet)))
 
-(defn yhdista-tyokonedata [uusi]
-  (let [vanhat (:tyokoneet @tilannekuva-kartalla/haetut-asiat)
-        uudet (:tyokoneet uusi)
-        uudet-idt (into #{} (keys uudet))]
-    (assoc uusi :tyokoneet
-                (into {}
-                      (filter
-                        (fn [[id _]]
-                          (uudet-idt id))
-                        (merge-with
-                          (fn [vanha uusi]
-                            (let [vanha-reitti (:reitti vanha)]
-                              (assoc uusi
-                                :reitti (if (= (:sijainti vanha) (:sijainti uusi))
-                                          vanha-reitti
-                                          (conj
-                                            (or vanha-reitti
-                                                [(:sijainti vanha)])
-                                            (:sijainti uusi))))))
-                          vanhat uudet))))))
-
 (def edellisen-haun-kayttajan-suodattimet
   (atom {:tila @valittu-tila
          :aikavali-nykytilanne @nykytilanteen-aikasuodattimen-arvo
@@ -370,6 +349,7 @@ hakutiheys-historiakuva 1200000)
                          :tyokoneet (vals (:tyokoneet tulos))})
   tulos)
 
+
 (defn hae-asiat [hakuparametrit]
   (log "Tilannekuva: Hae asiat (" (pr-str @valittu-tila) ") " (pr-str hakuparametrit))
   (go
@@ -390,7 +370,6 @@ hakutiheys-historiakuva 1200000)
 
     (let [tulos (-> (<! (k/post! :hae-tilannekuvaan (aikaparametrilla hakuparametrit)))
                     (assoc :tarkastukset (:tarkastukset hakuparametrit))
-                    (yhdista-tyokonedata)
                     (julkaise-tyokonedata!))]
       (when @nakymassa?
         (reset! tilannekuva-kartalla/haetut-asiat tulos))

--- a/src/cljs/harja/views/kartta/popupit.cljs
+++ b/src/cljs/harja/views/kartta/popupit.cljs
@@ -138,14 +138,16 @@
   (reset! klikattu-tyokone (:tyokoneid tapahtuma))
   (kartta/keskita-kartta-pisteeseen (:sijainti tapahtuma))
 
-  (kartta/nayta-popup! (:sijainti tapahtuma)
-                       (tee-arvolistaus-popup "Työkone"
-                                              [["Tyyppi" (:tyokonetyyppi tapahtuma)]
-                                               ["Viimeisin paikka\u00ADtieto" (pvm/pvm-aika-sek (:lahetysaika tapahtuma))]
-                                               ["Organisaatio" (or (:organisaationimi tapahtuma) "Ei organisaatiotietoja")]
-                                               ["Urakka" (or (:urakkanimi tapahtuma) "Ei urakkatietoja")]
-                                               ["Tehtävät" (let [tehtavat (str/join ", " (:tehtavat tapahtuma))]
-                                                             [:span tehtavat])]])))
+  (kartta/nayta-popup!
+   (:sijainti tapahtuma)
+   (tee-arvolistaus-popup "Työkone"
+                          [["Työ aloitettu" (pvm/pvm-aika-sek (:alkanut tapahtuma))]
+                           ["Viimeisin havainto" (pvm/pvm-aika-sek (:lahetysaika tapahtuma))]
+                           ["Tyyppi" (:tyokonetyyppi tapahtuma)]
+                           ["Organisaatio" (or (:organisaationimi tapahtuma) "Ei organisaatiotietoja")]
+                           ["Urakka" (or (:urakkanimi tapahtuma) "Ei urakkatietoja")]
+                           ["Tehtävät" (let [tehtavat (str/join ", " (:tehtavat tapahtuma))]
+                                         [:span tehtavat])]])))
 
 (defmethod nayta-popup :uusi-tyokonedata [data]
   (when-let [tk @klikattu-tyokone]
@@ -271,4 +273,3 @@
                                               {:linkki {:nimi   "Avaa varustekortti"
                                                         :href   (:varustekortti-url tapahtuma)
                                                         :target "_blank"}})))
-

--- a/tietokanta/src/main/resources/db/migration/V1_460__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_460__.sql
@@ -7,8 +7,10 @@ ALTER TABLE tyokonehavainto
 CREATE OR REPLACE FUNCTION paivita_tyokoneen_reitti() RETURNS trigger AS $$
 BEGIN
   IF NEW.reitti IS NULL THEN
+    -- Uusi tyokonehavainto luodaan
     NEW.reitti = ST_MakeLine(ARRAY[NEW.sijainti]::GEOMETRY[]);
   ELSE
+    -- Olemassaolevaa työkonehavaintoa päivitetään
     NEW.reitti = ST_AddPoint(NEW.reitti, NEW.sijainti::GEOMETRY);
  END IF;
  RETURN NEW;

--- a/tietokanta/src/main/resources/db/migration/V1_460__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_460__.sql
@@ -21,3 +21,6 @@ CREATE TRIGGER tg_paivita_tyokoneen_reitti
 BEFORE INSERT OR UPDATE ON tyokonehavainto
 FOR EACH ROW
 EXECUTE PROCEDURE paivita_tyokoneen_reitti();
+
+-- Päivitä kaikki, jotta trigger tekee reitin
+UPDATE tyokonehavainto SET tyokoneid = tyokoneid;

--- a/tietokanta/src/main/resources/db/migration/V1_460__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_460__.sql
@@ -9,7 +9,7 @@ BEGIN
   IF NEW.reitti IS NULL THEN
     NEW.reitti = ST_MakeLine(ARRAY[NEW.sijainti]::GEOMETRY[]);
   ELSE
-    NEW.reitti = ST_AddPoint(NEW.reitti, NEW.sijainti);
+    NEW.reitti = ST_AddPoint(NEW.reitti, NEW.sijainti::GEOMETRY);
  END IF;
  RETURN NEW;
 END;

--- a/tietokanta/src/main/resources/db/migration/V1_460__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_460__.sql
@@ -1,0 +1,21 @@
+-- Lisää työkoneelle reitti
+
+ALTER TABLE tyokonehavainto
+  ADD COLUMN reitti geometry,
+  ADD COLUMN alkanut timestamp without time zone DEFAULT NOW();
+
+CREATE OR REPLACE FUNCTION paivita_tyokoneen_reitti() RETURNS trigger AS $$
+BEGIN
+  IF NEW.reitti IS NULL THEN
+    NEW.reitti = ST_MakeLine(ARRAY[NEW.sijainti]::GEOMETRY[]);
+  ELSE
+    NEW.reitti = ST_AddPoint(NEW.reitti, NEW.sijainti);
+ END IF;
+ RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER tg_paivita_tyokoneen_reitti
+BEFORE INSERT OR UPDATE ON tyokonehavainto
+FOR EACH ROW
+EXECUTE PROCEDURE paivita_tyokoneen_reitti();


### PR DESCRIPTION
**Kerää työkoneen reitti talteen**
Kerätään reitti talteen ja lisätään uusi "alkanut" kenttä, joka kertoo
ensimmäisen tälle työkoneelle tehdyn havainnon.

**Lisää tyyppi cast**

**Testaa reitin kertyminen**

**Hae työkoneille myös reitti**

**Lisää kommentteja**

**Tee update, jotta reitti päivittyy kaikille**

**Reitti tulee nyt palvelimelta**

**Lisää alkamisaika tietoihin**

**Poista kaikki edellisen vuorokauden havainnot**

**Aja puhdistus vain 00:05**

**Näytä alkamisaika**

