### PR TITLE
Yöllisen lukon korjaus

### DIFF
--- a/src/clj/harja/palvelin/raportointi.clj
+++ b/src/clj/harja/palvelin/raportointi.clj
@@ -154,7 +154,7 @@
                                        (fn [_]
                                          (lukot/vain-yhdelta-nodelta
                                            db "paivita-raportti-cache-oisin!" 300
-                                           #(do
+                                           (do
                                               (log/info "paivita-raportti-cache-oisin! :: Alkaa " (pvm/nyt))
                                               (paivita-kaynnissolevien-hoitourakoiden-materiaalicachet-eiliselta db)
                                               (raportit-q/paivita_raportti_cachet db)

--- a/src/clj/harja/palvelin/raportointi.clj
+++ b/src/clj/harja/palvelin/raportointi.clj
@@ -155,10 +155,10 @@
                                          (lukot/vain-yhdelta-nodelta
                                            db "paivita-raportti-cache-oisin!" 300
                                            (do
-                                              (log/info "paivita-raportti-cache-oisin! :: Alkaa " (pvm/nyt))
-                                              (paivita-kaynnissolevien-hoitourakoiden-materiaalicachet-eiliselta db)
-                                              (raportit-q/paivita_raportti_cachet db)
-                                              (log/info "paivita-raportti-cache-oisin! :: Loppuu " (pvm/nyt)))))))
+                                             (log/info "paivita-raportti-cache-oisin! :: Alkaa " (pvm/nyt))
+                                             (paivita-kaynnissolevien-hoitourakoiden-materiaalicachet-eiliselta db)
+                                             (raportit-q/paivita_raportti_cachet db)
+                                             (log/info "paivita-raportti-cache-oisin! :: Loppuu " (pvm/nyt)))))))
 
 (defrecord Raportointi [raportit ajossa-olevien-raporttien-lkm]
   component/Lifecycle


### PR DESCRIPTION
Makrolla ajettavan lukon ajettavaan funktioon oli refactoroinnissa mennyt # merkki.
Se on nyt poistettu ja lukkomakrolle annettava funkkari menee nyt oikeasti ajoon.

Poistin vielä lisäksi "finally" määreen, jotta lukko toimisi myös tuon sleepin jälkeen eli kunnioittaisi kutsuttaessa annettua aikaa. 300 sek = 5min 