### PR TITLE
Korjaa UI regressioita

### DIFF
--- a/src/cljs/harja/ui/kentat.cljs
+++ b/src/cljs/harja/ui/kentat.cljs
@@ -362,7 +362,7 @@ toisen eventin kokonaan (react eventtiä ei laukea)."}
                   valitse-fn
                   (fn [data valinta valittu?]
                     (if valittu?
-                      (conj data valinta)
+                      (conj (or data #{}) valinta)
                       (disj data valinta))))]
     [:div.boolean-group
      (when tyhjenna-kaikki?

--- a/src/cljs/harja/views/urakka/laadunseuranta/tarkastukset.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/tarkastukset.cljs
@@ -318,7 +318,10 @@
                         [napit/palvelinkutsu-nappi
                          "Tallenna tarkastus"
                          (fn []
-                           (tarkastukset/tallenna-tarkastus (:id @nav/valittu-urakka) tarkastus (:nakyma optiot)))
+                           (tarkastukset/tallenna-tarkastus
+                            (:id @nav/valittu-urakka)
+                            (lomake/ilman-lomaketietoja tarkastus)
+                            (:nakyma optiot)))
                          {:disabled (not (lomake/voi-tallentaa? tarkastus))
                           :kun-onnistuu (fn [tarkastus]
                                           (reset! tarkastukset/valittu-tarkastus nil)

--- a/src/cljs/harja/views/urakka/turvallisuuspoikkeamat.cljs
+++ b/src/cljs/harja/views/urakka/turvallisuuspoikkeamat.cljs
@@ -225,7 +225,7 @@
            :footer [:div
                     [napit/palvelinkutsu-nappi
                      "Tallenna turvallisuuspoikkeama"
-                     #(tiedot/tallenna-turvallisuuspoikkeama @turvallisuuspoikkeama)
+                     #(tiedot/tallenna-turvallisuuspoikkeama (lomake/ilman-lomaketietoja @turvallisuuspoikkeama))
                      {:luokka "nappi-ensisijainen"
                       :ikoni (ikonit/tallenna)
                       :kun-onnistuu #(do


### PR DESCRIPTION
Lomaketiedot sisältävät uusia ei-transit yhteensopivia tietoja. Lisäksi checkbox-group oletustoiminta, jos
alkutila on nil, ei toiminut.