### PR TITLE
HAR-5789 Hae vain ylläpitokohdeosat, jotka osuvat alueeseen ja karkeista

### DIFF
--- a/src/clj/harja/kyselyt/tilannekuva.sql
+++ b/src/clj/harja/kyselyt/tilannekuva.sql
@@ -264,7 +264,11 @@ SELECT
   ypka.tiemerkinta_loppu AS "tiemerkinta-loppupvm",
   ypka.kohde_valmis AS "kohde-valmispvm",
   o.nimi                                AS "urakoitsija",
-  u.nimi AS "urakka"
+  u.nimi AS "urakka",
+  (SELECT array_agg(ST_Simplify(ypko.sijainti,:toleranssi)) FROM yllapitokohdeosa ypko
+    WHERE ypko.yllapitokohde=ypk.id
+      AND ST_Intersects(ST_MakeEnvelope(:xmin, :ymin, :xmax, :ymax), ypko.sijainti)
+      AND ypko.poistettu IS NOT TRUE) AS "osien-geometriat"
 FROM yllapitokohde ypk
   LEFT JOIN paallystysilmoitus pi ON pi.paallystyskohde = ypk.id
                                      AND pi.poistettu IS NOT TRUE
@@ -314,7 +318,11 @@ SELECT
   ypka.tiemerkinta_loppu AS "tiemerkinta-loppupvm",
   ypka.kohde_valmis AS "kohde-valmispvm",
   o.nimi                                AS "urakoitsija",
-  u.nimi AS "urakka"
+  u.nimi AS "urakka",
+  (SELECT array_agg(ST_Simplify(ypko.sijainti,:toleranssi)) FROM yllapitokohdeosa ypko
+    WHERE ypko.yllapitokohde=ypk.id
+      AND ST_Intersects(ST_MakeEnvelope(:xmin, :ymin, :xmax, :ymax), ypko.sijainti)
+      AND ypko.poistettu IS NOT TRUE) AS "osien-geometriat"
 FROM yllapitokohde ypk
   LEFT JOIN paallystysilmoitus pi ON pi.paallystyskohde = ypk.id
                                      AND pi.poistettu IS NOT TRUE
@@ -364,7 +372,11 @@ SELECT
   ypka.tiemerkinta_loppu AS "tiemerkinta-loppupvm",
   ypka.kohde_valmis AS "kohde-valmispvm",
   o.nimi                                AS "urakoitsija",
-  u.nimi AS "urakka"
+  u.nimi AS "urakka",
+  (SELECT array_agg(ST_Simplify(ypko.sijainti,:toleranssi)) FROM yllapitokohdeosa ypko
+    WHERE ypko.yllapitokohde=ypk.id
+      AND ST_Intersects(ST_MakeEnvelope(:xmin, :ymin, :xmax, :ymax), ypko.sijainti)
+      AND ypko.poistettu IS NOT TRUE) AS "osien-geometriat"
 FROM yllapitokohde ypk
   LEFT JOIN paallystysilmoitus pi ON pi.paallystyskohde = ypk.id
                                      AND pi.poistettu IS NOT TRUE
@@ -414,7 +426,11 @@ SELECT
   ypka.tiemerkinta_loppu AS "tiemerkinta-loppupvm",
   ypka.kohde_valmis AS "kohde-valmispvm",
   o.nimi                                AS "urakoitsija",
-  u.nimi AS "urakka"
+  u.nimi AS "urakka",
+  (SELECT array_agg(ST_Simplify(ypko.sijainti,:toleranssi)) FROM yllapitokohdeosa ypko
+    WHERE ypko.yllapitokohde=ypk.id
+      AND ST_Intersects(ST_MakeEnvelope(:xmin, :ymin, :xmax, :ymax), ypko.sijainti)
+      AND ypko.poistettu IS NOT TRUE) AS "osien-geometriat"
 FROM yllapitokohde ypk
   LEFT JOIN paallystysilmoitus pi ON pi.paallystyskohde = ypk.id
                                      AND pi.poistettu IS NOT TRUE

