### PR TITLE
HAR-7186 Nopeuta Tilannekuvan tekemä hae-tilannekuvan-urakat palvelukutsu

### DIFF
--- a/laadunseuranta/test-src/clj/harja_laadunseuranta/tarkastusreittimuunnin/tarkastusreittimuunnin_test.clj
+++ b/laadunseuranta/test-src/clj/harja_laadunseuranta/tarkastusreittimuunnin/tarkastusreittimuunnin_test.clj
@@ -571,7 +571,7 @@
 
     (let [tarkastusten-maara-ennen (ffirst (q "SELECT COUNT(*) FROM tarkastus"))
           _ (jdbc/with-db-transaction [tx db]
-              (ls-core/tallenna-muunnetut-tarkastukset-kantaan tx tarkastukset {:id 1} urakka-id))
+              (ls-core/tallenna-muunnetut-tarkastukset-kantaan tx tarkastukset +kayttaja-jvh+ urakka-id))
           tarkastusten-maara-jalkeen (ffirst (q "SELECT COUNT(*) FROM tarkastus"))
           tarkastukset-kannassa (q-map "SELECT * FROM tarkastus WHERE tarkastusajo = " tarkastusajo-id ";")]
 

--- a/src/clj/harja/palvelin/palvelut/tilannekuva.clj
+++ b/src/clj/harja/palvelin/palvelut/tilannekuva.clj
@@ -488,10 +488,13 @@
                         oikeudet/tilannekuva-historia)
         kayttajan-urakat-alueittain (->>
                                       (kayttajatiedot/kayttajan-urakat-aikavalilta-alueineen
-                                       db user (fn [urakka-id kayttaja]
-                                                 (oikeudet/voi-lukea? oikeus-nakyma
-                                                                      urakka-id
-                                                                      kayttaja))
+                                       db user
+                                       (if (roolit/tilaajan-kayttaja? user)
+                                         (constantly true)
+                                         (fn [urakka-id kayttaja]
+                                           (oikeudet/voi-lukea? oikeus-nakyma
+                                                                urakka-id
+                                                                kayttaja)))
                                        nil (:urakoitsija tiedot) nil
                                        nil (:alku tiedot) (:loppu tiedot))
                                       (map
@@ -509,20 +512,26 @@
         ;; löydettynä käyttäjän oma urakka. Tämä ajateltiin aluksi bugina, mutta sittemmin sitä pidettiinkin
         ;; ihan hyvänä rajoitteena. Käytännössä tämä rajaa haettavan aikavälin vain sellaiselle välille, jolla
         ;; käyttäjän oma urakka on voimassa.
-        lisaoikeudet (maarita-oikeudet-omien-urakoiden-muihin-ely-urakoihin
-                       user oikeus-nakyma
-                       kayttajan-urakat-alueittain)
-        lisaoikeuksien-urakat-alueittain (->>
-                                           (kayttajatiedot/kayttajan-urakat-aikavalilta-alueineen
-                                            db user (fn [urakka-id kayttaja]
-                                                      (lukuoikeus-urakkaan-lisaoikeudella? db urakka-id lisaoikeudet))
-                                            nil (:urakoitsija tiedot) nil
-                                            nil (:alku tiedot) (:loppu tiedot))
-                                           (map
-                                             (fn [alue]
-                                               (update alue :urakat
-                                                       (fn [urakat]
-                                                         (filter :urakkanro urakat))))))
+
+        ;; Tilaajan käyttäjillä on oikeus kaikki urakoihin. Ei tarkastella silloin
+        ;; lisäoikeuksia ollenkaan jotta ollaan nopeampia
+        lisaoikeudet (if (roolit/tilaajan-kayttaja? user)
+                       []
+                       (maarita-oikeudet-omien-urakoiden-muihin-ely-urakoihin
+                        user oikeus-nakyma
+                        kayttajan-urakat-alueittain))
+        lisaoikeuksien-urakat-alueittain (when-not (empty? lisaoikeudet)
+                                           (->>
+                                             (kayttajatiedot/kayttajan-urakat-aikavalilta-alueineen
+                                               db user (fn [urakka-id kayttaja]
+                                                         (lukuoikeus-urakkaan-lisaoikeudella? db urakka-id lisaoikeudet))
+                                               nil (:urakoitsija tiedot) nil
+                                               nil (:alku tiedot) (:loppu tiedot))
+                                             (map
+                                               (fn [alue]
+                                                 (update alue :urakat
+                                                         (fn [urakat]
+                                                           (filter :urakkanro urakat)))))))
         lopulliset-kayttajan-urakat-alueittain (kayttajatiedot/yhdista-kayttajan-urakat-alueittain
                                                  kayttajan-urakat-alueittain
                                                  lisaoikeuksien-urakat-alueittain)]

--- a/src/cljc/harja/domain/roolit.cljc
+++ b/src/cljc/harja/domain/roolit.cljc
@@ -194,9 +194,10 @@ rooleista."
   [kayttaja]
   (case (name (or (get-in kayttaja [:organisaatio :tyyppi]) "tilaaja"))
     "liikennevirasto" :tilaaja
+    "hallintayksikko" :tilaaja
     "urakoitsija" :urakoitsija
-    ;; FIXME: laadunvalvontakonsultti ?
-    :tilaaja))
+
+    :urakoitsija))
 
 (defn tilaajan-kayttaja?
   [kayttaja]

--- a/test/clj/harja/palvelin/oikeudet_test.clj
+++ b/test/clj/harja/palvelin/oikeudet_test.clj
@@ -1,9 +1,10 @@
 (ns harja.palvelin.oikeudet-test
-    (:require [clojure.test :refer :all]
-              [taoensso.timbre :as log]
-              [slingshot.slingshot :refer [try+ throw+]]
-              [harja.domain.oikeudet :as oikeudet]
-              [harja.testi :refer :all]))
+  (:require [clojure.test :refer :all]
+            [taoensso.timbre :as log]
+            [slingshot.slingshot :refer [try+ throw+]]
+            [harja.domain.oikeudet :as oikeudet]
+            [harja.testi :refer :all]
+            [harja.domain.roolit :as roolit]))
 
 ;; Järjestelmävastaava
 (def jvh {:roolit #{"Jarjestelmavastaava"}
@@ -99,8 +100,16 @@
              :organisaatio ely
              :organisaation-urakat ely-urakat})
 
