### PR TITLE
HAR-6117: Urakan loppumisajankohdan vertailuun current_date, ei now()

### DIFF
--- a/laadunseuranta/clj-src/harja_laadunseuranta/kyselyt/kyselyt.sql
+++ b/laadunseuranta/clj-src/harja_laadunseuranta/kyselyt/kyselyt.sql
@@ -154,7 +154,7 @@ WITH ur AS (SELECT
               a.alue
             FROM urakka u
               INNER JOIN alueurakka a ON u.urakkanro = a.alueurakkanro
-            WHERE NOW() BETWEEN u.alkupvm AND u.loppupvm
+            WHERE current_date BETWEEN u.alkupvm AND u.loppupvm
                   AND u.nimi NOT ILIKE '%testi%')
 SELECT ur.id
 FROM tarkastusreitti r

--- a/src/clj/harja/kyselyt/urakat.sql
+++ b/src/clj/harja/kyselyt/urakat.sql
@@ -48,16 +48,16 @@ FROM urakka u
 LEFT JOIN alueurakka au ON au.alueurakkanro = u.urakkanro
 WHERE
 -- Urakka on käynnissä
-(u.alkupvm <= now() AND
-u.loppupvm > now())
+(u.alkupvm <= current_date AND
+u.loppupvm >= current_date)
 OR
 -- Urakka on käynnissä (loppua ei tiedossa)
-(u.alkupvm <= now() AND
+(u.alkupvm <= current_date AND
 u.loppupvm IS NULL)
 OR
 -- Urakan takuuaika on voimassa
-(u.alkupvm <= now() AND
-u.takuu_loppupvm > now())
+(u.alkupvm <= current_date AND
+u.takuu_loppupvm >= current_date)
 ORDER BY etaisyys;
 
 -- name: hae-kaikki-urakat-aikavalilla
@@ -545,8 +545,8 @@ SELECT u.id
 FROM urakka u
   LEFT JOIN urakoiden_alueet ua ON u.id = ua.id
 WHERE u.tyyppi = :urakkatyyppi :: urakkatyyppi
-      AND (u.alkupvm IS NULL OR u.alkupvm <= current_timestamp)
-      AND (u.loppupvm IS NULL OR u.loppupvm > current_timestamp)
+      AND (u.alkupvm IS NULL OR u.alkupvm <= current_date)
+      AND (u.loppupvm IS NULL OR u.loppupvm >= current_date)
       AND
       ((:urakkatyyppi = 'hoito' AND (st_contains(ua.alue, ST_MakePoint(:x, :y))))
       OR
@@ -673,8 +673,8 @@ SELECT
 FROM urakka u
 JOIN alueurakka au ON au.alueurakkanro = u.urakkanro
 WHERE
-u.alkupvm <= now() AND
-u.loppupvm > now() AND
+u.alkupvm <= current_date AND
+u.loppupvm >= current_date AND
 st_distance(au.alue, st_makepoint(:x, :y)) <= :maksimietaisyys
 ORDER BY etaisyys ASC
 LIMIT 1;
@@ -698,8 +698,8 @@ FROM urakka u
   JOIN organisaatio e ON e.id = u.hallintayksikko
   JOIN organisaatio o ON o.id = u.urakoitsija
 WHERE urakkanro = :urakkanro AND
-      alkupvm <= now() AND
-      loppupvm > now();
+      alkupvm <= current_date AND
+      loppupvm >= current_date;
 
 -- name: onko-olemassa-urakkanro?
 -- single?: true

--- a/src/clj/harja/kyselyt/valitavoitteet.sql
+++ b/src/clj/harja/kyselyt/valitavoitteet.sql
@@ -117,7 +117,7 @@ SELECT
   alkupvm,
   loppupvm
 FROM urakka
-WHERE loppupvm >= NOW();
+WHERE loppupvm >= current_date;
 
 -- name: paivita-valtakunnallinen-valitavoite!
 -- Päivittää valtakunnallisen välitavoitteen tiedot

--- a/src/clj/harja/kyselyt/yllapitokohteet.sql
+++ b/src/clj/harja/kyselyt/yllapitokohteet.sql
@@ -625,7 +625,7 @@ SELECT
   nimi,
   hallintayksikko
 FROM urakka
-WHERE (loppupvm IS NULL OR loppupvm >= NOW())
+WHERE (loppupvm IS NULL OR loppupvm >= current_date)
       AND tyyppi = 'tiemerkinta' :: URAKKATYYPPI;
 
 -- name: tallenna-paallystyskohteen-aikataulu!


### PR DESCRIPTION
Käyttäjältä tuli kyselyä tilanteesta, jossa vanha urakka on merkitty päättyväksi
30.9, mutta uuteen urakkaan "urakoitsija vaihtuu 1.10. 12:00 alken", ja halusi tietää,
välittyvätkö HARJA -viestit viimeisen puoli vuorokautta vielä vanhaan urakkaan.

Aloin tutkimaan tätä, ja totesin, että ymmärtääkseni urakoidin loppumispvm-vertailu
on ollut 'aina' rikki. Tietokannassa alku- ja loppupvm ovat päivämääriä ilman
kellonaikoja, joten jos esim urakka päättyy 30.9.2017, ja samana päivänä kello 14:00
tehdään vertailu `u.loppupvm > now()`, tehdään todelisuudessa vertailu
`'2017-30-9 00:00:00' > '2017-30-9 14:00:00'`, eli tulos on false.

Tämä ongelma korjattaan vaihtamalla vertailuihin current_date, ja vaihtamalla
`>   ->   >=`.

Käyttäjän varsinaista ongelmaa tämä ei korjaa, mutta vastaus käyttäjälle taitaa olla,
että Harjassa urakat vaihtuvat yleensä keskiyöllä, joten ilmoitukset menevät keskiyöhön
asti vanhaan urakkaan, ja keskiyöstä alkaen uuteen..