### PR TITLE
Hanskaa puuttuva pois-kytketyt-ominaisuudet asetuksissa

### DIFF
--- a/src/clj/harja/palvelin/palvelut/pois_kytketyt_ominaisuudet.clj
+++ b/src/clj/harja/palvelin/palvelut/pois_kytketyt_ominaisuudet.clj
@@ -20,7 +20,7 @@
 (defrecord PoisKytketytOminaisuudet [pois-kytketyt-ominaisuudet-joukko]
   component/Lifecycle
   (start [this]
-    (reset! pois-kytketyt-ominaisuudet pois-kytketyt-ominaisuudet-joukko)
+    (reset! pois-kytketyt-ominaisuudet (or pois-kytketyt-ominaisuudet-joukko #{}))
     (let [http (:http-palvelin this)]
       (julkaise-palvelu http :pois-kytketyt-ominaisuudet
                         (fn [user tiedot]


### PR DESCRIPTION
Jos asetuksissa ei määritellä pois kytkettyjä ominaisuuksia, pidetään kaikki päällä