### PR TITLE
HAR-7875 Kanavaurakan alku- ja loppupvm on väärin

### DIFF
--- a/src/cljs/harja/tiedot/urakka.cljs
+++ b/src/cljs/harja/tiedot/urakka.cljs
@@ -106,7 +106,7 @@
                (pvm/hoitokauden-loppupvm (inc vuosi))])
             (range ensimmainen-vuosi viimeinen-vuosi))
 
-      (or (= :vesivayla-hoito tyyppi) (= :vesivayla-kanavien-hoito tyyppi))
+      (= :vesivayla-hoito tyyppi)
       (vesivaylien-sopimuskaudet ensimmainen-vuosi viimeinen-vuosi)
 
       :default

--- a/tietokanta/testidata/kanavat/kanavien_urakat.sql
+++ b/tietokanta/testidata/kanavat/kanavien_urakat.sql
@@ -6,7 +6,7 @@ INSERT INTO urakka (nimi, indeksi, alkupvm, loppupvm, hallintayksikko, urakoitsi
 VALUES
   ('Saimaan kanava',
     'MAKU 2005 kunnossapidon osaindeksi',
-    '2016-08-01', '2019-07-30',
+    '2016-01-01', '2019-12-31',
     (SELECT id
      FROM organisaatio
      WHERE nimi = 'Kanavat ja avattavat sillat'),
@@ -28,7 +28,7 @@ VALUES ('Saimaan huollon pääsopimus',
          FROM urakka
          WHERE nimi = 'Saimaan kanava'),
         NULL,
-        '2016-08-01', '2018-07-30', TRUE, NOW());
+        '2016-01-01', '2019-12-31', TRUE, NOW());
 
 INSERT INTO sopimus (nimi, urakka, paasopimus, alkupvm, loppupvm, harjassa_luotu, luotu)
 VALUES ('Saimaan huollon lisäsopimus',
@@ -38,7 +38,7 @@ VALUES ('Saimaan huollon lisäsopimus',
         (SELECT id
          FROM sopimus
          WHERE nimi = 'Saimaan huollon pääsopimus'),
-        '2016-08-01', '2018-07-30', TRUE, NOW());
+        '2016-01-01', '2019-12-31', TRUE, NOW());
 
 INSERT INTO hanke (nimi, alkupvm, loppupvm, harjassa_luotu, luotu)
 VALUES ('Joensuun huolto- ja kunnossapito', '2016-07-07', '2021-05-05', TRUE, NOW());
@@ -47,7 +47,7 @@ INSERT INTO urakka (nimi, indeksi, alkupvm, loppupvm, hallintayksikko, urakoitsi
 VALUES
   ('Joensuun kanava',
     'MAKU 2005 kunnossapidon osaindeksi',
-    '2016-08-01', '2019-07-30',
+    '2016-01-01', '2019-12-31',
     (SELECT id
      FROM organisaatio
      WHERE nimi = 'Kanavat ja avattavat sillat'),
@@ -69,7 +69,7 @@ VALUES ('Joensuun huollon pääsopimus',
          FROM urakka
          WHERE nimi = 'Joensuun kanava'),
         NULL,
-        '2016-08-01', '2018-07-30', TRUE, NOW());
+        '2016-01-01', '2019-12-31', TRUE, NOW());
 
 INSERT INTO sopimus (nimi, urakka, paasopimus, alkupvm, loppupvm, harjassa_luotu, luotu)
 VALUES ('Joensuun huollon lisäsopimus',
@@ -79,4 +79,4 @@ VALUES ('Joensuun huollon lisäsopimus',
         (SELECT id
          FROM sopimus
          WHERE nimi = 'Joensuun huollon pääsopimus'),
-        '2016-08-01', '2018-07-30', TRUE, NOW());
+        '2016-01-01', '2019-12-31', TRUE, NOW());


### PR DESCRIPTION
Asetetaan kanavaurakat käyttämään urakkavuotta 1.1.-31.12.
Lisäksi korjataan testidataan kahden kanavaurakan alkupvm ja loppupvm
noudattamaan samaa ajatusta.