### PR TITLE
HAR-5317 Korjaa tietyöilmoituksen avaus ylläpitokohteelle

### DIFF
--- a/src/clj/harja/kyselyt/tietyoilmoitukset.clj
+++ b/src/clj/harja/kyselyt/tietyoilmoitukset.clj
@@ -214,8 +214,8 @@
                                  {::t/id op/not-null?})
                                {::t/urakka-id
                                 (if urakattomat?
-                                  (op/or op/null? (op/in urakat))
-                                  (op/in urakat))})))]
+                                  (op/or op/null? (op/in (map :id urakat)))
+                                  (op/in (map :id urakat)))})))]
     ilmoitukset))
 
 (defn hae-ilmoitukset-tilannekuvaan [db {:keys [nykytilanne?

--- a/src/clj/harja/kyselyt/tietyoilmoitukset.clj
+++ b/src/clj/harja/kyselyt/tietyoilmoitukset.clj
@@ -196,6 +196,7 @@
                                   organisaatio
                                   kayttaja-id
                                   sijainti]}]
+
   (let [ilmoitukset (fetch db ::t/ilmoitus kaikki-ilmoituksen-kentat-ja-tyovaiheet
                            (op/and
                              (merge {::t/paatietyoilmoitus op/null?}
@@ -214,8 +215,8 @@
                                  {::t/id op/not-null?})
                                {::t/urakka-id
                                 (if urakattomat?
-                                  (op/or op/null? (op/in (map :id urakat)))
-                                  (op/in (map :id urakat)))})))]
+                                  (op/or op/null? (op/in urakat))
+                                  (op/in urakat))})))]
     ilmoitukset))
 
 (defn hae-ilmoitukset-tilannekuvaan [db {:keys [nykytilanne?

--- a/src/clj/harja/palvelin/palvelut/tietyoilmoitukset.clj
+++ b/src/clj/harja/palvelin/palvelut/tietyoilmoitukset.clj
@@ -62,7 +62,7 @@
                           :kaynnissa-alku kaynnissa-alku
                           :kaynnissa-loppu kaynnissa-loppu
                           :urakat (if urakka
-                                    [urakka]
+                                    #{(:id urakka)}
                                     kayttajan-urakat)
                           :urakattomat? (nil? urakka)
                           :luojaid (when vain-kayttajan-luomat (:id user))

--- a/src/cljs/harja/tiedot/urakka/siirtymat.cljs
+++ b/src/cljs/harja/tiedot/urakka/siirtymat.cljs
@@ -120,6 +120,6 @@
   "Navigoi joko luomaan uutta tietyöilmoitusta tai avaa annetun tietyöilmoituksen näkymässä"
   [{:keys [tietyoilmoitus-id] :as yllapitokohde}]
   (go
-    (nav/aseta-valittu-valilehti! :sivu :ilmoitukset)
     (nav/aseta-valittu-valilehti! :ilmoitukset :tietyo)
+    (nav/aseta-valittu-valilehti! :sivu :ilmoitukset)
     (tietyoilmoitukset/avaa-tietyoilmoitus tietyoilmoitus-id yllapitokohde)))

--- a/src/cljs/harja/views/ilmoitukset/tietyoilmoituslomake.cljs
+++ b/src/cljs/harja/views/ilmoitukset/tietyoilmoituslomake.cljs
@@ -485,6 +485,7 @@
                      :nimi ::t/vaikutussuunta
                      :valinnat (into [nil] (keys t/vaikutussuunta-vaihtoehdot-map))
                      :valinta-nayta #(or (t/vaikutussuunta-vaihtoehdot-map %) "- Valitse -")
+                     :pakollinen? true
                      :validoi [[:ei-tyhja]]})
       (lomake/ryhma "Muuta"
                     {:otsikko "Lisätietoja"


### PR DESCRIPTION
Korjaa uuden tietyöilmoituksen luomisen ja avaamisen ylläpito kohteelle aikataulunäkymästä. Samalla merkitty pakolliseksi vaikutussuunta.