### PR TITLE
HAR-4483 Korjaa erikoisvalinta tpi:ssä

### DIFF
--- a/src/cljs/harja/tiedot/urakka.cljs
+++ b/src/cljs/harja/tiedot/urakka.cljs
@@ -57,10 +57,14 @@
 (defn valitse-toimenpideinstanssi-koodilla!
   "Valitsee urakan toimenpideinstanssin 3. tason SAMPO koodin perusteella."
   [koodi]
+
   (reset! valitun-toimenpideinstanssin-koodi koodi))
 
 (defn valitse-toimenpideinstanssi! [{koodi :t3_koodi :as tpi}]
-  (valitse-toimenpideinstanssi-koodilla! koodi))
+  (if-not koodi
+    ;; Kooditon erikoisvalinta, kuten "Kaikki" tai "Muut"
+    (reset! valittu-toimenpideinstanssi tpi)
+    (valitse-toimenpideinstanssi-koodilla! koodi)))
 
 
 


### PR DESCRIPTION
**Korjaa erikoisvalinta tpi:ssä**
Valinta muutettiin reaktioksi, kun tehtiin siirtymä tpi koodin
perusteella. Tässä tuli regressio erikoisvalintojen "kaikki" ja "muut"
kanssa. Nyt valinnan asettaminen asettaa erikoisvalinnan suoraan tai
koodin kautta, jos koodi on.

