### PR TITLE
HAR-6056 Korjaa keyword/muuttuja-typo oikeustarkistuksessa

### DIFF
--- a/src/clj/harja/palvelin/palvelut/laadunseuranta/tarkastukset.clj
+++ b/src/clj/harja/palvelin/palvelut/laadunseuranta/tarkastukset.clj
@@ -126,7 +126,7 @@
   [user {:keys [havaintoja-sisaltavat? vain-laadunalitukset? tienumero
                 alkupvm loppupvm tyyppi urakka-id] :as parametrit}]
   (oikeudet/vaadi-lukuoikeus oikeudet/urakat-laadunseuranta-tarkastukset
-                             user :urakka-id)
+                             user urakka-id)
   {:urakka urakka-id
    :alku alkupvm :loppu loppupvm
    :rajaa_tienumerolla (some? tienumero) :tienumero tienumero


### PR DESCRIPTION
Tullut karttakuvan generoinniss aina EiOikeutta-poikkeuksia tästä