### PR TITLE
HAR-4659 Korjaa :positiivinen-numero kentän ongelma

### DIFF
--- a/src/cljs/harja/ui/kentat.cljs
+++ b/src/cljs/harja/ui/kentat.cljs
@@ -257,7 +257,10 @@ toisen eventin kokonaan (react eventtiä ei laukea)."}
                  :on-focus    (:on-focus kentta)
                  :on-blur     #(reset! teksti nil)
                  :value       nykyinen-teksti
-                 on-change*   #(let [v (normalisoi-numero (-> % .-target .-value))]
+                 on-change*   #(let [v (normalisoi-numero (-> % .-target .-value))
+                                     v (if vaadi-ei-negatiivinen?
+                                         (str/replace v #"-" "")
+                                         v)]
                                  (when (or (= v "")
                                            (when-not vaadi-ei-negatiivinen? (= v "-"))
                                            (re-matches (if kokonaisluku?

--- a/src/cljs/harja/ui/kentat.cljs
+++ b/src/cljs/harja/ui/kentat.cljs
@@ -278,8 +278,8 @@ toisen eventin kokonaan (react eventtiä ei laukea)."}
     [:span (normalisoi-numero (fmt @data))]))
 
 (defmethod tee-kentta :positiivinen-numero [kentta data]
-  (tee-kentta (assoc kentta :vaadi-ei-negatiivinen? true
-                            :tyyppi :numero) data))
+  [tee-kentta (assoc kentta :vaadi-ei-negatiivinen? true
+                     :tyyppi :numero) data])
 
 (defmethod nayta-arvo :positiivinen-numero [kentta data]
   (nayta-arvo (assoc kentta :tyyppi :numero) data))

--- a/test/cljs/harja/ui/kentat_test.cljs
+++ b/test/cljs/harja/ui/kentat_test.cljs
@@ -102,6 +102,29 @@
      --
      (is (= "0,66" (val))))))
 
+(deftest positiivinen-numero
+  (let [data (r/atom nil)
+        val! #(u/change :input %)
+        val #(some-> :input u/sel1 .-value)]
+    (komponenttitesti
+     [kentat/tee-kentta {:nimi :foo :tyyppi :positiivinen-numero}
+      data]
+
+     "aluksi arvo on tyhjä"
+     (is (= "" (val)))
+
+     "Normaali kokonaisluku päivittyy oikein"
+     (val! "80")
+     --
+     (is (= "80" (val)))
+     (is (= 80 @data))
+
+     "Miinusmerkkiä ei hyväksytä"
+     (val! "-12")
+     --
+     (is (= "12" (val)))
+     (is (= 12 @data)))))
+
 (deftest pvm
   (let [data (r/atom nil)
         val! #(u/change :input %)


### PR DESCRIPTION
**Testi positiviiselle numerolle**
Testaa, että :positiivinen-numero kenttään ei voi lainkaan kirjoittaa
miinusmerkkiä.

**Luo :positiivinen-numero komponenttina**

**Poista '-' merkki, jos vaadi-ei-negatiivinen? true**