### PR TITLE
HAR-7896 Päivitä materiaalicachet jos tehtävien joukossa on suolausta

### DIFF
--- a/src/clj/harja/kyselyt/materiaalit.sql
+++ b/src/clj/harja/kyselyt/materiaalit.sql
@@ -306,3 +306,8 @@ SELECT
   nimi,
   yksikko
 FROM materiaalikoodi;
+
+-- name: hae-suolauksen-toimenpidekoodi
+SELECT id
+  FROM toimenpidekoodi
+ WHERE nimi = 'Suolaus' AND taso = 4;


### PR DESCRIPTION
Urakoitsijat joskus poistavat materiaalitoteumia lähettämällä toteuman
uudestaan tehtävänä suolaus mutta kokonaan ilman materiaalit-payloadia.
Tämä siksi käsiteltävä erikseen ja varmuuden vuoksi päivitettävä
silloinkin materiaalicachet.