--- a/src/clj/harja/kyselyt/tilannekuva.sql
+++ b/src/clj/harja/kyselyt/tilannekuva.sql
@@ -264,11 +264,7 @@ SELECT
   ypka.tiemerkinta_loppu AS "tiemerkinta-loppupvm",
   ypka.kohde_valmis AS "kohde-valmispvm",
   o.nimi                                AS "urakoitsija",
-  u.nimi AS "urakka",
-  (SELECT array_agg(ST_Simplify(ypko.sijainti,:toleranssi)) FROM yllapitokohdeosa ypko
-    WHERE ypko.yllapitokohde=ypk.id
-      AND ST_Intersects(ST_MakeEnvelope(:xmin, :ymin, :xmax, :ymax), ypko.sijainti)
-      AND ypko.poistettu IS NOT TRUE) AS "osien-geometriat"
+  u.nimi AS "urakka"
 FROM yllapitokohde ypk
   LEFT JOIN paallystysilmoitus pi ON pi.paallystyskohde = ypk.id
                                      AND pi.poistettu IS NOT TRUE
@@ -318,11 +314,7 @@ SELECT
   ypka.tiemerkinta_loppu AS "tiemerkinta-loppupvm",
   ypka.kohde_valmis AS "kohde-valmispvm",
   o.nimi                                AS "urakoitsija",
-  u.nimi AS "urakka",
-  (SELECT array_agg(ST_Simplify(ypko.sijainti,:toleranssi)) FROM yllapitokohdeosa ypko
-    WHERE ypko.yllapitokohde=ypk.id
-      AND ST_Intersects(ST_MakeEnvelope(:xmin, :ymin, :xmax, :ymax), ypko.sijainti)
-      AND ypko.poistettu IS NOT TRUE) AS "osien-geometriat"
+  u.nimi AS "urakka"
 FROM yllapitokohde ypk
   LEFT JOIN paallystysilmoitus pi ON pi.paallystyskohde = ypk.id
                                      AND pi.poistettu IS NOT TRUE
@@ -372,11 +364,7 @@ SELECT
   ypka.tiemerkinta_loppu AS "tiemerkinta-loppupvm",
   ypka.kohde_valmis AS "kohde-valmispvm",
   o.nimi                                AS "urakoitsija",
-  u.nimi AS "urakka",
-  (SELECT array_agg(ST_Simplify(ypko.sijainti,:toleranssi)) FROM yllapitokohdeosa ypko
-    WHERE ypko.yllapitokohde=ypk.id
-      AND ST_Intersects(ST_MakeEnvelope(:xmin, :ymin, :xmax, :ymax), ypko.sijainti)
-      AND ypko.poistettu IS NOT TRUE) AS "osien-geometriat"
+  u.nimi AS "urakka"
 FROM yllapitokohde ypk
   LEFT JOIN paallystysilmoitus pi ON pi.paallystyskohde = ypk.id
                                      AND pi.poistettu IS NOT TRUE
@@ -426,11 +414,7 @@ SELECT
   ypka.tiemerkinta_loppu AS "tiemerkinta-loppupvm",
   ypka.kohde_valmis AS "kohde-valmispvm",
   o.nimi                                AS "urakoitsija",
-  u.nimi AS "urakka",
-  (SELECT array_agg(ST_Simplify(ypko.sijainti,:toleranssi)) FROM yllapitokohdeosa ypko
-    WHERE ypko.yllapitokohde=ypk.id
-      AND ST_Intersects(ST_MakeEnvelope(:xmin, :ymin, :xmax, :ymax), ypko.sijainti)
-      AND ypko.poistettu IS NOT TRUE) AS "osien-geometriat"
+  u.nimi AS "urakka"
 FROM yllapitokohde ypk
   LEFT JOIN paallystysilmoitus pi ON pi.paallystyskohde = ypk.id
                                      AND pi.poistettu IS NOT TRUE

