### PR TITLE
HAR-5466 Lisää Sopimusvastaava yhteyshenkilötyypiksi vesiväyliin

### DIFF
--- a/src/clj/harja/palvelin/integraatiot/api/sanomat/yhteystiedot.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/sanomat/yhteystiedot.clj
@@ -19,6 +19,7 @@
     "Kunnossapitopäällikkö"
     "Sillanvalvoja"
     "Kelikeskus"
+    "Sopimusvastaava"
     "Tieliikennekeskus"})
 
 (defn tee-yhteyshenkilo [rooli etunimi sukunimi puhelin sahkoposti organisaatio vastuuhenkilo varahenkilo]

--- a/src/cljs/harja/tiedot/urakka/yhteystiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/yhteystiedot.cljs
@@ -3,6 +3,7 @@
   (:require [reagent.core :as r]
             [harja.asiakas.kommunikaatio :as k]
             [harja.asiakas.tapahtumat :as t]
+            [harja.domain.urakka :as urakka-domain]
             [cljs.core.async :refer [<! >! chan]]
             [harja.loki :refer [log]]
             [harja.pvm :as pvm]
@@ -26,6 +27,9 @@
 (def yhteyshenkilotyypit-kaikille-urakoille
   (into [] (sort ["Kunnossapitopäällikkö" "Tieliikennekeskus"])))
 
+(def yhteyshenkilotyypit-vesivaylat
+  (into [] (sort ["Sopimusvastaava"])))
+
 (def yhteyshenkilotyypit-oletus
   (into [] (sort (concat yhteyshenkilotyypit-kaikille-urakoille
                          ["Sillanvalvoja" "Kelikeskus"]))))
@@ -41,10 +45,11 @@
                           "Turvallisuuskoordinaattori"]))))
 
 (defn urakkatyypin-mukaiset-yhteyshenkilotyypit [urakkatyyppi]
-  (case urakkatyyppi
-    :paallystys yhteyshenkilotyypit-paallystys
-    :tiemerkinta yhteyshenkilotyypit-tiemerkinta
-    yhteyshenkilotyypit-oletus))
+  (cond
+    (urakka-domain/vesivaylaurakkatyyppi? urakkatyyppi) yhteyshenkilotyypit-vesivaylat
+    (= :paallystys urakkatyyppi) yhteyshenkilotyypit-paallystys
+    (= :tiemerkinta urakkatyyppi) yhteyshenkilotyypit-tiemerkinta
+    :default yhteyshenkilotyypit-oletus))
 
 (defn tallenna-urakan-yhteyshenkilot
   "Tallentaa urakan yhteyshenkilöt, palauttaa kanavan, josta vastauksen voi lukea."


### PR DESCRIPTION
HAR-5466 mukaisesti, vesiväyläurakoilla on ainoastaan yksi
yhteyshenkilötyyppi: sopimusvastaava. Tämä rooli ei ole FIM-rooli.