### PR TITLE
HAR-6004 Vesiväylien kok.hint. kustannusten jako tarkemmin

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -140,7 +140,10 @@
                  [devcards "0.2.2" :exclusions [cljsjs/react]]
 
                   ;; Parsi sourcemapit
-                 [com.atlassian.sourcemap/sourcemap "1.7.5"]]
+                 [com.atlassian.sourcemap/sourcemap "1.7.5"]
+
+                 ;; Arbitrary precision math frontilla
+                 [cljsjs/big "3.1.3-1"]]
 
   :profiles {:dev {:dependencies [[prismatic/dommy "1.1.0"]
                                   [cljs-react-test "0.1.4-SNAPSHOT"]

--- a/src/clj/harja/kyselyt/kokonaishintaiset_tyot.sql
+++ b/src/clj/harja/kyselyt/kokonaishintaiset_tyot.sql
@@ -8,6 +8,7 @@ SELECT
   kt.maksupvm,
   kt.toimenpideinstanssi,
   kt.sopimus,
+  kt."osuus-hoitokauden-summasta",
   tpi.id         AS tpi_id,
   tpi.nimi       AS tpi_nimi,
   tpi.toimenpide AS toimenpide

--- a/src/clj/harja/kyselyt/kokonaishintaiset_tyot.sql
+++ b/src/clj/harja/kyselyt/kokonaishintaiset_tyot.sql
@@ -40,9 +40,10 @@ ORDER BY id;
 
 -- name: paivita-kokonaishintainen-tyo!
 -- Päivittää kokonaishintaisen tyon summan ja maksupvm:n, tunnisteena tpi, sop, vu ja kk
-
 UPDATE kokonaishintainen_tyo
-SET summa = :summa, maksupvm = :maksupvm
+SET summa = :summa,
+    "osuus-hoitokauden-summasta" = :osuus-hoitokauden-summasta,
+    maksupvm = :maksupvm
 WHERE toimenpideinstanssi = :toimenpideinstanssi AND sopimus = :sopimus
       AND vuosi = :vuosi AND kuukausi = :kuukausi;
 
@@ -50,8 +51,8 @@ WHERE toimenpideinstanssi = :toimenpideinstanssi AND sopimus = :sopimus
 -- name: lisaa-kokonaishintainen-tyo<!
 -- Lisää kokonaishintaisen tyon
 INSERT INTO kokonaishintainen_tyo
-(summa, maksupvm, toimenpideinstanssi, sopimus, vuosi, kuukausi, luoja)
-VALUES (:summa, :maksupvm, :toimenpideinstanssi, :sopimus, :vuosi, :kuukausi, :luoja);
+(summa, "osuus-hoitokauden-summasta", maksupvm, toimenpideinstanssi, sopimus, vuosi, kuukausi, luoja)
+VALUES (:summa, :osuus-hoitokauden-summasta, :maksupvm, :toimenpideinstanssi, :sopimus, :vuosi, :kuukausi, :luoja);
 
 -- name: merkitse-kustannussuunnitelmat-likaisiksi!
 -- Merkitsee kokonaishintaisia töitä vastaavat kustannussuunnitelmat likaisiksi: lähtetetään seuraavassa päivittäisessä lähetyksessä

--- a/src/clj/harja/kyselyt/toimenpideinstanssit.sql
+++ b/src/clj/harja/kyselyt/toimenpideinstanssit.sql
@@ -96,3 +96,7 @@ SELECT exists(SELECT id
               WHERE urakka = :urakka AND toimenpide = (SELECT id
                                                        FROM toimenpidekoodi
                                                        WHERE koodi = :toimenpidekoodi))
+
+-- name: urakan-toimenpideinstanssi-idt
+-- Palauttaa urakan toimenpideinstanssien idt
+SELECT id FROM toimenpideinstanssi WHERE urakka = :urakka

--- a/src/clj/harja/palvelin/palvelut/kokonaishintaiset_tyot.clj
+++ b/src/clj/harja/palvelin/palvelut/kokonaishintaiset_tyot.clj
@@ -9,7 +9,8 @@
             [harja.kyselyt.konversio :as konv]
             [harja.kyselyt.urakat :as urakat-q]
             [harja.kyselyt.kokonaishintaiset-tyot :as q]
-            [harja.domain.oikeudet :as oikeudet]))
+            [harja.domain.oikeudet :as oikeudet]
+            [harja.tyokalut.big :as big]))
 
 (declare hae-urakan-kokonaishintaiset-tyot tallenna-kokonaishintaiset-tyot)
 
