### PR TITLE
HAR-8303 Lisää laatupoikkeama -vaihtoehto puuttuu (API:n kautta tullut)

### DIFF
--- a/src/cljs/harja/views/urakka/laadunseuranta/tarkastukset.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/tarkastukset.cljs
@@ -387,7 +387,7 @@
             :nimi :tr
             :pakollinen? true
             :ala-nayta-virhetta-komponentissa? true
-            :validoi [[:validi-tr "Reittiä ei saada tehtyä" [:sijainti]]]
+            :varoita [[:validi-tr "Reittiä ei saada tehtyä" [:sijainti]]]
             :sijainti (r/wrap (:sijainti tarkastus)
                               #(swap! tarkastus-atom assoc :sijainti %))})
 


### PR DESCRIPTION
API:n kautta on tullut tarkastus, jonka tierekisteriosoitteelle ei
voitu luoda reittiä. Tämä estää laatupoikkeaman luonnin ja sapettaa
loppukäyttäjiä. Muutetaan tuon TR-reitin luonnon validointi varoituksek-
si niin saadaan laatupoikkeaman luonti onnistumaan.