### PR TITLE
korjaa infopaneelin linkkinappi testin kera

### DIFF
--- a/src/cljs/harja/views/kartta/infopaneeli.cljs
+++ b/src/cljs/harja/views/kartta/infopaneeli.cljs
@@ -31,14 +31,14 @@
 
 (defn yksityiskohdat
   "Näyttää infopaneelin asian yksityiskohdat otsikko/arvo riveinä."
-  [{:keys [otsikko tiedot data tyyppi] :as asia} linkin-kasittely-fn]
+  [{:keys [otsikko tiedot data tyyppi] :as asia} linkin-kasittelijat]
   (if-not (or (keyword? tyyppi) (fn? tyyppi))
     (do
       (error "yksityiskohdat: asian tyyppi huono, asia: " (clj->js asia))
       nil)
     ;; else
     [:div.ip-osio
-     (when-let [{:keys [teksti toiminto]} (tyyppi linkin-kasittely-fn)]
+     (when-let [{:keys [teksti toiminto]} (tyyppi @linkin-kasittelijat)]
        [:div [napit/yleinen teksti #(toiminto data) {:luokka "ip-toiminto btn-xs"}]])
      (apply yleiset/tietoja {}
             (mapcat (juxt :otsikko

--- a/test/cljs/harja/views/infopaneeli_test.cljs
+++ b/test/cljs/harja/views/infopaneeli_test.cljs
@@ -65,7 +65,7 @@
 (deftest otsikot
   (let [asiat-atomi (r/atom testidata)
         piilota-fn! #(log "piilota-fn! kutsuttu")
-        linkkifunktiot (r/atom {})]
+        linkkifunktiot (r/atom {:toteuma  {:teksti "linkkinappi" :toiminto #(fn [& argit] nil)}})]
     (tarkkaile! "mock-asiat-pisteessä" asiat-atomi)
     (komponenttitesti
      [:div.kartan-infopaneeli [sut/infopaneeli @asiat-atomi piilota-fn! linkkifunktiot]]
@@ -77,5 +77,6 @@
      (is (= 0 (count (u/sel [:.kartan-infopaneeli :.kentan-label]))))
      (u/click (u/sel1 [:.kartan-infopaneeli :span.ip-haitari-otsikko]))
      --
-     "yhden asian tiedot esillä klikkauksen jälkeen"
-     (is (= 5 (count (u/sel [:.kartan-infopaneeli :.tietorivi])))))))
+     "yhden asian tiedot esillä klikkauksen jälkeen, ja linkkinappi myös"
+     (is (= 5 (count (u/sel [:.kartan-infopaneeli :.tietorivi]))))
+     (is (= 1 (count (u/sel [:.ip-osio :div :button])))))))


### PR DESCRIPTION
Oli vain @ hukkunut refaktoroinnissa jossain vaiheessa. En kerennyt testaamaan kovin paljon, tarkastuksissa ainakin näytti toimivan.