### PR TITLE
HAR-5923 Lähetä vain urakka-id kok.hint. tallennuksessa

### DIFF
--- a/src/clj/harja/palvelin/palvelut/kokonaishintaiset_tyot.clj
+++ b/src/clj/harja/palvelin/palvelut/kokonaishintaiset_tyot.clj
@@ -42,14 +42,13 @@
 
 (defn tallenna-kokonaishintaiset-tyot
   "Palvelu joka tallentaa urakan kokonaishintaiset tyot."
-  [db user {:keys [urakka sopimusnumero tyot]}]
-  (let [urakkatyyppi-kannassa (keyword (first (urakat-q/hae-urakan-tyyppi db (:id urakka))))]
+  [db user {:keys [urakka-id sopimusnumero tyot]}]
+  (let [urakkatyyppi-kannassa (keyword (first (urakat-q/hae-urakan-tyyppi db urakka-id)))]
     (oikeudet/vaadi-kirjoitusoikeus
-      (oikeudet/tarkistettava-oikeus-kok-hint-tyot urakkatyyppi-kannassa) user (:id urakka)))
+      (oikeudet/tarkistettava-oikeus-kok-hint-tyot urakkatyyppi-kannassa) user urakka-id))
   (assert (vector? tyot) "tyot tulee olla vektori")
   (jdbc/with-db-transaction [c db]
-    (let [urakka-id (:id urakka)
-          nykyiset-arvot (hae-urakan-kokonaishintaiset-tyot c user urakka-id)
+    (let [nykyiset-arvot (hae-urakan-kokonaishintaiset-tyot c user urakka-id)
           valitut-vuosi-ja-kk (into #{} (map (juxt :vuosi :kuukausi) tyot))
           tyo-avain (fn [rivi]
                       [(:toimenpideinstanssi rivi) (:vuosi rivi) (:kuukausi rivi)])

--- a/src/cljs/harja/tiedot/urakka/suunnittelu/kokonaishintaiset_tyot.cljs
+++ b/src/cljs/harja/tiedot/urakka/suunnittelu/kokonaishintaiset_tyot.cljs
@@ -42,8 +42,8 @@
 
 (defn tallenna-kokonaishintaiset-tyot
   "Tallentaa urakan yksikköhintaiset työt, palauttaa kanavan, josta vastauksen voi lukea."
-  [urakka sopimusnumero tyot]
+  [urakka-id sopimusnumero tyot]
   (k/post! :tallenna-kokonaishintaiset-tyot
-           {:urakka        urakka
+           {:urakka-id        urakka-id
             :sopimusnumero (first sopimusnumero)
             :tyot          (into [] tyot)}))

--- a/src/cljs/harja/views/urakka/suunnittelu/kokonaishintaiset_tyot.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/kokonaishintaiset_tyot.cljs
@@ -62,7 +62,7 @@
                     (u/rivit-tulevillekin-kausille-kok-hint-tyot ur uudet-tyot valittu-hoitokausi)
                     uudet-tyot
                     ))
-            res (<! (kok-hint-tyot/tallenna-kokonaishintaiset-tyot ur sopimusnumero muuttuneet))
+            res (<! (kok-hint-tyot/tallenna-kokonaishintaiset-tyot (:id ur) sopimusnumero muuttuneet))
             res-jossa-hoitokausitieto (map #(kok-hint-tyot/aseta-hoitokausi hoitokaudet %) res)]
         (reset! tyot res-jossa-hoitokausitieto)
         (reset! tuleville? false)


### PR DESCRIPTION
Aiemmin lähetettiin koko urakan tiedot, ja hiljan tehdyn muutoksen
jälkeen tästä aiheutui mammuttimaisia hyötykuormia, koska urakan alueen
geometria lähetettiin turhaan hyötykuormassa.