### PR TITLE
HAR-4596/HAR-4594

### DIFF
--- a/src/clj/harja/kyselyt/urakat.sql
+++ b/src/clj/harja/kyselyt/urakat.sql
@@ -106,10 +106,10 @@ SELECT
     THEN ST_Simplify(sps.alue, 50)
   WHEN u.tyyppi = 'tekniset-laitteet' :: urakkatyyppi
     THEN ST_Simplify(tlu.alue, 50)
-  WHEN u.tyyppi = 'hoito' :: urakkatyyppi
+  WHEN (u.tyyppi = 'hoito' :: urakkatyyppi AND au.alue IS NOT NULL)
     THEN
       -- Luodaan yhtenäinen polygon alueurakan alueelle (multipolygonissa voi olla reikiä)
-      ST_MakePolygon(ST_ExteriorRing((ST_Dump(au.alue)).geom))
+     hoidon_alueurakan_geometria(u.urakkanro)
   ELSE
     ST_Simplify(au.alue, 50)
   END                         AS alueurakan_alue
@@ -529,7 +529,13 @@ WHERE u.id = :id;
 SELECT
   ST_Simplify(u.alue, :toleranssi)          AS urakka_alue,
   u.id                                      AS urakka_id,
-  ST_Simplify(alueurakka.alue, :toleranssi) AS alueurakka_alue
+  CASE
+  WHEN (u.tyyppi = 'hoito'::urakkatyyppi AND alueurakka.alue IS NOT NULL)
+  THEN
+    hoidon_alueurakan_geometria(alueurakka.alueurakkanro)
+  ELSE
+    ST_Simplify(alueurakka.alue, :toleranssi)
+  END AS alueurakka_alue
 FROM urakka u
   LEFT JOIN alueurakka ON u.urakkanro = alueurakka.alueurakkanro
 WHERE u.id IN (:idt);

--- a/tietokanta/src/main/resources/db/migration/R__Hoidon_alueurakan_geometria.sql
+++ b/tietokanta/src/main/resources/db/migration/R__Hoidon_alueurakan_geometria.sql
@@ -1,0 +1,8 @@
+-- Hoidon alueurakoiden geometrian reikien korjaus
+
+CREATE OR REPLACE FUNCTION hoidon_alueurakan_geometria(nro varchar) RETURNS GEOMETRY AS $$
+  SELECT ST_Collect(ST_MakePolygon(s.the_geom))
+    FROM (SELECT au.alueurakkanro, ST_ExteriorRing((ST_Dump(au.alue)).geom) AS the_geom
+            FROM alueurakka au
+	   WHERE au.alueurakkanro = nro)  AS s
+$$ LANGUAGE SQL IMMUTABLE;


### PR DESCRIPTION
Korjaa urakkalistojen haussa geometrian muodostus hoidon alueurakalle. 
Käytetään sprocia, jonka taakse tuo haku on tehty, jottei sitä tarvitse toistaa eri kyselyissä.