### PR TITLE
Vhar 725 yksikkohintaisille töille maarien desimaalit tarvittaessa 3:n tarkkuudella

### DIFF
--- a/src/clj/harja/palvelin/raportointi/excel.clj
+++ b/src/clj/harja/palvelin/raportointi/excel.clj
@@ -24,6 +24,7 @@
   (:require [taoensso.timbre :as log]
             [dk.ative.docjure.spreadsheet :as excel]
             [clojure.string :as str]
+            [harja.fmt :as fmt]
             [harja.domain.raportointi :as raportti-domain])
   (:import (org.apache.poi.ss.util CellReference WorkbookUtil CellRangeAddress CellUtil)
            (org.apache.poi.ss.usermodel HorizontalAlignment)))
@@ -120,6 +121,7 @@
     :raha (.setDataFormat tyyli 8)
     :prosentti (.setDataFormat tyyli 10)
     :numero (.setDataFormat tyyli 2)
+    :numero-3desim (.setDataFormat tyyli 3)
     :pvm (.setDataFormat tyyli 14)
     :pvm-aika (.setDataFormat tyyli 22)
     nil))
@@ -217,14 +219,20 @@
 
                                       :default
                                       (constantly nil))
-
-                       naytettava-arvo (if (and (number? naytettava-arvo) (= :prosentti (:fmt sarake)))
+                       naytettava-arvo (cond
+                                         (and (number? naytettava-arvo) (= :prosentti (:fmt sarake)))
                                          ;; Jos excelissä formatoidaan luku prosentiksi,
                                          ;; excel olettaa, että kyseessä on sadasosia.
                                          ;; Eli kokonaisluku 25 -> 2500%
                                          ;; Muualla Harjassa prosenttilukuformatointi
                                          ;; lisää lähinnä % merkin kokonaisluvun loppuun.
                                          (/ naytettava-arvo 100)
+
+                                         ;; Jos excelissä on raha määrityksenä. Pyöristä kahteen desimaaliin
+                                         (and (= :raha (:fmt sarake)) (not (nil? naytettava-arvo)))
+                                         (BigDecimal. (str/replace (fmt/desimaaliluku-opt naytettava-arvo 2 false) "," "."))
+
+                                         :default
                                          naytettava-arvo)
                        tyyli (if-let [tyyli (get @luodut-tyylit solun-tyyli)]
                                tyyli

--- a/src/clj/harja/palvelin/raportointi/pdf.clj
+++ b/src/clj/harja/palvelin/raportointi/pdf.clj
@@ -125,6 +125,7 @@
     ;; Jos halutaan tukea erityyppisiä sarakkeita,
     ;; pitää tänne lisätä formatter.
     :numero #(raportti-domain/yrita fmt/desimaaliluku-opt % 1 true)
+    :numero-3desim #(fmt/pyorista-ehka-kolmeen %)
     :prosentti #(raportti-domain/yrita fmt/prosentti-opt %)
     :raha #(raportti-domain/yrita fmt/euro-opt %)
     :pvm #(raportti-domain/yrita fmt/pvm-opt %)

--- a/src/clj/harja/palvelin/raportointi/raportit/yksikkohintaiset_tyot_tehtavittain.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/yksikkohintaiset_tyot_tehtavittain.clj
@@ -109,8 +109,8 @@
                                {:leveys 5 :otsikko "Yks."}
                                (when (= konteksti :urakka)
                                  [{:leveys 10 :otsikko "Yksikkö\u00adhinta €" :fmt :raha}
-                                  {:leveys 10 :otsikko "Suunniteltu määrä hoitokaudella" :fmt :numero}])
-                               {:leveys 10 :otsikko "Toteutunut määrä" :fmt :numero}
+                                  {:leveys 10 :otsikko "Suunniteltu määrä hoitokaudella" :fmt :numero-3desim}])
+                               {:leveys 10 :otsikko "Toteutunut määrä" :fmt :numero-3desim}
                                (when (= konteksti :urakka)
                                  [{:leveys 15 :otsikko "Suunnitellut kustannukset hoitokaudella €" :fmt :raha}
                                   {:leveys 15 :otsikko "Toteutuneet kustannukset €" :fmt :raha}])]))