--- a/src/clj/harja/kyselyt/yllapitokohteet.clj
+++ b/src/clj/harja/kyselyt/yllapitokohteet.clj
@@ -12,19 +12,13 @@
 (def kohdeosa-xf (geo/muunna-pg-tulokset :sijainti))
 
 (defn liita-kohdeosat-kohteisiin
-  ([db kohteet kohde-id-avain]
-   (liita-kohdeosat-kohteisiin db kohteet kohde-id-avain nil))
-  ([db kohteet kohde-id-avain {:keys [alue toleranssi]}]
-   (let [idt (map kohde-id-avain kohteet)
-         kohdeosat (into []
-                         kohdeosa-xf
-                         (if alue
-                           (hae-urakan-yllapitokohteiden-yllapitokohdeosat-alueelle
-                            db (merge alue {:idt idt :toleranssi toleranssi}))
-                           (hae-urakan-yllapitokohteiden-yllapitokohdeosat
-                            db {:idt (map kohde-id-avain kohteet)})))]
-     (mapv
-      (fn [kohde]
-        (let [kohteen-kohdeosat (filterv #(= (:yllapitokohde-id %) (kohde-id-avain kohde)) kohdeosat)]
-          (assoc kohde :kohdeosat kohteen-kohdeosat)))
-      kohteet))))
+  [db kohteet kohde-id-avain]
+  (let [kohdeosat (into []
+                        kohdeosa-xf
+                        (hae-urakan-yllapitokohteiden-yllapitokohdeosat
+                         db {:idt (map kohde-id-avain kohteet)}))]
+    (mapv
+     (fn [kohde]
+       (let [kohteen-kohdeosat (filterv #(= (:yllapitokohde-id %) (kohde-id-avain kohde)) kohdeosat)]
+         (assoc kohde :kohdeosat kohteen-kohdeosat)))
+     kohteet)))

--- a/src/clj/harja/kyselyt/yllapitokohteet.clj
+++ b/src/clj/harja/kyselyt/yllapitokohteet.clj
@@ -12,13 +12,19 @@
 (def kohdeosa-xf (geo/muunna-pg-tulokset :sijainti))
 
 (defn liita-kohdeosat-kohteisiin
-  [db kohteet kohde-id-avain]
-  (let [kohdeosat (into []
-                        kohdeosa-xf
-                        (hae-urakan-yllapitokohteiden-yllapitokohdeosat
-                         db {:idt (map kohde-id-avain kohteet)}))]
-    (mapv
-     (fn [kohde]
-       (let [kohteen-kohdeosat (filterv #(= (:yllapitokohde-id %) (kohde-id-avain kohde)) kohdeosat)]
-         (assoc kohde :kohdeosat kohteen-kohdeosat)))
-     kohteet)))
+  ([db kohteet kohde-id-avain]
+   (liita-kohdeosat-kohteisiin db kohteet kohde-id-avain nil))
+  ([db kohteet kohde-id-avain {:keys [alue toleranssi]}]
+   (let [idt (map kohde-id-avain kohteet)
+         kohdeosat (into []
+                         kohdeosa-xf
+                         (if alue
+                           (hae-urakan-yllapitokohteiden-yllapitokohdeosat-alueelle
+                            db (merge alue {:idt idt :toleranssi toleranssi}))
+                           (hae-urakan-yllapitokohteiden-yllapitokohdeosat
+                            db {:idt idt})))]
+     (mapv
+      (fn [kohde]
+        (let [kohteen-kohdeosat (filterv #(= (:yllapitokohde-id %) (kohde-id-avain kohde)) kohdeosat)]
+          (assoc kohde :kohdeosat kohteen-kohdeosat)))
+      kohteet))))

--- a/src/clj/harja/kyselyt/yllapitokohteet.clj
+++ b/src/clj/harja/kyselyt/yllapitokohteet.clj
@@ -11,13 +11,20 @@
 
 (def kohdeosa-xf (geo/muunna-pg-tulokset :sijainti))
 
-(defn liita-kohdeosat-kohteisiin [db kohteet kohde-id-avain]
-  (let [kohdeosat (into []
-                        kohdeosa-xf
-                        (hae-urakan-yllapitokohteiden-yllapitokohdeosat
-                          db {:idt (map kohde-id-avain kohteet)}))]
-    (mapv
+(defn liita-kohdeosat-kohteisiin
+  ([db kohteet kohde-id-avain]
+   (liita-kohdeosat-kohteisiin db kohteet kohde-id-avain nil))
+  ([db kohteet kohde-id-avain {:keys [alue toleranssi]}]
+   (let [idt (map kohde-id-avain kohteet)
+         kohdeosat (into []
+                         kohdeosa-xf
+                         (if alue
+                           (hae-urakan-yllapitokohteiden-yllapitokohdeosat-alueelle
+                            db (merge alue {:idt idt :toleranssi toleranssi}))
+                           (hae-urakan-yllapitokohteiden-yllapitokohdeosat
+                            db {:idt (map kohde-id-avain kohteet)})))]
+     (mapv
       (fn [kohde]
         (let [kohteen-kohdeosat (filterv #(= (:yllapitokohde-id %) (kohde-id-avain kohde)) kohdeosat)]
           (assoc kohde :kohdeosat kohteen-kohdeosat)))
-      kohteet)))
+      kohteet))))

--- a/src/clj/harja/kyselyt/yllapitokohteet.sql
+++ b/src/clj/harja/kyselyt/yllapitokohteet.sql
@@ -326,6 +326,33 @@ FROM yllapitokohdeosa ypko
 WHERE yllapitokohde IN (:idt)
       AND ypko.poistettu IS NOT TRUE;
 
+-- name: hae-urakan-yllapitokohteiden-yllapitokohdeosat-alueelle
+-- Hakee urakan ylläpitokohdeosat ylläpitokohteen id:llä.
+SELECT
+  ypko.id,
+  ypk.id                AS "yllapitokohde-id",
+  ypko.nimi,
+  ypko.tunnus,
+  ypko.tr_numero        AS "tr-numero",
+  ypko.tr_alkuosa       AS "tr-alkuosa",
+  ypko.tr_alkuetaisyys  AS "tr-alkuetaisyys",
+  ypko.tr_loppuosa      AS "tr-loppuosa",
+  ypko.tr_loppuetaisyys AS "tr-loppuetaisyys",
+  ypko.tr_ajorata       AS "tr-ajorata",
+  ypko.tr_kaista        AS "tr-kaista",
+  paallystetyyppi,
+  raekoko,
+  tyomenetelma,
+  massamaara            AS "massamaara",
+  toimenpide,
+  ST_Simplify(sijainti, :toleranssi) AS sijainti
+FROM yllapitokohdeosa ypko
+  JOIN yllapitokohde ypk ON ypko.yllapitokohde = ypk.id
+                            AND ypk.poistettu IS NOT TRUE
+WHERE yllapitokohde IN (:idt)
+      AND ypko.poistettu IS NOT TRUE
+      AND ST_Intersects(ST_MakeEnvelope(:xmin, :ymin, :xmax, :ymax), ypko.sijainti);
+
 -- name: luo-yllapitokohde<!
 -- Luo uuden ylläpitokohteen
 INSERT INTO yllapitokohde (urakka, sopimus, kohdenumero, nimi,

--- a/src/clj/harja/kyselyt/yllapitokohteet.sql
+++ b/src/clj/harja/kyselyt/yllapitokohteet.sql
@@ -326,33 +326,6 @@ FROM yllapitokohdeosa ypko
 WHERE yllapitokohde IN (:idt)
       AND ypko.poistettu IS NOT TRUE;
 
--- name: hae-urakan-yllapitokohteiden-yllapitokohdeosat-alueelle
--- Hakee urakan ylläpitokohdeosat ylläpitokohteen id:llä.
-SELECT
-  ypko.id,
-  ypk.id                AS "yllapitokohde-id",
-  ypko.nimi,
-  ypko.tunnus,
-  ypko.tr_numero        AS "tr-numero",
-  ypko.tr_alkuosa       AS "tr-alkuosa",
-  ypko.tr_alkuetaisyys  AS "tr-alkuetaisyys",
-  ypko.tr_loppuosa      AS "tr-loppuosa",
-  ypko.tr_loppuetaisyys AS "tr-loppuetaisyys",
-  ypko.tr_ajorata       AS "tr-ajorata",
-  ypko.tr_kaista        AS "tr-kaista",
-  paallystetyyppi,
-  raekoko,
-  tyomenetelma,
-  massamaara            AS "massamaara",
-  toimenpide,
-  ST_Simplify(sijainti, :toleranssi) AS sijainti
-FROM yllapitokohdeosa ypko
-  JOIN yllapitokohde ypk ON ypko.yllapitokohde = ypk.id
-                            AND ypk.poistettu IS NOT TRUE
-WHERE yllapitokohde IN (:idt)
-      AND ypko.poistettu IS NOT TRUE
-      AND ST_Intersects(ST_MakeEnvelope(:xmin, :ymin, :xmax, :ymax), ypko.sijainti);
-
 -- name: luo-yllapitokohde<!
 -- Luo uuden ylläpitokohteen
 INSERT INTO yllapitokohde (urakka, sopimus, kohdenumero, nimi,

--- a/src/clj/harja/palvelin/palvelut/tilannekuva.clj
+++ b/src/clj/harja/palvelin/palvelut/tilannekuva.clj
@@ -165,9 +165,7 @@
     (when (tk/valittu? yllapito (case tyyppi
                                   "paallystys" tk/paallystys
                                   "paikkaus" tk/paikkaus))
-      (let [params (merge alue
-                          {:toleranssi toleranssi})
-            vastaus (into []
+      (let [vastaus (into []
                           (comp
                             (map konv/alaviiva->rakenne)
                             (map #(assoc % :tila (yllapitokohteet-domain/yllapitokohteen-tarkka-tila %)))
@@ -177,17 +175,15 @@
                             (map #(konv/string-polusta->keyword % [:yllapitokohdetyyppi])))
                           (if nykytilanne?
                             (case tyyppi
-                              "paallystys" (q/hae-paallystykset-nykytilanteeseen db params)
-                              "paikkaus" (q/hae-paikkaukset-nykytilanteeseen db params))
+                              "paallystys" (q/hae-paallystykset-nykytilanteeseen db)
+                              "paikkaus" (q/hae-paikkaukset-nykytilanteeseen db))
                             (case tyyppi
                               "paallystys" (q/hae-paallystykset-historiakuvaan db
-                                                                               (assoc params
-                                                                                      :loppu (konv/sql-date loppu)
-                                                                                      :alku (konv/sql-date alku)))
+                                                                               {:loppu (konv/sql-date loppu)
+                                                                                :alku (konv/sql-date alku)})
                               "paikkaus" (q/hae-paikkaukset-historiakuvaan db
-                                                                           (assoc params
-                                                                                  :loppu (konv/sql-date loppu)
-                                                                                  :alku (konv/sql-date alku))))))
+                                                                           {:loppu (konv/sql-date loppu)
+                                                                            :alku (konv/sql-date alku)}))))
             vastaus (yllapitokohteet-q/liita-kohdeosat-kohteisiin db vastaus :id
                                                                   {:alue alue
                                                                    :toleranssi toleranssi})

--- a/src/clj/harja/palvelin/palvelut/tilannekuva.clj
+++ b/src/clj/harja/palvelin/palvelut/tilannekuva.clj
@@ -151,7 +151,7 @@
                                                                           :tilaaja? (roolit/tilaajan-kayttaja? user))))))
 
 (defn- hae-yllapitokohteet
-  [db user {:keys [toleranssi alku loppu yllapito nykytilanne? tyyppi]} urakat]
+  [db user {:keys [toleranssi alku loppu yllapito nykytilanne? tyyppi alue]} urakat]
   ;; Muut haut toimivat siten, että urakat parametrissa on vain urakoita, joihin
   ;; käyttäjällä on oikeudet. Jos lista on tyhjä, urakoita ei ole joko valittuna,
   ;; tai yritettiin hakea urakoilla, joihin käyttäjällä ei ole oikeuksia.
@@ -184,7 +184,10 @@
                               "paikkaus" (q/hae-paikkaukset-historiakuvaan db
                                                                            (konv/sql-date loppu)
                                                                            (konv/sql-date alku)))))
-            vastaus (yllapitokohteet-q/liita-kohdeosat-kohteisiin db vastaus :id)
+            vastaus (yllapitokohteet-q/liita-kohdeosat-kohteisiin db vastaus :id
+                                                                  {:alue alue
+                                                                   :toleranssi toleranssi})
+            vastaus (remove #(empty? (:kohdeosat %)) vastaus)
             osien-pituudet-tielle (yllapitokohteet-yleiset/laske-osien-pituudet db vastaus)
             vastaus (mapv #(assoc %
                              :pituus

--- a/src/clj/harja/palvelin/palvelut/tilannekuva.clj
+++ b/src/clj/harja/palvelin/palvelut/tilannekuva.clj
@@ -174,8 +174,7 @@
                             (map #(konv/string-polusta->keyword % [:paallystysilmoitus-tila]))
                             (map #(konv/string-polusta->keyword % [:paikkausilmoitus-tila]))
                             (map #(konv/string-polusta->keyword % [:yllapitokohdetyotyyppi]))
-                            (map #(konv/string-polusta->keyword % [:yllapitokohdetyyppi]))
-                            kohdeosien-sijainnit-xf)
+                            (map #(konv/string-polusta->keyword % [:yllapitokohdetyyppi])))
                           (if nykytilanne?
                             (case tyyppi
                               "paallystys" (q/hae-paallystykset-nykytilanteeseen db params)

--- a/src/clj/harja/palvelin/palvelut/tilannekuva.clj
+++ b/src/clj/harja/palvelin/palvelut/tilannekuva.clj
@@ -154,7 +154,7 @@
   ^{:doc "Laajentaa :osien-geometriat avaimella arrayna tulevat ylläpitokohteen kohdeosien sijainnit
   :kohdeosat vektoriksi. Muita kohdeosan tietoja ei tarvita tilannekuvassa. Poistaa lopuksi kohteet,
   joissa ei ole osia"}
-  laajenna-kohdeosien-sijainnit
+  kohdeosien-sijainnit-xf
   (comp (map #(konv/array->vec % :osien-geometriat))
         (map #(-> %
                   (assoc :kohdeosat
@@ -189,7 +189,7 @@
                             (map #(konv/string-polusta->keyword % [:paikkausilmoitus-tila]))
                             (map #(konv/string-polusta->keyword % [:yllapitokohdetyotyyppi]))
                             (map #(konv/string-polusta->keyword % [:yllapitokohdetyyppi]))
-                            laajenna-kohdeosien-sijainnit)
+                            kohdeosien-sijainnit-xf)
                           (if nykytilanne?
                             (case tyyppi
                               "paallystys" (q/hae-paallystykset-nykytilanteeseen db params)

--- a/test/clj/harja/palvelin/integraatiot/api/yllapitokohteet_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/yllapitokohteet_test.clj
@@ -552,7 +552,7 @@
                               :loppuet 1
                               :losa 17
                               :numero 20}
-          alikohteiden-tr-osoitteet (hae-yllapitokohteen-kohdeosien-tr-osoitteet kohde-id)
+          alikohteiden-tr-osoitteet (into #{} (hae-yllapitokohteen-kohdeosien-tr-osoitteet kohde-id))
           oletettu-ensimmaisen-alikohteen-tr-osoite {:aet 1
                                                      :ajorata 1
                                                      :aosa 14
@@ -569,9 +569,9 @@
                                                 :numero 20}]
       (is (= oletettu-tr-osoite kohteen-tr-osoite) "Kohteen tierekisteriosoite on onnistuneesti päivitetty")
       (is (= 2 (count alikohteiden-tr-osoitteet)) "Alikohteita on päivittynyt 2 kpl")
-      (is (= oletettu-ensimmaisen-alikohteen-tr-osoite (first alikohteiden-tr-osoitteet))
+      (is (alikohteiden-tr-osoitteet oletettu-ensimmaisen-alikohteen-tr-osoite)
           "Ensimmäisen alikohteen tierekisteriosite on päivittynyt oikein")
-      (is (= oletettu-toisen-alikohteen-tr-osoite (second alikohteiden-tr-osoitteet))
+      (is (alikohteiden-tr-osoitteet oletettu-toisen-alikohteen-tr-osoite)
           "Toisen alikohteen tierekisteriosite on päivittynyt oikein")
 
       (let [alikohteet (q-map (str "SELECT sijainti, tr_numero FROM yllapitokohdeosa WHERE yllapitokohde = " kohde-id))]
@@ -744,8 +744,8 @@
                                   :kaista 1}
               odotettu-1-alikohteen-osoite {:numero 20, :aosa 1, :aet 1, :losa 1, :loppuet 100, :kaista 1, :ajorata 1}
               odotettu-2-alikohteen-osoite {:numero 20, :aosa 1, :aet 100, :losa 4, :loppuet 100, :kaista 1, :ajorata 1}
-              alikohteiden-tr-osoitteet (hae-yllapitokohteen-kohdeosien-tr-osoitteet kohde-id)]
+              alikohteiden-tr-osoitteet (into #{} (hae-yllapitokohteen-kohdeosien-tr-osoitteet kohde-id))]
           (is (= oletettu-tr-osoite kohteen-tr-osoite) "Kohteen tierekisteriosoite on onnistuneesti päivitetty")
           (is (= 2 (count alikohteiden-tr-osoitteet)) "Alikohteita on päivittynyt 1 kpl")
-          (is (= odotettu-1-alikohteen-osoite (first alikohteiden-tr-osoitteet)))
-          (is (= odotettu-2-alikohteen-osoite (second alikohteiden-tr-osoitteet))))))))
+          (is (alikohteiden-tr-osoitteet odotettu-1-alikohteen-osoite))
+          (is (alikohteiden-tr-osoitteet odotettu-2-alikohteen-osoite)))))))

--- a/test/clj/harja/paneeliapurit.clj
+++ b/test/clj/harja/paneeliapurit.clj
@@ -1,5 +1,6 @@
 (ns harja.paneeliapurit
-  (:require [harja.ui.kartta.infopaneelin-sisalto :as paneeli]))
+  (:require [harja.ui.kartta.infopaneelin-sisalto :as paneeli]
+            [taoensso.timbre :as log]))
 
 (def infopaneeli-skeema (var paneeli/infopaneeli-skeema))
 (def skeema-ilman-tyhjia-riveja (var paneeli/skeema-ilman-tyhjia-riveja))
@@ -19,7 +20,7 @@
              (skeema-ilman-tyhjia-riveja)
              (validoi-infopaneeli-skeema true)))
        (catch Exception e
-         (taoensso.timbre/debug e)
+         (log/debug e)
          false)))))
 
 (defn skeeman-luonti-onnistuu-kaikille?

--- a/tietokanta/src/main/resources/db/migration/V1_588__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_588__.sql
@@ -1,0 +1,7 @@
+-- Indeksoi ylläpitokohteita
+
+-- Indeksoidaan sijainti, jotta sen perusteella voidaan hakea rajatulle alueelle
+CREATE INDEX yllapitokohdeosa_sijainti_idx ON yllapitokohdeosa USING GIST (sijainti);
+
+-- Indeksoidaan foreign key
+CREATE INDEX yllapitokohdeosa_yllapitokohde_idx ON yllapitokohdeosa (yllapitokohde);


### PR DESCRIPTION
**Hae vain ylläpitokohdeosat, jotka osuvat alueeseen ja karkeista**
Aiemmin tilannekuva haki kaikki ylläpitokohdeosat originaalissa
tarkkuudessaan. Haetaan nyt vain ne kohdeosat, jotka osuvat
tilannekuvan kartan ikkunaan ja tehdään ST_Simplify samalla
karkeistustoleranssilla kuin muissakin tasoissa.