### PR TITLE
HAR-5079 Ylläpidon aikataulun järjestys

### DIFF
--- a/src/clj/harja/palvelin/raportointi/raportit.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit.clj
@@ -44,7 +44,8 @@
     :urakkatyyppi #{:paallystys :paikkaus :tiemerkinta}}
 
    {:nimi :soratietarkastusraportti
-    :parametrit [{:tyyppi "aikavali", :konteksti nil, :pakollinen true, :nimi "Aikaväli"} {:tyyppi "tienumero", :konteksti nil, :pakollinen false, :nimi "Tienumero"}]
+    :parametrit [{:tyyppi "aikavali", :konteksti nil, :pakollinen true, :nimi "Aikaväli"}
+                 {:tyyppi "tienumero", :konteksti nil, :pakollinen false, :nimi "Tienumero"}]
     :konteksti #{"hallintayksikko" "koko maa" "urakka" "hankinta-alue"}
     :kuvaus "Soratietarkastusraportti"
     :suorita #'harja.palvelin.raportointi.raportit.soratietarkastus/suorita

--- a/src/clj/harja/palvelin/raportointi/raportit.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit.clj
@@ -269,7 +269,13 @@
     :urakkatyyppi #{:hoito}}
 
    {:nimi :yllapidon-aikataulu
-    :parametrit []
+    :parametrit [{:tyyppi :valinta
+                  :valinnat [:aika :kohdenumero :tr]
+                  :valinta-nayta {:aika "Aloitusajan mukaan"
+                                  :kohdenumero "Kohdenumeron mukaan"
+                                  :tr "Tieosoitteen mukaan"}
+                  :nimi :jarjestys
+                  :otsikko "Järjestä kohteet"}]
     :konteksti #{"urakka"}
     :suorita #'harja.palvelin.raportointi.raportit.yllapidon-aikataulu/suorita
     :kuvaus "Ylläpidon aikataulu"

--- a/src/clj/harja/palvelin/raportointi/raportit/yllapidon_aikataulu.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/yllapidon_aikataulu.clj
@@ -70,9 +70,14 @@
                    (hae %)
                    (get % nimi))))
 
-(defn suorita [db user parametrit]
+(defn suorita [db user {jarjestys :jarjestys :as parametrit}]
   (let [parametrit (parametrit-urakan-tiedoilla db parametrit)
         aikataulu (yllapitokohteet/hae-urakan-aikataulu db user parametrit)
+        aikataulu (if (or (nil? jarjestys) (= :aika jarjestys))
+                    aikataulu
+                    (sort-by (case jarjestys
+                               :kohdenumero :kohdenumero
+                               :tr tr/tieosoitteen-jarjestys) aikataulu))
         sarakkeet (kohdeluettelo-sarakkeet (:tyyppi parametrit))]
     [:raportti {:nimi "Ylläpidon aikataulu"
                 :orientaatio :landscape}

--- a/src/cljs/harja/tiedot/urakka/aikataulu.cljs
+++ b/src/cljs/harja/tiedot/urakka/aikataulu.cljs
@@ -1,6 +1,6 @@
 (ns harja.tiedot.urakka.aikataulu
   "Ylläpidon urakoiden aikataulu"
-  (:require [reagent.core :refer [atom]]
+  (:require [reagent.core :refer [atom] :as r]
             [harja.loki :refer [log logt tarkkaile!]]
             [cljs.core.async :refer [<!]]
             [harja.ui.protokollat :refer [Haku hae]]
@@ -27,6 +27,8 @@
    {:nayta-aikajana? true
     :jarjestys :aika}
    nil))
+
+(defonce nayta-aikajana? (r/cursor valinnat [:nayta-aikajana?]))
 
 (defn toggle-nayta-aikajana! []
   (swap! valinnat update :nayta-aikajana? not))

--- a/src/cljs/harja/ui/kentat.cljs
+++ b/src/cljs/harja/ui/kentat.cljs
@@ -9,6 +9,7 @@
             [harja.ui.tierekisteri :as tr]
             [harja.ui.yleiset :refer [linkki ajax-loader livi-pudotusvalikko nuolivalinta
                                       maarita-pudotusvalikon-suunta-ja-max-korkeus avautumissuunta-ja-korkeus-tyylit]]
+            [harja.ui.napit :as napit]
             [harja.loki :refer [log logt tarkkaile!]]
             [harja.tiedot.navigaatio :as nav]
             [clojure.string :as str]
@@ -1095,3 +1096,13 @@ toisen eventin kokonaan (react eventtiä ei laukea)."}
                                     (<= 0 (js/parseInt t) 23))
                            (reset! data (pvm/->Aika (js/parseInt t) 0 nil))))
              :value (or keskenerainen (fmt/aika aika))}]))