@@ -36,8 +37,12 @@
   [db user urakka-id]
   (oikeudet/vaadi-lukuoikeus oikeudet/urakat-suunnittelu-kokonaishintaisettyot user urakka-id)
   (into []
-        (map #(assoc %
-                :summa (if (:summa %) (double (:summa %)))))
+        (comp
+         (map #(assoc %
+                      :summa (if (:summa %) (double (:summa %)))))
+         (map #(if (:osuus-hoitokauden-summasta %)
+                 (update % :osuus-hoitokauden-summasta big/->big)
+                 %)))
         (q/listaa-kokonaishintaiset-tyot db urakka-id)))
 
 (defn tallenna-kokonaishintaiset-tyot

--- a/src/cljc/harja/tyokalut/big.cljc
+++ b/src/cljc/harja/tyokalut/big.cljc
@@ -15,7 +15,11 @@
   (minus [b1 b2])
   (mul [b1 b2])
   (div [b1 b2])
-  (eq [b1 b2])
+  (eq [b1 b2] "True, jos arvot yhtäsuuret")
+  (lt [b1 b2] "True, jos b1 pienenmpi kuin b2")
+  (gt [b1 b2] "True, jos b1 suurempi kuin b2")
+  (lte [b1 b2] "True, jos b1 pienempi tai yhtäsuuri kuin b2")
+  (gte [b1 b2] "True, jos b1 suurempi tai yhäsuuri kuin b2")
   (fmt [b1 decimals] "Formatoi annettuun desimaalitarkkuuten, poistaen loppunollat.")
   (fmt-full [b1 decimals] "Formatoi annetuun desimaalitarkkuuteen."))
 
@@ -45,6 +49,11 @@
   (eq [{b1 :b} {b2 :b}]
     #?(:clj (= b1 b2)
        :cljs (.eq b1 b2)))
