### PR TITLE
HAR-5991 Urakan valinnoissa aikavälikomponenttia ei kutsuttu oikein

### DIFF
--- a/src/cljs/harja/ui/valinnat.cljs
+++ b/src/cljs/harja/ui/valinnat.cljs
@@ -164,7 +164,7 @@
                           :valitse-fn valitse-yksikkohintainen-tehtava-fn}
      @urakan-yksikkohintainen-tehtavat-atom]]])
 
-(defn urakan-valinnat [urakka {:keys [sopimus hoitokausi kuukausi toimenpide aikavali] :as optiot}]
+(defn urakan-valinnat [urakka {:keys [sopimus hoitokausi kuukausi toimenpide aikavali-optiot] :as optiot}]
   [:span
    (when-let [{:keys [valittu-sopimusnumero-atom valitse-sopimus-fn optiot]} sopimus]
      [urakan-sopimus urakka valittu-sopimusnumero-atom valitse-sopimus-fn optiot])
@@ -174,7 +174,7 @@
      [hoitokauden-kuukausi hoitokauden-kuukaudet valittu-kuukausi-atom valitse-kuukausi-fn])
    (when-let [{:keys [urakan-toimenpideinstassit-atom valittu-toimenpideinstanssi-atom valitse-toimenpide-fn]} toimenpide]
      [urakan-toimenpide urakan-toimenpideinstassit-atom valittu-toimenpideinstanssi-atom valitse-toimenpide-fn])
-   (when-let [{:keys [valittu-aikavali-atom]} aikavali]
+   (when-let [{:keys [valittu-aikavali-atom]} aikavali-optiot]
      [aikavali valittu-aikavali-atom])])
 
 (defn vuosi

--- a/src/cljs/harja/views/urakka/valinnat.cljs
+++ b/src/cljs/harja/views/urakka/valinnat.cljs
@@ -219,7 +219,7 @@
       {:hoitokausi {:hoitokaudet u/valitun-urakan-hoitokaudet
                     :valittu-hoitokausi-atom u/valittu-hoitokausi
                     :valitse-hoitokausi-fn u/valitse-hoitokausi!}
-       :aikavali {:valittu-aikavali-atom u/valittu-aikavali}})))
+       :aikavali-optiot {:valittu-aikavali-atom u/valittu-aikavali}})))
 
 (defn urakan-sopimus-ja-hoitokausi-ja-aikavali-ja-toimenpide [ur]
   (fn [ur]
@@ -230,7 +230,7 @@
        :hoitokausi {:hoitokaudet u/valitun-urakan-hoitokaudet
                     :valittu-hoitokausi-atom u/valittu-hoitokausi
                     :valitse-hoitokausi-fn u/valitse-hoitokausi!}
-       :aikavali {:valittu-aikavali-atom u/valittu-aikavali}
+       :aikavali-optiot {:valittu-aikavali-atom u/valittu-aikavali}
        :toimenpide {:urakan-toimenpideinstassit-atom u/urakan-toimenpideinstanssit
                     :valittu-toimenpideinstanssi-atom u/valittu-toimenpideinstanssi
                     :valitse-toimenpide-fn u/valitse-toimenpideinstanssi!}})))
@@ -247,5 +247,5 @@
           :hoitokausi {:hoitokaudet u/valitun-urakan-hoitokaudet
                        :valittu-hoitokausi-atom u/valittu-hoitokausi
                        :valitse-hoitokausi-fn u/valitse-hoitokausi!}
-          :aikavali {:valittu-aikavali-atom u/valittu-aikavali}}
+          :aikavali-optiot {:valittu-aikavali-atom u/valittu-aikavali}}
          optiot)))))


### PR DESCRIPTION
Yritettiin kutsua aikavälikomponenttia, mutta todellisuudessa
palautettiin vektori, jossa ensimmäinen parametri oli map
(aikavali-niminen parametri).

Tämä muutos tuo aikaväli-filtteröinnin yksikköhintaisiin toteumiin,
ja vesiväylien toimenpidenäkymiin.