+
+(defmethod tee-kentta :toggle [{:keys [paalle-teksti pois-teksti toggle!]} data]
+  (assert (and paalle-teksti pois-teksti)
+          "Määrittele :paalle-teksti ja :pois-teksti kentät!")
+  (let [arvo-nyt @data]
+    [napit/yleinen (if arvo-nyt
+                     pois-teksti
+                     paalle-teksti)
+     (or toggle! #(swap! data not))
+     {:luokka "btn-xs"}]))

--- a/src/cljs/harja/views/raportit.cljs
+++ b/src/cljs/harja/views/raportit.cljs
@@ -26,7 +26,8 @@
             [harja.tiedot.hallintayksikot :as hy]
             [cljs-time.core :as t]
             [harja.fmt :as fmt]
-            [harja.ui.viesti :as viesti])
+            [harja.ui.viesti :as viesti]
+            [harja.ui.kentat :as kentat])
   (:require-macros [harja.atom :refer [reaction<! reaction-writable]]
                    [reagent.ratom :refer [reaction run!]]
                    [cljs.core.async.macros :refer [go]]))
@@ -429,7 +430,15 @@
                        valittu?])]))))]])))
 
 (defmethod raportin-parametri :default [p arvo]
-  [:span (pr-str p)])
+  (if (keyword? (:tyyppi p))
+    ;; Tehdään suoraan lomake kenttä annetuilla spekseillä
+    (let [nimi (:nimi p)]
+      [:div.label-ja-kentta
+       [:span (:otsikko p)]
+       [kentat/tee-kentta p (r/wrap (nimi @arvo)
+                                    #(swap! arvo merge {nimi %}))]])
+
+    [:span (pr-str p)]))
 
 ;; Tarkistaa raporttityypin mukaan voiko näillä parametreilla suorittaa
 (defmulti raportin-voi-suorittaa? (fn [raporttityyppi parametrit] (:nimi raporttityyppi)))

--- a/src/cljs/harja/views/urakka/aikataulu.cljs
+++ b/src/cljs/harja/views/urakka/aikataulu.cljs
@@ -159,14 +159,13 @@
      [valinnat/yllapitokohteen-kohdenumero yllapito-tiedot/kohdenumero]
      [valinnat/tienumero yllapito-tiedot/tienumero]
 
-     [:span.label-ja-kentta-puolikas
-      [:span.kentan-otsikko "Aikajana"]
-      [:div.kentta
-       [napit/yleinen (if aikajana?
-                        "Piilota aikajana"
-                        "Näytä aikajana")
-        tiedot/toggle-nayta-aikajana!
-        {:luokka "btn-xs"}]]]
+     [kentat/tee-otsikollinen-kentta
+      {:otsikko "Aikajana"
+       :kentta-params {:tyyppi :toggle
+                       :paalle-teksti "Näytä aikajana"
+                       :pois-teksti "Piilota aikajana"
+                       :toggle! tiedot/toggle-nayta-aikajana!}
+       :arvo-atom tiedot/nayta-aikajana?}]
 
      [yleiset/pudotusvalikko
       "Järjestä kohteet"

--- a/src/cljs/harja/views/urakka/aikataulu.cljs
+++ b/src/cljs/harja/views/urakka/aikataulu.cljs
@@ -178,7 +178,7 @@
       [:aika :kohdenumero :tr]]
 
      [upotettu-raportti/raportin-vientimuodot
-      (raportit/urakkaraportin-parametrit (:id ur) :yllapidon-aikataulu {})]]))
+      (raportit/urakkaraportin-parametrit (:id ur) :yllapidon-aikataulu {:jarjestys jarjestys})]]))
 
 (defn aikataulu
   [urakka optiot]

--- a/src/cljs/harja/views/urakka/aikataulu.cljs
+++ b/src/cljs/harja/views/urakka/aikataulu.cljs
@@ -28,7 +28,8 @@
             [harja.ui.aikajana :as aikajana]
             [harja.domain.aikataulu :as aikataulu]
             [harja.ui.upotettu-raportti :as upotettu-raportti]
-            [harja.tiedot.raportit :as raportit])
+            [harja.tiedot.raportit :as raportit]
+            [harja.ui.kentat :as kentat])
   (:require-macros [reagent.ratom :refer [reaction run!]]
                    [cljs.core.async.macros :refer [go]]))
 
@@ -148,6 +149,37 @@
     :epaonnistui-fn #(viesti/nayta! "Tallennus epäonnistui!"
                                     :warning
                                     viesti/viestin-nayttoaika-lyhyt)}))
