### PR TITLE
Käytä Travisin omaa PG 9.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+addons:
+  postgresql: "9.5"
 sudo: required
 cache:
   directories:

--- a/tietokanta/travis.sh
+++ b/tietokanta/travis.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-sudo /etc/init.d/postgresql stop
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
-sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main 9.5" >> /etc/apt/sources.list.d/postgresql.list'
-sudo apt-get update
-sudo apt-get install postgresql-9.5
+#sudo /etc/init.d/postgresql stop
+#wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+#sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main 9.5" >> /etc/apt/sources.list.d/postgresql.list'
+#sudo apt-get update
+#sudo apt-get install postgresql-9.5
 sudo apt-get install postgresql-9.5-postgis-2.2
 
 sudo /etc/init.d/postgresql restart
@@ -12,22 +12,6 @@ sudo /etc/init.d/postgresql restart
 sudo sh tietokanta/travis_pg_conf.sh
 
 sudo /etc/init.d/postgresql restart
-
-
-#echo "KATSOTAAN ONKO POSTGRES KÄYNNISSÄ"
-#ps axf | grep postgres
-#
-#echo "KATSOTAAN POSTGRES HAKEMISTOJA"
-#ls /var/lib/postgresql/9.5/main
-#
-#echo "POSTGRES.CONF"
-#cat /etc/postgresql/9.5/main/postgresql.conf
-#
-#echo "PG HBA"
-#cat /etc/postgresql/9.5/main/pg_hba.conf
-#
-#
-#sleep 5
 
 cd tietokanta
 psql -c "CREATE USER harjatest WITH CREATEDB;" -U postgres


### PR DESCRIPTION
Travis CI tukee PostgreSQL 9.5 versiota suoraan, enää ei tarvitse asentaa omaa paketeista.