### PR TITLE
HAR-5526 Tietyöilmoituksen muokkaus rasti

### DIFF
--- a/src/clj/harja/palvelin/palvelut/tietyoilmoitukset/pdf.clj
+++ b/src/clj/harja/palvelin/palvelut/tietyoilmoitukset/pdf.clj
@@ -80,14 +80,23 @@
            sisalto))])
 
 (defn- ilmoitus-koskee [ilm]
-  (tietotaulukko
-   [(checkbox-lista [["Ensimmäinen ilmoitus työstä" true]
-                     ["Työvaihetta koskeva ilmoitus" false]]
-                    #{(nil? (::t/paatietyoilmoitus ilm))})
-    (checkbox-lista [["Korjaus/muutos aiempaan tietoon" true]
-                     ["Työn päättymisilmoitus" false]]
-                    ;; FIXME: mistä tämä päätellään
-                    #{false})]))
+  (let [muokattu? (::m/muokattu ilm)
+        valinnat #{(if muokattu?
+                     :korjaus
+                     :ensimmainen)
+                   (if (::t/paatietyoilmoitus ilm)
+                     :tyovaihe
+                     :paailmoitus)
+                   (if (pvm/ennen? (pvm/nyt) (::t/loppu ilm))
+                     :menossa
+                     :paattyy)}]
+    (tietotaulukko
+     [(checkbox-lista [["Ensimmäinen ilmoitus työstä" :ensimmainen]
+                       ["Työvaihetta koskeva ilmoitus" :tyovaihe]]
+                      valinnat)
+      (checkbox-lista [["Korjaus/muutos aiempaan tietoon" :korjaus]
+                       ["Työn päättymisilmoitus" :paattyy]]
+                      valinnat)])))
 
 (def tyotyypit ["Tienrakennus"
                 "Päällystystyö"


### PR DESCRIPTION
**Korjaa ruksit muokkaustilan ja pvm perusteella**
Jos ilmoitusta on muokattu, ruksitaan korjaus/muutos. Jos loppupvm on
mennyt, lisätään ruksi työn päättymisilmoitus.