### PR TITLE
HAR-6000 Laskutusyhteenveto on hidas

### DIFF
--- a/tietokanta/src/main/resources/db/migration/V1_602__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_602__.sql
@@ -1,0 +1,2 @@
+-- Laskutusyhteenvedon toteumaindeksi
+CREATE INDEX CONCURRENTLY toteuma_ty_ur_alk_idx ON toteuma (tyyppi, urakka, alkanut);


### PR DESCRIPTION
**Tee indeksi kenttäjoukolle, jota laskutusyhteenveto käyttää**
Laskutusyhteenveto tekee paljon hakuja, joissa rajataan toteumia
tyypin, urakan ja alkamisajan perusteella. Ne ovat nyt hyvin hitaita.
Tämä indeksin lisäys nopeuttaa laskutusyhteenvedon hakuajan
murto-osaan nykyisestä.