### PR TITLE
HAR-5761 Korjaa tti PDF tulostus

### DIFF
--- a/src/clj/harja/kyselyt/tietyoilmoitukset.clj
+++ b/src/clj/harja/kyselyt/tietyoilmoitukset.clj
@@ -9,7 +9,8 @@
             [clojure.spec.alpha :as s]
             [harja.kyselyt.specql :as specql]
             [harja.domain.muokkaustiedot :as m]
-            [clojure.future :refer :all]))
+            [clojure.future :refer :all]
+            [clojure.set :as set]))
 
 (defqueries "harja/kyselyt/tietyoilmoitukset.sql")
 
@@ -62,60 +63,63 @@
 (s/def ::t/max-pituus number?)
 (s/def ::t/max-leveys number?)
 
+(def tloik-integraatio-kentat
+  #{::t/lahetetty ::t/tila})
+
 (def kaikki-ilmoituksen-kentat
-  #{::t/id
-    ::t/tloik-id
-    ::t/paatietyoilmoitus
-    ::t/tloik-paatietyoilmoitus-id
-    ::m/luotu
-    ::m/luoja-id
-    ::m/muokattu
-    ::m/muokkaaja-id
-    ::m/poistettu
-    ::m/poistaja-id
-    ::t/ilmoittaja-id
-    ::t/ilmoittaja
-    ::t/urakka-id
-    ::t/urakan-nimi
-    ::t/urakkatyyppi
-    ::t/urakoitsijan-nimi
-    ::t/urakoitsijan-ytunnus
-    ::t/urakoitsijayhteyshenkilo-id
-    ::t/urakoitsijayhteyshenkilo
-    ::t/tilaaja-id
-    ::t/tilaajan-nimi
-    ::t/tilaajayhteyshenkilo-id
-    ::t/tilaajayhteyshenkilo
-    ::t/tyotyypit
-    ::t/luvan-diaarinumero
-    ::t/osoite
-    ::t/tien-nimi
-    ::t/kunnat
-    ::t/alkusijainnin-kuvaus
-    ::t/loppusijainnin-kuvaus
-    ::t/alku
-    ::t/loppu
-    ::t/tyoajat
-    ::t/vaikutussuunta
-    ::t/kaistajarjestelyt
-    ::t/nopeusrajoitukset
-    ::t/tienpinnat
-    ::t/kiertotien-pituus
-    ::t/kiertotien-mutkaisuus
-    ::t/kiertotienpinnat
-    ::t/liikenteenohjaus
-    ::t/liikenteenohjaaja
-    ::t/viivastys-normaali-liikenteessa
-    ::t/viivastys-ruuhka-aikana
-    ::t/ajoneuvorajoitukset
-    ::t/huomautukset
-    ::t/ajoittaiset-pysaytykset
-    ::t/ajoittain-suljettu-tie
-    ::t/pysaytysten-alku
-    ::t/pysaytysten-loppu
-    ::t/lisatietoja
-    ::t/lahetetty
-    ::t/tila})
+  (into
+   tloik-integraatio-kentat
+   #{::t/id
+     ::t/tloik-id
+     ::t/paatietyoilmoitus
+     ::t/tloik-paatietyoilmoitus-id
+     ::m/luotu
+     ::m/luoja-id
+     ::m/muokattu
+     ::m/muokkaaja-id
+     ::m/poistettu
+     ::m/poistaja-id
+     ::t/ilmoittaja-id
+     ::t/ilmoittaja
+     ::t/urakka-id
+     ::t/urakan-nimi
+     ::t/urakkatyyppi
+     ::t/urakoitsijan-nimi
+     ::t/urakoitsijan-ytunnus
+     ::t/urakoitsijayhteyshenkilo-id
+     ::t/urakoitsijayhteyshenkilo
+     ::t/tilaaja-id
+     ::t/tilaajan-nimi
+     ::t/tilaajayhteyshenkilo-id
+     ::t/tilaajayhteyshenkilo
+     ::t/tyotyypit
+     ::t/luvan-diaarinumero
+     ::t/osoite
+     ::t/tien-nimi
+     ::t/kunnat
+     ::t/alkusijainnin-kuvaus
+     ::t/loppusijainnin-kuvaus
+     ::t/alku
+     ::t/loppu
+     ::t/tyoajat
+     ::t/vaikutussuunta
+     ::t/kaistajarjestelyt
+     ::t/nopeusrajoitukset
+     ::t/tienpinnat
+     ::t/kiertotien-pituus
+     ::t/kiertotien-mutkaisuus
+     ::t/kiertotienpinnat
+     ::t/liikenteenohjaus
+     ::t/liikenteenohjaaja
+     ::t/viivastys-normaali-liikenteessa
+     ::t/viivastys-ruuhka-aikana
+     ::t/ajoneuvorajoitukset
+     ::t/huomautukset
+     ::t/ajoittaiset-pysaytykset
+     ::t/ajoittain-suljettu-tie
+     ::t/pysaytysten-alku
+     ::t/pysaytysten-loppu
+     ::t/lisatietoja}))
 
 ;; Hakee pääilmoituksen kaikki kentät, sekä siihen liittyvät työvaiheet
 (def kaikki-ilmoituksen-kentat-ja-tyovaiheet
@@ -123,9 +127,10 @@
         [::t/tyovaiheet kaikki-ilmoituksen-kentat]))
 
 (def ilmoitus-pdf-kentat
-  (conj kaikki-ilmoituksen-kentat
-        ::t/pituus
-        [::t/paailmoitus (conj kaikki-ilmoituksen-kentat ::t/pituus)]))
+  (let [pdf-kentat (set/difference kaikki-ilmoituksen-kentat tloik-integraatio-kentat)]
+    (conj pdf-kentat
+          ::t/pituus
+          [::t/paailmoitus (conj pdf-kentat ::t/pituus)])))
 
 (def ilmoituslomakkeen-kentat
   #{[::t/paailmoitus #{::t/urakan-nimi ::t/urakoitsijayhteyshenkilo ::t/tilaajayhteyshenkilo

--- a/tietokanta/devdb_migrate_only.sh
+++ b/tietokanta/devdb_migrate_only.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "Ajetaan migraatiot harja-kantaan"
+
+until mvn flyway:info &> /dev/null; do
+    echo "Odotetaan että flyway saa yhteyden kantaan..."
+    sleep 0.5
+done
+
+echo "Yhteys saatu!"
+mvn flyway:migrate
+

--- a/tietokanta/src/main/resources/db/migration/R__Tietyoilmoitukset.sql
+++ b/tietokanta/src/main/resources/db/migration/R__Tietyoilmoitukset.sql
@@ -3,6 +3,7 @@
 -- pituuden tierekisteriosoitteen perusteella
 DROP VIEW IF EXISTS tietyoilmoitus_pituus;
 
+
 CREATE VIEW tietyoilmoitus_pituus AS
   SELECT tti.*, CASE
                   WHEN (tti.osoite).losa IS NOT NULL THEN
@@ -14,3 +15,5 @@ CREATE VIEW tietyoilmoitus_pituus AS
                      0
                   END
                 AS pituus FROM tietyoilmoitus tti;
+
+-- 27.7.2017 muutettu, jotta tti view päivittyy


### PR DESCRIPTION
Uudet kentät olivat aiheuttaneet ongelmia, koska niitä ei löydy viewistä.
Pakotettu R migraatio päivittymään muuttamalla sitä ja poistettu integraation
tila ja lähtettty kentät PDF tulostusta varten tehtävästä hausta.