### PR TITLE
Lisää käyttöseurantapalvelu

### DIFF
--- a/src/clj/harja/kyselyt/kayttoseuranta.sql
+++ b/src/clj/harja/kyselyt/kayttoseuranta.sql
@@ -1,0 +1,5 @@
+-- name: kirjaa-kaytto<!
+INSERT INTO kayttoseuranta
+(kayttaja, aika, tila, sivu, lisatieto)
+VALUES
+  (:kayttaja, NOW(), :tila, :sivu, :lisatieto);

--- a/src/clj/harja/palvelin/asetukset.clj
+++ b/src/clj/harja/palvelin/asetukset.clj
@@ -47,7 +47,7 @@
                                                (s/optional-key :sahkoposti-ulos-jono) s/Str
                                                (s/optional-key :sahkoposti-ulos-kuittausjono) s/Str}}
    (s/optional-key :solita-sahkoposti) {:vastausosoite s/Str
-                                        :palvelin/Str s/Str}
+                                        (s/optional-key :palvelin) s/Str}
    (s/optional-key :sampo) {:lahetysjono-sisaan s/Str
                             :kuittausjono-sisaan s/Str
                             :lahetysjono-ulos s/Str

--- a/src/clj/harja/palvelin/main.clj
+++ b/src/clj/harja/palvelin/main.clj
@@ -129,6 +129,7 @@
 
     ;; Metriikat
     [harja.palvelin.komponentit.metriikka :as metriikka]
+    [harja.palvelin.palvelut.kayttoseuranta :as kayttoseuranta]
 
     ;; Vesiväylät
     [harja.palvelin.palvelut.vesivaylat.toimenpiteet :as vv-toimenpiteet]
@@ -172,6 +173,9 @@
                        (http-palvelin/luo-http-palvelin http-palvelin
                                                         kehitysmoodi)
                        [:todennus :metriikka])
+      :kayttoseuranta (component/using
+                        (kayttoseuranta/->Kayttoseuranta)
+                        [:db :http-palvelin])
 
       :pdf-vienti (component/using
                     (pdf-vienti/luo-pdf-vienti)

--- a/src/clj/harja/palvelin/palvelut/kayttoseuranta.clj
+++ b/src/clj/harja/palvelin/palvelut/kayttoseuranta.clj
@@ -1,0 +1,45 @@
+(ns harja.palvelin.palvelut.kayttoseuranta
+  (:require [clojure.java.jdbc :as jdbc]
+            [jeesql.core :refer [defqueries]]
+            [com.stuartsierra.component :as component]
+            [taoensso.timbre :as log]
+            [harja.palvelin.komponentit.http-palvelin :refer [julkaise-palvelu poista-palvelut]]
+            [harja.domain.oikeudet :as oikeudet]
+            [harja.kyselyt.konversio :as konv]
+            [harja.kyselyt.kanavat.kanavat :as q]
+
+            [harja.domain.kanavat.kanava :as kan]
+            [harja.domain.kanavat.kanavan-kohde :as kohde]
+            [harja.domain.kanavat.kanavan-huoltokohde :as huoltokohde]
+            [harja.domain.urakka :as ur]
+            [clojure.spec.alpha :as s]))
+
+(defqueries "harja/kyselyt/kayttoseuranta.sql")
+
+(s/def ::lokita-kaytto-kysely (s/keys :req []))
+
+(defn lokita-kaytto! [db user tiedot]
+  (log/debug "Kirjaa käyttö")
+  (kirjaa-kaytto<! db {:kayttaja (:id user)
+                       :tila (:tila tiedot)
+                       :sivu (:sivu tiedot)
+                       :lisatieto (:lisatieto tiedot)}))
+
+(defrecord Kayttoseuranta []
+  component/Lifecycle
+  (start [{http :http-palvelin
+           db :db :as this}]
+    (julkaise-palvelu
+      http
+      :lokita-kaytto
+      (fn [user tiedot]
+        (lokita-kaytto! db user tiedot))
+      {:kysely-spec ::lokita-kaytto-kysely})
+
+    this)
+
+  (stop [this]
+    (poista-palvelut
+      (:http-palvelin this)
+      :lokita-kaytto)
+    this))

--- a/src/cljs/harja/tiedot/navigaatio.cljs
+++ b/src/cljs/harja/tiedot/navigaatio.cljs
@@ -25,7 +25,8 @@
     [harja.geo :as geo]
     [harja.domain.oikeudet :as oikeudet]
     [harja.domain.urakka :as urakka-domain]
-    [taoensso.timbre :as log])
+    [taoensso.timbre :as log]
+    [harja.tyokalut.kayttoseuranta :as kayttoseuranta])
 
   (:require-macros [cljs.core.async.macros :refer [go]]
                    [reagent.ratom :refer [reaction run!]])
@@ -244,6 +245,11 @@
                       (and (= sivu :urakat)
                            (not v-ur)) :XL
                       :default valittu-koko)))))
+
+(kayttoseuranta/seuraa-kayttoa! kartan-koko
+                                "Kartan koko"
+                                (fn [] (str @kartan-edellinen-koko " => " @kartan-koko))
+                                (fn [tila] (not= :hidden tila)))
 
 (def kartta-nakyvissa?
   "Kartta ei piilotettu"

--- a/src/cljs/harja/tiedot/navigaatio.cljs
+++ b/src/cljs/harja/tiedot/navigaatio.cljs
@@ -77,6 +77,11 @@
                     :vanha-koko vanha-koko
                     :uusi-koko uusi-koko}))))
 
+(kayttoseuranta/seuraa-kayttoa! kartan-kokovalinta
+                                "Kartan kokovalinta"
+                                (fn [] @kartan-kokovalinta)
+                                (fn [tila] (if (#{:hidden :S} tila) false tila)))
+
 (def valittu-vaylamuoto "Tällä hetkellä valittu väylämuoto" (atom :tie))
 
 (defn vaihda-vaylamuoto! [ut]
@@ -245,11 +250,6 @@
                       (and (= sivu :urakat)
                            (not v-ur)) :XL
                       :default valittu-koko)))))
-
-(kayttoseuranta/seuraa-kayttoa! kartan-koko
-                                "Kartan koko"
-                                (fn [] (str @kartan-edellinen-koko " => " @kartan-koko))
-                                (fn [tila] (not= :hidden tila)))
 
 (def kartta-nakyvissa?
   "Kartta ei piilotettu"

--- a/src/cljs/harja/tiedot/urakka/paallystys.cljs
+++ b/src/cljs/harja/tiedot/urakka/paallystys.cljs
@@ -27,8 +27,6 @@
 (def kohdeluettelossa? (atom false))
 (def paallystysilmoitukset-nakymassa? (atom false))
 
-(seuraa-kayttoa! paallystysilmoitukset-nakymassa? "Päällystysilmoitukset")
-
 (defn hae-paallystysilmoitukset [urakka-id sopimus-id vuosi]
   (k/post! :urakan-paallystysilmoitukset {:urakka-id urakka-id
                                           :sopimus-id sopimus-id

--- a/src/cljs/harja/tiedot/urakka/paallystys.cljs
+++ b/src/cljs/harja/tiedot/urakka/paallystys.cljs
@@ -16,7 +16,9 @@
     [harja.domain.paallystysilmoitus :as pot]
     [harja.domain.urakka :as urakka-domain]
     [harja.tiedot.urakka.yllapito :as yllapito-tiedot]
-    [harja.ui.viesti :as viesti])
+    [harja.ui.viesti :as viesti]
+
+    [harja.tyokalut.kayttoseuranta :refer [seuraa-kayttoa!]])
 
   (:require-macros [reagent.ratom :refer [reaction]]
                    [cljs.core.async.macros :refer [go]]
@@ -24,6 +26,8 @@
 
 (def kohdeluettelossa? (atom false))
 (def paallystysilmoitukset-nakymassa? (atom false))
+
+(seuraa-kayttoa! paallystysilmoitukset-nakymassa? "Päällystysilmoitukset")
 
 (defn hae-paallystysilmoitukset [urakka-id sopimus-id vuosi]
   (k/post! :urakan-paallystysilmoitukset {:urakka-id urakka-id

--- a/src/cljs/harja/tyokalut/kayttoseuranta.cljs
+++ b/src/cljs/harja/tyokalut/kayttoseuranta.cljs
@@ -1,9 +1,14 @@
 (ns harja.tyokalut.kayttoseuranta
+  "Mahdollistaa datan keräämisen käyttöliittymän käytöstä.
+
+  Lähettää palvelimelle timestampin, sivun, ja lisätiedon.
+  Katso myös harja.ui.komponentti/kirjaa-kaytto!"
   (:require [harja.asiakas.kommunikaatio :as k]
-            [cljs.core.async :refer [<!]])
+            [cljs.core.async :refer [<!]]
+            [reagent.core :as r])
   (:require-macros [cljs.core.async.macros :refer [go]]))
 
-(defn- laheta-kaytto! [sivu lisatieto tila]
+(defn laheta-kaytto! [sivu lisatieto tila]
   (go (let [vastaus (<! (k/post!
                           :lokita-kaytto
                           {:sivu sivu
@@ -11,6 +16,8 @@
                            :tila tila}))])))
 
 (defn seuraa-kayttoa!
+  "Rekisteröi atomin seurattavaksi, ja lähettää palvelimelle tiedon,
+  kun atomin arvo muuttuu. Lähetettävä tila on aina boolean."
   ([atomi sivu]
     (seuraa-kayttoa! atomi sivu nil))
   ([atomi sivu lisatieto]
@@ -21,3 +28,11 @@
                        uusi (boolean uusi)]
                    (when-not (= vanha uusi)
                      (laheta-kaytto! sivu lisatieto uusi)))))))
+
+(defn seuraa-polkua!
+  "Luo kursorin atomista annetun polun perusteella, ja rekisteröi atomin
+  seurattavaksi."
+  ([atomi polku sivu]
+    (seuraa-polkua! atomi polku sivu nil))
+  ([atomi polku sivu lisatieto]
+    (seuraa-kayttoa! (r/cursor atomi polku) sivu lisatieto)))

--- a/src/cljs/harja/tyokalut/kayttoseuranta.cljs
+++ b/src/cljs/harja/tyokalut/kayttoseuranta.cljs
@@ -17,17 +17,31 @@
 
 (defn seuraa-kayttoa!
   "Rekisteröi atomin seurattavaksi, ja lähettää palvelimelle tiedon,
-  kun atomin arvo muuttuu. Lähetettävä tila on aina boolean."
+  kun atomin arvo muuttuu. Katso myös harja.ui.komponentti/kirjaa-kaytto!
+
+  Parametrit:
+  * Atomi: Seurattava atomi
+  * Sivu: Kantaan tallennettava otsikkotieto, pakollinen. Merkkijono, tai funktio joka palauttaa merkkijonon.
+  * Lisätieto: Kantaan tallennettava lisätieto, esim 'Lomake' tai 'Grid'. Merkkijono, tai funktio joka palauttaa merkkijonon.
+  * Tila-fn: Funktio, joka muuntaa atomin vanhan ja uuden tilan booleaniksi. Oletuksena 'boolean'"
   ([atomi sivu]
     (seuraa-kayttoa! atomi sivu nil))
   ([atomi sivu lisatieto]
-    (add-watch atomi
-               (keyword (str sivu lisatieto))
-               (fn [_ _ vanha uusi]
-                 (let [vanha (boolean vanha)
-                       uusi (boolean uusi)]
-                   (when-not (= vanha uusi)
-                     (laheta-kaytto! sivu lisatieto uusi)))))))
+    (seuraa-kayttoa! atomi sivu lisatieto boolean))
+  ([atomi sivu lisatieto tila-fn]
+   (add-watch atomi
+              (keyword (str sivu lisatieto))
+              (fn [_ _ vanha uusi]
+                (let [vanha (tila-fn vanha)
+                      uusi (tila-fn uusi)]
+                  (when-not (= vanha uusi)
+                    (laheta-kaytto! (if (fn? sivu)
+                                      (sivu)
+                                      sivu)
+                                    (if (fn? lisatieto)
+                                      (lisatieto)
+                                      lisatieto)
+                                    uusi)))))))
 
 (defn seuraa-polkua!
   "Luo kursorin atomista annetun polun perusteella, ja rekisteröi atomin

--- a/src/cljs/harja/tyokalut/kayttoseuranta.cljs
+++ b/src/cljs/harja/tyokalut/kayttoseuranta.cljs
@@ -11,9 +11,9 @@
 (defn laheta-kaytto! [sivu lisatieto tila]
   (go (let [vastaus (<! (k/post!
                           :lokita-kaytto
-                          {:sivu sivu
-                           :lisatieto lisatieto
-                           :tila tila}))])))
+                          {:sivu (str sivu)
+                           :lisatieto (when lisatieto (str lisatieto))
+                           :tila (boolean tila)}))])))
 
 (defn seuraa-kayttoa!
   "Rekisteröi atomin seurattavaksi, ja lähettää palvelimelle tiedon,

--- a/src/cljs/harja/tyokalut/kayttoseuranta.cljs
+++ b/src/cljs/harja/tyokalut/kayttoseuranta.cljs
@@ -1,0 +1,23 @@
+(ns harja.tyokalut.kayttoseuranta
+  (:require [harja.asiakas.kommunikaatio :as k]
+            [cljs.core.async :refer [<!]])
+  (:require-macros [cljs.core.async.macros :refer [go]]))
+
+(defn- laheta-kaytto! [sivu lisatieto tila]
+  (go (let [vastaus (<! (k/post!
+                          :lokita-kaytto
+                          {:sivu sivu
+                           :lisatieto lisatieto
+                           :tila tila}))])))
+
+(defn seuraa-kayttoa!
+  ([atomi sivu]
+    (seuraa-kayttoa! atomi sivu nil))
+  ([atomi sivu lisatieto]
+    (add-watch atomi
+               (keyword (str sivu lisatieto))
+               (fn [_ _ vanha uusi]
+                 (let [vanha (boolean vanha)
+                       uusi (boolean uusi)]
+                   (when-not (= vanha uusi)
+                     (laheta-kaytto! sivu lisatieto uusi)))))))

--- a/src/cljs/harja/views/haku.cljs
+++ b/src/cljs/harja/views/haku.cljs
@@ -13,12 +13,15 @@
             [harja.atom :refer-macros [reaction<!]]
             [harja.domain.oikeudet :as oikeudet]
             [harja.ui.komponentti :as komp]
-            [harja.tiedot.istunto :as istunto])
+            [harja.tiedot.istunto :as istunto]
+            [harja.tyokalut.kayttoseuranta :as kayttoseuranta])
 
   (:require-macros [cljs.core.async.macros :refer [go]]
                    [reagent.ratom :refer [reaction run!]]))
 
 (def hakutermi (atom ""))
+
+(kayttoseuranta/seuraa-kayttoa! hakutermi "Hakutermi" nil empty?)
 
 (def hakutulokset
   (reaction<! [termi @hakutermi]

--- a/src/cljs/harja/views/hallinta.cljs
+++ b/src/cljs/harja/views/hallinta.cljs
@@ -17,63 +17,66 @@
             [harja.views.hallinta.api-jarjestelmatunnukset :as api-jarjestelmatunnukset]
             [harja.views.vesivaylat.hallinta :as vu]
             [harja.ui.grid :as g]
-            [harja.tiedot.istunto :as istunto]))
+            [harja.tiedot.istunto :as istunto]
+            [harja.ui.komponentti :as komp]))
 
 (defn hallinta []
-  [bs/tabs {:style :tabs :classes "tabs-taso1"
-            :active (nav/valittu-valilehti-atom :hallinta)}
+  (komp/luo
+    (komp/kirjaa-kaytto! "Hallinta")
+    (fn [] [bs/tabs {:style :tabs :classes "tabs-taso1"
+               :active (nav/valittu-valilehti-atom :hallinta)}
 
-   "Indeksit"
-   :indeksit
-   (when (oikeudet/hallinta-indeksit)
-     ^{:key "indeksit"}
-     [i/indeksit-elementti])
+      "Indeksit"
+      :indeksit
+      (when (oikeudet/hallinta-indeksit)
+        ^{:key "indeksit"}
+        [i/indeksit-elementti])
 
-   "Tehtävät"
-   :tehtavat
-   (when (oikeudet/hallinta-tehtavat)
-     ^{:key "tehtävät"}
-     [tp/toimenpidekoodit])
+      "Tehtävät"
+      :tehtavat
+      (when (oikeudet/hallinta-tehtavat)
+        ^{:key "tehtävät"}
+        [tp/toimenpidekoodit])
 
-   "Välitavoitteet"
-   :valtakunnalliset-valitavoitteet
-   (when (oikeudet/hallinta-valitavoitteet)
-     ^{:key "valtakunnalliset-valitavoitteet"}
-     [valitavoitteet/valitavoitteet])
+      "Välitavoitteet"
+      :valtakunnalliset-valitavoitteet
+      (when (oikeudet/hallinta-valitavoitteet)
+        ^{:key "valtakunnalliset-valitavoitteet"}
+        [valitavoitteet/valitavoitteet])
 
-   "Lämpötilat"
-   :lampotilat
-   (when (oikeudet/hallinta-lampotilat)
-     ^{:key "lämpötilat"}
-     [lampotilat/lampotilat])
+      "Lämpötilat"
+      :lampotilat
+      (when (oikeudet/hallinta-lampotilat)
+        ^{:key "lämpötilat"}
+        [lampotilat/lampotilat])
 
-   "Integraatioloki"
-   :integraatioloki
-   (when (oikeudet/hallinta-integraatioloki)
-     ^{:key "integraatioloki"}
-     [integraatioloki/integraatioloki])
+      "Integraatioloki"
+      :integraatioloki
+      (when (oikeudet/hallinta-integraatioloki)
+        ^{:key "integraatioloki"}
+        [integraatioloki/integraatioloki])
 
-   "Yhteydenpito"
-   :yhteydenpito
-   (when (oikeudet/hallinta-yhteydenpito)
-     ^{:key "yhteydenpito"}
-     [yhteydenpito/yhteydenpito])
+      "Yhteydenpito"
+      :yhteydenpito
+      (when (oikeudet/hallinta-yhteydenpito)
+        ^{:key "yhteydenpito"}
+        [yhteydenpito/yhteydenpito])
 
-   "Häiriöilmoitukset"
-   :hairioilmoitukset
-   (when (oikeudet/hallinta-hairioilmoitukset)
-     ^{:key "integraatioloki"}
-     [hairiot/hairiot])
+      "Häiriöilmoitukset"
+      :hairioilmoitukset
+      (when (oikeudet/hallinta-hairioilmoitukset)
+        ^{:key "integraatioloki"}
+        [hairiot/hairiot])
 
-   "API-järjestelmätunnukset"
-   :api-jarjestelmatunnukset
-   (when (oikeudet/hallinta-api-jarjestelmatunnukset)
-     ^{:key "jarjestelmatunnukset"}
-     [api-jarjestelmatunnukset/api-jarjestelmatunnukset-paakomponentti])
+      "API-järjestelmätunnukset"
+      :api-jarjestelmatunnukset
+      (when (oikeudet/hallinta-api-jarjestelmatunnukset)
+        ^{:key "jarjestelmatunnukset"}
+        [api-jarjestelmatunnukset/api-jarjestelmatunnukset-paakomponentti])
 
-   "Vesiväyläurakat"
-   :vesivayla-hallinta
-   (when (and (istunto/ominaisuus-kaytossa? :vesivayla)
-              (oikeudet/hallinta-vesivaylat))
-     ^{:key "vesivaylaurakat"}
-     [vu/vesivayla-hallinta])])
+      "Vesiväyläurakat"
+      :vesivayla-hallinta
+      (when (and (istunto/ominaisuus-kaytossa? :vesivayla)
+                 (oikeudet/hallinta-vesivaylat))
+        ^{:key "vesivaylaurakat"}
+        [vu/vesivayla-hallinta])])))

--- a/src/cljs/harja/views/hallinta/api_jarjestelmatunnukset.cljs
+++ b/src/cljs/harja/views/hallinta/api_jarjestelmatunnukset.cljs
@@ -12,6 +12,8 @@
                    [harja.atom :refer [reaction<!]]
                    [cljs.core.async.macros :refer [go]]))
 