--- a/src/cljc/harja/fmt.cljc
+++ b/src/cljc/harja/fmt.cljc
@@ -524,6 +524,19 @@
      ""
      (desimaaliluku luku tarkkuus ryhmitelty?))))
 
+(defn pyorista-ehka-kolmeen [arvo]
+  (let [desimaalit-seq (s/split (str arvo) #"\.")
+        desimaalit (if (> (count desimaalit-seq) 1)
+                     (count (second desimaalit-seq))
+                     0)
+        arvo (try
+               (if (> desimaalit 2)
+                 (desimaaliluku-opt arvo 3 true)
+                 (desimaaliluku-opt arvo 2 true))
+               #?(:cljs (catch js/Object _ arvo))
+               #?(:clj (catch Exception _ arvo)))]
+    arvo))
+
 (defn prosentti
   ([luku] (prosentti luku 1))
   ([luku tarkkuus]

--- a/src/cljs/harja/tiedot/urakka.cljs
+++ b/src/cljs/harja/tiedot/urakka.cljs
@@ -206,6 +206,7 @@
   (reaction-writable (paattele-valittu-hoitokausi @valitun-urakan-hoitokaudet)))
 
 (defonce valittu-aikavali (reaction-writable @valittu-hoitokausi))
+(defonce yksikkohintaiset-aikavali (atom (pvm/kuukauden-aikavali (pvm/nyt))))
 
 (defn valitse-aikavali! [alku loppu]
   (reset! valittu-aikavali [alku loppu]))
@@ -213,7 +214,8 @@
 (defn valitse-hoitokausi! [hk]
   (log "------- VALITAAN HOITOKAUSI:" (pr-str hk))
   (reset! valittu-hoitokausi hk)
-  (reset! valittu-aikavali [(first hk) (second hk)]))
+  (reset! valittu-aikavali [(first hk) (second hk)])
+  (reset! yksikkohintaiset-aikavali [(first hk) (second hk)]))
 
 (def aseta-kuluva-kk-jos-hoitokaudella? (atom false))
 

--- a/src/cljs/harja/tiedot/urakka/toteumat/yksikkohintaiset_tyot.cljs
+++ b/src/cljs/harja/tiedot/urakka/toteumat/yksikkohintaiset_tyot.cljs
@@ -2,7 +2,6 @@
   (:require [reagent.core :refer [atom]]
             [cljs.core.async :refer [<!]]
             [harja.loki :refer [log tarkkaile!]]
-            [harja.tiedot.urakka :as urakka]
             [harja.tiedot.navigaatio :as nav]
             [harja.asiakas.kommunikaatio :as k]
             [harja.pvm :as pvm]
@@ -21,8 +20,8 @@
                       [valittu-sopimus-id _] @u/valittu-sopimusnumero
                       nakymassa? @yksikkohintaiset-tyot-nakymassa?
                       valittu-hoitokausi @u/valittu-hoitokausi
-                      valittu-aikavali @u/valittu-aikavali
-                      valittu-toimenpide-id (:tpi_id @urakka/valittu-toimenpideinstanssi)
+                      valittu-aikavali @u/yksikkohintaiset-aikavali
+                      valittu-toimenpide-id (:tpi_id @u/valittu-toimenpideinstanssi)
                       valittu-tehtava-id (:id @u/valittu-yksikkohintainen-tehtava)]
                      {:nil-kun-haku-kaynnissa? true}
                      (when (and valittu-urakka-id valittu-sopimus-id valittu-hoitokausi nakymassa?)
@@ -104,9 +103,9 @@
 (defonce yksikkohintainen-toteuma-kartalla
   (reaction
    (let [urakka-id (:id @nav/valittu-urakka)
-         sopimus-id (first @urakka/valittu-sopimusnumero)
-         hoitokausi @urakka/valittu-hoitokausi
-         aikavali @u/valittu-aikavali
+         sopimus-id (first @u/valittu-sopimusnumero)
+         hoitokausi @u/valittu-hoitokausi
+         aikavali @u/yksikkohintaiset-aikavali
          toimenpide (:tpi_id @u/valittu-toimenpideinstanssi)
          tehtava (:id @u/valittu-yksikkohintainen-tehtava)
          taso-paalla? @karttataso-yksikkohintainen-toteuma

--- a/src/cljs/harja/ui/raportti.cljs
+++ b/src/cljs/harja/ui/raportti.cljs
@@ -66,7 +66,6 @@
       :numero-3desim #(fmt/pyorista-ehka-kolmeen %)
       :prosentti #(raportti-domain/yrita fmt/prosentti-opt % 1)
       :raha #(raportti-domain/yrita fmt/euro-opt %)
-      :raha2 #(raportti-domain/yrita fmt/euro-opt %)
       :pvm #(raportti-domain/yrita fmt/pvm-opt %)
       str)))
 

--- a/src/cljs/harja/ui/raportti.cljs
+++ b/src/cljs/harja/ui/raportti.cljs
@@ -60,12 +60,15 @@
     (if fmt (fmt arvo) arvo)]])
 
 (defn- formatoija-fmt-mukaan [fmt]
-  (case fmt
-    :numero #(raportti-domain/yrita fmt/desimaaliluku-opt % 2 true)
-    :prosentti #(raportti-domain/yrita fmt/prosentti-opt % 1)
-    :raha #(raportti-domain/yrita fmt/euro-opt % )
-    :pvm #(raportti-domain/yrita fmt/pvm-opt %)
-    str))
+  (let [_ (println "formatoija-fmt-mukaan :: fmt " (pr-str fmt))]
+    (case fmt
+      :numero #(raportti-domain/yrita fmt/desimaaliluku-opt % 2 true)
+      :numero-3desim #(fmt/pyorista-ehka-kolmeen %)
+      :prosentti #(raportti-domain/yrita fmt/prosentti-opt % 1)
+      :raha #(raportti-domain/yrita fmt/euro-opt %)
+      :raha2 #(raportti-domain/yrita fmt/euro-opt %)
+      :pvm #(raportti-domain/yrita fmt/pvm-opt %)
+      str)))
 
 (defmethod muodosta-html :taulukko [[_ {:keys [otsikko viimeinen-rivi-yhteenveto?
                                                rivi-ennen

--- a/src/cljs/harja/ui/raportti.cljs
+++ b/src/cljs/harja/ui/raportti.cljs
@@ -60,14 +60,13 @@
     (if fmt (fmt arvo) arvo)]])
 
 (defn- formatoija-fmt-mukaan [fmt]
-  (let [_ (println "formatoija-fmt-mukaan :: fmt " (pr-str fmt))]
-    (case fmt
-      :numero #(raportti-domain/yrita fmt/desimaaliluku-opt % 2 true)
-      :numero-3desim #(fmt/pyorista-ehka-kolmeen %)
-      :prosentti #(raportti-domain/yrita fmt/prosentti-opt % 1)
-      :raha #(raportti-domain/yrita fmt/euro-opt %)
-      :pvm #(raportti-domain/yrita fmt/pvm-opt %)
-      str)))
+  (case fmt
+    :numero #(raportti-domain/yrita fmt/desimaaliluku-opt % 2 true)
+    :numero-3desim #(fmt/pyorista-ehka-kolmeen %)
+    :prosentti #(raportti-domain/yrita fmt/prosentti-opt % 1)
+    :raha #(raportti-domain/yrita fmt/euro-opt %)
+    :pvm #(raportti-domain/yrita fmt/pvm-opt %)
+    str))
 
 (defmethod muodosta-html :taulukko [[_ {:keys [otsikko viimeinen-rivi-yhteenveto?
                                                rivi-ennen

--- a/src/cljs/harja/views/urakka/toteumat/yksikkohintaiset_tyot.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/yksikkohintaiset_tyot.cljs
@@ -422,9 +422,9 @@
          {:otsikko "Yksikkö" :nimi :yksikko :muokattava? (constantly false) :tyyppi :numero :leveys 10}
          {:otsikko "Yksikkö\u00ADhinta" :nimi :yksikkohinta :muokattava? (constantly false) :tyyppi :numero :leveys 10 :tasaa :oikea :fmt fmt/euro-opt}
          {:otsikko "Suunni\u00ADteltu määrä" :nimi :hoitokauden-suunniteltu-maara :muokattava? (constantly false) :tyyppi :numero :leveys 10
-          :fmt #(fmt/desimaaliluku-opt % 2) :tasaa :oikea}
+          :fmt #(fmt/pyorista-ehka-kolmeen %) :tasaa :oikea}
          {:otsikko "Toteutu\u00ADnut määrä" :nimi :maara :muokattava? (constantly false) :tyyppi :numero :leveys 10
-          :fmt #(fmt/desimaaliluku-opt % 2) :tasaa :oikea}
+          :fmt #(fmt/pyorista-ehka-kolmeen %) :tasaa :oikea}
          {:otsikko "Suunni\u00ADtellut kustan\u00ADnukset" :nimi :hoitokauden-suunnitellut-kustannukset :fmt fmt/euro-opt
           :tasaa :oikea :muokattava? (constantly false) :tyyppi :numero :leveys 10}
          {:otsikko "Toteutu\u00ADneet kustan\u00ADnukset" :nimi :hoitokauden-toteutuneet-kustannukset :fmt fmt/euro-opt

--- a/src/cljs/harja/views/urakka/valinnat.cljs
+++ b/src/cljs/harja/views/urakka/valinnat.cljs
@@ -241,15 +241,6 @@ valintaoptiot {:sopimus {:valittu-sopimusnumero-atom u/valittu-sopimusnumero
   (fn [ur]
     (valinnat/urakan-valinnat ur (select-keys valintaoptiot [:sopimus :hoitokausi :aikavali-optiot :toimenpide]))))
 
-(defn urakan-sopimus-ja-hoitokausi-ja-aikavali-ja-toimenpide+kaikki
-  [ur]
-  (fn [ur]
-    (let [sopimus-ja-hoitokausi-ja-aikavali-ja-toimenpide (select-keys valintaoptiot [:sopimus :hoitokausi :aikavali-optiot :toimenpide])
-          sopimus-ja-hoitokausi-ja-aikavali-ja-toimenpide+kaikki (update-in sopimus-ja-hoitokausi-ja-aikavali-ja-toimenpide [:toimenpide :urakan-toimenpideinstassit-atom]
-                                                                            (fn [urakan-toimenpideinstanssit]
-                                                                              (r/wrap (vec (concat @urakan-toimenpideinstanssit [{:tpi_nimi "Kaikki"}])) identity)))]
-      (valinnat/urakan-valinnat ur sopimus-ja-hoitokausi-ja-aikavali-ja-toimenpide+kaikki))))
-
 (defn urakan-sopimus-ja-hoitokausi-ja-aikavali
   ([ur] (urakan-sopimus-ja-hoitokausi-ja-aikavali ur {}))
   ([ur optiot]

--- a/test/clj/harja/palvelin/raportointi/yksikkohintaiset_tyot_tehtavittain_test.clj
+++ b/test/clj/harja/palvelin/raportointi/yksikkohintaiset_tyot_tehtavittain_test.clj
@@ -106,7 +106,7 @@
                        :otsikko "Tehtävä"}
                        {:leveys  5
                         :otsikko "Yks."}
-                       {:fmt     :numero
+                       {:fmt     :numero-3desim
                         :leveys  10
                         :otsikko "Toteutunut määrä"})
                      '(("Opastustaulujen ja opastusviittojen uusiminen -porttaalissa olevan viitan/opastetaulun uusiminen"
@@ -143,7 +143,7 @@
                        :otsikko "Tehtävä"}
                        {:leveys  5
                         :otsikko "Yks."}
-                       {:fmt     :numero
+                       {:fmt     :numero-3desim
                         :leveys  10
                         :otsikko "Toteutunut määrä"})
                      '(("Opastustaulujen ja opastusviittojen uusiminen -porttaalissa olevan viitan/opastetaulun uusiminen"


### PR DESCRIPTION
Korjattu loppumaton looppu yksikköhintaiset työt näkymästä jos hoitokautta vaihtaa.
Samaan näkymään lisätty kolmen desimaalin tarkkuus määrille (mutta ei euroille)

Sama kolme desimaalia mahdollistettu raporteissa (excel, pdf, nettisivu) yksikköhintaiset työt tehtävämäärittäin raportissa.