### PR TITLE
HAR-6793 Älä näytä urakattomia työkoneita

### DIFF
--- a/src/clj/harja/kyselyt/tilannekuva.sql
+++ b/src/clj/harja/kyselyt/tilannekuva.sql
@@ -240,10 +240,7 @@ FROM
   LEFT JOIN organisaatio o ON t.organisaatio = o.id
   LEFT JOIN urakka u ON u.id = t.urakkaid
 WHERE sijainti IS NOT NULL AND
-      (t.urakkaid IN (:urakat) OR
-       -- Jos urakkatietoa ei ole, näytetään vain oman organisaation (tai tilaajalle kaikki)
-       (t.urakkaid IS NULL AND
-        (:nayta-kaikki OR t.organisaatio = :organisaatio))) AND
+      (t.urakkaid IN (:urakat)) AND
       (t.lahetysaika BETWEEN :alku AND :loppu) AND
       ST_Distance(t.sijainti :: GEOMETRY, ST_MakePoint(:x, :y)::geometry) < :toleranssi
 GROUP BY t.tyokoneid, t.jarjestelma, t.tehtavat, t.tyokonetyyppi, t.urakkaid, o.nimi, u.nimi;
@@ -554,10 +551,7 @@ SELECT
   MAX(t.lahetysaika) AS viimeisin
 FROM tyokonehavainto t
 WHERE ST_distance(t.sijainti::GEOMETRY, st_makepoint(:keskipiste_x, :keskipiste_y)) < :sade AND
-(t.urakkaid IN (:urakat) OR
--- Jos urakkatietoa ei ole, näytetään vain oman organisaation (tai tilaajalle kaikki)
-(t.urakkaid IS NULL AND
-(:nayta-kaikki OR t.organisaatio = :organisaatio))) AND
+(t.urakkaid IN (:urakat)) AND
 -- Rajaa toimenpiteellä
 (t.tehtavat && :toimenpiteet :: suoritettavatehtava []) AND
 -- Rajaa ajalla
@@ -576,10 +570,7 @@ SELECT
 FROM tyokonehavainto t
 WHERE
   ST_distance(t.sijainti::GEOMETRY, st_makepoint(:keskipiste_x, :keskipiste_y)) < :sade AND
-(t.urakkaid IN (:urakat) OR
--- Jos urakkatietoa ei ole, näytetään vain oman organisaation (tai tilaajalle kaikki)
-(t.urakkaid IS NULL AND
-(:nayta-kaikki OR t.organisaatio = :organisaatio))) AND
+(t.urakkaid IN (:urakat)) AND
 -- Rajaa toimenpiteellä
 (t.tehtavat && :toimenpiteet :: suoritettavatehtava []) AND
 -- Rajaa ajalla

--- a/src/clj/harja/palvelin/palvelut/tilannekuva.clj
+++ b/src/clj/harja/palvelin/palvelut/tilannekuva.clj
@@ -281,8 +281,7 @@
                   db
                   (merge
                     (laajenna-tyokone-extent alue)
-                    {:nayta-kaikki (roolit/tilaajan-kayttaja? user)
-                     :organisaatio (:id (:organisaatio user))
+                    {:organisaatio (:id (:organisaatio user))
                      :urakat urakat
                      :toimenpiteet (tyokoneiden-toimenpiteet talvi kesa yllapito tarkastukset user)
                      :alku alku
@@ -342,7 +341,6 @@
     (merge
       (laajenna-tyokone-extent alue)
       {:urakat urakat
-       :nayta-kaikki (roolit/tilaajan-kayttaja? user)
        :toimenpiteet (tyokoneiden-toimenpiteet talvi kesa yllapito tarkastukset user)
        :alku alku
        :loppu loppu
@@ -674,7 +672,6 @@
                                          :urakat (rajaa-urakat-hakuoikeudella db user p)
                                          :x x
                                          :y y
-                                         :nayta-kaikki (roolit/tilaajan-kayttaja? user)
                                          :organisaatio (-> user :organisaatio :id))))))
 
 (defn hae-paallystysten-sijainnit-kartalle


### PR DESCRIPTION
Joillekin työkonehavainnoille ei ole urakkatietoa. Aiemmin nämä
haluttiin näyttää kartalla, mutta käytännössä tämä aiheutti vain
sekavuutta kartalla, ja sai käyttäjälle sellaisen fiiliksen, että
Harja käyttäytyy epävakaasti.