### PR TITLE
HAR-4588 Älä yritä luoda yhtenäistä polygonia NULL geom

### DIFF
--- a/src/clj/harja/kyselyt/urakat.sql
+++ b/src/clj/harja/kyselyt/urakat.sql
@@ -106,7 +106,7 @@ SELECT
     THEN ST_Simplify(sps.alue, 50)
   WHEN u.tyyppi = 'tekniset-laitteet' :: urakkatyyppi
     THEN ST_Simplify(tlu.alue, 50)
-  WHEN u.tyyppi = 'hoito' :: urakkatyyppi
+  WHEN (u.tyyppi = 'hoito' :: urakkatyyppi AND au.alue IS NOT NULL)
     THEN
       -- Luodaan yhtenäinen polygon alueurakan alueelle (multipolygonissa voi olla reikiä)
       ST_MakePolygon(ST_ExteriorRing((ST_Dump(au.alue)).geom))


### PR DESCRIPTION
**Älä yritä luoda yhtenäistä polygonia NULL geom**
Jos alueurakalle ei löydy geometriaa, ei yritetä luoda siitä
ST_Dump/ST_ExteriorRing avulla yhtenäistä polygonia vaan annetaan sen
tapauksen valua ELSE lohkoon.