+
+(defn valinnat [ur]
+  (let [{aikajana? :nayta-aikajana?
+         jarjestys :jarjestys
+         :as valinnat} @tiedot/valinnat]
+    [:span.aikataulu-valinnat
+     [valinnat/urakan-vuosi ur]
+     [valinnat/yllapitokohteen-kohdenumero yllapito-tiedot/kohdenumero]
+     [valinnat/tienumero yllapito-tiedot/tienumero]
+
+     [:span.label-ja-kentta-puolikas
+      [:span.kentan-otsikko "Aikajana"]
+      [:div.kentta
+       [napit/yleinen (if aikajana?
+                        "Piilota aikajana"
+                        "Näytä aikajana")
+        tiedot/toggle-nayta-aikajana!
+        {:luokka "btn-xs"}]]]
+
+     [yleiset/pudotusvalikko
+      "Järjestä kohteet"
+      {:valinta jarjestys
+       :valitse-fn tiedot/jarjesta-kohteet!
+       :format-fn  {:aika "Aloistusajan mukaan"
+                    :kohdenumero "Kohdenumeron mukaan"
+                    :tr "Tieosoitteen mukaan"}}
+      [:aika :kohdenumero :tr]]
+
+     [upotettu-raportti/raportin-vientimuodot
+      (raportit/urakkaraportin-parametrit (:id ur) :yllapidon-aikataulu {})]]))
+
 (defn aikataulu
   [urakka optiot]
   (komp/luo
@@ -161,30 +193,22 @@
             {:keys [voi-tallentaa? saa-muokata?
                     saa-asettaa-valmis-takarajan?
                     saa-merkita-valmiiksi?]} (oikeudet urakka-id)
-            otsikoidut-aikataulurivit (otsikoi-aikataulurivit
-                                       (tiedot/aikataulurivit-valmiuden-mukaan aikataulurivit urakkatyyppi))
+
+
+            otsikoidut-aikataulurivit (if (= :aika (:jarjestys @tiedot/valinnat))
+                                        (otsikoi-aikataulurivit
+                                         (tiedot/aikataulurivit-valmiuden-mukaan aikataulurivit urakkatyyppi))
+                                        aikataulurivit)
+
             voi-muokata-paallystys? #(and (= (:nakyma optiot) :paallystys)
                                           saa-muokata?)
             voi-muokata-tiemerkinta? #(and (= (:nakyma optiot) :tiemerkinta)
                                            saa-merkita-valmiiksi?
                                            (:valmis-tiemerkintaan %))
-            aikajana? @tiedot/nayta-aikajana?]
+            aikajana? (:nayta-aikajana? @tiedot/valinnat)]
         [:div.aikataulu
-         [valinnat/urakan-vuosi ur]
-         [valinnat/yllapitokohteen-kohdenumero yllapito-tiedot/kohdenumero]
-         [valinnat/tienumero yllapito-tiedot/tienumero]
 
-         [:span.label-ja-kentta-puolikas
-          [:span.kentan-otsikko "Aikajana"]
-          [:div.kentta
-           [napit/yleinen (if aikajana?
-                            "Piilota aikajana"
-                            "Näytä aikajana")
-            #(swap! tiedot/nayta-aikajana? not)
-            {:luokka "btn-xs"}]]]
-
-         [upotettu-raportti/raportin-vientimuodot
-          (raportit/urakkaraportin-parametrit urakka-id :yllapidon-aikataulu {})]
+         [valinnat ur]
 
          (when aikajana?
            [aikajana/aikajana

--- a/src/cljs/harja/views/urakka/aikataulu.cljs
+++ b/src/cljs/harja/views/urakka/aikataulu.cljs
@@ -164,7 +164,7 @@
             otsikoidut-aikataulurivit (otsikoi-aikataulurivit
                                        (tiedot/aikataulurivit-valmiuden-mukaan aikataulurivit urakkatyyppi))
             voi-muokata-paallystys? #(and (= (:nakyma optiot) :paallystys)
-                                          (constantly saa-muokata?))
+                                          saa-muokata?)
             voi-muokata-tiemerkinta? #(and (= (:nakyma optiot) :tiemerkinta)
                                            saa-merkita-valmiiksi?
                                            (:valmis-tiemerkintaan %))

--- a/src/shared-cljc/harja/domain/tierekisteri.cljc
+++ b/src/shared-cljc/harja/domain/tierekisteri.cljc
@@ -190,7 +190,7 @@
                    (str " / " loppuosa " / " loppuetaisyys)))
             ei-tierekisteriosoitetta)))))
 
-(defn- tieosoitteen-jarjestys
+(defn tieosoitteen-jarjestys
   "Palauttaa vectorin TR-osoitteen tiedoista. Voidaan käyttää järjestämään tieosoitteet järjestykseen."
   [kohde]
   ((juxt :tie :tr-numero :tienumero


### PR DESCRIPTION
**Korjaa HAR-5154**

**Lisää valinnat atom**
Valinnoissa on samassa sekä aikajana että valittu järjestys

**Tee osoitteen sort avain funktiosta julkinen**

**Muuta valinnat omaan komponenttiin**
Lisää valintoihin alasvetona järjestyksen vaihtao.

**Salli tee-kentta määritys raportin parametriksi**
Jos parametrin nimi on keyword, tehdään siitä suoraan
kentat/tee-kentta funktiolla lomakekenttä.

**Lisää :jarjestys raporttiparametri**

**Rivitä paremmin**

**Tee järjestys kuten frontilla**