+(def sivu "API-tunnukset")
+
 (defn- api-jarjestelmatunnukset [jarjestelmatunnukset-atom]
   (let [ei-muokattava (constantly false)]
     [grid/grid {:otsikko "API järjestelmätunnukset"
@@ -97,6 +99,7 @@
 (defn api-jarjestelmatunnukset-paakomponentti []
   (komp/luo
     (komp/lippu tiedot/nakymassa?)
+    (komp/kirjaa-kaytto! sivu)
     (fn []
       (let [nakyma-alustettu? (some? @tiedot/urakkavalinnat)]
         (if nakyma-alustettu?

--- a/src/cljs/harja/views/hallinta/hairiot.cljs
+++ b/src/cljs/harja/views/hallinta/hairiot.cljs
@@ -13,6 +13,8 @@
             [harja.ui.yleiset :as yleiset])
   (:require-macros [harja.tyokalut.ui :refer [for*]]))
 
+(def sivu "Hallinta/Häiriöt")
+
 (defn- listaa-hairioilmoitus [hairio]
   (str (fmt/pvm (::hairio/pvm hairio))
        " - "
@@ -62,6 +64,7 @@
 (defn hairiot []
   (komp/luo
     (komp/lippu tiedot/nakymassa?)
+    (komp/kirjaa-kaytto! sivu)
     (komp/ulos #(do (reset! tiedot/hairiot nil)
                     (reset! tiedot/asetetaan-hairioilmoitus? false)))
     (komp/sisaan tiedot/hae-hairiot)

--- a/src/cljs/harja/views/hallinta/indeksit.cljs
+++ b/src/cljs/harja/views/hallinta/indeksit.cljs
@@ -15,7 +15,6 @@
             [clojure.string :as str])
   (:require-macros [cljs.core.async.macros :refer [go]]))
 
-
 (defn indeksi-grid [{:keys [indeksinimi koodi]}]
 
   (let [indeksit @i/indeksit

--- a/src/cljs/harja/views/hallinta/integraatioloki.cljs
+++ b/src/cljs/harja/views/hallinta/integraatioloki.cljs
@@ -18,6 +18,8 @@
   (:require-macros [cljs.core.async.macros :refer [go]]
                    [reagent.ratom :refer [reaction run!]]))
 
+(def sivu "Integraatioloki")
+
 (defn kartta-merkkijonoksi [kartta]
   (when kartta
     (clojure.string/join
@@ -288,6 +290,7 @@
 (defn integraatioloki []
   (komp/luo
     (komp/ulos (aloita-tapahtumien-paivitys!))
+    (komp/kirjaa-kaytto! sivu)
     (komp/lippu tiedot/nakymassa?)
     (fn []
       [:div.integraatioloki

--- a/src/cljs/harja/views/hallinta/lampotilat.cljs
+++ b/src/cljs/harja/views/hallinta/lampotilat.cljs
@@ -19,6 +19,7 @@
                    [reagent.ratom :refer [reaction run!]]
                    [harja.atom :refer [reaction<! reaction-writable]]))
 
+(def sivu "Lämpötilat")
 (defonce lampotilarivit (reaction-writable @tiedot/hoitourakoiden-lampotilat))
 
 (defonce taulukon-virheet (atom nil))
@@ -34,6 +35,7 @@
   "Lämpötilojen pääkomponentti"
   []
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (komp/lippu tiedot/lampotilojen-hallinnassa?)
     (fn []
       (let [voi-muokata? (oikeudet/voi-kirjoittaa? oikeudet/hallinta-lampotilat)

--- a/src/cljs/harja/views/hallinta/valtakunnalliset_valitavoitteet.cljs
+++ b/src/cljs/harja/views/hallinta/valtakunnalliset_valitavoitteet.cljs
@@ -23,6 +23,8 @@
 (def kertaluontoiset-otsikko {:tiemerkinta "Tiemerkinnän kertaluontoisten välitavoitteiden mallipohjat"})
 (def toistuvat-otsikko {:tiemerkinta "Tiemerkinnän vuosittain toistuvien välitavoitteiden mallipohjat"})
 
+(def sivu "Hallinta/Välitavoitteet")
+
 (defn kertaluontoiset-valitavoitteet-grid
   [valitavoitteet-atom kertaluontoiset-valitavoitteet-atom valittu-urakkatyyppi-atom]
   [grid/grid
@@ -93,6 +95,7 @@
 (defn valitavoitteet []
   (komp/luo
     (komp/lippu tiedot/nakymassa?)
+    (komp/kirjaa-kaytto! sivu)
     (fn []
       (let [nayta-kertaluontoiset-valtakunnalliset?
             (some? (tiedot/valtakunnalliset-kertaluontoiset-valitavoitteet-kaytossa

--- a/src/cljs/harja/views/hallinta/yhteydenpito.cljs
+++ b/src/cljs/harja/views/hallinta/yhteydenpito.cljs
@@ -12,6 +12,8 @@
             [harja.loki :refer [log]]
             [harja.ui.varmista-kayttajalta :as varmista-kayttajalta]))
 
+(def sivu "Hallinta/Yhteydenpito")
+
 (defn yhteydenttolomake [e! {yhteydenotto :yhteydenotto
                              lahetys-kaynnissa? :lahetys-kaynnissa?
                              :as app}]
@@ -44,6 +46,7 @@
 
 (defn yhteydenpito* []
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (komp/lippu tiedot/nakymassa?)
     (fn [e! app]
       (yhteydenttolomake e! app))))

--- a/src/cljs/harja/views/ilmoituksen_tiedot.cljs
+++ b/src/cljs/harja/views/ilmoituksen_tiedot.cljs
@@ -17,7 +17,10 @@
             [harja.domain.tierekisteri :as tr-domain]
             [harja.tiedot.ilmoitukset.viestit :as v]
             [harja.loki :refer [log]]
-            [reagent.core :refer [atom] :as r]))
+            [reagent.core :refer [atom] :as r]
+            [harja.ui.komponentti :as komp]))
+
+(def sivu "Ilmoituksen tiedot")
 
 (defn selitelista [{:keys [selitteet] :as ilmoitus}]
   (let [virka-apu? (ilmoitukset/virka-apupyynto? ilmoitus)]
@@ -28,64 +31,67 @@
      (parsi-selitteet (filter #(not= % :virkaApupyynto) selitteet))]))
 
 (defn ilmoitus [e! ilmoitus]
-  (let [nayta-valitykset? (atom false)]
+  (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (fn [e! ilmoitus]
-      [:div
-       [bs/panel {}
-        (ilmoitustyypin-nimi (:ilmoitustyyppi ilmoitus))
-        [:span
-         [yleiset/tietoja {}
-          "Urakka: " (:urakkanimi ilmoitus)
-          "Id: " (:ilmoitusid ilmoitus)
-          "Tunniste: " (:tunniste ilmoitus)
-          "Ilmoitettu: " (pvm/pvm-aika-sek (:ilmoitettu ilmoitus))
-          "Yhteydenottopyyntö:" (if (:yhteydenottopyynto ilmoitus) "Kyllä" "Ei")
-          "Sijainti: " (tr-domain/tierekisteriosoite-tekstina (:tr ilmoitus))
-          "Otsikko: " (:otsikko ilmoitus)
-          "Paikan kuvaus: " (:paikankuvaus ilmoitus)
-          "Lisatieto:  " (when (:lisatieto ilmoitus)
-                           [yleiset/pitka-teksti (:lisatieto ilmoitus)])
-          "Selitteet: " [selitelista ilmoitus]
-          "Aiheutti toimenpiteitä:" (if (:aiheutti-toimenpiteita ilmoitus) "Kyllä" "Ei")]
-         [:br]
-         [yleiset/tietoja {}
-          "Ilmoittaja:" (let [henkilo (nayta-henkilo (:ilmoittaja ilmoitus))
-                              tyyppi (capitalize (name (get-in ilmoitus [:ilmoittaja :tyyppi])))]
-                          (if (and henkilo tyyppi)
-                            (str henkilo ", " tyyppi)
-                            (str (or henkilo tyyppi))))
-          "Puhelinnumero: " (parsi-puhelinnumero (:ilmoittaja ilmoitus))
-          "Sähköposti: " (get-in ilmoitus [:ilmoittaja :sahkoposti])]
+      (let [nayta-valitykset? (atom false)]
+       (fn [e! ilmoitus]
+         [:div
+          [bs/panel {}
+           (ilmoitustyypin-nimi (:ilmoitustyyppi ilmoitus))
+           [:span
+            [yleiset/tietoja {}
+             "Urakka: " (:urakkanimi ilmoitus)
+             "Id: " (:ilmoitusid ilmoitus)
+             "Tunniste: " (:tunniste ilmoitus)
+             "Ilmoitettu: " (pvm/pvm-aika-sek (:ilmoitettu ilmoitus))
+             "Yhteydenottopyyntö:" (if (:yhteydenottopyynto ilmoitus) "Kyllä" "Ei")
+             "Sijainti: " (tr-domain/tierekisteriosoite-tekstina (:tr ilmoitus))
+             "Otsikko: " (:otsikko ilmoitus)
+             "Paikan kuvaus: " (:paikankuvaus ilmoitus)
+             "Lisatieto:  " (when (:lisatieto ilmoitus)
+                              [yleiset/pitka-teksti (:lisatieto ilmoitus)])
+             "Selitteet: " [selitelista ilmoitus]
+             "Aiheutti toimenpiteitä:" (if (:aiheutti-toimenpiteita ilmoitus) "Kyllä" "Ei")]
+            [:br]
+            [yleiset/tietoja {}
+             "Ilmoittaja:" (let [henkilo (nayta-henkilo (:ilmoittaja ilmoitus))
+                                 tyyppi (capitalize (name (get-in ilmoitus [:ilmoittaja :tyyppi])))]
+                             (if (and henkilo tyyppi)
+                               (str henkilo ", " tyyppi)
+                               (str (or henkilo tyyppi))))
+             "Puhelinnumero: " (parsi-puhelinnumero (:ilmoittaja ilmoitus))
+             "Sähköposti: " (get-in ilmoitus [:ilmoittaja :sahkoposti])]
 
-         [:br]
-         [yleiset/tietoja {}
-          "Lähettäjä:" (nayta-henkilo (:lahettaja ilmoitus))
-          "Puhelinnumero: " (parsi-puhelinnumero (:lahettaja ilmoitus))
-          "Sähköposti: " (get-in ilmoitus [:lahettaja :sahkoposti])]]]
-       [:div.kuittaukset
-        [:h3 "Kuittaukset"]
-        [:div
-         ;; Tilannekuvanäkymässä ei voi tehdä kuittauksia, mutta tätä komponenttia käytetään
-         ;; näyttämään ilmoituksen tarkempia tietoja. Tällöin e! on nil
-         (when e!
-           (if-let [uusi-kuittaus (:uusi-kuittaus ilmoitus)]
-             [kuittaukset/uusi-kuittaus e! uusi-kuittaus]
-             (when (oikeudet/voi-kirjoittaa? oikeudet/ilmoitukset-ilmoitukset
-                                             (:id @nav/valittu-urakka))
-
-               (if (:ilmoitusid ilmoitus)
-                 [:button.nappi-ensisijainen
-                  {:class "uusi-kuittaus-nappi"
-                   :on-click #(e! (v/->AvaaUusiKuittaus))}
-                  (ikonit/livicon-plus) " Uusi kuittaus"]
-                 [yleiset/vihje tiedot/vihje-liito]))))
-
-         [harja.ui.kentat/tee-kentta {:tyyppi :checkbox
-                                      :teksti "Näytä välitysviestit"
-                                      :nayta-rivina? true} nayta-valitykset?]
-
-         (when-not (empty? (:kuittaukset ilmoitus))
+            [:br]
+            [yleiset/tietoja {}
+             "Lähettäjä:" (nayta-henkilo (:lahettaja ilmoitus))
+             "Puhelinnumero: " (parsi-puhelinnumero (:lahettaja ilmoitus))
+             "Sähköposti: " (get-in ilmoitus [:lahettaja :sahkoposti])]]]
+          [:div.kuittaukset
+           [:h3 "Kuittaukset"]
            [:div
-            (for [kuittaus (cond->> (sort-by :kuitattu pvm/jalkeen? (:kuittaukset ilmoitus))
-                                    (not @nayta-valitykset?) (remove ilmoitukset/valitysviesti?))]
-              (kuittaukset/kuittauksen-tiedot kuittaus))])]]])))
+            ;; Tilannekuvanäkymässä ei voi tehdä kuittauksia, mutta tätä komponenttia käytetään
+            ;; näyttämään ilmoituksen tarkempia tietoja. Tällöin e! on nil
+            (when e!
+              (if-let [uusi-kuittaus (:uusi-kuittaus ilmoitus)]
+                [kuittaukset/uusi-kuittaus e! uusi-kuittaus]
+                (when (oikeudet/voi-kirjoittaa? oikeudet/ilmoitukset-ilmoitukset
+                                                (:id @nav/valittu-urakka))
+
+                  (if (:ilmoitusid ilmoitus)
+                    [:button.nappi-ensisijainen
+                     {:class "uusi-kuittaus-nappi"
+                      :on-click #(e! (v/->AvaaUusiKuittaus))}
+                     (ikonit/livicon-plus) " Uusi kuittaus"]
+                    [yleiset/vihje tiedot/vihje-liito]))))
+
+            [harja.ui.kentat/tee-kentta {:tyyppi :checkbox
+                                         :teksti "Näytä välitysviestit"
+                                         :nayta-rivina? true} nayta-valitykset?]
+
+            (when-not (empty? (:kuittaukset ilmoitus))
+              [:div
+               (for [kuittaus (cond->> (sort-by :kuitattu pvm/jalkeen? (:kuittaukset ilmoitus))
+                                       (not @nayta-valitykset?) (remove ilmoitukset/valitysviesti?))]
+                 (kuittaukset/kuittauksen-tiedot kuittaus))])]]])))))

--- a/src/cljs/harja/views/ilmoitukset/tietyoilmoitukset.cljs
+++ b/src/cljs/harja/views/ilmoitukset/tietyoilmoitukset.cljs
@@ -19,10 +19,13 @@
   (:require-macros
     [cljs.core.async.macros :refer [go]]))
 
+(def sivu "Tietyöilmoitukset")
+
 (defn ilmoitukset* [e! ilmoitukset]
   (e! (tiedot/->HaeKayttajanUrakat @hallintayksikot-tiedot/vaylamuodon-hallintayksikot))
   (e! (tiedot/->YhdistaValinnat @tiedot/ulkoisetvalinnat))
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (komp/lippu tiedot/karttataso-tietyoilmoitukset)
     (komp/kuuntelija :ilmoitus-klikattu (fn [_ ilmoitus]
                                           (e! (tiedot/->ValitseIlmoitus

--- a/src/cljs/harja/views/ilmoitukset/tietyoilmoitushakulomake.cljs
+++ b/src/cljs/harja/views/ilmoitukset/tietyoilmoitushakulomake.cljs
@@ -245,6 +245,7 @@
 (defn hakulomake
   [e! _]
   (komp/luo
+    (komp/kirjaa-kaytto! "Tietyöilmoitukset" "Hakulomake")
     (komp/sisaan #(e! (tiedot/->HaeIlmoitukset)))
     (fn [e! {valinnat-nyt :valinnat
              haetut-ilmoitukset :tietyoilmoitukset

--- a/src/cljs/harja/views/ilmoituskuittaukset.cljs
+++ b/src/cljs/harja/views/ilmoituskuittaukset.cljs
@@ -24,6 +24,7 @@
             [harja.ui.leijuke :as leijuke])
   (:require-macros [cljs.core.async.macros :refer [go]]))
 
+(def sivu "Ilmoituskuittaukset")
 
 (def fraasihaku
   (reify protokollat/Haku
@@ -38,89 +39,91 @@
       (nil? (:tyyppi kuittaus))))
 
 (defn uusi-kuittaus [e! kuittaus]
-  [:div
-   {:class "uusi-kuittaus"}
-   [lomake/lomake
-    {:muokkaa! #(e! (v/->AsetaKuittausTiedot %))
-     :luokka :horizontal
-     :footer [:div
-              [napit/tallenna
-               "Lähetä"
-               #(e! (v/->Kuittaa))
-               {:tallennus-kaynnissa? (:tallennus-kaynnissa? kuittaus)
-                :ikoni (ikonit/tallenna)
-                :disabled (esta-lahetys? kuittaus)
-                :virheviesti "Kuittauksen tallennuksessa tai lähetyksessä T-LOIK:n tapahtui virhe."
-                :luokka "nappi-ensisijainen"}]
-              [napit/peruuta
-               "Peruuta"
-               #(e! (v/->SuljeUusiKuittaus))
-               {:luokka "pull-right"}]]}
-    [(lomake/ryhma {:otsikko "Kuittaus"}
-                   {:nimi :tyyppi
-                    :otsikko "Tyyppi"
-                    :pakollinen? true
-                    :tyyppi :valinta
-                    :valinnat apurit/kuittaustyypit
-                    :valinta-nayta #(if %
-                                      (apurit/kuittaustyypin-selite %)
-                                      "- Valitse kuittaustyyppi -")
-                    :vihje (when (= :vaara-urakka (:tyyppi kuittaus))
-                             "Oikean urakan tiedot pyydetään välitettäväksi vapaatekstikentässä.")}
-                   (when (:tyyppi kuittaus)
-                     {:nimi :aiheutti-toimenpiteita
-                      :otsikko "Aiheutti toimenpiteita"
-                      :tyyppi :checkbox
-                      :vihje "Ilmoituksen myötä jouduttiin tekemään toimenpiteitä."})
-                   {:nimi :vakiofraasi
-                    :otsikko "Vakiofraasi"
-                    :tyyppi :haku
-                    :lahde fraasihaku
-                    :hae-kun-yli-n-merkkia 0}
-                   {:nimi :vapaateksti
-                    :otsikko "Vapaateksti"
-                    :tyyppi :text
-                    ;; pituus on XSD-skeeman maksimi 1024 - pisimmän vakiofraasin mitta (48)
-                    :pituus-max 976})
+  (komp/luo
+    (komp/kirjaa-kaytto! sivu "Uusi kuittaus")
+    (fn [e! kuittaus] [:div
+      {:class "uusi-kuittaus"}
+      [lomake/lomake
+       {:muokkaa! #(e! (v/->AsetaKuittausTiedot %))
+        :luokka :horizontal
+        :footer [:div
+                 [napit/tallenna
+                  "Lähetä"
+                  #(e! (v/->Kuittaa))
+                  {:tallennus-kaynnissa? (:tallennus-kaynnissa? kuittaus)
+                   :ikoni (ikonit/tallenna)
+                   :disabled (esta-lahetys? kuittaus)
+                   :virheviesti "Kuittauksen tallennuksessa tai lähetyksessä T-LOIK:n tapahtui virhe."
+                   :luokka "nappi-ensisijainen"}]
+                 [napit/peruuta
+                  "Peruuta"
+                  #(e! (v/->SuljeUusiKuittaus))
+                  {:luokka "pull-right"}]]}
+       [(lomake/ryhma {:otsikko "Kuittaus"}
+                      {:nimi :tyyppi
+                       :otsikko "Tyyppi"
+                       :pakollinen? true
+                       :tyyppi :valinta
+                       :valinnat apurit/kuittaustyypit
+                       :valinta-nayta #(if %
+                                         (apurit/kuittaustyypin-selite %)
+                                         "- Valitse kuittaustyyppi -")
+                       :vihje (when (= :vaara-urakka (:tyyppi kuittaus))
+                                "Oikean urakan tiedot pyydetään välitettäväksi vapaatekstikentässä.")}
+                      (when (:tyyppi kuittaus)
+                        {:nimi :aiheutti-toimenpiteita
+                         :otsikko "Aiheutti toimenpiteita"
+                         :tyyppi :checkbox
+                         :vihje "Ilmoituksen myötä jouduttiin tekemään toimenpiteitä."})
+                      {:nimi :vakiofraasi
+                       :otsikko "Vakiofraasi"
+                       :tyyppi :haku
+                       :lahde fraasihaku
+                       :hae-kun-yli-n-merkkia 0}
+                      {:nimi :vapaateksti
+                       :otsikko "Vapaateksti"
+                       :tyyppi :text
+                       ;; pituus on XSD-skeeman maksimi 1024 - pisimmän vakiofraasin mitta (48)
+                       :pituus-max 976})
 
-     (lomake/ryhma {:otsikko "Käsittelijä"
-                    :leveys-col 3}
-                   {:nimi :kasittelija-etunimi
-                    :otsikko "Etunimi"
-                    :leveys-col 3
-                    :tyyppi :string
-                    :pituus-max 32}
-                   {:nimi :kasittelija-sukunimi
-                    :otsikko "Sukunimi"
-                    :leveys-col 3
-                    :tyyppi :string
-                    :pituus-max 32}
-                   {:nimi :kasittelija-matkapuhelin
-                    :otsikko "Matkapuhelin"
-                    :leveys-col 3
-                    :tyyppi :puhelin
-                    :pituus-max 32}
-                   {:nimi :kasittelija-tyopuhelin
-                    :otsikko "Työpuhelin"
-                    :leveys-col 3
-                    :tyyppi :puhelin
-                    :pituus-max 32}
-                   {:nimi :kasittelija-sahkoposti
-                    :otsikko "Sähköposti"
-                    :leveys-col 3
-                    :tyyppi :email
-                    :pituus-max 64}
-                   {:nimi :kasittelija-organisaatio
-                    :otsikko "Organisaation nimi"
-                    :leveys-col 3
-                    :tyyppi :string
-                    :pituus-max 128}
-                   {:nimi :kasittelija-ytunnus
-                    :otsikko "Organisaation y-tunnus"
-                    :leveys-col 3
-                    :tyyppi :string
-                    :pituus-max 9})]
-    kuittaus]])
+        (lomake/ryhma {:otsikko "Käsittelijä"
+                       :leveys-col 3}
+                      {:nimi :kasittelija-etunimi
+                       :otsikko "Etunimi"
+                       :leveys-col 3
+                       :tyyppi :string
+                       :pituus-max 32}
+                      {:nimi :kasittelija-sukunimi
+                       :otsikko "Sukunimi"
+                       :leveys-col 3
+                       :tyyppi :string
+                       :pituus-max 32}
+                      {:nimi :kasittelija-matkapuhelin
+                       :otsikko "Matkapuhelin"
+                       :leveys-col 3
+                       :tyyppi :puhelin
+                       :pituus-max 32}
+                      {:nimi :kasittelija-tyopuhelin
+                       :otsikko "Työpuhelin"
+                       :leveys-col 3
+                       :tyyppi :puhelin
+                       :pituus-max 32}
+                      {:nimi :kasittelija-sahkoposti
+                       :otsikko "Sähköposti"
+                       :leveys-col 3
+                       :tyyppi :email
+                       :pituus-max 64}
+                      {:nimi :kasittelija-organisaatio
+                       :otsikko "Organisaation nimi"
+                       :leveys-col 3
+                       :tyyppi :string
+                       :pituus-max 128}
+                      {:nimi :kasittelija-ytunnus
+                       :otsikko "Organisaation y-tunnus"
+                       :leveys-col 3
+                       :tyyppi :string
+                       :pituus-max 9})]
+       kuittaus]])))
 
 (defn kanavan-ikoni [kuittaus]
   (case (:kanava kuittaus)
@@ -131,34 +134,37 @@
     nil))
 
 (defn kuittauksen-tiedot [kuittaus]
-  (let [valitys? (apurit/valitysviesti? kuittaus)]
-    ^{:key (str "kuittaus-paneeli-" (:id kuittaus))}
-    [bs/panel
-     {:class (if valitys? "valitys-viesti" "kuittaus-viesti")}
-     [:span (str (apurit/kuittaustyypin-otsikko (:kuittaustyyppi kuittaus)) " ") (kanavan-ikoni kuittaus)]
-     [:span
-      ^{:key "kuitattu"}
-      [yleiset/tietoja {}
-       (if valitys? "Lähetetty: " "Kuitattu: ") (pvm/pvm-aika-sek (:kuitattu kuittaus))
-       "Vakiofraasi: " (:vakiofraasi kuittaus)
+  (komp/luo
+    (komp/kirjaa-kaytto! sivu "Kuittauksen tiedot")
+    (fn [kuittaus]
+      (let [valitys? (apurit/valitysviesti? kuittaus)]
+       ^{:key (str "kuittaus-paneeli-" (:id kuittaus))}
+       [bs/panel
+        {:class (if valitys? "valitys-viesti" "kuittaus-viesti")}
+        [:span (str (apurit/kuittaustyypin-otsikko (:kuittaustyyppi kuittaus)) " ") (kanavan-ikoni kuittaus)]
+        [:span
+         ^{:key "kuitattu"}
+         [yleiset/tietoja {}
+          (if valitys? "Lähetetty: " "Kuitattu: ") (pvm/pvm-aika-sek (:kuitattu kuittaus))
+          "Vakiofraasi: " (:vakiofraasi kuittaus)
 
-       ;; Välitysviestien tapauksessa vapaatekstissä on viestin määrämittainen raakadata, eli sähköpostin tapauksessa
-       ;; HTML:ää. Ei näytetä sitä turhaan, tärkeää on joka tapauksessa tieto, kenelle välitysviesti on lähtenyt
-       "Vapaateksti: " (when-not valitys? (:vapaateksti kuittaus))
-       "Kanava: " (apurit/kanavan-otsikko (:kanava kuittaus))]
-      [:br]
-      ^{:key "kuittaaja"}
-      [yleiset/tietoja {}
-       (if valitys? "Vastaanottaja: " "Kuittaaja: ") (apurit/nayta-henkilo (:kuittaaja kuittaus))
-       "Puhelinnumero: " (apurit/parsi-puhelinnumero (:kuittaaja kuittaus))
-       "Sähköposti: " (get-in kuittaus [:kuittaaja :sahkoposti])]
-      [:br]
-      (when (:kasittelija kuittaus)
-        ^{:key "kasittelija"}
-        [yleiset/tietoja {}
-         "Käsittelijä: " (apurit/nayta-henkilo (:kasittelija kuittaus))
-         "Puhelinnumero: " (apurit/parsi-puhelinnumero (:kasittelija kuittaus))
-         "Sähköposti: " (get-in kuittaus [:kasittelija :sahkoposti])])]]))
+          ;; Välitysviestien tapauksessa vapaatekstissä on viestin määrämittainen raakadata, eli sähköpostin tapauksessa
+          ;; HTML:ää. Ei näytetä sitä turhaan, tärkeää on joka tapauksessa tieto, kenelle välitysviesti on lähtenyt
+          "Vapaateksti: " (when-not valitys? (:vapaateksti kuittaus))
+          "Kanava: " (apurit/kanavan-otsikko (:kanava kuittaus))]
+         [:br]
+         ^{:key "kuittaaja"}
+         [yleiset/tietoja {}
+          (if valitys? "Vastaanottaja: " "Kuittaaja: ") (apurit/nayta-henkilo (:kuittaaja kuittaus))
+          "Puhelinnumero: " (apurit/parsi-puhelinnumero (:kuittaaja kuittaus))
+          "Sähköposti: " (get-in kuittaus [:kuittaaja :sahkoposti])]
+         [:br]
+         (when (:kasittelija kuittaus)
+           ^{:key "kasittelija"}
+           [yleiset/tietoja {}
+            "Käsittelijä: " (apurit/nayta-henkilo (:kasittelija kuittaus))
+            "Puhelinnumero: " (apurit/parsi-puhelinnumero (:kasittelija kuittaus))
+            "Sähköposti: " (get-in kuittaus [:kasittelija :sahkoposti])])]]))))
 
 (def vakiofraasi-kentta
   {:otsikko "Vakiofraasi"
@@ -169,52 +175,56 @@
 
 (defn kuittaa-monta-lomake [e! {:keys [ilmoitukset tyyppi vapaateksti tallennus-kaynnissa?]
                                 :as data}]
-  (let [valittuna (count ilmoitukset)]
-    [:div.ilmoitukset-kuittaa-monta
-     [lomake/lomake
-      {:muokkaa! #(e! (v/->AsetaKuittausTiedot %))
-       :palstoja 3
-       :otsikko "Kuittaa monta ilmoitusta"}
-      [
-       (lomake/rivi
-         {:otsikko "Kuittaustyyppi"
-          :pakollinen? true
-          :tyyppi :valinta
-          :valinnat apurit/kuittaustyypit
-          :valinta-nayta #(or (apurit/kuittaustyypin-selite %) "- Valitse kuittaustyyppi -")
-          :nimi :tyyppi
-          :vihje (when (= :vaara-urakka (:tyyppi data))
-                   "Oikean urakan tiedot pyydetään välitettäväksi vapaatekstikentässä.")}
-         (when (= tyyppi :lopetus)
-           {:otsikko "Aiheutti toimenpiteitä"
-            :tyyppi :checkbox
-            :nimi :aiheutti-toimenpiteita})
-         vakiofraasi-kentta
-         {:otsikko "Vapaateksti"
-          :tyyppi :text
-          :koko [80 :auto]
-          :pituus-max 976
-          :nimi :vapaateksti})]
+  (komp/luo
+    (komp/kirjaa-kaytto! sivu "Kuittaa monta")
+    (fn [e! {:keys [ilmoitukset tyyppi vapaateksti tallennus-kaynnissa?]
+             :as data}] (let [valittuna (count ilmoitukset)]
+       [:div.ilmoitukset-kuittaa-monta
+        [lomake/lomake
+         {:muokkaa! #(e! (v/->AsetaKuittausTiedot %))
+          :palstoja 3
+          :otsikko "Kuittaa monta ilmoitusta"}
+         [
+          (lomake/rivi
+            {:otsikko "Kuittaustyyppi"
+             :pakollinen? true
+             :tyyppi :valinta
+             :valinnat apurit/kuittaustyypit
+             :valinta-nayta #(or (apurit/kuittaustyypin-selite %) "- Valitse kuittaustyyppi -")
+             :nimi :tyyppi
+             :vihje (when (= :vaara-urakka (:tyyppi data))
+                      "Oikean urakan tiedot pyydetään välitettäväksi vapaatekstikentässä.")}
+            (when (= tyyppi :lopetus)
+              {:otsikko "Aiheutti toimenpiteitä"
+               :tyyppi :checkbox
+               :nimi :aiheutti-toimenpiteita})
+            vakiofraasi-kentta
+            {:otsikko "Vapaateksti"
+             :tyyppi :text
+             :koko [80 :auto]
+             :pituus-max 976
+             :nimi :vapaateksti})]
 
-      data]
-     [napit/tallenna
-      (if (> valittuna 1)
-        (str "Kuittaa " valittuna " ilmoitusta")
-        "Kuittaa ilmoitus")
-      #(e! (v/->Kuittaa))
+         data]
+        [napit/tallenna
+         (if (> valittuna 1)
+           (str "Kuittaa " valittuna " ilmoitusta")
+           "Kuittaa ilmoitus")
+         #(e! (v/->Kuittaa))
 
-      {:ikoni (ikonit/tallenna)
-       :tallennus-kaynnissa? tallennus-kaynnissa?
-       :luokka (str (when tallennus-kaynnissa? "disabled ") "nappi-ensisijainen kuittaa-monta-tallennus")
-       :disabled (or (:tallennus-kaynnissa? data)
-                     (not (lomake/voi-tallentaa-ja-muokattu? data))
-                     (zero? valittuna))}]
-     [napit/peruuta "Peruuta" #(e! (v/->PeruMonenKuittaus))]
-     [yleiset/vihje "Valitse kuitattavat ilmoitukset listalta."]]))
+         {:ikoni (ikonit/tallenna)
+          :tallennus-kaynnissa? tallennus-kaynnissa?
+          :luokka (str (when tallennus-kaynnissa? "disabled ") "nappi-ensisijainen kuittaa-monta-tallennus")
+          :disabled (or (:tallennus-kaynnissa? data)
+                        (not (lomake/voi-tallentaa-ja-muokattu? data))
+                        (zero? valittuna))}]
+        [napit/peruuta "Peruuta" #(e! (v/->PeruMonenKuittaus))]
+        [yleiset/vihje "Valitse kuitattavat ilmoitukset listalta."]]))))
 
 (defn- pikakuittauslomake [e! pikakuittaus]
   (komp/luo
    (komp/fokusoi "input.form-control")
+   (komp/kirjaa-kaytto! sivu "Pikakuittauslomake")
    (fn [e! {:keys [tyyppi tallennus-kaynnissa?] :as pikakuittaus}]
      [lomake/lomake {:muokkaa! #(e! (v/->PaivitaPikakuittaus %))
                      :otsikko (apurit/kuittaustyypin-selite tyyppi)

--- a/src/cljs/harja/views/kanavat/urakka/laadunseuranta/hairiotilanteet.cljs
+++ b/src/cljs/harja/views/kanavat/urakka/laadunseuranta/hairiotilanteet.cljs
@@ -32,6 +32,8 @@
     [harja.makrot :refer [defc fnc]]
     [harja.tyokalut.ui :refer [for*]]))
 
+(def sivu "Kanavat/Häiriötilanteet")
+
 (defn- suodattimet-ja-toiminnot [e! app]
   (let [valittu-urakka (get-in app [:valinnat :urakka])]
     [valinnat/urakkavalinnat {:urakka valittu-urakka}
@@ -79,33 +81,37 @@
          {:disabled (not oikeus?)}])]]))
 
 (defn- hairiolista [e! {:keys [hairiotilanteet hairiotilanteiden-haku-kaynnissa?] :as app}]
-  [grid/grid
-   {:otsikko (if (and (some? hairiotilanteet) hairiotilanteiden-haku-kaynnissa?)
-               [ajax-loader-pieni "Päivitetään listaa"]
-               "Häiriötilanteet")
-    :tunniste ::hairiotilanne/id
-    :tyhja (if (nil? hairiotilanteet)
-             [ajax-loader "Haetaan häiriötilanteita"]
-             "Häiriötilanteita ei löytynyt")}
-   [{:otsikko "Päivä\u00ADmäärä" :nimi ::hairiotilanne/pvm :tyyppi :pvm :fmt pvm/pvm-opt :leveys 4}
-    {:otsikko "Kohde" :nimi ::hairiotilanne/kohde :tyyppi :string
-     :fmt kkohde/fmt-kohteen-kanava-nimi :leveys 10}
-    {:otsikko "Vika\u00ADluokka" :nimi ::hairiotilanne/vikaluokka :tyyppi :string :leveys 6
-     :fmt hairio/fmt-vikaluokka}
-    {:otsikko "Syy" :nimi ::hairiotilanne/syy :tyyppi :string :leveys 6}
-    {:otsikko "Odo\u00ADtus\u00ADaika (h)" :nimi ::hairiotilanne/odotusaika-h :tyyppi :numero :leveys 2}
-    {:otsikko "Am\u00ADmat\u00ADti\u00ADlii\u00ADkenne lkm" :nimi ::hairiotilanne/ammattiliikenne-lkm :tyyppi :numero :leveys 2}
-    {:otsikko "Hu\u00ADvi\u00ADlii\u00ADkenne lkm" :nimi ::hairiotilanne/huviliikenne-lkm :tyyppi :numero :leveys 2}
-    {:otsikko "Kor\u00ADjaus\u00ADtoimenpide" :nimi ::hairiotilanne/korjaustoimenpide :tyyppi :string :leveys 10}
-    {:otsikko "Kor\u00ADjaus\u00ADaika" :nimi ::hairiotilanne/korjausaika-h :tyyppi :numero :leveys 2}
-    {:otsikko "Kor\u00ADjauk\u00ADsen tila" :nimi ::hairiotilanne/korjauksen-tila :tyyppi :string :leveys 3
-     :fmt hairio/fmt-korjauksen-tila}
-    {:otsikko "Paikal\u00ADlinen käyt\u00ADtö" :nimi ::hairiotilanne/paikallinen-kaytto?
-     :tyyppi :string :fmt fmt/totuus :leveys 2}]
-   hairiotilanteet])
+  (komp/luo
+    (komp/kirjaa-gridin-kaytto! sivu)
+    (fn [e! {:keys [hairiotilanteet hairiotilanteiden-haku-kaynnissa?] :as app}]
+      [grid/grid
+      {:otsikko (if (and (some? hairiotilanteet) hairiotilanteiden-haku-kaynnissa?)
+                  [ajax-loader-pieni "Päivitetään listaa"]
+                  "Häiriötilanteet")
+       :tunniste ::hairiotilanne/id
+       :tyhja (if (nil? hairiotilanteet)
+                [ajax-loader "Haetaan häiriötilanteita"]
+                "Häiriötilanteita ei löytynyt")}
+      [{:otsikko "Päivä\u00ADmäärä" :nimi ::hairiotilanne/pvm :tyyppi :pvm :fmt pvm/pvm-opt :leveys 4}
+       {:otsikko "Kohde" :nimi ::hairiotilanne/kohde :tyyppi :string
+        :fmt kkohde/fmt-kohteen-kanava-nimi :leveys 10}
+       {:otsikko "Vika\u00ADluokka" :nimi ::hairiotilanne/vikaluokka :tyyppi :string :leveys 6
+        :fmt hairio/fmt-vikaluokka}
+       {:otsikko "Syy" :nimi ::hairiotilanne/syy :tyyppi :string :leveys 6}
+       {:otsikko "Odo\u00ADtus\u00ADaika (h)" :nimi ::hairiotilanne/odotusaika-h :tyyppi :numero :leveys 2}
+       {:otsikko "Am\u00ADmat\u00ADti\u00ADlii\u00ADkenne lkm" :nimi ::hairiotilanne/ammattiliikenne-lkm :tyyppi :numero :leveys 2}
+       {:otsikko "Hu\u00ADvi\u00ADlii\u00ADkenne lkm" :nimi ::hairiotilanne/huviliikenne-lkm :tyyppi :numero :leveys 2}
+       {:otsikko "Kor\u00ADjaus\u00ADtoimenpide" :nimi ::hairiotilanne/korjaustoimenpide :tyyppi :string :leveys 10}
+       {:otsikko "Kor\u00ADjaus\u00ADaika" :nimi ::hairiotilanne/korjausaika-h :tyyppi :numero :leveys 2}
+       {:otsikko "Kor\u00ADjauk\u00ADsen tila" :nimi ::hairiotilanne/korjauksen-tila :tyyppi :string :leveys 3
+        :fmt hairio/fmt-korjauksen-tila}
+       {:otsikko "Paikal\u00ADlinen käyt\u00ADtö" :nimi ::hairiotilanne/paikallinen-kaytto?
+        :tyyppi :string :fmt fmt/totuus :leveys 2}]
+      hairiotilanteet])))
 
 (defn hairiotilanteet* [e! app]
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (komp/watcher tiedot/valinnat (fn [_ _ uusi]
                                     (e! (tiedot/->PaivitaValinnat uusi))))
     (komp/sisaan-ulos #(do (e! (tiedot/->Nakymassa? true))

--- a/src/cljs/harja/views/main.cljs
+++ b/src/cljs/harja/views/main.cljs
@@ -243,6 +243,7 @@
   (kuuntele-oikeusvirheita)
   (hairiotiedot/tarkkaile-hairioilmoituksia!)
   (komp/luo
+    (komp/kirjaa-kaytto! "Main")
     (fn []
       (if @nav/render-lupa?
         (let [sivu @nav/valittu-sivu

--- a/src/cljs/harja/views/raportit.cljs
+++ b/src/cljs/harja/views/raportit.cljs
@@ -34,6 +34,8 @@
                    [reagent.ratom :refer [reaction run!]]
                    [cljs.core.async.macros :refer [go]]))
 
+(def sivu "Raportit")
+
 (def valittu-raporttityyppi-nimi (reaction (nav/valittu-valilehti :raportit)))
 (defn- valitse-raporttityyppi! [nimi]
   (nav/aseta-valittu-valilehti! :raportit nimi))
@@ -727,6 +729,7 @@
 
 (defn nayta-raportti [tyyppi r]
   (komp/luo
+    (komp/kirjaa-kaytto! sivu (:nimi tyyppi))
     (fn [tyyppi r]
       [:span
        [raportti/muodosta-html (assoc-in r [1 :tunniste] (:nimi tyyppi))]])))
@@ -768,6 +771,7 @@
 (defn raportit []
   (komp/luo
     (komp/lippu raportit/raportit-nakymassa?)
+    (komp/kirjaa-kaytto! sivu)
     (komp/sisaan #(do (when (nil? @raporttityypit)
                         (go (reset! raporttityypit (<! (raportit/hae-raportit)))))
                       (nav/valitse-urakoitsija! nil)))

--- a/src/cljs/harja/views/tilannekuva/tilannekuva.cljs
+++ b/src/cljs/harja/views/tilannekuva/tilannekuva.cljs
@@ -29,6 +29,8 @@
                    [harja.atom :refer [reaction-writable]]
                    [harja.tyokalut.ui :refer [for*]]))
 
+(def sivu "Tilannekuva")
+
 (def hallintapaneeli-max-korkeus (atom nil))
 
 (defn aseta-hallintapaneelin-max-korkeus [paneelin-sisalto]
@@ -275,17 +277,24 @@ suodatinryhmat
         tiedot/suodattimet [:varustetoteumat tk/varustetoteumat]]]]]))
 
 (defn nykytilanne-valinnat []
-  [:span.tilannekuva-nykytilanne-valinnat
-   [aikasuodattimet]
-   [aluesuodattimet]])
+  (komp/luo
+    (komp/kirjaa-kaytto! sivu "Nykytilanne")
+    (fn []
+      [:span.tilannekuva-nykytilanne-valinnat
+      [aikasuodattimet]
+      [aluesuodattimet]])))
 
 (defn historiakuva-valinnat []
-  [:span.tilannekuva-historiakuva-valinnat
-   [aikasuodattimet]
-   [aluesuodattimet]])
+  (komp/luo
+    (komp/kirjaa-kaytto! sivu "Historiakuva")
+    (fn []
+      [:span.tilannekuva-historiakuva-valinnat
+      [aikasuodattimet]
+      [aluesuodattimet]])))
 
 (defn tienakyma []
   (komp/luo
+    (komp/kirjaa-kaytto! sivu "Tienäkymä")
     (fn []
       [tienakyma/tienakyma])))
 
@@ -360,6 +369,7 @@ suodatinryhmat
 
 (defn tilannekuva []
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (komp/lippu tiedot/nakymassa? istunto/ajastin-taukotilassa?)
     (komp/watcher tiedot/valittu-tila
                   (fn [_ _ uusi]

--- a/src/cljs/harja/views/urakat.cljs
+++ b/src/cljs/harja/views/urakat.cljs
@@ -21,65 +21,72 @@
             [harja.tiedot.kartta :as kartta-tiedot])
   (:require-macros [cljs.core.async.macros :refer [go]]))
 
+(def sivu "Hallintayksikön tai urakan valinta")
+
 (defn valitse-hallintayksikko []
-  (let [hallintayksikot @hal/vaylamuodon-hallintayksikot]
-    [:div.row
-     [:div.col-md-4
-      (if (nil? hallintayksikot)
-        [yleiset/ajax-loader "Hallintayksiköitä haetaan..."]
-        [:span
-         [:h5.haku-otsikko "Valitse hallintayksikkö"]
-         [:div
-          ^{:key "hy-lista"}
-          [suodatettu-lista {:format hal/elynumero-ja-nimi :haku :nimi
-                             :selection nav/valittu-hallintayksikko
-                             :on-select nav/valitse-hallintayksikko!
-                             :aputeksti "Kirjoita hallintayksikön nimi tähän"}
-           hallintayksikot]]])]
-     [:div.col-md-8
-      [kartta/kartan-paikka hallintayksikot]]]))
+  (komp/luo
+    (komp/kirjaa-kaytto! sivu "Hallintayksikön valinta")
+    (fn []
+      (let [hallintayksikot @hal/vaylamuodon-hallintayksikot]
+       [:div.row
+        [:div.col-md-4
+         (if (nil? hallintayksikot)
+           [yleiset/ajax-loader "Hallintayksiköitä haetaan..."]
+           [:span
+            [:h5.haku-otsikko "Valitse hallintayksikkö"]
+            [:div
+             ^{:key "hy-lista"}
+             [suodatettu-lista {:format hal/elynumero-ja-nimi :haku :nimi
+                                :selection nav/valittu-hallintayksikko
+                                :on-select nav/valitse-hallintayksikko!
+                                :aputeksti "Kirjoita hallintayksikön nimi tähän"}
+              hallintayksikot]]])]
+        [:div.col-md-8
+         [kartta/kartan-paikka hallintayksikot]]]))))
 
 (defn valitse-urakka []
-  (let [urakkalista @nav/hallintayksikon-urakkalista
-        suodatettu-urakkalista @nav/suodatettu-urakkalista
-        nyt (pvm/nyt)
-        tulevia? (some #(pvm/ennen? nyt (:alkupvm %)) suodatettu-urakkalista)
-        kaynnissaolevia? (some #(and
-                                 (pvm/jalkeen? nyt (:alkupvm %))
-                                 (pvm/ennen? nyt (:loppupvm %))) suodatettu-urakkalista)
-        paattyneita? (some #(pvm/jalkeen? nyt (:loppupvm %)) suodatettu-urakkalista)
-        naytettavat-ryhmat (into []
-                                 (keep identity)
-                                 [(when tulevia? :tulevat)
-                                  (when kaynnissaolevia? :kaynnissa)
-                                  (when paattyneita? :paattyneet)])]
-    [:div.row
-     [:div.col-md-4
-      (if (nil? urakkalista)
-        [yleiset/ajax-loader "Urakoita haetaan..."]
-        [:span
-         [:h5.haku-otsikko "Valitse hallintayksikön urakka"]
-         [:div
-          ^{:key "ur-lista"}
-          [suodatettu-lista {:format         :nimi :haku :nimi
-                             :selection      nav/valittu-urakka
-                             :nayta-ryhmat   naytettavat-ryhmat
-                             :ryhmittely     #(if (pvm/ennen? nyt (:alkupvm %))
+  (komp/luo
+    (komp/kirjaa-kaytto! sivu "Urakan valinta")
+    (fn [] (let [urakkalista @nav/hallintayksikon-urakkalista
+           suodatettu-urakkalista @nav/suodatettu-urakkalista
+           nyt (pvm/nyt)
+           tulevia? (some #(pvm/ennen? nyt (:alkupvm %)) suodatettu-urakkalista)
+           kaynnissaolevia? (some #(and
+                                     (pvm/jalkeen? nyt (:alkupvm %))
+                                     (pvm/ennen? nyt (:loppupvm %))) suodatettu-urakkalista)
+           paattyneita? (some #(pvm/jalkeen? nyt (:loppupvm %)) suodatettu-urakkalista)
+           naytettavat-ryhmat (into []
+                                    (keep identity)
+                                    [(when tulevia? :tulevat)
+                                     (when kaynnissaolevia? :kaynnissa)
+                                     (when paattyneita? :paattyneet)])]
+       [:div.row
+        [:div.col-md-4
+         (if (nil? urakkalista)
+           [yleiset/ajax-loader "Urakoita haetaan..."]
+           [:span
+            [:h5.haku-otsikko "Valitse hallintayksikön urakka"]
+            [:div
+             ^{:key "ur-lista"}
+             [suodatettu-lista {:format :nimi :haku :nimi
+                                :selection nav/valittu-urakka
+                                :nayta-ryhmat naytettavat-ryhmat
+                                :ryhmittely #(if (pvm/ennen? nyt (:alkupvm %))
                                                :tulevat
                                                (if (pvm/jalkeen? nyt (:loppupvm %))
                                                  :paattyneet
                                                  :kaynnissa))
-                             :ryhman-otsikko #(case %
-                                               :tulevat "Tulevat urakat"
-                                               :kaynnissa "Käynnissä olevat urakat"
-                                               :paattyneet "Päättyneet urakat")
-                             :on-select      nav/valitse-urakka!
-                             :vinkki         #(when (empty? suodatettu-urakkalista)
-                                               "Hakuehdoilla ei löytynyt urakoita, joita on oikeus tarkastella.")
-                             :aputeksti      "Kirjoita urakan nimi tähän"}
-           suodatettu-urakkalista]]])]
-     [:div.col-md-8
-      [kartta/kartan-paikka suodatettu-urakkalista]]]))
+                                :ryhman-otsikko #(case %
+                                                   :tulevat "Tulevat urakat"
+                                                   :kaynnissa "Käynnissä olevat urakat"
+                                                   :paattyneet "Päättyneet urakat")
+                                :on-select nav/valitse-urakka!
+                                :vinkki #(when (empty? suodatettu-urakkalista)
+                                           "Hakuehdoilla ei löytynyt urakoita, joita on oikeus tarkastella.")
+                                :aputeksti "Kirjoita urakan nimi tähän"}
+              suodatettu-urakkalista]]])]
+        [:div.col-md-8
+         [kartta/kartan-paikka suodatettu-urakkalista]]]))))
 
 (defn valitse-hallintayksikko-ja-urakka
   "Jos hallintayksikköä ei ole valittu, palauttaa hallintayksikönvalintakomponentin
@@ -87,6 +94,7 @@
    Jos molemmat on valittu, palauttaa nil"
   []
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (komp/sisaan #(nav/paivita-url))
     {:component-did-mount (fn [& _] (kartta-tiedot/zoomaa-valittuun-hallintayksikkoon-tai-urakkaan))}
     (fn []

--- a/src/cljs/harja/views/urakka.cljs
+++ b/src/cljs/harja/views/urakka.cljs
@@ -31,7 +31,8 @@
             [harja.domain.urakka :as u-domain]
             [harja.domain.oikeudet :as oikeudet]
             [harja.tiedot.istunto :as istunto]
-            [harja.domain.urakka :as urakka])
+            [harja.domain.urakka :as urakka]
+            [harja.ui.komponentti :as komp])
 
   (:require-macros [cljs.core.async.macros :refer [go]]
                    [reagent.ratom :refer [reaction run!]]))
@@ -96,135 +97,137 @@
 (defn urakka
   "Urakkanäkymä"
   []
-  (let [ur @nav/valittu-urakka
-        _ (when-not (valilehti-mahdollinen? (nav/valittu-valilehti :urakat) ur)
-            (nav/aseta-valittu-valilehti! :urakat :yleiset))
-        hae-urakan-tyot (fn [ur]
-                          (when (oikeudet/urakat-suunnittelu-kokonaishintaisettyot (:id ur))
-                            (go (reset! u/urakan-kok-hint-tyot (<! (kok-hint-tyot/hae-urakan-kokonaishintaiset-tyot ur)))))
-                          (when (or (oikeudet/urakat-suunnittelu-yksikkohintaisettyot (:id ur))
-                                    (oikeudet/urakat-toteumat-yksikkohintaisettyot (:id ur)))
-                            (go (reset! u/urakan-yks-hint-tyot
-                                        (s/prosessoi-tyorivit ur
-                                                              (<! (yks-hint-tyot/hae-urakan-yksikkohintaiset-tyot (:id ur))))))))]
+  (komp/luo
+    (komp/kirjaa-kaytto! "Urakkanäkymä")
+    (fn [] (let [ur @nav/valittu-urakka
+           _ (when-not (valilehti-mahdollinen? (nav/valittu-valilehti :urakat) ur)
+               (nav/aseta-valittu-valilehti! :urakat :yleiset))
+           hae-urakan-tyot (fn [ur]
+                             (when (oikeudet/urakat-suunnittelu-kokonaishintaisettyot (:id ur))
+                               (go (reset! u/urakan-kok-hint-tyot (<! (kok-hint-tyot/hae-urakan-kokonaishintaiset-tyot ur)))))
+                             (when (or (oikeudet/urakat-suunnittelu-yksikkohintaisettyot (:id ur))
+                                       (oikeudet/urakat-toteumat-yksikkohintaisettyot (:id ur)))
+                               (go (reset! u/urakan-yks-hint-tyot
+                                           (s/prosessoi-tyorivit ur
+                                                                 (<! (yks-hint-tyot/hae-urakan-yksikkohintaiset-tyot (:id ur))))))))]
 
-    ;; Luetaan toimenpideinstanssi, jotta se ei menetä arvoaan kun vaihdetaan välilehtiä
-    @u/valittu-toimenpideinstanssi
+       ;; Luetaan toimenpideinstanssi, jotta se ei menetä arvoaan kun vaihdetaan välilehtiä
+       @u/valittu-toimenpideinstanssi
 
-    (hae-urakan-tyot ur)
-    (if @u/urakan-tiedot-ladattu?
-      [bs/tabs {:style :tabs :classes "tabs-taso1"
-                :active (nav/valittu-valilehti-atom :urakat)}
-       "Yleiset"
-       :yleiset
-       (when (oikeudet/urakat-yleiset (:id ur))
-         ^{:key "yleiset"}
-         [urakka-yleiset/yleiset ur])
+       (hae-urakan-tyot ur)
+       (if @u/urakan-tiedot-ladattu?
+         [bs/tabs {:style :tabs :classes "tabs-taso1"
+                   :active (nav/valittu-valilehti-atom :urakat)}
+          "Yleiset"
+          :yleiset
+          (when (oikeudet/urakat-yleiset (:id ur))
+            ^{:key "yleiset"}
+            [urakka-yleiset/yleiset ur])
 
-       "Suunnittelu"
-       :suunnittelu
-       (when (valilehti-mahdollinen? :suunnittelu ur)
-         ^{:key "suunnittelu"}
-         [suunnittelu/suunnittelu ur])
+          "Suunnittelu"
+          :suunnittelu
+          (when (valilehti-mahdollinen? :suunnittelu ur)
+            ^{:key "suunnittelu"}
+            [suunnittelu/suunnittelu ur])
 
-       "Toteumat"
-       :toteumat
-       (when (valilehti-mahdollinen? :toteumat ur)
-         ^{:key "toteumat"}
-         [toteumat/toteumat ur])
+          "Toteumat"
+          :toteumat
+          (when (valilehti-mahdollinen? :toteumat ur)
+            ^{:key "toteumat"}
+            [toteumat/toteumat ur])
 
-       "Toimenpiteet"
-       :toimenpiteet
-       (when (valilehti-mahdollinen? :toimenpiteet ur)
-         ^{:key "toimenpiteet"}
-         [toimenpiteet/toimenpiteet ur])
+          "Toimenpiteet"
+          :toimenpiteet
+          (when (valilehti-mahdollinen? :toimenpiteet ur)
+            ^{:key "toimenpiteet"}
+            [toimenpiteet/toimenpiteet ur])
 
-       "Liikenne"
-       :liikenne
-       (when (valilehti-mahdollinen? :liikenne ur)
-         ^{:key "liikenne"}
-         [liikenne/liikenne])
+          "Liikenne"
+          :liikenne
+          (when (valilehti-mahdollinen? :liikenne ur)
+            ^{:key "liikenne"}
+            [liikenne/liikenne])
 
-       "Materiaalit"
-       :vv-materiaalit
-       (when (valilehti-mahdollinen? :vv-materiaalit ur)
-         ^{:key "vv-materiaalit"}
-         [vv-materiaalit/materiaalit ur])
+          "Materiaalit"
+          :vv-materiaalit
+          (when (valilehti-mahdollinen? :vv-materiaalit ur)
+            ^{:key "vv-materiaalit"}
+            [vv-materiaalit/materiaalit ur])
 
-       ;; TODO Enabloi vasta kun tehty kokonaan, ei keskeneräistä kamaa tuotantoon
-       ;;"Turvalaitteet"
-       ;;:turvalaitteet
-       ;;(when (valilehti-mahdollinen? :turvalaitteet ur)
-       ;;  ^{:key "turvalaitteet"}
-       ;;  [turvalaitteet/turvalaitteet ur])
+          ;; TODO Enabloi vasta kun tehty kokonaan, ei keskeneräistä kamaa tuotantoon
+          ;;"Turvalaitteet"
+          ;;:turvalaitteet
+          ;;(when (valilehti-mahdollinen? :turvalaitteet ur)
+          ;;  ^{:key "turvalaitteet"}
+          ;;  [turvalaitteet/turvalaitteet ur])
 
-       "Toteutus"
-       :toteutus
-       (when (valilehti-mahdollinen? :toteutus ur)
-         ^{:key "toteutus"}
-         [toteutus/toteutus ur])
+          "Toteutus"
+          :toteutus
+          (when (valilehti-mahdollinen? :toteutus ur)
+            ^{:key "toteutus"}
+            [toteutus/toteutus ur])
 
-       "Aikataulu"
-       :aikataulu
-       (when (valilehti-mahdollinen? :aikataulu ur)
-         ^{:key "aikataulu"}
-         [aikataulu/aikataulu ur {:nakyma (:tyyppi ur)}])
+          "Aikataulu"
+          :aikataulu
+          (when (valilehti-mahdollinen? :aikataulu ur)
+            ^{:key "aikataulu"}
+            [aikataulu/aikataulu ur {:nakyma (:tyyppi ur)}])
 
-       "Kohdeluettelo"
-       :kohdeluettelo-paallystys
-       (when (valilehti-mahdollinen? :kohdeluettelo-paallystys ur)
-         ^{:key "kohdeluettelo"}
-         [paallystyksen-kohdeluettelo/kohdeluettelo ur])
+          "Kohdeluettelo"
+          :kohdeluettelo-paallystys
+          (when (valilehti-mahdollinen? :kohdeluettelo-paallystys ur)
+            ^{:key "kohdeluettelo"}
+            [paallystyksen-kohdeluettelo/kohdeluettelo ur])
 
-       "Kohdeluettelo"
-       :kohdeluettelo-paikkaus
-       (when (valilehti-mahdollinen? :kohdeluettelo-paikkaus ur)
-         ^{:key "kohdeluettelo"}
-         [paikkauksen-kohdeluettelo/kohdeluettelo ur])
+          "Kohdeluettelo"
+          :kohdeluettelo-paikkaus
+          (when (valilehti-mahdollinen? :kohdeluettelo-paikkaus ur)
+            ^{:key "kohdeluettelo"}
+            [paikkauksen-kohdeluettelo/kohdeluettelo ur])
 
-       "Laadunseuranta"
-       :laadunseuranta
-       (when (valilehti-mahdollinen? :laadunseuranta ur)
-         ^{:key "laadunseuranta"}
-         [laadunseuranta/laadunseuranta ur])
+          "Laadunseuranta"
+          :laadunseuranta
+          (when (valilehti-mahdollinen? :laadunseuranta ur)
+            ^{:key "laadunseuranta"}
+            [laadunseuranta/laadunseuranta ur])
 
-       "Välitavoitteet"
-       :valitavoitteet
-       (when (valilehti-mahdollinen? :valitavoitteet ur)
-         ^{:key "valitavoitteet"}
-         [valitavoitteet/valitavoitteet ur])
+          "Välitavoitteet"
+          :valitavoitteet
+          (when (valilehti-mahdollinen? :valitavoitteet ur)
+            ^{:key "valitavoitteet"}
+            [valitavoitteet/valitavoitteet ur])
 
-       "Turvallisuus"
-       :turvallisuuspoikkeamat
-       (when (valilehti-mahdollinen? :turvallisuuspoikkeamat ur)
-         ^{:key "turvallisuuspoikkeamat"}
-         [turvallisuuspoikkeamat/turvallisuuspoikkeamat ur])
+          "Turvallisuus"
+          :turvallisuuspoikkeamat
+          (when (valilehti-mahdollinen? :turvallisuuspoikkeamat ur)
+            ^{:key "turvallisuuspoikkeamat"}
+            [turvallisuuspoikkeamat/turvallisuuspoikkeamat ur])
 
-       "Laskutus"
-       :laskutus
-       (when (valilehti-mahdollinen? :laskutus ur)
-         ^{:key "laskutus"}
-         [laskutus/laskutus])
+          "Laskutus"
+          :laskutus
+          (when (valilehti-mahdollinen? :laskutus ur)
+            ^{:key "laskutus"}
+            [laskutus/laskutus])
 
-       "Laskutus"
-       :laskutus-vesivaylat
-       (when (valilehti-mahdollinen? :laskutus-vesivaylat ur)
-         ^{:key "laskutus"}
-         [laskutus-vesivaylat/laskutus])
+          "Laskutus"
+          :laskutus-vesivaylat
+          (when (valilehti-mahdollinen? :laskutus-vesivaylat ur)
+            ^{:key "laskutus"}
+            [laskutus-vesivaylat/laskutus])
 
-       "Laskutus"
-       :laskutus-kanavat
-       (when (valilehti-mahdollinen? :laskutus-kanavat ur)
-         ^{:key "laskutus"}
-         [laskutus-kanavat/laskutus])
+          "Laskutus"
+          :laskutus-kanavat
+          (when (valilehti-mahdollinen? :laskutus-kanavat ur)
+            ^{:key "laskutus"}
+            [laskutus-kanavat/laskutus])
 
-       "Kustannukset"
-       :tiemerkinnan-kustannukset
-       (when (valilehti-mahdollinen? :tiemerkinnan-kustannukset ur)
-         ^{:key "tiemerkinnan-kustannukset"}
-         [tiemerkinnan-kustannukset/kustannukset
-          ur
-          tiemerkinnan-kustannukset-tiedot/raportin-parametrit
-          tiemerkinnan-kustannukset-tiedot/raportin-tiedot])]
+          "Kustannukset"
+          :tiemerkinnan-kustannukset
+          (when (valilehti-mahdollinen? :tiemerkinnan-kustannukset ur)
+            ^{:key "tiemerkinnan-kustannukset"}
+            [tiemerkinnan-kustannukset/kustannukset
+             ur
+             tiemerkinnan-kustannukset-tiedot/raportin-parametrit
+             tiemerkinnan-kustannukset-tiedot/raportin-tiedot])]
 
-      [ajax-loader "Ladataan urakan tietoja..."])))
+         [ajax-loader "Ladataan urakan tietoja..."])))))

--- a/src/cljs/harja/views/urakka/aikataulu.cljs
+++ b/src/cljs/harja/views/urakka/aikataulu.cljs
@@ -35,6 +35,8 @@
   (:require-macros [reagent.ratom :refer [reaction run!]]
                    [cljs.core.async.macros :refer [go]]))
 
+(def sivu "Aikataulu")
+
 (defn tiemerkintavalmius-modal
   "Modaali, jossa joko merkitään kohde valmiiksi tiemerkintään tai perutaan aiemmin annettu valmius."
   [data]
@@ -195,6 +197,7 @@
   [urakka optiot]
   (komp/luo
     (komp/lippu tiedot/aikataulu-nakymassa?)
+    (komp/kirjaa-kaytto! sivu)
     (fn [urakka optiot]
       (let [{urakka-id :id :as ur} @nav/valittu-urakka
             sopimus-id (first @u/valittu-sopimusnumero)

--- a/src/cljs/harja/views/urakka/laadunseuranta/laatupoikkeama.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/laatupoikkeama.cljs
@@ -299,6 +299,7 @@ sekä sanktio-virheet atomin, jonne yksittäisen sanktion virheet kirjoitetaan (
                                                 oikeudet/urakat-laadunseuranta-sanktiot
                                                 urakka-id @istunto/kayttaja)]
      (komp/luo
+       (komp/kirjaa-lomakkeen-kaytto! laatupoikkeamat/sivu)
        (fn [laatupoikkeama optiot]
          (let [uusi? (not (:id @laatupoikkeama))
                sanktion-validointi (partial lisaa-sanktion-validointi

--- a/src/cljs/harja/views/urakka/laadunseuranta/laatupoikkeama.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/laatupoikkeama.cljs
@@ -299,7 +299,7 @@ sekä sanktio-virheet atomin, jonne yksittäisen sanktion virheet kirjoitetaan (
                                                 oikeudet/urakat-laadunseuranta-sanktiot
                                                 urakka-id @istunto/kayttaja)]
      (komp/luo
-       (komp/kirjaa-lomakkeen-kaytto! laatupoikkeamat/sivu)
+       (komp/kirjaa-lomakkeen-kaytto! "Laadunseuranta/Tarkastukset")
        (fn [laatupoikkeama optiot]
          (let [uusi? (not (:id @laatupoikkeama))
                sanktion-validointi (partial lisaa-sanktion-validointi

--- a/src/cljs/harja/views/urakka/laadunseuranta/laatupoikkeamat.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/laatupoikkeamat.cljs
@@ -27,7 +27,7 @@
                    [cljs.core.async.macros :refer [go]]
                    [harja.atom :refer [reaction<!]]))
 
-(def sivu "laadunseuranta/laatupoikkeamat")
+(def sivu "Laadunseuranta/Laatupoikkeamat")
 
 (defn laatupoikkeamalistaus
   "Listaa urakan laatupoikkeamat"

--- a/src/cljs/harja/views/urakka/laadunseuranta/laatupoikkeamat.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/laatupoikkeamat.cljs
@@ -27,68 +27,73 @@
                    [cljs.core.async.macros :refer [go]]
                    [harja.atom :refer [reaction<!]]))
 
+(def sivu "laadunseuranta/laatupoikkeamat")
+
 (defn laatupoikkeamalistaus
   "Listaa urakan laatupoikkeamat"
   [optiot]
-  (let [poikkeamat (when @laatupoikkeamat/urakan-laatupoikkeamat
-                     (reverse (sort-by :aika @laatupoikkeamat/urakan-laatupoikkeamat)))
-        nakyma (:nakyma optiot)]
-    [:div.laatupoikkeamat
-     [valinnat/urakkavalinnat {:urakka (:urakka optiot)}
-      ^{:key "urakkavalinnat"}
-      [:div
-       [urakka-valinnat/urakan-hoitokausi @nav/valittu-urakka]
-       [yleiset/pudotusvalikko
-        "Näytä laatupoikkeamat"
-        {:valinta @laatupoikkeamat/listaus
-         :valitse-fn #(reset! laatupoikkeamat/listaus %)
-         :format-fn #(case %
-                       :kaikki "Kaikki"
-                       :kasitellyt "Käsitellyt (päätös tehty)"
-                       :selvitys "Odottaa urakoitsijan selvitystä"
-                       :omat "Minun kirjaamat / kommentoimat"
-                       :poikkeamaraportilliset "Poikkeamaraportilliset")}
-        [:kaikki :selvitys :kasitellyt :omat :poikkeamaraportilliset]]
-       [urakka-valinnat/aikavali]]
+  (komp/luo
+    (komp/kirjaa-gridin-kaytto! sivu)
+    (fn [optiot]
+      (let [poikkeamat (when @laatupoikkeamat/urakan-laatupoikkeamat
+                         (reverse (sort-by :aika @laatupoikkeamat/urakan-laatupoikkeamat)))
+            nakyma (:nakyma optiot)]
+        [:div.laatupoikkeamat
+         [valinnat/urakkavalinnat {:urakka (:urakka optiot)}
+          ^{:key "urakkavalinnat"}
+          [:div
+           [urakka-valinnat/urakan-hoitokausi @nav/valittu-urakka]
+           [yleiset/pudotusvalikko
+            "Näytä laatupoikkeamat"
+            {:valinta @laatupoikkeamat/listaus
+             :valitse-fn #(reset! laatupoikkeamat/listaus %)
+             :format-fn #(case %
+                           :kaikki "Kaikki"
+                           :kasitellyt "Käsitellyt (päätös tehty)"
+                           :selvitys "Odottaa urakoitsijan selvitystä"
+                           :omat "Minun kirjaamat / kommentoimat"
+                           :poikkeamaraportilliset "Poikkeamaraportilliset")}
+            [:kaikki :selvitys :kasitellyt :omat :poikkeamaraportilliset]]
+           [urakka-valinnat/aikavali]]
 
-      ^{:key "urakkatoiminnot"}
-      [valinnat/urakkatoiminnot {:urakka (:urakka optiot)}
-       (let [oikeus? @laatupoikkeamat/voi-kirjata?]
-         (yleiset/wrap-if
-           (not oikeus?)
-           [yleiset/tooltip {} :%
-            (oikeudet/oikeuden-puute-kuvaus :kirjoitus
-                                            oikeudet/urakat-laadunseuranta-laatupoikkeamat)]
-           ^{:key "uusi-laatupoikkeama"}
-           [napit/uusi "Uusi laatupoikkeama"
-            #(reset! laatupoikkeamat/valittu-laatupoikkeama-id :uusi)
-            {:disabled (not oikeus?)}]))]]
+          ^{:key "urakkatoiminnot"}
+          [valinnat/urakkatoiminnot {:urakka (:urakka optiot)}
+           (let [oikeus? @laatupoikkeamat/voi-kirjata?]
+             (yleiset/wrap-if
+               (not oikeus?)
+               [yleiset/tooltip {} :%
+                (oikeudet/oikeuden-puute-kuvaus :kirjoitus
+                                                oikeudet/urakat-laadunseuranta-laatupoikkeamat)]
+               ^{:key "uusi-laatupoikkeama"}
+               [napit/uusi "Uusi laatupoikkeama"
+                #(reset! laatupoikkeamat/valittu-laatupoikkeama-id :uusi)
+                {:disabled (not oikeus?)}]))]]
 
-     [grid/grid
-      {:otsikko "Laatu\u00ADpoikkeamat" :rivi-klikattu #(reset! laatupoikkeamat/valittu-laatupoikkeama-id (:id %))
-       :tyhja (if (nil? poikkeamat)
-                [yleiset/ajax-loader "Laatupoikkeamia ladataan"]
-                "Ei laatupoikkeamia")}
-      [{:otsikko "Päivä\u00ADmäärä" :nimi :aika :fmt pvm/pvm-aika :leveys 1}
-       (when (or (= :paallystys nakyma)
-                 (= :paikkaus nakyma)
-                 (= :tiemerkinta nakyma))
-         {:otsikko "Yllä\u00ADpito\u00ADkoh\u00ADde" :nimi :kohde :leveys 2
-          :hae (fn [rivi]
-                 (yllapitokohde-domain/yllapitokohde-tekstina {:kohdenumero (get-in rivi [:yllapitokohde :numero])
-                                                               :nimi (get-in rivi [:yllapitokohde :nimi])}))})
-       (when (= :hoito nakyma)
-         {:otsikko "Koh\u00ADde" :nimi :kohde :leveys 1})
-       (when-not (urakka/vesivaylaurakkatyyppi? nakyma)
-         {:otsikko "TR-osoite"
-          :nimi :tr
-          :leveys 2
-          :fmt tierekisteri/tierekisteriosoite-tekstina})
-       {:otsikko "Kuvaus" :nimi :kuvaus :leveys 3}
-       {:otsikko "Tekijä" :nimi :tekija :leveys 1 :fmt laatupoikkeamat/kuvaile-tekija}
-       {:otsikko "Päätös" :nimi :paatos :fmt laatupoikkeamat/kuvaile-paatos :leveys 2}
-       {:otsikko "Poikkeamaraportti" :nimi :sisaltaa-poikkeamaraportin? :fmt fmt/totuus :tasaa :keskita :leveys 1}]
-      poikkeamat]]))
+         [grid/grid
+          {:otsikko "Laatu\u00ADpoikkeamat" :rivi-klikattu #(reset! laatupoikkeamat/valittu-laatupoikkeama-id (:id %))
+           :tyhja (if (nil? poikkeamat)
+                    [yleiset/ajax-loader "Laatupoikkeamia ladataan"]
+                    "Ei laatupoikkeamia")}
+          [{:otsikko "Päivä\u00ADmäärä" :nimi :aika :fmt pvm/pvm-aika :leveys 1}
+           (when (or (= :paallystys nakyma)
+                     (= :paikkaus nakyma)
+                     (= :tiemerkinta nakyma))
+             {:otsikko "Yllä\u00ADpito\u00ADkoh\u00ADde" :nimi :kohde :leveys 2
+              :hae (fn [rivi]
+                     (yllapitokohde-domain/yllapitokohde-tekstina {:kohdenumero (get-in rivi [:yllapitokohde :numero])
+                                                                   :nimi (get-in rivi [:yllapitokohde :nimi])}))})
+           (when (= :hoito nakyma)
+             {:otsikko "Koh\u00ADde" :nimi :kohde :leveys 1})
+           (when-not (urakka/vesivaylaurakkatyyppi? nakyma)
+             {:otsikko "TR-osoite"
+              :nimi :tr
+              :leveys 2
+              :fmt tierekisteri/tierekisteriosoite-tekstina})
+           {:otsikko "Kuvaus" :nimi :kuvaus :leveys 3}
+           {:otsikko "Tekijä" :nimi :tekija :leveys 1 :fmt laatupoikkeamat/kuvaile-tekija}
+           {:otsikko "Päätös" :nimi :paatos :fmt laatupoikkeamat/kuvaile-paatos :leveys 2}
+           {:otsikko "Poikkeamaraportti" :nimi :sisaltaa-poikkeamaraportin? :fmt fmt/totuus :tasaa :keskita :leveys 1}]
+          poikkeamat]]))))
 
 (defn paatos?
   "Onko annetussa laatupoikkeamassa päätös?"
@@ -100,6 +105,7 @@
 
 (defn laatupoikkeamat [optiot]
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (komp/lippu lp-kartalla/karttataso-laatupoikkeamat)
     (komp/kuuntelija :laatupoikkeama-klikattu #(reset! laatupoikkeamat/valittu-laatupoikkeama-id (:id %2)))
     (komp/ulos (kartta-tiedot/kuuntele-valittua! laatupoikkeamat/valittu-laatupoikkeama))

--- a/src/cljs/harja/views/urakka/laadunseuranta/mobiilityokalu.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/mobiilityokalu.cljs
@@ -2,33 +2,39 @@
   (:require [reagent.core :refer [atom] :as r]
             [harja.loki :refer [log logt tarkkaile!]]
             [cljs.core.async :refer [<! >! chan]]
-            [harja.ui.ikonit :as ikonit]))
+            [harja.ui.ikonit :as ikonit]
+            [harja.ui.komponentti :as komp]))
+
+(def sivu "laadunseuranta/mobiilityokalu")
 
 (defn mobiilityokalu []
-  [:div.mobiilityokalu-container
-   [:img.mobiilityokalu {:src "images/mobiilityokalu.jpg"}]
-   [:h3 "Esittely"]
-   [:p "Tarkastuksien ja havaintojen tekemistä helpottamaan on olemassa erillinen Mobiili laadunseurantatyökalu. Työkalua käytetään kirjaamaan havaintoja, mittauksia ja valokuvia suoraan tien päällä tarkastusajon aikana. Havaintoja voi kirjata joko pikahavaintonapeilla tai omin sanoin lomakkeella. Kun tarkastusajo on valmis, voidaan valita urakka, johon tulokset kirjataan (oletuksena ehdotetaan käyttäjän omaa lähintä urakkaa). Tarkastusten tietoja voi myöhemmin täydentää Harjassa."]
-   [:p "Sovellus on tehty ensisijaisesti Android-tableteille, mutta se toimii myös iPadilla. Myös puhelinkäyttö on mahdollista Android-puhelimilla ja iPhonella."]
-   [:p [:strong "Laitevaatimukset:"]]
-   [:ul
-    [:li "Android-tabletti tai iPad"]
-    [:li "GPS-yhteys"]
-    [:li "Internet-yhteys (ainoastaan tarkastusajon aloittamista ja päättämistä varten)"]
-    [:li "Selain: Chrome (53 tai uudempi), Firefox (49 tai uudempi), iPad Safari (9.3 tai uudempi)"]]
+  (komp/luo
+    (komp/kirjaa-kaytto! sivu)
+    (fn []
+      [:div.mobiilityokalu-container
+       [:img.mobiilityokalu {:src "images/mobiilityokalu.jpg"}]
+       [:h3 "Esittely"]
+       [:p "Tarkastuksien ja havaintojen tekemistä helpottamaan on olemassa erillinen Mobiili laadunseurantatyökalu. Työkalua käytetään kirjaamaan havaintoja, mittauksia ja valokuvia suoraan tien päällä tarkastusajon aikana. Havaintoja voi kirjata joko pikahavaintonapeilla tai omin sanoin lomakkeella. Kun tarkastusajo on valmis, voidaan valita urakka, johon tulokset kirjataan (oletuksena ehdotetaan käyttäjän omaa lähintä urakkaa). Tarkastusten tietoja voi myöhemmin täydentää Harjassa."]
+       [:p "Sovellus on tehty ensisijaisesti Android-tableteille, mutta se toimii myös iPadilla. Myös puhelinkäyttö on mahdollista Android-puhelimilla ja iPhonella."]
+       [:p [:strong "Laitevaatimukset:"]]
+       [:ul
+        [:li "Android-tabletti tai iPad"]
+        [:li "GPS-yhteys"]
+        [:li "Internet-yhteys (ainoastaan tarkastusajon aloittamista ja päättämistä varten)"]
+        [:li "Selain: Chrome (53 tai uudempi), Firefox (49 tai uudempi), iPad Safari (9.3 tai uudempi)"]]
 
-   [:p "Kaikkien merkintöjen tallentumiseksi sovellus tulee pitää koko ajan näkyvissä. On myös suositeltavaa asettaa laitteen automaattilukitus pois päältä tai viive mahdollisimman suureksi tarkastusajon ajaksi:"
-    [:br] "- iPadissa Asetukset -> Yleiset -> Automaattilukitus -> Pois"
-    [:br] "- Androidissa Asetukset -> Näyttö -> Näytön aikakatkaisu -> Pois"]
+       [:p "Kaikkien merkintöjen tallentumiseksi sovellus tulee pitää koko ajan näkyvissä. On myös suositeltavaa asettaa laitteen automaattilukitus pois päältä tai viive mahdollisimman suureksi tarkastusajon ajaksi:"
+        [:br] "- iPadissa Asetukset -> Yleiset -> Automaattilukitus -> Pois"
+        [:br] "- Androidissa Asetukset -> Näyttö -> Näytön aikakatkaisu -> Pois"]
 
-   [:h3 "Käyttö"]
-   [:a {:href "https://extranet.liikennevirasto.fi/harja/laadunseuranta/"}
-    (ikonit/ikoni-ja-teksti (ikonit/livicon-arrow-right)
-                            "Siirry Mobiiliin laadunseurantatyökaluun")]
-   [:p "Työkalulla kirjatut tarkastukset kirjataan suoraan Harjaan käyttäjän valitsemaan urakkaan."]
-   [:a {:href "https://testiextranet.liikennevirasto.fi/harja/laadunseuranta/"}
-    (ikonit/ikoni-ja-teksti (ikonit/livicon-arrow-right)
-                            "Siirry testiympäristöön")]
-   [:p "Jos haluat ensin testata työkalua, voit käyttää sitä Harjan testiympäristössä, jossa suoritetut ajot tallentuvat ainoastaan testiympäristöön."]
-   [:br]
-   [:br]])
+       [:h3 "Käyttö"]
+       [:a {:href "https://extranet.liikennevirasto.fi/harja/laadunseuranta/"}
+        (ikonit/ikoni-ja-teksti (ikonit/livicon-arrow-right)
+                                "Siirry Mobiiliin laadunseurantatyökaluun")]
+       [:p "Työkalulla kirjatut tarkastukset kirjataan suoraan Harjaan käyttäjän valitsemaan urakkaan."]
+       [:a {:href "https://testiextranet.liikennevirasto.fi/harja/laadunseuranta/"}
+        (ikonit/ikoni-ja-teksti (ikonit/livicon-arrow-right)
+                                "Siirry testiympäristöön")]
+       [:p "Jos haluat ensin testata työkalua, voit käyttää sitä Harjan testiympäristössä, jossa suoritetut ajot tallentuvat ainoastaan testiympäristöön."]
+       [:br]
+       [:br]])))

--- a/src/cljs/harja/views/urakka/laadunseuranta/mobiilityokalu.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/mobiilityokalu.cljs
@@ -5,7 +5,7 @@
             [harja.ui.ikonit :as ikonit]
             [harja.ui.komponentti :as komp]))
 
-(def sivu "laadunseuranta/mobiilityokalu")
+(def sivu "Laadunseuranta/Mobiilityökalu")
 
 (defn mobiilityokalu []
   (komp/luo

--- a/src/cljs/harja/views/urakka/laadunseuranta/sanktiot.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/sanktiot.cljs
@@ -33,7 +33,7 @@
   (:require-macros [harja.atom :refer [reaction<!]]
                    [reagent.ratom :refer [reaction]]))
 
-(def sivu "laadunseuranta/sanktiot")
+(def sivu "Laadunseuranta/Sanktiot")
 
 (defn sanktion-tiedot
   [optiot]

--- a/src/cljs/harja/views/urakka/laadunseuranta/sanktiot.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/sanktiot.cljs
@@ -33,220 +33,224 @@
   (:require-macros [harja.atom :refer [reaction<!]]
                    [reagent.ratom :refer [reaction]]))
 
+(def sivu "laadunseuranta/sanktiot")
+
 (defn sanktion-tiedot
   [optiot]
   (let [muokattu (atom @tiedot/valittu-sanktio)
         voi-muokata? (oikeudet/voi-kirjoittaa? oikeudet/urakat-laadunseuranta-sanktiot
                                                (:id @nav/valittu-urakka))
         tallennus-kaynnissa (atom false)]
-    (fn [optiot]
-      (let [yllapitokohteet (conj (:yllapitokohteet optiot) {:id nil})
-            mahdolliset-sanktiolajit @tiedot-urakka/urakkatyypin-sanktiolajit
-            yllapito? (:yllapito? optiot)
-            vesivayla? (:vesivayla? optiot)
-            yllapitokohdeurakka? @tiedot-urakka/yllapitokohdeurakka?]
-        [:div
-         [napit/takaisin "Takaisin sanktioluetteloon" #(reset! tiedot/valittu-sanktio nil)]
-         ;; Vaadi tarvittavat tiedot ennen rendausta
-         (if (and mahdolliset-sanktiolajit
-                  (or (not yllapitokohdeurakka?)
-                      (and yllapitokohdeurakka? yllapitokohteet)))
-           [lomake/lomake
-            {:otsikko (if (:id @muokattu)
-                        (if (:suorasanktio @muokattu)
-                          "Muokkaa suoraa sanktiota"
-                          "Muokkaa laatupoikkeaman kautta tehtyä sanktiota")
-                        "Luo uusi suora sanktio")
-             :luokka :horizontal
-             :muokkaa! #(reset! muokattu %)
-             :voi-muokata? voi-muokata?
-             :footer-fn (fn [tarkastus]
-                          [:span.nappiwrappi
-                           [napit/palvelinkutsu-nappi
-                            "Tallenna sanktio"
-                            #(tiedot/tallenna-sanktio @muokattu (:id @nav/valittu-urakka))
-                            {:luokka "nappi-ensisijainen"
-                             :ikoni (ikonit/tallenna)
-                             :kun-onnistuu #(reset! tiedot/valittu-sanktio nil)
-                             :disabled (or (not voi-muokata?)
-                                           (not (lomake/voi-tallentaa? tarkastus)))}]
-                           (when (and voi-muokata? (:id @muokattu))
-                             [:button.nappi-kielteinen
-                              {:class (when @tallennus-kaynnissa "disabled")
-                               :on-click
-                               (fn [e]
-                                 (.preventDefault e)
-                                 (varmista-kayttajalta/varmista-kayttajalta
-                                   {:otsikko "Sanktion poistaminen"
-                                    :sisalto (str "Haluatko varmasti poistaa sanktion "
-                                                  (or (str (:summa @muokattu) "€") "")
-                                                  " päivämäärällä "
-                                                  (pvm/pvm (:perintapvm @muokattu)) "?")
-                                    :hyvaksy "Poista"
-                                    :toiminto-fn #(do
-                                                    (let [res (tiedot/tallenna-sanktio
-                                                                (assoc @muokattu
-                                                                  :poistettu true)
-                                                                (:id @nav/valittu-urakka))]
-                                                      (do (viesti/nayta! "Sanktio poistettu")
-                                                          (reset! tiedot/valittu-sanktio nil))))}))}
-                              (ikonit/livicon-trash) " Poista sanktio"])])}
-            [{:otsikko "Tekijä" :nimi :tekijanimi
-              :hae (comp :tekijanimi :laatupoikkeama)
-              :aseta (fn [rivi arvo] (assoc-in rivi [:laatupoikkeama :tekijanimi] arvo))
-              :leveys 1 :tyyppi :string
-              :muokattava? (constantly false)}
+    (komp/luo
+      (komp/kirjaa-lomakkeen-kaytto! sivu)
+      (fn [optiot]
+        (let [yllapitokohteet (conj (:yllapitokohteet optiot) {:id nil})
+              mahdolliset-sanktiolajit @tiedot-urakka/urakkatyypin-sanktiolajit
+              yllapito? (:yllapito? optiot)
+              vesivayla? (:vesivayla? optiot)
+              yllapitokohdeurakka? @tiedot-urakka/yllapitokohdeurakka?]
+          [:div
+           [napit/takaisin "Takaisin sanktioluetteloon" #(reset! tiedot/valittu-sanktio nil)]
+           ;; Vaadi tarvittavat tiedot ennen rendausta
+           (if (and mahdolliset-sanktiolajit
+                    (or (not yllapitokohdeurakka?)
+                        (and yllapitokohdeurakka? yllapitokohteet)))
+             [lomake/lomake
+              {:otsikko (if (:id @muokattu)
+                          (if (:suorasanktio @muokattu)
+                            "Muokkaa suoraa sanktiota"
+                            "Muokkaa laatupoikkeaman kautta tehtyä sanktiota")
+                          "Luo uusi suora sanktio")
+               :luokka :horizontal
+               :muokkaa! #(reset! muokattu %)
+               :voi-muokata? voi-muokata?
+               :footer-fn (fn [tarkastus]
+                            [:span.nappiwrappi
+                             [napit/palvelinkutsu-nappi
+                              "Tallenna sanktio"
+                              #(tiedot/tallenna-sanktio @muokattu (:id @nav/valittu-urakka))
+                              {:luokka "nappi-ensisijainen"
+                               :ikoni (ikonit/tallenna)
+                               :kun-onnistuu #(reset! tiedot/valittu-sanktio nil)
+                               :disabled (or (not voi-muokata?)
+                                             (not (lomake/voi-tallentaa? tarkastus)))}]
+                             (when (and voi-muokata? (:id @muokattu))
+                               [:button.nappi-kielteinen
+                                {:class (when @tallennus-kaynnissa "disabled")
+                                 :on-click
+                                 (fn [e]
+                                   (.preventDefault e)
+                                   (varmista-kayttajalta/varmista-kayttajalta
+                                     {:otsikko "Sanktion poistaminen"
+                                      :sisalto (str "Haluatko varmasti poistaa sanktion "
+                                                    (or (str (:summa @muokattu) "€") "")
+                                                    " päivämäärällä "
+                                                    (pvm/pvm (:perintapvm @muokattu)) "?")
+                                      :hyvaksy "Poista"
+                                      :toiminto-fn #(do
+                                                      (let [res (tiedot/tallenna-sanktio
+                                                                  (assoc @muokattu
+                                                                    :poistettu true)
+                                                                  (:id @nav/valittu-urakka))]
+                                                        (do (viesti/nayta! "Sanktio poistettu")
+                                                            (reset! tiedot/valittu-sanktio nil))))}))}
+                                (ikonit/livicon-trash) " Poista sanktio"])])}
+              [{:otsikko "Tekijä" :nimi :tekijanimi
+                :hae (comp :tekijanimi :laatupoikkeama)
+                :aseta (fn [rivi arvo] (assoc-in rivi [:laatupoikkeama :tekijanimi] arvo))
+                :leveys 1 :tyyppi :string
+                :muokattava? (constantly false)}
 
-             (lomake/ryhma {:rivi? true}
-                           {:otsikko "Havaittu" :nimi :laatupoikkeamaaika
-                            :pakollinen? true
-                            :hae (comp :aika :laatupoikkeama)
-                            :aseta (fn [rivi arvo] (assoc-in rivi [:laatupoikkeama :aika] arvo))
-                            :fmt pvm/pvm-aika :leveys 1 :tyyppi :pvm
-                            :validoi [[:ei-tyhja "Valitse päivämäärä"]]
-                            :huomauta [[:urakan-aikana-ja-hoitokaudella]]}
-                           {:otsikko "Käsitelty" :nimi :kasittelyaika
-                            :pakollinen? true
-                            :hae (comp :kasittelyaika :paatos :laatupoikkeama)
-                            :aseta (fn [rivi arvo] (assoc-in rivi [:laatupoikkeama :paatos :kasittelyaika] arvo))
-                            :fmt pvm/pvm-aika :leveys 1 :tyyppi :pvm
-                            :validoi [[:ei-tyhja "Valitse päivämäärä"]
-                                      [:pvm-kentan-jalkeen (comp :aika :laatupoikkeama) "Ei voi olla ennen havaintoa"]]}
-                           {:otsikko "Perintäpvm" :nimi :perintapvm
-                            :pakollinen? true
-                            :fmt pvm/pvm-aika :leveys 1 :tyyppi :pvm
-                            :validoi [[:ei-tyhja "Valitse päivämäärä"]
-                                      [:pvm-kentan-jalkeen (comp :aika :laatupoikkeama)
-                                       "Ei voi olla ennen havaintoa"]]})
+               (lomake/ryhma {:rivi? true}
+                             {:otsikko "Havaittu" :nimi :laatupoikkeamaaika
+                              :pakollinen? true
+                              :hae (comp :aika :laatupoikkeama)
+                              :aseta (fn [rivi arvo] (assoc-in rivi [:laatupoikkeama :aika] arvo))
+                              :fmt pvm/pvm-aika :leveys 1 :tyyppi :pvm
+                              :validoi [[:ei-tyhja "Valitse päivämäärä"]]
+                              :huomauta [[:urakan-aikana-ja-hoitokaudella]]}
+                             {:otsikko "Käsitelty" :nimi :kasittelyaika
+                              :pakollinen? true
+                              :hae (comp :kasittelyaika :paatos :laatupoikkeama)
+                              :aseta (fn [rivi arvo] (assoc-in rivi [:laatupoikkeama :paatos :kasittelyaika] arvo))
+                              :fmt pvm/pvm-aika :leveys 1 :tyyppi :pvm
+                              :validoi [[:ei-tyhja "Valitse päivämäärä"]
+                                        [:pvm-kentan-jalkeen (comp :aika :laatupoikkeama) "Ei voi olla ennen havaintoa"]]}
+                             {:otsikko "Perintäpvm" :nimi :perintapvm
+                              :pakollinen? true
+                              :fmt pvm/pvm-aika :leveys 1 :tyyppi :pvm
+                              :validoi [[:ei-tyhja "Valitse päivämäärä"]
+                                        [:pvm-kentan-jalkeen (comp :aika :laatupoikkeama)
+                                         "Ei voi olla ennen havaintoa"]]})
 
-             (when yllapitokohdeurakka?
-               {:otsikko "Ylläpitokohde" :tyyppi :valinta :nimi :yllapitokohde
-                :palstoja 1 :pakollinen? false :muokattava? (constantly voi-muokata?)
-                :valinnat yllapitokohteet :jos-tyhja "Ei valittavia kohteita"
-                :valinta-nayta (fn [arvo voi-muokata?]
-                                 (if (:id arvo)
-                                   (yllapitokohde-domain/yllapitokohde-tekstina
-                                     arvo
-                                     {:osoite {:tr-numero (:tr-numero arvo)
-                                               :tr-alkuosa (:tr-alkuosa arvo)
-                                               :tr-alkuetaisyys (:tr-alkuetaisyys arvo)
-                                               :tr-loppuosa (:tr-loppuosa arvo)
-                                               :tr-loppuetaisyys (:tr-loppuetaisyys arvo)}})
-                                   (if (and voi-muokata? (not arvo))
-                                     "- Valitse kohde -"
-                                     (if (and voi-muokata? (nil? (:id arvo)))
-                                       "Ei liity kohteeseen"
-                                       ""))))})
-             (when (and (not yllapitokohdeurakka?) (not vesivayla?))
-               {:otsikko "Kohde" :tyyppi :string :nimi :kohde
-                :hae (comp :kohde :laatupoikkeama)
-                :aseta (fn [rivi arvo] (assoc-in rivi [:laatupoikkeama :kohde] arvo))
-                :palstoja 1
+               (when yllapitokohdeurakka?
+                 {:otsikko "Ylläpitokohde" :tyyppi :valinta :nimi :yllapitokohde
+                  :palstoja 1 :pakollinen? false :muokattava? (constantly voi-muokata?)
+                  :valinnat yllapitokohteet :jos-tyhja "Ei valittavia kohteita"
+                  :valinta-nayta (fn [arvo voi-muokata?]
+                                   (if (:id arvo)
+                                     (yllapitokohde-domain/yllapitokohde-tekstina
+                                       arvo
+                                       {:osoite {:tr-numero (:tr-numero arvo)
+                                                 :tr-alkuosa (:tr-alkuosa arvo)
+                                                 :tr-alkuetaisyys (:tr-alkuetaisyys arvo)
+                                                 :tr-loppuosa (:tr-loppuosa arvo)
+                                                 :tr-loppuetaisyys (:tr-loppuetaisyys arvo)}})
+                                     (if (and voi-muokata? (not arvo))
+                                       "- Valitse kohde -"
+                                       (if (and voi-muokata? (nil? (:id arvo)))
+                                         "Ei liity kohteeseen"
+                                         ""))))})
+               (when (and (not yllapitokohdeurakka?) (not vesivayla?))
+                 {:otsikko "Kohde" :tyyppi :string :nimi :kohde
+                  :hae (comp :kohde :laatupoikkeama)
+                  :aseta (fn [rivi arvo] (assoc-in rivi [:laatupoikkeama :kohde] arvo))
+                  :palstoja 1
+                  :pakollinen? true
+                  :muokattava? (constantly voi-muokata?)
+                  :validoi [[:ei-tyhja "Anna sanktion kohde"]]})
+
+               {:otsikko "Käsitelty" :nimi :kasittelytapa
                 :pakollinen? true
-                :muokattava? (constantly voi-muokata?)
-                :validoi [[:ei-tyhja "Anna sanktion kohde"]]})
-
-             {:otsikko "Käsitelty" :nimi :kasittelytapa
-              :pakollinen? true
-              :hae (comp :kasittelytapa :paatos :laatupoikkeama)
-              :aseta #(assoc-in %1 [:laatupoikkeama :paatos :kasittelytapa] %2)
-              :tyyppi :valinta
-              :valinnat [:tyomaakokous :puhelin :kommentit :muu]
-              :valinta-nayta #(if % (case %
-                                      :tyomaakokous "Työmaakokous"
-                                      :puhelin "Puhelimitse"
-                                      :kommentit "Harja-kommenttien perusteella"
-                                      :muu "Muu tapa"
-                                      nil) "- valitse käsittelytapa -")
-              :palstoja 1}
-
-             (when yllapito?
-               {:otsikko "Puute tai laiminlyönti"
-                :nimi :vakiofraasi
+                :hae (comp :kasittelytapa :paatos :laatupoikkeama)
+                :aseta #(assoc-in %1 [:laatupoikkeama :paatos :kasittelytapa] %2)
                 :tyyppi :valinta
-                :valinta-arvo first
-                :valinta-nayta second
-                :valinnat sanktio-domain/+yllapidon-sanktiofraasit+
-                :palstoja 2})
-             {:otsikko "Perustelu" :nimi :perustelu
-              :pakollinen? true
-              :hae (comp :perustelu :paatos :laatupoikkeama)
-              :aseta (fn [rivi arvo] (assoc-in rivi [:laatupoikkeama :paatos :perustelu] arvo))
-              :palstoja 2 :tyyppi :text :koko [80 :auto]
-              :validoi [[:ei-tyhja "Anna perustelu"]]}
+                :valinnat [:tyomaakokous :puhelin :kommentit :muu]
+                :valinta-nayta #(if % (case %
+                                        :tyomaakokous "Työmaakokous"
+                                        :puhelin "Puhelimitse"
+                                        :kommentit "Harja-kommenttien perusteella"
+                                        :muu "Muu tapa"
+                                        nil) "- valitse käsittelytapa -")
+                :palstoja 1}
 
-             (when (= :muu (get-in @muokattu [:laatupoikkeama :paatos :kasittelytapa]))
-               {:otsikko "Muu käsittelytapa" :nimi :muukasittelytapa
-                :hae (comp :muukasittelytapa :paatos :laatupoikkeama)
-                :aseta (fn [rivi arvo] (assoc-in rivi [:laatupoikkeama :paatos :muukasittelytapa] arvo))
-                :leveys 2 :tyyppi :string
-                :validoi [[:ei-tyhja "Anna lyhyt kuvaus käsittelytavasta."]]})
-
-             (when-not vesivayla? ;; Vesiväylässä lajeina on vain sakko
-               {:otsikko "Laji" :tyyppi :valinta :pakollinen? true
-                :palstoja 1 :uusi-rivi? true :nimi :laji
-                :hae (comp keyword :laji)
-                :aseta (fn [rivi arvo]
-                         (let [paivitetty (assoc rivi :laji arvo :tyyppi nil)]
-                           (if-not (sanktio-domain/sakko? paivitetty)
-                             (assoc paivitetty :summa nil :toimenpideinstanssi nil :indeksi nil)
-                             paivitetty)))
-                :valinnat mahdolliset-sanktiolajit
-                :valinta-nayta #(case %
-                                  :A "Ryhmä A"
-                                  :B "Ryhmä B"
-                                  :C "Ryhmä C"
-                                  :muistutus "Muistutus"
-                                  :yllapidon_muistutus "Muistutus"
-                                  :yllapidon_sakko "Sakko"
-                                  :yllapidon_bonus "Bonus"
-                                  :vesivayla_muistutus "Muistutus"
-                                  :vesivayla_sakko "Sakko"
-                                  :vesivayla_bonus "Bonus"
-                                  "- valitse laji -")
-                :validoi [[:ei-tyhja "Valitse laji"]]})
-
-             (when-not (or yllapito? vesivayla?)
-               {:otsikko "Tyyppi" :tyyppi :valinta
-                :palstoja 1
+               (when yllapito?
+                 {:otsikko "Puute tai laiminlyönti"
+                  :nimi :vakiofraasi
+                  :tyyppi :valinta
+                  :valinta-arvo first
+                  :valinta-nayta second
+                  :valinnat sanktio-domain/+yllapidon-sanktiofraasit+
+                  :palstoja 2})
+               {:otsikko "Perustelu" :nimi :perustelu
                 :pakollinen? true
-                :nimi :tyyppi
-                :aseta (fn [sanktio {tpk :toimenpidekoodi :as tyyppi}]
-                         (assoc sanktio
-                           :tyyppi tyyppi
-                           :toimenpideinstanssi
-                           (when tpk
-                             (:tpi_id (tiedot-urakka/urakan-toimenpideinstanssi-toimenpidekoodille tpk)))))
-                ;; TODO: Kysely ei palauta sanktiotyyppien lajeja, joten tässä se pitää dissocata. Onko ok? Laatupoikkeamassa käytetään.
-                :valinnat-fn (fn [_] (map #(dissoc % :laji) (sanktiot/lajin-sanktiotyypit (:laji @muokattu))))
-                :valinta-nayta #(if % (:nimi %) " - valitse tyyppi -")
-                :validoi [[:ei-tyhja "Valitse sanktiotyyppi"]]})
+                :hae (comp :perustelu :paatos :laatupoikkeama)
+                :aseta (fn [rivi arvo] (assoc-in rivi [:laatupoikkeama :paatos :perustelu] arvo))
+                :palstoja 2 :tyyppi :text :koko [80 :auto]
+                :validoi [[:ei-tyhja "Anna perustelu"]]}
 
-             (when (sanktio-domain/sakko? @muokattu)
-               {:otsikko "Summa" :nimi :summa :palstoja 1 :tyyppi :positiivinen-numero
-                :hae #(when (:summa %) (Math/abs (:summa %)))
-                :pakollinen? true :uusi-rivi? true :yksikko "€"
-                :validoi [[:ei-tyhja "Anna summa"] [:rajattu-numero 0 999999999 "Anna arvo väliltä 0 - 999 999 999"]]})
+               (when (= :muu (get-in @muokattu [:laatupoikkeama :paatos :kasittelytapa]))
+                 {:otsikko "Muu käsittelytapa" :nimi :muukasittelytapa
+                  :hae (comp :muukasittelytapa :paatos :laatupoikkeama)
+                  :aseta (fn [rivi arvo] (assoc-in rivi [:laatupoikkeama :paatos :muukasittelytapa] arvo))
+                  :leveys 2 :tyyppi :string
+                  :validoi [[:ei-tyhja "Anna lyhyt kuvaus käsittelytavasta."]]})
 
-             (when (and (sanktio-domain/sakko? @muokattu) (urakka/indeksi-kaytossa?))
-               {:otsikko "Indeksi" :nimi :indeksi :leveys 2
-                :tyyppi :valinta
-                :valinnat ["MAKU 2005" "MAKU 2010"]
-                :valinta-nayta #(or % "Ei sidota indeksiin")
-                :palstoja 1})
+               (when-not vesivayla?                         ;; Vesiväylässä lajeina on vain sakko
+                 {:otsikko "Laji" :tyyppi :valinta :pakollinen? true
+                  :palstoja 1 :uusi-rivi? true :nimi :laji
+                  :hae (comp keyword :laji)
+                  :aseta (fn [rivi arvo]
+                           (let [paivitetty (assoc rivi :laji arvo :tyyppi nil)]
+                             (if-not (sanktio-domain/sakko? paivitetty)
+                               (assoc paivitetty :summa nil :toimenpideinstanssi nil :indeksi nil)
+                               paivitetty)))
+                  :valinnat mahdolliset-sanktiolajit
+                  :valinta-nayta #(case %
+                                    :A "Ryhmä A"
+                                    :B "Ryhmä B"
+                                    :C "Ryhmä C"
+                                    :muistutus "Muistutus"
+                                    :yllapidon_muistutus "Muistutus"
+                                    :yllapidon_sakko "Sakko"
+                                    :yllapidon_bonus "Bonus"
+                                    :vesivayla_muistutus "Muistutus"
+                                    :vesivayla_sakko "Sakko"
+                                    :vesivayla_bonus "Bonus"
+                                    "- valitse laji -")
+                  :validoi [[:ei-tyhja "Valitse laji"]]})
 
-             (when (and (sanktio-domain/sakko? @muokattu))
-               {:otsikko "Toimenpide"
-                :pakollinen? true
-                :nimi :toimenpideinstanssi
-                :tyyppi :valinta
-                :valinta-arvo :tpi_id
-                :valinta-nayta #(if % (:tpi_nimi %) " - valitse toimenpide -")
-                :valinnat @tiedot-urakka/urakan-toimenpideinstanssit
-                :palstoja 1
-                :validoi [[:ei-tyhja "Valitse toimenpide, johon sanktio liittyy"]]})]
-            @muokattu]
-           [ajax-loader "Ladataan..."])]))))
+               (when-not (or yllapito? vesivayla?)
+                 {:otsikko "Tyyppi" :tyyppi :valinta
+                  :palstoja 1
+                  :pakollinen? true
+                  :nimi :tyyppi
+                  :aseta (fn [sanktio {tpk :toimenpidekoodi :as tyyppi}]
+                           (assoc sanktio
+                             :tyyppi tyyppi
+                             :toimenpideinstanssi
+                             (when tpk
+                               (:tpi_id (tiedot-urakka/urakan-toimenpideinstanssi-toimenpidekoodille tpk)))))
+                  ;; TODO: Kysely ei palauta sanktiotyyppien lajeja, joten tässä se pitää dissocata. Onko ok? Laatupoikkeamassa käytetään.
+                  :valinnat-fn (fn [_] (map #(dissoc % :laji) (sanktiot/lajin-sanktiotyypit (:laji @muokattu))))
+                  :valinta-nayta #(if % (:nimi %) " - valitse tyyppi -")
+                  :validoi [[:ei-tyhja "Valitse sanktiotyyppi"]]})
+
+               (when (sanktio-domain/sakko? @muokattu)
+                 {:otsikko "Summa" :nimi :summa :palstoja 1 :tyyppi :positiivinen-numero
+                  :hae #(when (:summa %) (Math/abs (:summa %)))
+                  :pakollinen? true :uusi-rivi? true :yksikko "€"
+                  :validoi [[:ei-tyhja "Anna summa"] [:rajattu-numero 0 999999999 "Anna arvo väliltä 0 - 999 999 999"]]})
+
+               (when (and (sanktio-domain/sakko? @muokattu) (urakka/indeksi-kaytossa?))
+                 {:otsikko "Indeksi" :nimi :indeksi :leveys 2
+                  :tyyppi :valinta
+                  :valinnat ["MAKU 2005" "MAKU 2010"]
+                  :valinta-nayta #(or % "Ei sidota indeksiin")
+                  :palstoja 1})
+
+               (when (and (sanktio-domain/sakko? @muokattu))
+                 {:otsikko "Toimenpide"
+                  :pakollinen? true
+                  :nimi :toimenpideinstanssi
+                  :tyyppi :valinta
+                  :valinta-arvo :tpi_id
+                  :valinta-nayta #(if % (:tpi_nimi %) " - valitse toimenpide -")
+                  :valinnat @tiedot-urakka/urakan-toimenpideinstanssit
+                  :palstoja 1
+                  :validoi [[:ei-tyhja "Valitse toimenpide, johon sanktio liittyy"]]})]
+              @muokattu]
+             [ajax-loader "Ladataan..."])])))))
 
 (defn- suodattimet-ja-toiminnot [valittu-urakka]
   [valinnat/urakkavalinnat {:urakka valittu-urakka}
@@ -268,51 +272,55 @@
 
 (defn sanktiolistaus
   [optiot valittu-urakka]
-  (let [sanktiot (reverse (sort-by :perintapvm @tiedot/haetut-sanktiot))
-        yllapito? (:yllapito? optiot)
-        vesivayla? (:vesivayla? optiot)
-        yhteensa (reduce + (map :summa sanktiot))
-        yhteensa (when yhteensa
-                   (if yllapito?
-                     (- yhteensa) ; ylläpidossa sakot miinusmerkkisiä
-                     yhteensa))
-        yllapitokohdeurakka? @tiedot-urakka/yllapitokohdeurakka?]
-    [:div.sanktiot
-     [suodattimet-ja-toiminnot valittu-urakka]
-     [grid/grid
-      {:otsikko (if yllapito? "Sakot ja bonukset" "Sanktiot")
-       :tyhja (if @tiedot/haetut-sanktiot "Ei löytyneitä tietoja" [ajax-loader "Haetaan sanktioita."])
-       :rivi-klikattu #(reset! tiedot/valittu-sanktio %)}
-      [{:otsikko "Päivä\u00ADmäärä" :nimi :perintapvm :fmt pvm/pvm-aika :leveys 1}
-       (when yllapitokohdeurakka?
-         {:otsikko "Yllä\u00ADpito\u00ADkoh\u00ADde" :nimi :kohde :leveys 2
-          :hae (fn [rivi]
-                 (if (get-in rivi [:yllapitokohde :id])
-                   (yllapitokohde-domain/yllapitokohde-tekstina {:kohdenumero (get-in rivi [:yllapitokohde :numero])
-                                                                 :nimi (get-in rivi [:yllapitokohde :nimi])})
-                   "Ei liity kohteeseen"))})
-       (when (and (not yllapitokohdeurakka?) (not vesivayla?))
-         {:otsikko "Kohde" :nimi :kohde :hae (comp :kohde :laatupoikkeama) :leveys 1})
-       {:otsikko "Perus\u00ADtelu" :nimi :kuvaus :hae (comp :perustelu :paatos :laatupoikkeama) :leveys 3}
-       (if yllapito?
-         {:otsikko "Puute tai laiminlyönti" :nimi :vakiofraasi
-          :hae #(sanktio-domain/yllapidon-sanktiofraasin-nimi (:vakiofraasi %)) :leveys 3}
-         {:otsikko "Tyyppi" :nimi :sanktiotyyppi :hae (comp :nimi :tyyppi) :leveys 3})
-       {:otsikko "Tekijä" :nimi :tekija :hae (comp :tekijanimi :laatupoikkeama) :leveys 1}
-       {:otsikko "Summa €" :nimi :summa :leveys 1 :tyyppi :numero :tasaa :oikea
-        :hae #(or (when (:summa %)
-                    (if yllapito?
-                      (- (:summa %)) ;ylläpidossa on sakkoja ja -bonuksia, sakot miinusmerkillä
-                      (:summa %)))
-                  "Muistutus")}]
-      sanktiot]
-     (when yllapito?
-       (yleiset/vihje "Huom! Sakot ovat miinusmerkkisiä ja bonukset plusmerkkisiä."))
-     (when (> (count sanktiot) 0)
-       [:div.pull-right.bold (str "Yhteensä " (fmt/euro-opt yhteensa))])]))
+  (komp/luo
+    (komp/kirjaa-gridin-kaytto! sivu)
+    (fn [optiot valittu-urakka]
+      (let [sanktiot (reverse (sort-by :perintapvm @tiedot/haetut-sanktiot))
+            yllapito? (:yllapito? optiot)
+            vesivayla? (:vesivayla? optiot)
+            yhteensa (reduce + (map :summa sanktiot))
+            yhteensa (when yhteensa
+                       (if yllapito?
+                         (- yhteensa)                       ; ylläpidossa sakot miinusmerkkisiä
+                         yhteensa))
+            yllapitokohdeurakka? @tiedot-urakka/yllapitokohdeurakka?]
+        [:div.sanktiot
+         [suodattimet-ja-toiminnot valittu-urakka]
+         [grid/grid
+          {:otsikko (if yllapito? "Sakot ja bonukset" "Sanktiot")
+           :tyhja (if @tiedot/haetut-sanktiot "Ei löytyneitä tietoja" [ajax-loader "Haetaan sanktioita."])
+           :rivi-klikattu #(reset! tiedot/valittu-sanktio %)}
+          [{:otsikko "Päivä\u00ADmäärä" :nimi :perintapvm :fmt pvm/pvm-aika :leveys 1}
+           (when yllapitokohdeurakka?
+             {:otsikko "Yllä\u00ADpito\u00ADkoh\u00ADde" :nimi :kohde :leveys 2
+              :hae (fn [rivi]
+                     (if (get-in rivi [:yllapitokohde :id])
+                       (yllapitokohde-domain/yllapitokohde-tekstina {:kohdenumero (get-in rivi [:yllapitokohde :numero])
+                                                                     :nimi (get-in rivi [:yllapitokohde :nimi])})
+                       "Ei liity kohteeseen"))})
+           (when (and (not yllapitokohdeurakka?) (not vesivayla?))
+             {:otsikko "Kohde" :nimi :kohde :hae (comp :kohde :laatupoikkeama) :leveys 1})
+           {:otsikko "Perus\u00ADtelu" :nimi :kuvaus :hae (comp :perustelu :paatos :laatupoikkeama) :leveys 3}
+           (if yllapito?
+             {:otsikko "Puute tai laiminlyönti" :nimi :vakiofraasi
+              :hae #(sanktio-domain/yllapidon-sanktiofraasin-nimi (:vakiofraasi %)) :leveys 3}
+             {:otsikko "Tyyppi" :nimi :sanktiotyyppi :hae (comp :nimi :tyyppi) :leveys 3})
+           {:otsikko "Tekijä" :nimi :tekija :hae (comp :tekijanimi :laatupoikkeama) :leveys 1}
+           {:otsikko "Summa €" :nimi :summa :leveys 1 :tyyppi :numero :tasaa :oikea
+            :hae #(or (when (:summa %)
+                        (if yllapito?
+                          (- (:summa %))                    ;ylläpidossa on sakkoja ja -bonuksia, sakot miinusmerkillä
+                          (:summa %)))
+                      "Muistutus")}]
+          sanktiot]
+         (when yllapito?
+           (yleiset/vihje "Huom! Sakot ovat miinusmerkkisiä ja bonukset plusmerkkisiä."))
+         (when (> (count sanktiot) 0)
+           [:div.pull-right.bold (str "Yhteensä " (fmt/euro-opt yhteensa))])]))))
 
 (defn sanktiot [optiot]
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (komp/lippu tiedot/nakymassa?)
     (komp/sisaan-ulos #(do
                          (reset! nav/kartan-edellinen-koko @nav/kartan-koko)

--- a/src/cljs/harja/views/urakka/laadunseuranta/siltatarkastukset.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/siltatarkastukset.cljs
@@ -31,6 +31,7 @@
                    [reagent.ratom :refer [reaction run!]]
                    [harja.atom :refer [reaction<!]]))
 
+(def sivu "laadunseuranta/siltatarkastukset")
 
 (defonce muokattava-tarkastus (local-storage/local-storage-atom :muokattava-siltatarkastus
                                                                 nil
@@ -299,6 +300,7 @@
 
 (defn sillan-tarkastukset []
   (komp/luo
+    (komp/kirjaa-gridin-kaytto! sivu)
     (fn []
       (let [muut-tarkastukset (reaction (let [kaikki @st/valitun-sillan-tarkastukset
                                               aika (:tarkastusaika @st/valittu-tarkastus)]
@@ -370,6 +372,7 @@
                   "Luo uusi siltatarkastus"
                   (str "Muokkaa tarkastusta " (pvm/pvm (:tarkastusaika @muokattava-tarkastus))))]
     (komp/luo
+      (komp/kirjaa-lomakkeen-kaytto! sivu)
       (komp/piirretty
         #(do (when (:nayta-localstorage-tarkastus? @muokattava-tarkastus)
                (let [tarkastuksen-muokkaus-aika (:viimeksi-muokattu @muokattava-tarkastus)]
@@ -498,6 +501,7 @@
 (defn siltatarkastukset []
 
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (komp/sisaan-ulos #(do
                          (kartta-tasot/taso-paalle! :sillat)
                          (reset! nav/kartan-edellinen-koko @nav/kartan-koko)

--- a/src/cljs/harja/views/urakka/laadunseuranta/siltatarkastukset.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/siltatarkastukset.cljs
@@ -31,7 +31,7 @@
                    [reagent.ratom :refer [reaction run!]]
                    [harja.atom :refer [reaction<!]]))
 
-(def sivu "laadunseuranta/siltatarkastukset")
+(def sivu "Laadunseuranta/Siltatarkastukset")
 
 (defonce muokattava-tarkastus (local-storage/local-storage-atom :muokattava-siltatarkastus
                                                                 nil

--- a/src/cljs/harja/views/urakka/laadunseuranta/tarkastukset.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/tarkastukset.cljs
@@ -41,7 +41,7 @@
                    [harja.atom :refer [reaction<!]]
                    [cljs.core.async.macros :refer [go]]))
 
-(def sivu "laadunseuranta/tarkastukset")
+(def sivu "Laadunseuranta/Tarkastukset")
 
 (def +tarkastustyyppi-hoidolle+ [:tiesto :talvihoito :soratie :laatu])
 (def +tarkastustyyppi-yllapidolle+ [:katselmus :pistokoe :vastaanotto :takuu])

--- a/src/cljs/harja/views/urakka/laskutusyhteenveto.cljs
+++ b/src/cljs/harja/views/urakka/laskutusyhteenveto.cljs
@@ -25,7 +25,7 @@
                    [reagent.ratom :refer [reaction run!]]
                    [harja.atom :refer [reaction<!]]))
 
-
+(def sivu "Laskutusyhteenveto")
 (defonce laskutusyhteenveto-nakyvissa? (atom false))
 
 (defonce laskutusyhteenvedon-parametrit
@@ -51,6 +51,7 @@
   []
   (komp/luo
     (komp/lippu laskutusyhteenveto-nakyvissa?)
+    (komp/kirjaa-kaytto! sivu)
     (fn []
       (let [ur @nav/valittu-urakka
             tiedot @laskutusyhteenvedon-tiedot

--- a/src/cljs/harja/views/urakka/maksuerat.cljs
+++ b/src/cljs/harja/views/urakka/maksuerat.cljs
@@ -21,6 +21,8 @@
                    [reagent.ratom :refer [reaction run!]]
                    [harja.atom :refer [reaction<! reaction-writable]]))
 
+(def sivu "Maksuerät")
+
 (defn- tyyppi-enum->string-monikko [tyyppi]
   (case tyyppi
     :kokonaishintainen "Kokonaishintaiset"
@@ -177,6 +179,7 @@
   (komp/luo
     (komp/sisaan #(pollaa-kantaa))
     (komp/ulos #(lopeta-pollaus))
+    (komp/kirjaa-kaytto! sivu)
     (komp/lippu maksuerat/nakymassa?)
     (fn []
       (let [urakka-id (:id @nav/valittu-urakka)

--- a/src/cljs/harja/views/urakka/paallystyksen_maksuerat.cljs
+++ b/src/cljs/harja/views/urakka/paallystyksen_maksuerat.cljs
@@ -23,6 +23,8 @@
                    [cljs.core.async.macros :refer [go]]
                    [harja.atom :refer [reaction<!]]))
 
+(def sivu "Päällystys/Maksuerät")
+
 (defn- maksuerat* [e! tila]
   (e! (tiedot/->PaivitaValinnat @tiedot/valinnat))
 
@@ -86,6 +88,7 @@
 (defn maksuerat []
   (komp/luo
     (komp/lippu paikkaus/paikkausilmoitukset-nakymassa?)
+    (komp/kirjaa-kaytto! sivu)
 
     (fn []
       [tuck tiedot/tila maksuerat*])))

--- a/src/cljs/harja/views/urakka/paallystys_indeksit.cljs
+++ b/src/cljs/harja/views/urakka/paallystys_indeksit.cljs
@@ -12,6 +12,8 @@
                       "kevyt_polttooljy" "Kevyt polttoöljy"
                       "nestekaasu" "Nestekaasu"})
 
+(def sivu "Päällystys/Indeksit")
+
 (defn- indeksinimi-ja-lahtotaso-fmt
   [rivi]
   (str (:indeksinimi rivi)
@@ -30,6 +32,7 @@
   "Käyttöliittymä päällystysurakassa käytettävien indeksien valintaan."
   [ur]
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (fn [ur]
       (let [indeksivalinnat (indeksit/urakkatyypin-indeksit :paallystys)]
         [grid/grid

--- a/src/cljs/harja/views/urakka/paallystys_muut_kustannukset.cljs
+++ b/src/cljs/harja/views/urakka/paallystys_muut_kustannukset.cljs
@@ -18,6 +18,8 @@
 (def kustannus-hinta-leveys 3)
 (def kustannus-pvm-leveys 3)
 
+(def sivu "Päällystys/Muut kustannukset")
+
 (defn- rivi-poistettavissa? [m]
   (log "rivi-poistettavissa? " (pr-str m))
   (or (-> m :muokattava) (-> m :id neg?)))
@@ -48,6 +50,7 @@
 (defn muut-kustannukset [urakka]
   (komp/luo
    (komp/lippu tiedot/nakymassa?)
+   (komp/kirjaa-kaytto! sivu)
    (fn [urakka]
      [:div.muut-kustannukset
       [grid/grid (assoc grid-opts

--- a/src/cljs/harja/views/urakka/paallystysilmoitukset.cljs
+++ b/src/cljs/harja/views/urakka/paallystysilmoitukset.cljs
@@ -48,6 +48,8 @@
                    [cljs.core.async.macros :refer [go]]
                    [harja.atom :refer [reaction<!]]))
 
+(def sivu "Päällystysilmoitukset")
+
 (defn laske-hinta [lomakedata-nyt]
   (let [urakkasopimuksen-mukainen-kokonaishinta (:kokonaishinta-ilman-maaramuutoksia lomakedata-nyt)
         muutokset-kokonaishintaan (:maaramuutokset lomakedata-nyt)
@@ -612,6 +614,7 @@
 (defn- ilmoitusluettelo
   []
   (komp/luo
+    (komp/kirjaa-gridin-kaytto! sivu)
     (komp/kuuntelija :avaa-paallystysilmoitus
                      (fn [_ rivi]
                        (avaa-paallystysilmoitus (:paallystyskohde-id rivi))))
@@ -636,6 +639,7 @@
 (defn paallystysilmoituslomake-historia [ilmoituslomake]
   (let [historia (historia/historia ilmoituslomake)]
     (komp/luo
+      (komp/kirjaa-lomakkeen-kaytto! sivu)
       (komp/ulos (historia/kuuntele! historia))
       (fn [ilmoituslomake]
         [paallystysilmoituslomake
@@ -654,6 +658,7 @@
 (defn paallystysilmoitukset [urakka]
   (komp/luo
     (komp/lippu paallystys/paallystysilmoitukset-nakymassa?)
+    (komp/kirjaa-kaytto! sivu)
 
     (fn [urakka]
       [:div.paallystysilmoitukset

--- a/src/cljs/harja/views/urakka/paallystyskohteet.cljs
+++ b/src/cljs/harja/views/urakka/paallystyskohteet.cljs
@@ -22,6 +22,8 @@
   (:require-macros [reagent.ratom :refer [reaction]]
                    [cljs.core.async.macros :refer [go]]))
 
+(def sivu "Päällystyskohteet")
+
 (defn- materiaalin-indeksisidontarivi
   [{:keys [indeksi lahtotason-vuosi lahtotason-kuukausi]}]
   [:div
@@ -51,6 +53,7 @@
                             (reset! urakka/paallystysurakan-indeksitiedot (<! ch)))))]
     (hae-tietoja ur)
     (komp/kun-muuttuu (hae-tietoja ur))
+    (komp/kirjaa-kaytto! sivu)
     (komp/luo
      (fn [ur]
        [:div.paallystyskohteet

--- a/src/cljs/harja/views/urakka/paikkausilmoitukset.cljs
+++ b/src/cljs/harja/views/urakka/paikkausilmoitukset.cljs
@@ -30,6 +30,8 @@
                    [cljs.core.async.macros :refer [go]]
                    [harja.atom :refer [reaction<!]]))
 
+(def sivu "Paikkausilmoitukset")
+
 (defn lisaa-suoritteet-tyhjaan-toteumaan [toteumat]
   (if (or (nil? toteumat) (empty? toteumat))
     (mapv
@@ -148,6 +150,7 @@
         kokonaishinta (reaction (minipot/laske-kokonaishinta (get-in @paikkaus/paikkausilmoitus-lomakedata [:ilmoitustiedot :toteumat])))]
 
     (komp/luo
+      (komp/kirjaa-lomakkeen-kaytto! sivu)
       (komp/lukko (lukko/muodosta-lukon-id "paikkausilmoitus" (:kohdenumero @paikkaus/paikkausilmoitus-lomakedata)))
       (fn []
         (let [kohteen-tiedot (r/wrap {:aloituspvm (:aloituspvm @paikkaus/paikkausilmoitus-lomakedata)
@@ -323,6 +326,7 @@
 (defn ilmoitusluettelo
   []
   (komp/luo
+    (komp/kirjaa-gridin-kaytto! sivu)
     (komp/kuuntelija :avaa-paikkausilmoitus
                      (fn [_ rivi]
                        (avaa-paikkausilmoitus (:paikkauskohde-id rivi))))
@@ -359,6 +363,7 @@
 (defn paikkausilmoitukset [urakka]
   (komp/luo
     (komp/lippu paikkaus/paikkausilmoitukset-nakymassa?)
+    (komp/kirjaa-kaytto! sivu)
 
     (fn [urakka]
       [:span.paikkausilmoitukset

--- a/src/cljs/harja/views/urakka/paikkauskohteet.cljs
+++ b/src/cljs/harja/views/urakka/paikkauskohteet.cljs
@@ -24,9 +24,11 @@
                    [cljs.core.async.macros :refer [go]]
                    [harja.atom :refer [reaction<!]]))
 
+(def sivu "Paikkauskohteet")
 
 (defn paikkauskohteet [ur]
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (fn [ur]
       [:div.paikkauskohteet
        [kartta/kartan-paikka]

--- a/src/cljs/harja/views/urakka/suunnittelu/kokonaishintaiset_tyot.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/kokonaishintaiset_tyot.cljs
@@ -32,7 +32,7 @@
                    [reagent.ratom :refer [reaction run!]]
                    [harja.atom :refer [reaction-writable]]))
 
-(def sivu "suunnittelu/kokonaishintaiset_tyot")
+(def sivu "Suunnittelu/Kokonaishintaiset työt")
 
 (defn luo-tyhja-tyo [urakkatyyppi tpi [alkupvm loppupvm] kk sn]
   (let [tyon-kalenteri-vuosi (case urakkatyyppi

--- a/src/cljs/harja/views/urakka/suunnittelu/kokonaishintaiset_tyot.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/kokonaishintaiset_tyot.cljs
@@ -32,7 +32,7 @@
                    [reagent.ratom :refer [reaction run!]]
                    [harja.atom :refer [reaction-writable]]))
 
-
+(def sivu "suunnittelu/kokonaishintaiset_tyot")
 
 (defn luo-tyhja-tyo [urakkatyyppi tpi [alkupvm loppupvm] kk sn]
   (let [tyon-kalenteri-vuosi (case urakkatyyppi
@@ -325,6 +325,7 @@
     (aseta-urakka! ur)
 
     (komp/luo
+      (komp/kirjaa-kaytto! sivu)
       {:component-will-receive-props
        (fn [this & [_ ur]]
          (aseta-urakka! ur))

--- a/src/cljs/harja/views/urakka/suunnittelu/materiaalit.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/materiaalit.cljs
@@ -18,7 +18,7 @@
                    [reagent.ratom :refer [run! reaction]]
                    [harja.atom :refer [reaction-writable]]))
 
-(def sivu "suunnittelu/materiaalit")
+(def sivu "Suunnittelu/Materiaalit")
 
 (defn aseta-hoitokausi [rivi]
   (let [[alkupvm loppupvm] @u/valittu-hoitokausi]

--- a/src/cljs/harja/views/urakka/suunnittelu/materiaalit.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/materiaalit.cljs
@@ -18,6 +18,8 @@
                    [reagent.ratom :refer [run! reaction]]
                    [harja.atom :refer [reaction-writable]]))
 
+(def sivu "suunnittelu/materiaalit")
+
 (defn aseta-hoitokausi [rivi]
   (let [[alkupvm loppupvm] @u/valittu-hoitokausi]
     ;; lisätään kaikkiin riveihin valittu hoitokausi
@@ -133,6 +135,7 @@
     (hae-urakan-materiaalit ur)
 
     (komp/luo
+      (komp/kirjaa-kaytto! sivu)
 
      {:component-will-receive-props (fn [this & [_ ur]]
                                       (hae-urakan-materiaalit ur))}

--- a/src/cljs/harja/views/urakka/suunnittelu/muut_tyot.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/muut_tyot.cljs
@@ -21,7 +21,7 @@
                    [reagent.ratom :refer [reaction run!]]
                    [harja.atom :refer [reaction<!]]))
 
-(def sivu "suunnittelu/muut_tyot")
+(def sivu "Suunnittelu/Muut työt")
 
 (defn tallenna-tyot [tyot atomi]
   (go (let [ur @nav/valittu-urakka

--- a/src/cljs/harja/views/urakka/suunnittelu/muut_tyot.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/muut_tyot.cljs
@@ -21,6 +21,7 @@
                    [reagent.ratom :refer [reaction run!]]
                    [harja.atom :refer [reaction<!]]))
 
+(def sivu "suunnittelu/muut_tyot")
 
 (defn tallenna-tyot [tyot atomi]
   (go (let [ur @nav/valittu-urakka
@@ -34,63 +35,66 @@
         res)))
 
 (defn muut-tyot [ur]
-  (let [g (grid/grid-ohjaus)
-        jo-valitut-tehtavat (atom nil)]
+  (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (fn [ur]
-      (let [toimenpideinstanssit @u/urakan-toimenpideinstanssit
-            tehtavat-tasoineen @u/urakan-muutoshintaiset-toimenpiteet-ja-tehtavat
-            tehtavat (map #(nth % 3) tehtavat-tasoineen)
-            valittu-tpi-id (:tpi_id @u/valittu-toimenpideinstanssi)
-            valitut-tyot (doall (filter #(and
-                                          (= (:sopimus %) (first @u/valittu-sopimusnumero))
-                                          (= (:toimenpideinstanssi %) valittu-tpi-id))
-                                        @u/muutoshintaiset-tyot))
-            valitun-tpin-tehtavat-tasoineen (urakan-toimenpiteet/toimenpideinstanssin-tehtavat
-                                              valittu-tpi-id
-                                              toimenpideinstanssit tehtavat-tasoineen)]
-        [:div.row.muut-tyot
-         [valinnat/urakan-sopimus ur]
-         [valinnat/urakan-toimenpide+muut ur]
-         [grid/grid
-          {:otsikko      "Urakkasopimuksen mukaiset muutos- ja lisätyöhinnat"
-           :luokat       ["col-md-10"]
-           :tyhja        (if (nil? @u/muutoshintaiset-tyot)
-                    [ajax-loader "Muutoshintaisia töitä haetaan..."]
-                    "Ei muutoshintaisia töitä")
-           :tallenna     (if (oikeudet/voi-kirjoittaa? oikeudet/urakat-suunnittelu-muutos-ja-lisatyot (:id @nav/valittu-urakka))
-                       #(tallenna-tyot
-                          % u/muutoshintaiset-tyot)
-                       :ei-mahdollinen)
-           :tallennus-ei-mahdollinen-tooltip
-           (oikeudet/oikeuden-puute-kuvaus :kirjoitus
-                                           oikeudet/urakat-suunnittelu-muutos-ja-lisatyot)
-           :ohjaus       g
-           :muutos       #(reset! jo-valitut-tehtavat (into #{} (map (fn [rivi]
-                                                                 (:tehtava rivi))
-                                                               (vals (grid/hae-muokkaustila %)))))
-           :voi-poistaa? (constantly (oikeudet/voi-kirjoittaa? oikeudet/urakat-suunnittelu-muutos-ja-lisatyot
-                                                               (:id @nav/valittu-urakka)))}
+      (let [g (grid/grid-ohjaus)
+            jo-valitut-tehtavat (atom nil)]
+        (fn [ur]
+          (let [toimenpideinstanssit @u/urakan-toimenpideinstanssit
+                tehtavat-tasoineen @u/urakan-muutoshintaiset-toimenpiteet-ja-tehtavat
+                tehtavat (map #(nth % 3) tehtavat-tasoineen)
+                valittu-tpi-id (:tpi_id @u/valittu-toimenpideinstanssi)
+                valitut-tyot (doall (filter #(and
+                                               (= (:sopimus %) (first @u/valittu-sopimusnumero))
+                                               (= (:toimenpideinstanssi %) valittu-tpi-id))
+                                            @u/muutoshintaiset-tyot))
+                valitun-tpin-tehtavat-tasoineen (urakan-toimenpiteet/toimenpideinstanssin-tehtavat
+                                                  valittu-tpi-id
+                                                  toimenpideinstanssit tehtavat-tasoineen)]
+            [:div.row.muut-tyot
+             [valinnat/urakan-sopimus ur]
+             [valinnat/urakan-toimenpide+muut ur]
+             [grid/grid
+              {:otsikko "Urakkasopimuksen mukaiset muutos- ja lisätyöhinnat"
+               :luokat ["col-md-10"]
+               :tyhja (if (nil? @u/muutoshintaiset-tyot)
+                        [ajax-loader "Muutoshintaisia töitä haetaan..."]
+                        "Ei muutoshintaisia töitä")
+               :tallenna (if (oikeudet/voi-kirjoittaa? oikeudet/urakat-suunnittelu-muutos-ja-lisatyot (:id @nav/valittu-urakka))
+                           #(tallenna-tyot
+                              % u/muutoshintaiset-tyot)
+                           :ei-mahdollinen)
+               :tallennus-ei-mahdollinen-tooltip
+               (oikeudet/oikeuden-puute-kuvaus :kirjoitus
+                                               oikeudet/urakat-suunnittelu-muutos-ja-lisatyot)
+               :ohjaus g
+               :muutos #(reset! jo-valitut-tehtavat (into #{} (map (fn [rivi]
+                                                                     (:tehtava rivi))
+                                                                   (vals (grid/hae-muokkaustila %)))))
+               :voi-poistaa? (constantly (oikeudet/voi-kirjoittaa? oikeudet/urakat-suunnittelu-muutos-ja-lisatyot
+                                                                   (:id @nav/valittu-urakka)))}
 
-          [{:otsikko       "Tehtävä" :nimi :tehtavanimi
-            :jos-tyhja     "Ei valittavia tehtäviä"
-            :valinta-arvo  #(:nimi (nth % 3))
-            :valinta-nayta #(if % (:nimi (nth % 3)) "- Valitse tehtävä -")
-            :tyyppi        :valinta
-            :validoi       [[:ei-tyhja "Anna tehtävä"]]
-            :valinnat-fn   #(sort-by (fn [rivi] (:nimi (nth rivi 3)))
-                                     (filter (fn [t]
-                                               (not ((disj @jo-valitut-tehtavat (:tehtava %))
-                                                      (:id (nth t 3))))) valitun-tpin-tehtavat-tasoineen))
-            :muokattava?   #(neg? (:id %))
-            :aseta         #(assoc %1 :tehtavanimi %2
-                                      :tehtava (:id (urakan-toimenpiteet/tehtava-nimella %2 tehtavat))
-                                      :yksikko (:yksikko (urakan-toimenpiteet/tehtava-nimella %2 tehtavat)))
-            :leveys        "45%"}
-           {:otsikko "Yksikkö" :nimi :yksikko :tyyppi :string :muokattava? (constantly false) :leveys "10%"}
-           {:otsikko "Muutoshinta / yksikkö" :nimi :yksikkohinta :tasaa :oikea
-            :validoi [[:ei-tyhja "Anna muutoshinta"]]
-            :tyyppi :numero :fmt fmt/euro-opt :leveys "20%"}]
+              [{:otsikko "Tehtävä" :nimi :tehtavanimi
+                :jos-tyhja "Ei valittavia tehtäviä"
+                :valinta-arvo #(:nimi (nth % 3))
+                :valinta-nayta #(if % (:nimi (nth % 3)) "- Valitse tehtävä -")
+                :tyyppi :valinta
+                :validoi [[:ei-tyhja "Anna tehtävä"]]
+                :valinnat-fn #(sort-by (fn [rivi] (:nimi (nth rivi 3)))
+                                       (filter (fn [t]
+                                                 (not ((disj @jo-valitut-tehtavat (:tehtava %))
+                                                        (:id (nth t 3))))) valitun-tpin-tehtavat-tasoineen))
+                :muokattava? #(neg? (:id %))
+                :aseta #(assoc %1 :tehtavanimi %2
+                                  :tehtava (:id (urakan-toimenpiteet/tehtava-nimella %2 tehtavat))
+                                  :yksikko (:yksikko (urakan-toimenpiteet/tehtava-nimella %2 tehtavat)))
+                :leveys "45%"}
+               {:otsikko "Yksikkö" :nimi :yksikko :tyyppi :string :muokattava? (constantly false) :leveys "10%"}
+               {:otsikko "Muutoshinta / yksikkö" :nimi :yksikkohinta :tasaa :oikea
+                :validoi [[:ei-tyhja "Anna muutoshinta"]]
+                :tyyppi :numero :fmt fmt/euro-opt :leveys "20%"}]
 
-          valitut-tyot]
+              valitut-tyot]
 
-         [vihje yleiset/+tehtavien-hinta-vaihtoehtoinen+ "col-xs-12"]]))))
+             [vihje yleiset/+tehtavien-hinta-vaihtoehtoinen+ "col-xs-12"]]))))))

--- a/src/cljs/harja/views/urakka/suunnittelu/suola.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/suola.cljs
@@ -26,6 +26,8 @@
                    [reagent.ratom :refer [reaction]]
                    [harja.atom :refer [reaction<! reaction-writable]]))
 
+(def sivu "suunnittelu/suola")
+
 (defonce suolasakot-nakyvissa? (atom false))
 
 (defonce suolasakot-ja-lampotilat
@@ -220,6 +222,7 @@
 
 (defn suola []
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (komp/lippu suolasakot-nakyvissa? pohjavesialueet/karttataso-pohjavesialueet)
     (komp/sisaan #(do
                    (reset! nav/kartan-edellinen-koko @nav/kartan-koko)

--- a/src/cljs/harja/views/urakka/suunnittelu/suola.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/suola.cljs
@@ -26,7 +26,7 @@
                    [reagent.ratom :refer [reaction]]
                    [harja.atom :refer [reaction<! reaction-writable]]))
 
-(def sivu "suunnittelu/suola")
+(def sivu "Suunnittelu/Suola")
 
 (defonce suolasakot-nakyvissa? (atom false))
 

--- a/src/cljs/harja/views/urakka/suunnittelu/yksikkohintaiset_tyot.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/yksikkohintaiset_tyot.cljs
@@ -25,6 +25,7 @@
   (:require-macros [cljs.core.async.macros :refer [go]]
                    [reagent.ratom :refer [reaction run!]]))
 
+(def sivu "suunnittelu/yksikkohintaiset_tyot")
 
 (def tuleville? (atom false))
 
@@ -216,6 +217,7 @@
 
     (hae-urakan-tiedot ur)
     (komp/luo
+      (komp/kirjaa-kaytto! sivu)
       {:component-will-receive-props
        (fn [_ & [_ ur]]
          (log "UUSI URAKKA: " (pr-str (dissoc ur :alue)))

--- a/src/cljs/harja/views/urakka/suunnittelu/yksikkohintaiset_tyot.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/yksikkohintaiset_tyot.cljs
@@ -25,7 +25,7 @@
   (:require-macros [cljs.core.async.macros :refer [go]]
                    [reagent.ratom :refer [reaction run!]]))
 
-(def sivu "suunnittelu/yksikkohintaiset_tyot")
+(def sivu "Suunnittelu/Yksikköhintaiset Työt")
 
 (def tuleville? (atom false))
 

--- a/src/cljs/harja/views/urakka/tiemerkinnan_kustannukset.cljs
+++ b/src/cljs/harja/views/urakka/tiemerkinnan_kustannukset.cljs
@@ -24,9 +24,12 @@
                    [reagent.ratom :refer [reaction run!]]
                    [harja.atom :refer [reaction<!]]))
 
+(def sivu "Tiemerkinnän kustannukset")
+
 (defn kustannukset [urakka raportin-parametrit-atom raportin-tiedot-atom]
   (komp/luo
     (komp/lippu tiedot/kustannukset-valilehti-nakyvissa?)
+    (komp/kirjaa-kaytto! sivu)
     (fn [urakka raportin-parametrit-atom raportin-tiedot-atom]
       (let []
         [:div

--- a/src/cljs/harja/views/urakka/tiemerkinnan_yksikkohintaiset_tyot.cljs
+++ b/src/cljs/harja/views/urakka/tiemerkinnan_yksikkohintaiset_tyot.cljs
@@ -24,6 +24,8 @@
   (:require-macros [cljs.core.async.macros :refer [go]]
                    [reagent.ratom :refer [reaction run!]]))
 
+(def sivu "Tiemerkinnän yksikköhintaiset")
+
 (defn toteutuneet-tiemerkinnat
   [urakka tiemerkinnan-toteumat-atom paallystysurakan-kohteet]
   (komp/luo
@@ -197,7 +199,10 @@
      (fmt/euro-opt kaikki-yhteensa)]))
 
 (defn yksikkohintaiset-tyot [urakka tiemerkinnan-toteumat-atom paallystysurakan-kohteet-atom]
-  [:div.tiemerkinnan-yks-hint-tyot
-   [toteutuneet-tiemerkinnat urakka tiemerkinnan-toteumat-atom @paallystysurakan-kohteet-atom]
-   [yhteenveto @tiemerkinnan-toteumat-atom]
-   [paallystysurakan-kohteet urakka @paallystysurakan-kohteet-atom]])
+  (komp/luo
+    (komp/kirjaa-kaytto! sivu)
+    (fn [urakka tiemerkinnan-toteumat-atom paallystysurakan-kohteet-atom]
+      [:div.tiemerkinnan-yks-hint-tyot
+      [toteutuneet-tiemerkinnat urakka tiemerkinnan-toteumat-atom @paallystysurakan-kohteet-atom]
+      [yhteenveto @tiemerkinnan-toteumat-atom]
+      [paallystysurakan-kohteet urakka @paallystysurakan-kohteet-atom]])))

--- a/src/cljs/harja/views/urakka/toteumat/muut_tyot.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/muut_tyot.cljs
@@ -34,6 +34,8 @@
                    [reagent.ratom :refer [reaction run!]]
                    [harja.atom :refer [reaction-writable]]))
 
+(def sivu "Toteumat/Muut työt")
+
 (defn hae-muutoshintainen-tyo-tpklla [tpk]
   (first (filter (fn [muutoshinta]
                    (= (:tehtava muutoshinta) tpk))
@@ -121,6 +123,7 @@
   "Muutos-, lisä- ja äkillisen hoitotyön toteuman muokkaaminen ja lisääminen"
   [urakka]
   (komp/luo
+    (komp/kirjaa-lomakkeen-kaytto! sivu)
     (let [muokattu (reaction-writable
                      (if (get-in @muut-tyot/valittu-toteuma [:toteuma :id])
                        (assoc @muut-tyot/valittu-toteuma
@@ -434,6 +437,7 @@
                  toteutuneet-muut-tyot)))]
 
     (komp/luo
+      (komp/kirjaa-gridin-kaytto! sivu)
       (fn []
         (reset! muut-tyot/haetut-muut-tyot @tyorivit)
         (let [aseta-rivin-luokka (aseta-rivin-luokka @korostettavan-rivin-id)
@@ -501,6 +505,7 @@
 (defn muut-tyot-toteumat [ur]
   (komp/luo
     (komp/lippu muut-tyot-kartalla/karttataso-muut-tyot)
+    (komp/kirjaa-kaytto! sivu)
     (komp/kuuntelija :toteuma-klikattu #(reset! muut-tyot/valittu-toteuma %2))
     (komp/sisaan-ulos #(kartta-tiedot/kasittele-infopaneelin-linkit!
                          {:toteuma {:toiminto

--- a/src/cljs/harja/views/urakka/toteumat/suola.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/suola.cljs
@@ -20,6 +20,8 @@
                    [harja.atom :refer [reaction<!]]
                    [cljs.core.async.macros :refer [go]]))
 
+(def sivu "Toteumat/Suola")
+
 (defonce suolatoteumissa? (atom false))
 
 (defonce toteumat
@@ -48,6 +50,7 @@
   (komp/luo
    (komp/lippu suolatoteumissa? pohjavesialueet/karttataso-pohjavesialueet
                tiedot-urakka/aseta-kuluva-kk-jos-hoitokaudella?)
+   (komp/kirjaa-kaytto! sivu)
    (fn []
      (let [ur @nav/valittu-urakka
            [sopimus-id _] @tiedot-urakka/valittu-sopimusnumero

--- a/src/cljs/harja/views/urakka/toteumat/tiemerkinta_muut_kustannukset.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/tiemerkinta_muut_kustannukset.cljs
@@ -27,6 +27,8 @@
                    [reagent.ratom :refer [reaction run!]]
                    [harja.atom :refer [reaction-writable]]))
 
+(def sivu "Tiemerkintä/Muut kustannukset")
+
 (defn- voi-kirjoittaa? [urakka-id]
   (oikeudet/voi-kirjoittaa?
     oikeudet/urakat-toteutus-muutkustannukset
@@ -64,89 +66,92 @@
       {:disabled (not muokkausoikeus?)}]]))
 
 (defn muu-tyo-lomake [e! tila {:keys [valittu-urakka valittu-sopimusnumero] :as riippuvuudet}]
-  (let [vanha-toteuma? (get-in tila [:valittu-toteuma :id])
-        valinnat (:valinnat tila)
-        muokkausoikeus? (voi-kirjoittaa? (:id valittu-urakka))
-        tallenna (fn [{:keys [toteuma urakka-id sopimusnumero
-                              sopimuskauden-alkupvm sopimuskauden-loppupvm
-                              uusi-laskentakohde]} laskentakohteet]
-                   (tiedot/tallenna-toteuma {:toteuma toteuma
-                                             :urakka urakka-id
-                                             :sopimus sopimusnumero
-                                             :alkupvm sopimuskauden-alkupvm
-                                             :loppupvm sopimuskauden-loppupvm
-                                             :uusi-laskentakohde uusi-laskentakohde}
-                                            laskentakohteet))]
-    [:div
-     [napit/takaisin "Takaisin toteumaluetteloon"
-      #(e! (tiedot/->ValitseToteuma nil))]
-     [lomake {:otsikko (if vanha-toteuma?
-                         "Muokkaa toteumaa"
-                         "Luo uusi toteuma")
-              :luokka :horizontal
-              :voi-muokata? muokkausoikeus?
-              :muokkaa! #(e! (tiedot/->MuokkaaToteumaa %))
-              :footer [:span
-                       [napit/palvelinkutsu-nappi
-                        "Tallenna toteuma"
-                        #(tallenna {:toteuma (:valittu-toteuma tila)
-                                    :urakka-id (:id valittu-urakka)
-                                    :sopimusnumero (first valittu-sopimusnumero)
-                                    :sopimuskauden-alkupvm (first (:sopimuskausi valinnat))
-                                    :sopimuskauden-loppupvm (second (:sopimuskausi valinnat))
-                                    :uusi-laskentakohde (:uusi-laskentakohde tila)}
-                                   (:laskentakohteet tila))
-                        {:luokka "nappi-ensisijainen"
-                         :ikoni (ikonit/tallenna)
-                         :kun-onnistuu #(e! (tiedot/->ToteumaTallennettu %))
-                         :disabled (or (not (lomake/voi-tallentaa? (:valittu-toteuma tila)))
-                                       (not muokkausoikeus?))}]
-                       [napit/palvelinkutsu-nappi
-                        "Poista toteuma"
-                        #(tallenna {:toteuma (assoc (:valittu-toteuma tila) :poistettu true)
-                                    :urakka-id (:id valittu-urakka)
-                                    :sopimusnumero (first valittu-sopimusnumero)
-                                    :sopimuskauden-alkupvm (first (:sopimuskausi valinnat))
-                                    :sopimuskauden-loppupvm (second (:sopimuskausi valinnat))
-                                    :uusi-laskentakohde (:uusi-laskentakohde tila)}
-                                   (:laskentakohteet tila))
-                        {:luokka "nappi-kielteinen pull-right"
-                         :ikoni (ikonit/livicon-trash)
-                         :kun-onnistuu #(e! (tiedot/->ToteumaTallennettu %))
-                         :disabled (or (not vanha-toteuma?)
-                                       (not (lomake/voi-tallentaa? (:valittu-toteuma tila)))
-                                       (not muokkausoikeus?))}]]}
+  (komp/luo
+    (komp/kirjaa-lomakkeen-kaytto! sivu)
+    (fn [e! tila {:keys [valittu-urakka valittu-sopimusnumero] :as riippuvuudet}]
+      (let [vanha-toteuma? (get-in tila [:valittu-toteuma :id])
+           valinnat (:valinnat tila)
+           muokkausoikeus? (voi-kirjoittaa? (:id valittu-urakka))
+           tallenna (fn [{:keys [toteuma urakka-id sopimusnumero
+                                 sopimuskauden-alkupvm sopimuskauden-loppupvm
+                                 uusi-laskentakohde]} laskentakohteet]
+                      (tiedot/tallenna-toteuma {:toteuma toteuma
+                                                :urakka urakka-id
+                                                :sopimus sopimusnumero
+                                                :alkupvm sopimuskauden-alkupvm
+                                                :loppupvm sopimuskauden-loppupvm
+                                                :uusi-laskentakohde uusi-laskentakohde}
+                                               laskentakohteet))]
+       [:div
+        [napit/takaisin "Takaisin toteumaluetteloon"
+         #(e! (tiedot/->ValitseToteuma nil))]
+        [lomake {:otsikko (if vanha-toteuma?
+                            "Muokkaa toteumaa"
+                            "Luo uusi toteuma")
+                 :luokka :horizontal
+                 :voi-muokata? muokkausoikeus?
+                 :muokkaa! #(e! (tiedot/->MuokkaaToteumaa %))
+                 :footer [:span
+                          [napit/palvelinkutsu-nappi
+                           "Tallenna toteuma"
+                           #(tallenna {:toteuma (:valittu-toteuma tila)
+                                       :urakka-id (:id valittu-urakka)
+                                       :sopimusnumero (first valittu-sopimusnumero)
+                                       :sopimuskauden-alkupvm (first (:sopimuskausi valinnat))
+                                       :sopimuskauden-loppupvm (second (:sopimuskausi valinnat))
+                                       :uusi-laskentakohde (:uusi-laskentakohde tila)}
+                                      (:laskentakohteet tila))
+                           {:luokka "nappi-ensisijainen"
+                            :ikoni (ikonit/tallenna)
+                            :kun-onnistuu #(e! (tiedot/->ToteumaTallennettu %))
+                            :disabled (or (not (lomake/voi-tallentaa? (:valittu-toteuma tila)))
+                                          (not muokkausoikeus?))}]
+                          [napit/palvelinkutsu-nappi
+                           "Poista toteuma"
+                           #(tallenna {:toteuma (assoc (:valittu-toteuma tila) :poistettu true)
+                                       :urakka-id (:id valittu-urakka)
+                                       :sopimusnumero (first valittu-sopimusnumero)
+                                       :sopimuskauden-alkupvm (first (:sopimuskausi valinnat))
+                                       :sopimuskauden-loppupvm (second (:sopimuskausi valinnat))
+                                       :uusi-laskentakohde (:uusi-laskentakohde tila)}
+                                      (:laskentakohteet tila))
+                           {:luokka "nappi-kielteinen pull-right"
+                            :ikoni (ikonit/livicon-trash)
+                            :kun-onnistuu #(e! (tiedot/->ToteumaTallennettu %))
+                            :disabled (or (not vanha-toteuma?)
+                                          (not (lomake/voi-tallentaa? (:valittu-toteuma tila)))
+                                          (not muokkausoikeus?))}]]}
 
-      [{:otsikko "Päivämäärä" :nimi :pvm :tyyppi :pvm :pakollinen? true}
-       {:otsikko "Tyyppi" :nimi :tyyppi
-        :pakollinen? true
-        :tyyppi :valinta
-        :valinta-nayta #(if (nil? %) "- Valitse tyyppi -" (kustannustyyppi-fmt %))
-        :valinnat tiedot/+kustannustyypit+
-        :fmt #(kustannustyyppi-fmt %)
-        :validoi [[:ei-tyhja "Anna kustannustyyppi"]]}
-       {:otsikko "Hinta" :nimi :hinta :tyyppi :numero :pakollinen? true
-        :validoi [[:ei-negatiivinen-jos-avaimen-arvo
-                   :tyyppi :muu "Valittu hintatyyppi ei voi olla negatiivinen"]]}
-       {:otsikko "Ylläpitoluokka" :nimi :yllapitoluokka :tyyppi :valinta
-        :valinta-nayta #(if % (:nimi %) "- valitse -")
-        :fmt :nimi
-        :valinnat yllapitokohteet-domain/nykyiset-yllapitoluokat}
+         [{:otsikko "Päivämäärä" :nimi :pvm :tyyppi :pvm :pakollinen? true}
+          {:otsikko "Tyyppi" :nimi :tyyppi
+           :pakollinen? true
+           :tyyppi :valinta
+           :valinta-nayta #(if (nil? %) "- Valitse tyyppi -" (kustannustyyppi-fmt %))
+           :valinnat tiedot/+kustannustyypit+
+           :fmt #(kustannustyyppi-fmt %)
+           :validoi [[:ei-tyhja "Anna kustannustyyppi"]]}
+          {:otsikko "Hinta" :nimi :hinta :tyyppi :numero :pakollinen? true
+           :validoi [[:ei-negatiivinen-jos-avaimen-arvo
+                      :tyyppi :muu "Valittu hintatyyppi ei voi olla negatiivinen"]]}
+          {:otsikko "Ylläpitoluokka" :nimi :yllapitoluokka :tyyppi :valinta
+           :valinta-nayta #(if % (:nimi %) "- valitse -")
+           :fmt :nimi
+           :valinnat yllapitokohteet-domain/nykyiset-yllapitoluokat}
 
-       {:otsikko "Laskentakohde"
-        :nimi :laskentakohde
-        :placeholder "Hae kohde tai luo uusi"
-        :tyyppi :haku
-        :kun-muuttuu #(e! (tiedot/->LaskentakohdeMuuttui %))
-        :hae-kun-yli-n-merkkia 0
-        :nayta second
-        :lahde tiedot/laskentakohdehaku
-        :sort-fn #(let [termi (str/lower-case (second %))]
-                    (if (nil? (first %))
-                      "000" ;; verrattava samaa tyyppiä, siksi nil castattu stringiksi joka sorttautuu ensimmäiseksi
-                      termi))}
-       {:otsikko "Selite" :nimi :selite :tyyppi :text :pakollinen? true}]
-      (:valittu-toteuma tila)]]))
+          {:otsikko "Laskentakohde"
+           :nimi :laskentakohde
+           :placeholder "Hae kohde tai luo uusi"
+           :tyyppi :haku
+           :kun-muuttuu #(e! (tiedot/->LaskentakohdeMuuttui %))
+           :hae-kun-yli-n-merkkia 0
+           :nayta second
+           :lahde tiedot/laskentakohdehaku
+           :sort-fn #(let [termi (str/lower-case (second %))]
+                       (if (nil? (first %))
+                         "000" ;; verrattava samaa tyyppiä, siksi nil castattu stringiksi joka sorttautuu ensimmäiseksi
+                         termi))}
+          {:otsikko "Selite" :nimi :selite :tyyppi :text :pakollinen? true}]
+         (:valittu-toteuma tila)]]))))
 
 
 (defn- yhteenveto [toteumat valittu-kustannustyyppi]
@@ -167,43 +172,54 @@
                                 valittu-kustannustyyppi valitse-kustannustyyppi
                                 kustannustyypit]
                          :as riippuvuudet}]
-  (let [valitut-toteumat (filter #(if-not (nil? @valittu-kustannustyyppi)
-                                    (= @valittu-kustannustyyppi (:tyyppi %))
-                                    identity)
-                                 toteumat)]
-    [:div
-     [valinnat e! {:valittu-urakka valittu-urakka
-                   :valittu-sopimusnumero valittu-sopimusnumero
-                   :valitse-sopimusnumero valitse-sopimusnumero
-                   :valitun-urakan-hoitokaudet valitun-urakan-hoitokaudet
-                   :valittu-hoitokausi valittu-hoitokausi
-                   :valitse-hoitokausi valitse-hoitokausi
-                   :valittu-kustannustyyppi valittu-kustannustyyppi
-                   :valitse-kustannustyyppi valitse-kustannustyyppi
-                   :kustannustyypit kustannustyypit}]
-     [grid/grid
-      {:otsikko (str "Muut työt")
-       :tyhja (if (nil? toteumat)
-                [ajax-loader "Toteumia haetaan..."]
-                "Ei toteumia.")
-       :rivi-klikattu #(e! (tiedot/->HaeToteuma {:id (:id %)
-                                                 :urakka (:id valittu-urakka)}))}
-      [{:otsikko "Pvm" :tyyppi :pvm :fmt pvm/pvm-opt :nimi :pvm :leveys 10}
-       {:otsikko "Tyyppi" :tyyppi :string :nimi :tyyppi :leveys 20 :fmt #(kustannustyyppi-fmt %)}
-       {:otsikko "Selite" :tyyppi :string :nimi :selite :leveys 20}
-       {:otsikko "Hinta" :tyyppi :numero :nimi :hinta :fmt (partial fmt/euro-opt true) :leveys 10}
-       {:otsikko "Ylläpitoluokka" :tyyppi :string :nimi :yllapitoluokka
-        :hae #(when (:yllapitoluokka %) (get-in % [:yllapitoluokka :nimi]))
-        :leveys 10}
-       {:otsikko "Laskentakohde" :tyyppi :string :nimi :laskentakohde :fmt second :leveys 10}]
-      valitut-toteumat]
-     [yhteenveto valitut-toteumat @valittu-kustannustyyppi]]))
+  (komp/luo
+    (komp/kirjaa-gridin-kaytto! sivu)
+    (fn [e!
+         {:keys [toteumat] :as tila}
+         {:keys [valittu-urakka valittu-sopimusnumero
+                 valitse-sopimusnumero valitun-urakan-hoitokaudet
+                 valittu-hoitokausi valitse-hoitokausi
+                 valittu-kustannustyyppi valitse-kustannustyyppi
+                 kustannustyypit]
+          :as riippuvuudet}]
+      (let [valitut-toteumat (filter #(if-not (nil? @valittu-kustannustyyppi)
+                                       (= @valittu-kustannustyyppi (:tyyppi %))
+                                       identity)
+                                    toteumat)]
+       [:div
+        [valinnat e! {:valittu-urakka valittu-urakka
+                      :valittu-sopimusnumero valittu-sopimusnumero
+                      :valitse-sopimusnumero valitse-sopimusnumero
+                      :valitun-urakan-hoitokaudet valitun-urakan-hoitokaudet
+                      :valittu-hoitokausi valittu-hoitokausi
+                      :valitse-hoitokausi valitse-hoitokausi
+                      :valittu-kustannustyyppi valittu-kustannustyyppi
+                      :valitse-kustannustyyppi valitse-kustannustyyppi
+                      :kustannustyypit kustannustyypit}]
+        [grid/grid
+         {:otsikko (str "Muut työt")
+          :tyhja (if (nil? toteumat)
+                   [ajax-loader "Toteumia haetaan..."]
+                   "Ei toteumia.")
+          :rivi-klikattu #(e! (tiedot/->HaeToteuma {:id (:id %)
+                                                    :urakka (:id valittu-urakka)}))}
+         [{:otsikko "Pvm" :tyyppi :pvm :fmt pvm/pvm-opt :nimi :pvm :leveys 10}
+          {:otsikko "Tyyppi" :tyyppi :string :nimi :tyyppi :leveys 20 :fmt #(kustannustyyppi-fmt %)}
+          {:otsikko "Selite" :tyyppi :string :nimi :selite :leveys 20}
+          {:otsikko "Hinta" :tyyppi :numero :nimi :hinta :fmt (partial fmt/euro-opt true) :leveys 10}
+          {:otsikko "Ylläpitoluokka" :tyyppi :string :nimi :yllapitoluokka
+           :hae #(when (:yllapitoluokka %) (get-in % [:yllapitoluokka :nimi]))
+           :leveys 10}
+          {:otsikko "Laskentakohde" :tyyppi :string :nimi :laskentakohde :fmt second :leveys 10}]
+         valitut-toteumat]
+        [yhteenveto valitut-toteumat @valittu-kustannustyyppi]]))))
 
 (defn- muut-tyot-paakomponentti [e! tila]
   ;; Kun näkymään tullaan, yhdistetään navigaatiosta tulevat valinnat
   (e! (tiedot/->YhdistaValinnat @tiedot/valinnat))
 
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (komp/watcher tiedot/valinnat (fn [_ _ uusi]
                                     (e! (tiedot/->YhdistaValinnat uusi))))
     (fn [e! {:keys [valittu-toteuma] :as tila}]

--- a/src/cljs/harja/views/urakka/toteumat/varusteet.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/varusteet.cljs
@@ -47,6 +47,7 @@
                    [reagent.ratom :refer [reaction run!]]
                    [tuck.intercept :refer [intercept send-to]]))
 
+(def sivu "Varusteet")
 (def nayta-max-toteumaa 500)
 
 (defn oikeus-varusteiden-muokkaamiseen? []
@@ -261,54 +262,60 @@
 (def tietolajien-sisaltojen-kuvaukset-url "http://www.liikennevirasto.fi/documents/20473/244621/Tierekisteri_tietosis%C3%A4ll%C3%B6n_kuvaus_2017/b70fdd1d-fac8-4f07-b0d9-d8343e6c485c")
 
 (defn varustetoteumalomake [e! valinnat varustetoteuma]
-  (let [muokattava? (:muokattava? varustetoteuma)
-        ominaisuudet (:ominaisuudet (:tietolajin-kuvaus varustetoteuma))]
-    [:span.varustetoteumalomake
-     [napit/takaisin "Takaisin varusteluetteloon"
-      #(e! (v/->TyhjennaValittuToteuma))]
+  (komp/luo
+    (komp/kirjaa-kaytto! sivu "Toteumalomake")
+    (fn [e! valinnat varustetoteuma]
+      (let [muokattava? (:muokattava? varustetoteuma)
+           ominaisuudet (:ominaisuudet (:tietolajin-kuvaus varustetoteuma))]
+       [:span.varustetoteumalomake
+        [napit/takaisin "Takaisin varusteluetteloon"
+         #(e! (v/->TyhjennaValittuToteuma))]
 
-     [:div {:style {:margin-top "1em" :margin-bottom "1em"}}
-      [:a {:href tietolajien-sisaltojen-kuvaukset-url
-           :target "_blank"}
-       "Tietolajien sisältöjen kuvaukset"]]
-     [lomake/lomake
-      {:otsikko (case (:toiminto varustetoteuma)
-                  :lisatty "Uusi varuste"
-                  :paivitetty "Muokkaa varustetta"
-                  :nayta "Varuste"
-                  "Varustetoteuma")
-       :muokkaa! #(e! (v/->AsetaToteumanTiedot %))
-       :footer-fn (fn [toteuma]
-                    (when muokattava?
-                      [:div
-                       (when (and (istunto/ominaisuus-kaytossa? :tierekisterin-varusteet) (empty? ominaisuudet))
-                         (lomake/yleinen-varoitus "Ladataan tietolajin kuvausta. Kirjaus voidaan tehdä vasta, kun kuvaus on ladattu"))
-                       [napit/palvelinkutsu-nappi
-                        "Tallenna"
-                        #(varustetiedot/tallenna-varustetoteuma valinnat toteuma)
-                        {:luokka "nappi-ensisijainen"
-                         :ikoni (ikonit/tallenna)
-                         :kun-onnistuu #(e! (v/->VarustetoteumaTallennettu %))
-                         :kun-virhe #(viesti/nayta! "Varusteen tallennus epäonnistui" :warning viesti/viestin-nayttoaika-keskipitka)
-                         :disabled (not (lomake/voi-tallentaa? toteuma))}]]))}
-      [(varustetoteuman-tiedot muokattava? varustetoteuma)
-       (varusteen-tunnistetiedot e! muokattava? varustetoteuma)
-       (varusteen-ominaisuudet muokattava? ominaisuudet (:arvot varustetoteuma))
-       (varusteen-liitteet e! muokattava? varustetoteuma)]
-      varustetoteuma]]))
+        [:div {:style {:margin-top "1em" :margin-bottom "1em"}}
+         [:a {:href tietolajien-sisaltojen-kuvaukset-url
+              :target "_blank"}
+          "Tietolajien sisältöjen kuvaukset"]]
+        [lomake/lomake
+         {:otsikko (case (:toiminto varustetoteuma)
+                     :lisatty "Uusi varuste"
+                     :paivitetty "Muokkaa varustetta"
+                     :nayta "Varuste"
+                     "Varustetoteuma")
+          :muokkaa! #(e! (v/->AsetaToteumanTiedot %))
+          :footer-fn (fn [toteuma]
+                       (when muokattava?
+                         [:div
+                          (when (and (istunto/ominaisuus-kaytossa? :tierekisterin-varusteet) (empty? ominaisuudet))
+                            (lomake/yleinen-varoitus "Ladataan tietolajin kuvausta. Kirjaus voidaan tehdä vasta, kun kuvaus on ladattu"))
+                          [napit/palvelinkutsu-nappi
+                           "Tallenna"
+                           #(varustetiedot/tallenna-varustetoteuma valinnat toteuma)
+                           {:luokka "nappi-ensisijainen"
+                            :ikoni (ikonit/tallenna)
+                            :kun-onnistuu #(e! (v/->VarustetoteumaTallennettu %))
+                            :kun-virhe #(viesti/nayta! "Varusteen tallennus epäonnistui" :warning viesti/viestin-nayttoaika-keskipitka)
+                            :disabled (not (lomake/voi-tallentaa? toteuma))}]]))}
+         [(varustetoteuman-tiedot muokattava? varustetoteuma)
+          (varusteen-tunnistetiedot e! muokattava? varustetoteuma)
+          (varusteen-ominaisuudet muokattava? ominaisuudet (:arvot varustetoteuma))
+          (varusteen-liitteet e! muokattava? varustetoteuma)]
+         varustetoteuma]]))))
 
 (defn varustehakulomake [e! nykyiset-valinnat naytettavat-toteumat app]
-  [:span
-   [:div.sisalto-container
-    [:h1 "Varustekirjaukset Harjassa"]
-    [valinnat e! nykyiset-valinnat]
-    [toteumataulukko e! naytettavat-toteumat]]
-   (when (istunto/ominaisuus-kaytossa? :tierekisterin-varusteet)
-     [:div.sisalto-container
-      [:h1 "Varusteet Tierekisterissä"]
-      (when (oikeus-varusteiden-muokkaamiseen?)
-        [napit/uusi "Lisää uusi varuste" #(e! (v/->UusiVarusteToteuma :lisatty nil))])
-      [varustehaku e! app]])])
+  (komp/luo
+    (komp/kirjaa-kaytto! sivu "Hakulomake")
+    (fn [e! nykyiset-valinnat naytettavat-toteumat app]
+      [:span
+      [:div.sisalto-container
+       [:h1 "Varustekirjaukset Harjassa"]
+       [valinnat e! nykyiset-valinnat]
+       [toteumataulukko e! naytettavat-toteumat]]
+      (when (istunto/ominaisuus-kaytossa? :tierekisterin-varusteet)
+        [:div.sisalto-container
+         [:h1 "Varusteet Tierekisterissä"]
+         (when (oikeus-varusteiden-muokkaamiseen?)
+           [napit/uusi "Lisää uusi varuste" #(e! (v/->UusiVarusteToteuma :lisatty nil))])
+         [varustehaku e! app]])])))
 
 (defn kasittele-alkutila [e! {:keys [uudet-varustetoteumat muokattava-varuste naytettava-varuste]}]
   (when uudet-varustetoteumat
@@ -324,6 +331,7 @@
   (e! (v/->YhdistaValinnat @varustetiedot/valinnat))
   (komp/luo
     (komp/lippu varustetiedot/karttataso-varustetoteuma)
+    (komp/kirjaa-kaytto! sivu)
     (komp/watcher varustetiedot/valinnat
                   (fn [_ _ uusi]
                     (e! (v/->YhdistaValinnat uusi))))

--- a/src/cljs/harja/views/urakka/toteumat/yksikkohintaiset_tyot.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/yksikkohintaiset_tyot.cljs
@@ -33,6 +33,8 @@
   (:require-macros [cljs.core.async.macros :refer [go]]
                    [reagent.ratom :refer [reaction run!]]))
 
+(def sivu "Toteumat/Yksikköhintaiset")
+
 (defn- rivi-tehtavaksi [rivi]
   {:toimenpidekoodi (:tehtava rivi)
    :maara (:maara rivi)
@@ -195,6 +197,7 @@
     (log "Lomake-toteuma: " (pr-str @lomake-toteuma))
     (log "Lomake tehtävät: " (pr-str @lomake-tehtavat))
     (komp/luo
+      (komp/kirjaa-lomakkeen-kaytto! sivu)
       (fn [ur]
         [:div.toteuman-tiedot
          [napit/takaisin "Takaisin toteumaluetteloon" #(reset! tiedot/valittu-yksikkohintainen-toteuma nil)]
@@ -354,6 +357,7 @@
   "Yksikköhintaisten töiden toteumat tehtävittäin"
   []
   (komp/luo
+    (komp/kirjaa-gridin-kaytto! sivu)
     (fn []
       [:div
        [valinnat/urakan-sopimus-ja-hoitokausi-ja-aikavali-ja-toimenpide+kaikki @nav/valittu-urakka]
@@ -402,6 +406,7 @@
 (defn yksikkohintaisten-toteumat []
   (komp/luo
     (komp/lippu tiedot/yksikkohintaiset-tyot-nakymassa? tiedot/karttataso-yksikkohintainen-toteuma)
+    (komp/kirjaa-kaytto! sivu)
     (komp/sisaan-ulos #(do
                          (kartta-tiedot/kasittele-infopaneelin-linkit!
                           {:toteuma

--- a/src/cljs/harja/views/urakka/valitavoitteet.cljs
+++ b/src/cljs/harja/views/urakka/valitavoitteet.cljs
@@ -21,6 +21,8 @@
   (:require-macros [reagent.ratom :refer [reaction run!]]
                    [cljs.core.async.macros :refer [go]]))
 
+(def sivu "Välitavoitteet")
+
 (defn valmiustilan-kuvaus [{:keys [valmispvm takaraja]}]
   (cond (nil? takaraja)
         "Uusi"
@@ -267,6 +269,7 @@
         nayta-urakkakohtaiset-grid? (not nayta-yhdistetty-grid?)]
     (komp/luo
       (komp/lippu tiedot/nakymassa?)
+      (komp/kirjaa-kaytto! sivu)
       (komp/ulos #(when (= @urakka/valittu-urakan-vuosi :kaikki)
                     ;; Muut näkymät eivät tue vuosivalintaa "Kaikki",
                     ;; joten resetoidaan valinta

--- a/src/cljs/harja/views/urakka/yleiset.cljs
+++ b/src/cljs/harja/views/urakka/yleiset.cljs
@@ -46,6 +46,8 @@
 ;; organisaatio = valinta siitä mitä on tietokannassa
 ;; sampoid
 
+(def sivu "Yleiset")
+
 (defn tallenna-yhteyshenkilot [ur yhteyshenkilot uudet-yhteyshenkilot]
   (go (let [tallennettavat
             (into []
@@ -600,6 +602,7 @@
     (hae! ur)
     (komp/luo
       (komp/kun-muuttuu hae!)
+      (komp/kirjaa-kaytto! sivu)
       (komp/sisaan (fn [_]
                      (nayta-yha-tuontidialogi-tarvittaessa ur)))
       (fn [ur]

--- a/src/cljs/harja/views/vesivaylat/hallinta.cljs
+++ b/src/cljs/harja/views/vesivaylat/hallinta.cljs
@@ -9,43 +9,48 @@
             [harja.views.kanavat.hallinta.huoltokohteiden-hallinta :as huoltokohteiden-hallinta]
 
             [harja.tiedot.istunto :as istunto]
-            [harja.domain.oikeudet :as oikeudet]))
+            [harja.domain.oikeudet :as oikeudet]
+            [harja.ui.komponentti :as komp]))
+
+(def sivu "Vesiväylähallinta")
 
 (defn vesivayla-hallinta
   []
-  [bs/tabs {:style :tabs :classes "tabs-taso2"
-            :active (nav/valittu-valilehti-atom :vesivayla-hallinta)}
-   "Sopimuksien luonti"
-   :vesivaylasopimuksien-luonti
-   (when (and (istunto/ominaisuus-kaytossa? :vesivayla)
-              (oikeudet/hallinta-vesivaylat))
-     ^{:key "vesivaylasopimukset"}
-     [vsu/vesivaylasopimuksien-luonti])
+  (komp/luo
+    (komp/kirjaa-kaytto! sivu)
+    (fn [] [bs/tabs {:style :tabs :classes "tabs-taso2"
+               :active (nav/valittu-valilehti-atom :vesivayla-hallinta)}
+      "Sopimuksien luonti"
+      :vesivaylasopimuksien-luonti
+      (when (and (istunto/ominaisuus-kaytossa? :vesivayla)
+                 (oikeudet/hallinta-vesivaylat))
+        ^{:key "vesivaylasopimukset"}
+        [vsu/vesivaylasopimuksien-luonti])
 
-   "Urakoitsijoiden luonti"
-   :vesivaylaurakoitsijoiden-luonti
-   (when (and (istunto/ominaisuus-kaytossa? :vesivayla)
-              (oikeudet/hallinta-vesivaylat))
-     ^{:key "vesivaylaurakoitsijat"}
-     [vuu/vesivaylaurakoitsijoiden-luonti])
+      "Urakoitsijoiden luonti"
+      :vesivaylaurakoitsijoiden-luonti
+      (when (and (istunto/ominaisuus-kaytossa? :vesivayla)
+                 (oikeudet/hallinta-vesivaylat))
+        ^{:key "vesivaylaurakoitsijat"}
+        [vuu/vesivaylaurakoitsijoiden-luonti])
 
-   "Urakoiden luonti"
-   :vesivaylaurakoiden-luonti
-   (when (and (istunto/ominaisuus-kaytossa? :vesivayla)
-              (oikeudet/hallinta-vesivaylat))
-     ^{:key "vesivaylaurakat"}
-     [vu/vesivaylaurakoiden-luonti])
+      "Urakoiden luonti"
+      :vesivaylaurakoiden-luonti
+      (when (and (istunto/ominaisuus-kaytossa? :vesivayla)
+                 (oikeudet/hallinta-vesivaylat))
+        ^{:key "vesivaylaurakat"}
+        [vu/vesivaylaurakoiden-luonti])
 
-   "Kohteiden luonti"
-   :kanavaurakoiden-kohteiden-luonti
-   (when (and (istunto/ominaisuus-kaytossa? :vesivayla)
-              (oikeudet/hallinta-kanavat))
-     ^{:key "kohteiden-luonti"}
-     [kohteiden-luonti/kohteiden-luonti])
+      "Kohteiden luonti"
+      :kanavaurakoiden-kohteiden-luonti
+      (when (and (istunto/ominaisuus-kaytossa? :vesivayla)
+                 (oikeudet/hallinta-kanavat))
+        ^{:key "kohteiden-luonti"}
+        [kohteiden-luonti/kohteiden-luonti])
 
-   "Huoltokohteiden hallinta"
-   :kanavien-huoltokohteet
-   (when (and (istunto/ominaisuus-kaytossa? :vesivayla)
-              (oikeudet/hallinta-kanavat))
-     ^{:key "huoltokohteiden-hallinta"}
-     [huoltokohteiden-hallinta/hallinta])])
+      "Huoltokohteiden hallinta"
+      :kanavien-huoltokohteet
+      (when (and (istunto/ominaisuus-kaytossa? :vesivayla)
+                 (oikeudet/hallinta-kanavat))
+        ^{:key "huoltokohteiden-hallinta"}
+        [huoltokohteiden-hallinta/hallinta])])))

--- a/src/cljs/harja/views/vesivaylat/hallinta/hankkeiden_luonti.cljs
+++ b/src/cljs/harja/views/vesivaylat/hallinta/hankkeiden_luonti.cljs
@@ -12,37 +12,43 @@
             [harja.ui.ikonit :as ikonit]
             [harja.domain.oikeudet :as oikeudet]))
 
+(def sivu "Vesiväylät/Hankkeiden luonti")
+
 (defn luontilomake [e! {:keys [valittu-hanke tallennus-kaynnissa?] :as app}]
-  [:div
-   [napit/takaisin "Takaisin luetteloon" #(e! (tiedot/->ValitseHanke nil))
-    {:disabled tallennus-kaynnissa?}]
-   [lomake/lomake
-    {:otsikko (if (::h/id valittu-hanke)
-                "Muokkaa hanketta"
-                "Luo uusi hanke")
-     :muokkaa! #(e! (tiedot/->HankettaMuokattu (lomake/ilman-lomaketietoja %)))
-     :voi-muokata? (oikeudet/hallinta-vesivaylat)
-     :footer-fn (fn [hanke]
-                  [napit/tallenna
-                   "Tallenna hanke"
-                   #(e! (tiedot/->TallennaHanke (lomake/ilman-lomaketietoja hanke)))
-                   {:ikoni (ikonit/tallenna)
-                    :disabled (or tallennus-kaynnissa?
-                                  (not (lomake/voi-tallentaa? hanke))
-                                  (not (oikeudet/hallinta-vesivaylat)))
-                    :tallennus-kaynnissa? tallennus-kaynnissa?}])}
-    [{:otsikko "Nimi" :nimi ::h/nimi :tyyppi :string :pakollinen? true}
-     (lomake/rivi
-       {:otsikko "Alku" :nimi ::h/alkupvm :tyyppi :pvm :pakollinen? true}
-       {:otsikko "Loppu" :nimi ::h/loppupvm :tyyppi :pvm :pakollinen? true ;; TODO Validointi ei herjaa!?
-        :validoi [[:pvm-kentan-jalkeen :alkupvm "Loppu ei voi olla ennen alkua"]]})
-     (when (get-in valittu-hanke [:urakka :nimi])
-       {:otsikko "Urakka" :nimi :urakan-nimi :tyyppi :string :muokattava? (constantly false)
-        :hae #(get-in % [::h/urakka ::u/nimi])})]
-    valittu-hanke]])
+  (komp/luo
+    (komp/kirjaa-lomakkeen-kaytto! sivu)
+    (fn [e! {:keys [valittu-hanke tallennus-kaynnissa?] :as app}]
+      [:div
+      [napit/takaisin "Takaisin luetteloon" #(e! (tiedot/->ValitseHanke nil))
+       {:disabled tallennus-kaynnissa?}]
+      [lomake/lomake
+       {:otsikko (if (::h/id valittu-hanke)
+                   "Muokkaa hanketta"
+                   "Luo uusi hanke")
+        :muokkaa! #(e! (tiedot/->HankettaMuokattu (lomake/ilman-lomaketietoja %)))
+        :voi-muokata? (oikeudet/hallinta-vesivaylat)
+        :footer-fn (fn [hanke]
+                     [napit/tallenna
+                      "Tallenna hanke"
+                      #(e! (tiedot/->TallennaHanke (lomake/ilman-lomaketietoja hanke)))
+                      {:ikoni (ikonit/tallenna)
+                       :disabled (or tallennus-kaynnissa?
+                                     (not (lomake/voi-tallentaa? hanke))
+                                     (not (oikeudet/hallinta-vesivaylat)))
+                       :tallennus-kaynnissa? tallennus-kaynnissa?}])}
+       [{:otsikko "Nimi" :nimi ::h/nimi :tyyppi :string :pakollinen? true}
+        (lomake/rivi
+          {:otsikko "Alku" :nimi ::h/alkupvm :tyyppi :pvm :pakollinen? true}
+          {:otsikko "Loppu" :nimi ::h/loppupvm :tyyppi :pvm :pakollinen? true ;; TODO Validointi ei herjaa!?
+           :validoi [[:pvm-kentan-jalkeen :alkupvm "Loppu ei voi olla ennen alkua"]]})
+        (when (get-in valittu-hanke [:urakka :nimi])
+          {:otsikko "Urakka" :nimi :urakan-nimi :tyyppi :string :muokattava? (constantly false)
+           :hae #(get-in % [::h/urakka ::u/nimi])})]
+       valittu-hanke]])))
 
 (defn hankegrid [e! app]
   (komp/luo
+    (komp/kirjaa-gridin-kaytto! sivu)
     (komp/sisaan #(e! (tiedot/->HaeHankkeet)))
     (fn [e! {:keys [haetut-hankkeet hankkeiden-haku-kaynnissa?] :as app}]
       [:div
@@ -67,6 +73,7 @@
 
 (defn vesivaylahankkeiden-luonti* [e! app]
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (komp/sisaan-ulos #(e! (tiedot/->Nakymassa? true))
                       #(e! (tiedot/->Nakymassa? false)))
 

--- a/src/cljs/harja/views/vesivaylat/hallinta/urakoiden_luonti.cljs
+++ b/src/cljs/harja/views/vesivaylat/hallinta/urakoiden_luonti.cljs
@@ -26,6 +26,8 @@
     [cljs.core.async.macros :refer [go]]
     [harja.makrot :refer [defc fnc]]))
 
+(def sivu "Urakoiden luonti")
+
 (defn- sopimukset-grid [e! urakka haetut-sopimukset]
   (let [urakan-sopimukset (remove :poistettu (::u/sopimukset urakka))]
     [grid/muokkaus-grid
@@ -64,6 +66,7 @@
 
 (defn luontilomake [e! app]
   (komp/luo
+    (komp/kirjaa-lomakkeen-kaytto! sivu)
     (komp/sisaan #(e! (tiedot/->HaeLomakevaihtoehdot)))
     (fn [e! {:keys [valittu-urakka tallennus-kaynnissa?
                     haetut-hallintayksikot haetut-hankkeet haetut-urakoitsijat
@@ -224,6 +227,7 @@
 
 (defn urakkagrid [e! app]
   (komp/luo
+    (komp/kirjaa-gridin-kaytto! sivu)
     (komp/sisaan #(e! (tiedot/->HaeUrakat)))
     (fn [e! {:keys [haetut-urakat urakoiden-haku-kaynnissa?] :as app}]
       [:div
@@ -253,6 +257,7 @@
 
 (defn vesivaylaurakoiden-luonti* [e! app]
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (komp/sisaan-ulos #(e! (tiedot/->Nakymassa? true))
                       #(e! (tiedot/->Nakymassa? false)))
 

--- a/src/cljs/harja/views/vesivaylat/hallinta/urakoitsijoiden_luonti.cljs
+++ b/src/cljs/harja/views/vesivaylat/hallinta/urakoitsijoiden_luonti.cljs
@@ -14,6 +14,8 @@
             [harja.domain.oikeudet :as oikeudet]
             [harja.fmt :as fmt]))
 
+(def sivu "Vesiväylät/Urakoitsijoiden luonti")
+
 (defn urakan-nimi-ja-pvm [urakat]
   [apply
    tietoja
@@ -25,6 +27,7 @@
 (defn luontilomake [e! app]
   (komp/luo
     (komp/sisaan #(e! (tiedot/->HaeLomakevaihtoehdot)))
+    (komp/kirjaa-lomakkeen-kaytto! sivu)
     (fn [e! {:keys [valittu-urakoitsija tallennus-kaynnissa? haetut-ytunnukset] :as app}]
       (let [urakat (tiedot/urakoitsijan-urakat valittu-urakoitsija)]
        [:div
@@ -81,6 +84,7 @@
 
 (defn urakoitsijagrid [e! app]
   (komp/luo
+    (komp/kirjaa-gridin-kaytto! sivu)
     (komp/sisaan #(e! (tiedot/->HaeUrakoitsijat)))
     (fn [e! {:keys [haetut-urakoitsijat urakoitsijoiden-haku-kaynnissa?] :as app}]
       [:div
@@ -109,6 +113,7 @@
 
 (defn vesivaylaurakoitsijoiden-luonti* [e! app]
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (komp/sisaan-ulos #(e! (tiedot/->Nakymassa? true))
                       #(e! (tiedot/->Nakymassa? false)))
 

--- a/src/cljs/harja/views/vesivaylat/urakka/laadunseuranta/viat.cljs
+++ b/src/cljs/harja/views/vesivaylat/urakka/laadunseuranta/viat.cljs
@@ -4,8 +4,11 @@
             [harja.ui.komponentti :as komp]
             [harja.tiedot.vesivaylat.urakka.laadunseuranta.viat :as tiedot]))
 
+(def sivu "Vesiväylät/Viat")
+
 (defn viat* [e! app]
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (komp/sisaan-ulos #(e! (tiedot/->Nakymassa? true))
                       #(e! (tiedot/->Nakymassa? false)))
     (fn [e! app]

--- a/src/cljs/harja/views/vesivaylat/urakka/laskutus.cljs
+++ b/src/cljs/harja/views/vesivaylat/urakka/laskutus.cljs
@@ -18,6 +18,7 @@
                    [reagent.ratom :refer [reaction run!]]))
 
 (defonce laskutus-nakyvissa? (atom false))
+(def sivu "Vesiväylät/Laskutus")
 
 (defonce laskutuksen-parametrit
   (reaction (let [ur @nav/valittu-urakka
@@ -41,6 +42,7 @@
 (defn laskutus
   []
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (komp/lippu laskutus-nakyvissa?)
     (fn []
       (let [ur @nav/valittu-urakka

--- a/src/cljs/harja/views/vesivaylat/urakka/suunnittelu/kiintiot.cljs
+++ b/src/cljs/harja/views/vesivaylat/urakka/suunnittelu/kiintiot.cljs
@@ -25,33 +25,39 @@
             [clojure.string :as str])
   (:require-macros [cljs.core.async.macros :refer [go]]))
 
+(def sivu "Vesiväylät/Kiintiöt")
+
 (defn kiintion-toimenpiteet [e! app kiintio]
-  [grid/grid
-   {:tyhja "Ei liitettyjä toimenpiteitä"
-    :tunniste ::to/id}
-   [{:otsikko "Työluokka" :nimi ::to/tyoluokka :fmt to/reimari-tyoluokka-fmt :leveys 10}
-    {:otsikko "Toimenpide" :nimi ::to/toimenpide :fmt to/reimari-toimenpidetyyppi-fmt :leveys 10}
-    {:otsikko "Hintatyyppi" :nimi ::to/hintatyyppi :fmt to/hintatyyppi-fmt :leveys 10}
-    {:otsikko "Päivämäärä" :nimi ::to/pvm :fmt pvm/pvm-opt :leveys 10}
-    {:otsikko "Turvalaite" :nimi ::to/turvalaite :leveys 10 :hae #(get-in % [::to/turvalaite ::tu/nimi])}
-    {:otsikko "Valitse" :nimi :valinta :tyyppi :komponentti :tasaa :keskita
-     :solu-klikattu (fn [rivi]
-                      (let [valittu? (boolean ((:valitut-toimenpide-idt app) (::to/id rivi)))]
-                        (e! (tiedot/->ValitseToimenpide {:id (::to/id rivi)
-                                                         :valittu? (not valittu?)}))))
-     :komponentti (fn [rivi]
-                    (let [valittu? (boolean ((:valitut-toimenpide-idt app) (::to/id rivi)))]
-                      [kentat/tee-kentta
-                       {:tyyppi :checkbox}
-                       (r/wrap valittu?
-                               (fn [uusi]
-                                 (e! (tiedot/->ValitseToimenpide {:id (::to/id rivi)
-                                                                  :valittu? uusi}))))]))
-     :leveys 5}]
-   (::kiintio/toimenpiteet kiintio)])
+  (komp/luo
+    (komp/kirjaa-kaytto! sivu "Kiintiön toimenpiteet")
+    (fn [e! app kiintio]
+      [grid/grid
+      {:tyhja "Ei liitettyjä toimenpiteitä"
+       :tunniste ::to/id}
+      [{:otsikko "Työluokka" :nimi ::to/tyoluokka :fmt to/reimari-tyoluokka-fmt :leveys 10}
+       {:otsikko "Toimenpide" :nimi ::to/toimenpide :fmt to/reimari-toimenpidetyyppi-fmt :leveys 10}
+       {:otsikko "Hintatyyppi" :nimi ::to/hintatyyppi :fmt to/hintatyyppi-fmt :leveys 10}
+       {:otsikko "Päivämäärä" :nimi ::to/pvm :fmt pvm/pvm-opt :leveys 10}
+       {:otsikko "Turvalaite" :nimi ::to/turvalaite :leveys 10 :hae #(get-in % [::to/turvalaite ::tu/nimi])}
+       {:otsikko "Valitse" :nimi :valinta :tyyppi :komponentti :tasaa :keskita
+        :solu-klikattu (fn [rivi]
+                         (let [valittu? (boolean ((:valitut-toimenpide-idt app) (::to/id rivi)))]
+                           (e! (tiedot/->ValitseToimenpide {:id (::to/id rivi)
+                                                            :valittu? (not valittu?)}))))
+        :komponentti (fn [rivi]
+                       (let [valittu? (boolean ((:valitut-toimenpide-idt app) (::to/id rivi)))]
+                         [kentat/tee-kentta
+                          {:tyyppi :checkbox}
+                          (r/wrap valittu?
+                                  (fn [uusi]
+                                    (e! (tiedot/->ValitseToimenpide {:id (::to/id rivi)
+                                                                     :valittu? uusi}))))]))
+        :leveys 5}]
+      (::kiintio/toimenpiteet kiintio)])))
 
 (defn kiintiot* [e! app]
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (komp/watcher tiedot/valinnat (fn [_ _ uusi]
                                     (e! (tiedot/->PaivitaValinnat uusi))))
     (komp/sisaan-ulos #(do (e! (tiedot/->Nakymassa? true))

--- a/src/cljs/harja/views/vesivaylat/urakka/toimenpiteet.cljs
+++ b/src/cljs/harja/views/vesivaylat/urakka/toimenpiteet.cljs
@@ -13,8 +13,11 @@
             [harja.domain.urakka :as urakka-domain])
   (:require-macros [cljs.core.async.macros :refer [go]]))
 
-(defn toimenpiteet []
+(def sivu "Toimenpiteet")
+
+(defn toimenpiteet [{:keys [id] :as ur}]
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (fn [{:keys [id] :as ur}]
       [bs/tabs {:style :tabs :classes "tabs-taso2"
                 :active (nav/valittu-valilehti-atom :toimenpiteet)}

--- a/src/cljs/harja/views/vesivaylat/urakka/toimenpiteet/kokonaishintaiset.cljs
+++ b/src/cljs/harja/views/vesivaylat/urakka/toimenpiteet/kokonaishintaiset.cljs
@@ -20,6 +20,8 @@
   (:require-macros [cljs.core.async.macros :refer [go]]
                    [harja.tyokalut.ui :refer [for*]]))
 
+(def sivu "Vesiväylät/Kokonaishintaiset")
+
 (defn- kiintiovaihtoehdot [e! {:keys [valittu-kiintio-id toimenpiteet kiintiot] :as app}]
   [:div.inline-block {:style {:margin-right "10px"}}
    [yleiset/livi-pudotusvalikko
@@ -63,6 +65,7 @@
 
 (defn- kokonaishintaiset-toimenpiteet-nakyma [e! app valinnat]
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (komp/watcher tiedot/valinnat (fn [_ _ uusi]
                                     (e! (tiedot/->PaivitaValinnat uusi))))
     (komp/sisaan-ulos #(do

--- a/src/cljs/harja/views/vesivaylat/urakka/toimenpiteet/yksikkohintaiset.cljs
+++ b/src/cljs/harja/views/vesivaylat/urakka/toimenpiteet/yksikkohintaiset.cljs
@@ -32,6 +32,8 @@
   (:require-macros [cljs.core.async.macros :refer [go]]
                    [harja.tyokalut.ui :refer [for*]]))
 
+(def sivu "Vesiväylät/Yksikköhintaiset")
+
 ;;;;;;;
 ;; Urakkatoiminnot: Hintaryhmän valitseminen
 
@@ -226,6 +228,7 @@
 
 (defn- yksikkohintaiset-toimenpiteet-nakyma [e! app ulkoiset-valinnat]
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (komp/watcher tiedot/valinnat (fn [_ _ uusi]
                                     (e! (tiedot/->PaivitaValinnat uusi))))
     (komp/sisaan-ulos #(do

--- a/src/cljs/harja/views/vesivaylat/urakka/turvalaitteet.cljs
+++ b/src/cljs/harja/views/vesivaylat/urakka/turvalaitteet.cljs
@@ -5,8 +5,11 @@
             [harja.ui.komponentti :as komp])
   (:require-macros [cljs.core.async.macros :refer [go]]))
 
+(def sivu "Turvalaitteet")
+
 (defn turvalaitteet* [e! app]
   (komp/luo
+    (komp/kirjaa-kaytto! sivu)
     (komp/sisaan-ulos #(e! (tiedot/->Nakymassa? true))
                       #(e! (tiedot/->Nakymassa? false)))
     (fn [e! app]

--- a/test/clj/harja/palvelin/main_test.clj
+++ b/test/clj/harja/palvelin/main_test.clj
@@ -66,7 +66,8 @@
     :kan-kanavat
     :kan-liikennetapahtumat
     :kan-hairio
-    :kan-toimenpiteet})
+    :kan-toimenpiteet
+    :kayttoseuranta})
 
 (deftest main-komponentit-loytyy
   (let [jarjestelma (sut/luo-jarjestelma (asetukset/lue-asetukset *testiasetukset*))

--- a/tietokanta/src/main/resources/db/migration/V1_649__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_649__.sql
@@ -1,0 +1,7 @@
+CREATE TABLE kayttoseuranta(
+  id SERIAL PRIMARY KEY,
+  kayttaja INTEGER REFERENCES kayttaja (id) NOT NULL,
+  aika TIMESTAMP NOT NULL,
+  tila BOOLEAN NOT NULL,
+  sivu TEXT NOT NULL,
+  lisatieto TEXT);


### PR DESCRIPTION
Näkymät voivat rekisteröidä atomeja seurantaan, ja kun atomien
arvot muuttuvat, tallennetaan timestamp kantaan.