+;; Käyttäjä ilman organisaatiota
+(def kayttaja-ilman-organisaatiota
+  {:roolit #{}
+   :urakkaroolit {}
+   :organisaatioroolit {}
+   :organisaatio nil
+   :organisaation-urakat ely-urakat})
 
-
+(deftest kayttaja-ilman-organisaatiota-ei-tulkita-tilaajan-kayttajaksi
+  (is (not (roolit/tilaajan-kayttaja? kayttaja-ilman-organisaatiota))))
 
 (deftest vaadi-jvh-saa-tehda-mita-vaan
   (is (oikeudet/voi-kirjoittaa? oikeudet/hallinta-lampotilat nil jvh))

--- a/test/clj/harja/palvelin/palvelut/tilannekuva_test.clj
+++ b/test/clj/harja/palvelin/palvelut/tilannekuva_test.clj
@@ -393,7 +393,12 @@
   (let [vastaus (hae-urakat-tilannekuvaan +kayttaja-jvh+ hakuargumentit-laaja-historia)
         elynumerot (set (distinct (keep #(get-in % [:hallintayksikko :elynumero]) vastaus)))]
     (is (>= (count elynumerot) 6)
-        "JVH:n pitäisi nähdä aika monta ELYä")))
+        "JVH:n pitäisi nähdä kaikki ELY:t")))
+
+(deftest hae-urakat-tilannekuvaan-urakanvalvoja
+  (let [vastaus (hae-urakat-tilannekuvaan +kayttaja-tero+ hakuargumentit-laaja-historia)
+        elynumerot (set (distinct (keep #(get-in % [:hallintayksikko :elynumero]) vastaus)))]
+    (is (= (count elynumerot) 6)) "Urakanvalvojan pitäisi nähdä kaikki ELY:t"))
 
 (deftest hae-urakat-tilannekuvaan-ei-nay-mitaan
   (let [vastaus (hae-urakat-tilannekuvaan +kayttaja-seppo+ hakuargumentit-laaja-historia)


### PR DESCRIPTION
Nopeutetaan kyselyä niin, että tilaajan käyttäjille ei turhaan tehdä lisäoikeustarkistuksia.
Tilaajan käyttäjillä on oikeus kaikkiin urakoihin tilannekuvassa.