### PR TITLE
HAR-4227 tyokoneen sijainti selvemmin

### DIFF
--- a/src/clj/harja/palvelin/palvelut/karttakuvat/piirto.clj
+++ b/src/clj/harja/palvelin/palvelut/karttakuvat/piirto.clj
@@ -147,9 +147,9 @@ Kasvata arvoa, jos haluat tiheämmin näkyvät ikonit."
   (let [viivat (reverse (sort-by :width viivat))]
     (doseq [viiva viivat
             line lines]
-      (piirra-viiva g line viiva)
-      (piirra-ikonit g {:points (:points line)
-                        :ikonit ikonit} ruudukko))))
+      (piirra-viiva g line viiva))
+    (piirra-ikonit g {:points (mapcat :points lines)
+                      :ikonit ikonit} ruudukko)))
 
 (def varoitusteksti
   "Paljon tuloksia, kaikkea ei ehditty piirtää! Tarkenna hakuehtoja tai zoomaa lähemmäs.")

--- a/src/cljc/harja/ui/kartta/asioiden_ulkoasu.cljc
+++ b/src/cljc/harja/ui/kartta/asioiden_ulkoasu.cljc
@@ -218,14 +218,16 @@
   (pinni-ikoni vari))
 
 (defn toteuman-nuoli [nuolen-vari]
-  {:paikka [:taitokset :loppu]
-   :tyyppi :nuoli
-   :img    (nuoli-ikoni nuolen-vari)})
+  [{:paikka [:loppu]
+    :tyyppi :nuoli
+    :img (nuoli-ikoni nuolen-vari)}
+   {:paikka [:taitokset]
+    :scale 0.8
+    :tyyppi :nuoli
+    :img (nuoli-ikoni "musta")}])
 
 (defn tyokoneen-nuoli [nuolen-vari]
-  {:paikka [:loppu]
-   :tyyppi :nuoli
-   :img (nuoli-ikoni nuolen-vari)})
+  (toteuman-nuoli nuolen-vari))
 
 (defn yllapidon-ikoni []
   {:paikka [:loppu]


### PR DESCRIPTION
Näytetään taitosten viivat mustalla ja pienempinä.

Tuli korjattua bugi moniviivojen ikoneissa. Jos toteuma oli moniviiva, ja haluttiin piirtää ikoni loppuun, niin ikoni piirrettiin _jokaisen_ viivan loppuun. Ei näin.