### PR TITLE
HAR-5772 Poista liian tiukka työajan validointi

### DIFF
--- a/src/clj/harja/palvelin/palvelut/tietyoilmoitukset/pdf.clj
+++ b/src/clj/harja/palvelin/palvelut/tietyoilmoitukset/pdf.clj
@@ -173,10 +173,14 @@
       (tieto "Työvaiheen pituus"
              (pituus ilm))])))
 
+(def viikonpaivan-jarjestys
+  {"maanantai" 1 "tiistai" 2 "keskiviikko" 3 "torstai" 4 "perjantai" 5
+   "lauantai" 6 "sunnuntai" 7})
+
 (defn- tyoaika [{tyoajat ::t/tyoajat}]
   [:fo:block
    (for [ta tyoajat]
-     [:fo:block (str/join ", " (::t/paivat ta)) ": "
+     [:fo:block (str/join ", " (sort-by viikonpaivan-jarjestys (::t/paivat ta))) ": "
       (str (::t/alkuaika ta)) " \u2013 " (str (::t/loppuaika ta))])])
 
 

--- a/src/cljs/harja/views/ilmoitukset/tietyoilmoituslomake.cljs
+++ b/src/cljs/harja/views/ilmoitukset/tietyoilmoituslomake.cljs
@@ -160,7 +160,6 @@
     :leveys 1}
    {:otsikko "Loppuaika" :tyyppi :aika :placeholder "esim. 18:00"
     :nimi ::t/loppuaika
-    :validoi [[:aika-jalkeen ::t/alkuaika "Loppuajan tulee olla alkuajan jälkeen"]]
     :leveys 1}])
 
 (def aikataulu-grid-optiot {:otsikko ""

--- a/test/clj/harja/palvelin/palvelut/tietyoilmoitukset_test.clj
+++ b/test/clj/harja/palvelin/palvelut/tietyoilmoitukset_test.clj
@@ -244,7 +244,7 @@
                             "Ylihärmä, Hakola"
                             "11.05.2017"
                             "2686,0 m"
-                            "Työaika tiistai, maanantai, perjantai, keskiviikko, torstai: 06:00 – 22:00"]]
+                            "Työaika maanantai, tiistai, keskiviikko, torstai, perjantai: 06:00 – 22:00"]]
               (is (str/includes? text teksti)))))))))
 
 ;; TODO Lisää testit:


### PR DESCRIPTION
Vanhalla paperilomakkeella voi merkitä helposti yön ajan
olevia työaikoja (esim. 21:00 - 06:00). Meidän lomake rajoitti tätä turhaan. Poistettu validointisääntö.

Drive by korjauksena päivien järjestys PDF-tiedoissa.