+
+  (lt [{b1 :b} {b2 :b}] #?(:clj (< b1 b2) :cljs (.lt b1 b2)))
+  (gt [{b1 :b} {b2 :b}] #?(:clj (> b1 b2) :cljs (.gt b1 b2)))
+  (lte [{b1 :b} {b2 :b}] #?(:clj (<= b1 b2) :cljs (.lte b1 b2)))
+  (gte [{b1 :b} {b2 :b}] #?(:clj (>= b1 b2) :cljs (.gte b1 b2)))
 
   (fmt [{b :b} decimals]
     #?(:clj
@@ -84,3 +93,12 @@
   (-> string
       (str/replace #"," ".")
       (->big)))
+
+#?(:clj
+   (defn unwrap
+     "Jos annettu numero on BigDec, palauttaa sen sisäisen BigDecimal numeron.
+  Muussa tapauksessa palauttaa annetun parametrin sellaisenaan."
+     [b]
+     (if (big? b)
+       (:b b)
+       b)))

--- a/src/cljc/harja/tyokalut/big.cljc
+++ b/src/cljc/harja/tyokalut/big.cljc
@@ -3,7 +3,13 @@
   Valitettavasti java.math.BigDecimal on transit kerroksessa muunnettu JS numeroksi, koska yleensä
   ei tarvita big decimal laskenta.
 
-  Tämän takia clj puolella on wrapper record."
+  Tämän takia on wrapper record ja molemmilla puolilla toteutettu operaatiot bigdec
+  käsittelyyn.
+
+  Käytä funktiota `->big` kun haluat muuntaa merkkijonon tai normaalin numeron tähän
+  muotoon ja `unwrap` (clj puolella) palauttaaksesi käärityn `java.math.BigDecimal`
+  instanssin esim. tietokantaan tallentamista varten."
+
   (:refer-clojure :exclude [+ - * /])
   #?(:clj (:import java.math.BigDecimal))
   (:require [clojure.string :as str]

--- a/src/cljc/harja/tyokalut/big.cljc
+++ b/src/cljc/harja/tyokalut/big.cljc
@@ -1,0 +1,86 @@
+(ns harja.tyokalut.big
+  "Työkaluja abitrary precision desimaalilukujen laskentaan.
+  Valitettavasti java.math.BigDecimal on transit kerroksessa muunnettu JS numeroksi, koska yleensä
+  ei tarvita big decimal laskenta.
+
+  Tämän takia clj puolella on wrapper record."
+  (:refer-clojure :exclude [+ - * /])
+  #?(:clj (:import java.math.BigDecimal))
+  (:require [clojure.string :as str]
+            #?@(:cljs [[cljsjs.big]])))
+
+
+(defprotocol BigDecOps
+  (plus [b1 b2])
+  (minus [b1 b2])
+  (mul [b1 b2])
+  (div [b1 b2])
+  (eq [b1 b2])
+  (fmt [b1 decimals] "Formatoi annettuun desimaalitarkkuuten, poistaen loppunollat.")
+  (fmt-full [b1 decimals] "Formatoi annetuun desimaalitarkkuuteen."))
+
+(defrecord BigDec [b])
+
+(defn big? [x]
+  (instance? BigDec x))
+
+(extend-protocol BigDecOps
+  BigDec
+  (plus [{b1 :b} {b2 :b}]
+    (->BigDec (#?(:clj .add
+                  :cljs .plus) b1 b2)))
+
+  (minus [{b1 :b} {b2 :b}]
+    (->BigDec (#?(:clj .subtract
+                  :cljs .minus) b1 b2)))
+
+  (mul [{b1 :b} {b2 :b}]
+    (->BigDec (#?(:clj .multiply
+                  :cljs .times) b1 b2)))
+
+  (div [{b1 :b} {b2 :b}]
+    (->BigDec (#?(:clj .divide
+                  :cljs .div) b1 b2)))
+
+  (eq [{b1 :b} {b2 :b}]
+    #?(:clj (= b1 b2)
+       :cljs (.eq b1 b2)))
+
+  (fmt [{b :b} decimals]
+    #?(:clj
+       (.format (doto (java.text.DecimalFormat.)
+                  (.setMaximumFractionDigits decimals)
+                  (.setMinimumFractionDigits 0))
+                b)
+       :cljs
+       (-> (.toFixed b decimals)
+           (str/replace #"\.0+$" "")
+           (str/replace #"(\.[^0]+)([0]+)" second)
+           (str/replace #"\." ","))))
+
+  (fmt-full [{b :b} decimals]
+    #?(:clj (.format (doto (java.text.DecimalFormat.)
+                       (.setMaximumFractionDigits decimals)
+                       (.setMinimumFractionDigits decimals))
+                     b)
+       :cljs
+       (-> b (.toFixed decimals) (str/replace #"\." ",")))))
+
+(defn ->big [arvo]
+  (if (big? arvo)
+    arvo
+    (try
+      (->BigDec #?(:clj (if (instance? java.math.BigDecimal arvo)
+                          arvo
+                          (java.math.BigDecimal. arvo))
+                   :cljs (js/Big. arvo)))
+      (catch #?(:clj Exception
+                :cljs js/Error) e
+          nil))))
+
+(defn parse
+  "Muuttaa merkkijonon big instanssiksi. Palauttaa nil, jos merkkijono ei kelpaa."
+  [string]
+  (-> string
+      (str/replace #"," ".")
+      (->big)))

--- a/src/cljs/harja/views/urakka/suunnittelu/kokonaishintaiset_tyot.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/kokonaishintaiset_tyot.cljs
@@ -403,9 +403,14 @@
               ;; sarakkeet
               [(when @prosenttijako?
                  {:otsikko "%" :nimi :prosentti
-                  :tyyppi :big :desimaalien-maara 4
+                  :tyyppi :big
+                  :desimaalien-maara 4
+                  :validoi [#(when-not (and %
+                                            (big/gte % (big/->big 0))
+                                            (big/lte % (big/->big 100)))
+                               "Anna prosentti välillä 0 - 100")]
                   :fmt #(when % (big/fmt % 4))
-                  :leveys 10})
+                  :leveys 12})
 
                {:otsikko "Vuosi" :nimi :vuosi :muokattava? (constantly false) :tyyppi :numero :leveys 25}
                {:otsikko "Kuukausi" :nimi "kk" :hae #(if (= -1 (:kuukausi %))

--- a/src/cljs/harja/views/urakka/suunnittelu/kokonaishintaiset_tyot.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/kokonaishintaiset_tyot.cljs
@@ -24,7 +24,9 @@
             [harja.tyokalut.functor :refer [fmap]]
             [harja.ui.kentat :as kentat]
             [harja.ui.valinnat :as valinnat]
-            [harja.domain.urakka :as u-domain])
+            [harja.domain.urakka :as u-domain]
+            [harja.tyokalut.big :as big]
+            [harja.ui.debug :as debug])
 
   (:require-macros [cljs.core.async.macros :refer [go]]
                    [reagent.ratom :refer [reaction run!]]
@@ -138,13 +140,13 @@
     "Tehtävät ovat järjestelmän laajuisia ja vain järjestelmän vastuuhenkilö voi muuttaa niitä."]])
 
 (defn- prosenttiosuudet [tyorivit]
-  (let [summa (reduce + 0 (keep :summa tyorivit))]
+  (let [summa (reduce big/plus (big/->big 0)
+                      (keep (comp big/->big :summa) tyorivit))]
     (with-meta
       (mapv (fn [{s :summa :as rivi}]
-              (assoc rivi :prosentti
-                          (if (and s (pos? summa))
-                            (Math/round (/ (* 100 s) summa))
-                            0)))
+              (assoc rivi :prosentti (big/mul (big/->big 100)
+                                              (or (:osuus-hoitokauden-summasta rivi)
+                                                  (big/->big 0)))))
             tyorivit)
       {:vuosisumma summa})))
 
@@ -186,17 +188,19 @@
   (not (#{:tiemerkinta :vesivayla-hoito} tyyppi)))
 
 
-(defn- paivita-kk-arvo-prosentin-mukaan [{:keys [prosentti] :as rivi} vuosihinta]
-  (assoc rivi :summa (if prosentti
-                       (/ (* vuosihinta prosentti) 100)
-                       nil)))
+(defn- paivita-kk-arvo-prosentin-mukaan [{:keys [prosentti] :as rivi} vuosisumma]
+  (let [* (fnil big/mul (big/->big 0) (big/->big 0))]
+    (assoc rivi :summa (if prosentti
+                         (big/div (* prosentti vuosisumma) (big/->big 100))
+                         nil))))
 
 (defn- vuosisumma-kentta [g vuosisumma-atom muokattava-atom?]
   [(if @muokattava-atom?
      kentat/tee-otsikollinen-kentta
      kentat/nayta-otsikollinen-kentta)
    {:otsikko "Vuoden kokonaishintaiset työt"
-    :kentta-params {:tyyppi :positiivinen-numero
+    :kentta-params {:tyyppi :big
+                    :desimaalien-maara 2
                     :fmt fmt/euro-opt
                     :placeholder "Syötä hoitokauden urakkasumma (€)"}
     :arvo-atom (r/wrap @vuosisumma-atom
@@ -235,6 +239,9 @@
   [valinnat/urakkavalinnat {:urakka urakka}
    ^{:key "valinnat"}
    [u-valinnat/urakan-sopimus-ja-hoitokausi-ja-toimenpide urakka]])
+
+(defn prosentit-yht [rivit]
+  (reduce big/plus (big/->big 0) (keep :prosentti rivit)))
 
 (defn kokonaishintaiset-tyot [ur valitun-hoitokauden-yks-hint-kustannukset]
   (let [urakan-kok-hint-tyot u/urakan-kok-hint-tyot
@@ -356,7 +363,8 @@
                :tallenna-vain-muokatut false
                :validoi-fn (when @prosenttijako?
                              (fn [rivit]
-                               (when (not= 100 (int (reduce + 0 (keep :prosentti rivit))))
+                               (when (not (big/eq (big/->big 100)
+                                                  (prosentit-yht rivit)))
                                  "Prosenttien tulee olla yhteensä 100")))
                :peruuta #(do
                            (reset! vuosisumma-muokattava? false)
@@ -379,17 +387,24 @@
                                      @tuleville?]]))
                :rivi-jalkeen-fn (when @prosenttijako?
                                   (fn [rivit]
-                                    (let [prosentti-yht (reduce + 0 (map :prosentti rivit))]
+                                    (let [prosentti-yht (prosentit-yht rivit)]
                                       ^{:luokka "yhteenveto"}
-                                      [{:teksti (fmt/prosentti prosentti-yht 0)}
+                                      [{:teksti (big/fmt prosentti-yht 4)}
                                        {:teksti "Yhteensä" :sarakkeita 2}
-                                       {:teksti (fmt/euro (/ (* prosentti-yht @vuosisumma) 100))}
+                                       {:teksti (str (big/fmt
+                                                      (big/div ((fnil big/mul
+                                                                      (big/->big 0)
+                                                                      (big/->big 0))
+                                                                prosentti-yht
+                                                                @vuosisumma)
+                                                               (big/->big 100)) 2) " €")}
                                        {:teksti ""}])))}
 
               ;; sarakkeet
               [(when @prosenttijako?
                  {:otsikko "%" :nimi :prosentti
-                  :tyyppi :positiivinen-numero :kokonaisluku? true
+                  :tyyppi :big :desimaalien-maara 4
+                  :fmt #(when % (big/fmt % 4))
                   :leveys 10})
 
                {:otsikko "Vuosi" :nimi :vuosi :muokattava? (constantly false) :tyyppi :numero :leveys 25}
@@ -398,7 +413,8 @@
                                                        (pvm/kuukauden-nimi (:kuukausi %)))
                 :muokattava? (constantly false)
                 :tyyppi :numero :leveys 25}
-               {:otsikko "Summa" :nimi :summa :fmt fmt/euro-opt :tasaa :oikea
+               {:otsikko "Summa" :nimi :summa :tasaa :oikea
+                :fmt fmt/euro-opt
                 :muokattava? (constantly (not @prosenttijako?))
                 :tyyppi :positiivinen-numero :leveys 25
                 :tayta-alas? #(not (nil? %))
@@ -411,6 +427,8 @@
                 :tayta-tooltip "Kopioi sama maksupäivän tuleville kuukausille"
                 :tayta-fn tayta-maksupvm}]
               @tyorivit]
+
+             [debug/debug @tyorivit]
 
              (when (nayta-tehtavalista-ja-kustannukset? (:tyyppi @urakka))
                [kokonaishintaiset-tyot-tehtavalista

--- a/src/cljs/harja/views/urakka/suunnittelu/kokonaishintaiset_tyot.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/kokonaishintaiset_tyot.cljs
@@ -143,10 +143,21 @@
   (let [summa (reduce big/plus (big/->big 0)
                       (keep (comp big/->big :summa) tyorivit))]
     (with-meta
-      (mapv (fn [{s :summa :as rivi}]
-              (assoc rivi :prosentti (big/mul (big/->big 100)
-                                              (or (:osuus-hoitokauden-summasta rivi)
-                                                  (big/->big 0)))))
+      (mapv (fn [{s :summa osuus :osuus-hoitokauden-summasta :as rivi}]
+              (assoc rivi :prosentti
+                     (cond
+
+                       ;; Osuus tiedossa, muunnetaan se prosenteiksi
+                       osuus
+                       (big/mul (big/->big 100)
+                                (or (:osuus-hoitokauden-summasta rivi)
+                                    (big/->big 0)))
+
+                       ;; Summat tiedossa, lasketaan prosenttimäärä
+                       (and s (big/gt summa (big/->big 0)))
+                       (big/mul (big/->big 100) (big/div (big/->big s) summa))
+
+                       :default nil)))
             tyorivit)
       {:vuosisumma summa})))
 

--- a/tietokanta/src/main/resources/db/migration/V1_609__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_609__.sql
@@ -1,0 +1,4 @@
+-- Lisää vesiväylien prosenttijaolle taulu
+
+ALTER TABLE kokonaishintainen_tyo
+  ADD COLUMN "osuus-hoitokauden-summasta" NUMERIC (6,6);


### PR DESCRIPTION
Mahdollistetaan jopa neljän desimaalin käyttö vesiväylien kokonaishintaisten
kustannusten jakotaulukossa. Käytetään big.js kirjastoa JS puolen arbitrary
precision laskentaan. Lisätty .cljc kirjasto, helpottamaan bigdecimal käyttöä

**BigDecimal käsittelyn jaettu apukirjasto**
Koska JS ja JVM ympäristöissä on ihan erilaiset bigdecimal kirjastot,
tehdään oma wrapper tyyppi, jota voidaan käyttää kun halutaan
arbitrary precision lukuja käsitellä.

**Transit siirto BigDec wrapperille**

**Lisää osuus hoitokauden summasta prosenttiarvo (0 - 1)**

**Uusi :big kenttätyyppi, jolla voi syöttää BigDec arvon**

**Lisätty big js kirjasto**

**Euro formatointi ymmärtää myös BigDec luvun**

**Käytä :big kenttätyyppiä prosenteissa**
Prosentit otetaan nyt "osuus-hoitokauden-summasta" kentän arvosta.

**Hae osuus-hoitokauden-summasta kenttä kyselyssä**

**Tallenna osuus hoitokauden summasta, yksinkertaista db koodia**

**Lisää vertailuoperaattorit**

**Validoi prosentin olevan 0-100 välillä**