### PR TITLE
VHAR-3110 Lisää liikennemerkki-attribuutti jarjestely-elementtiin

### DIFF
--- a/resources/api/examples/tieluvan-kirjaus-request-tilapaisen-liikennemerkkijarjestely.json
+++ b/resources/api/examples/tieluvan-kirjaus-request-tilapaisen-liikennemerkkijarjestely.json
@@ -87,6 +87,7 @@
       "jarjestelyt": [
         {
           "jarjestely": {
+            "liikennemerkki": "Nopeusrajoitusmerkki",
             "alkuperainen-nopeusrajoitus": "60",
             "alennettu-nopeusrajoitus": "30",
             "nopeusrajoituksen-pituus": "250",

--- a/resources/api/schemas/entities/tielupa.schema.json
+++ b/resources/api/schemas/entities/tielupa.schema.json
@@ -875,6 +875,10 @@
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
+                  "liikennemerkki": {
+                    "id": "urn:/harja/tielupa/tilapaiset-liikennemerkkijarjestelyt/jarjestelyt/0/jarjestely/liikennemerkki",
+                    "type": "string"
+                  },
                   "alkuperainen-nopeusrajoitus": {
                     "id": "urn:/harja/tielupa/tilapaiset-liikennemerkkijarjestelyt/jarjestelyt/0/jarjestely/alkuperainen-nopeusrajoitus",
                     "type": "string"

--- a/src/clj/harja/palvelin/integraatiot/api/sanomat/tielupa_sanoma.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/sanomat/tielupa_sanoma.clj
@@ -202,7 +202,8 @@
 
 (defn liikennemerkkijarjestelyt [jarjestelyt]
   (mapv (fn [{jarjestely :jarjestely}]
-          (merge {::tielupa/alkuperainen-nopeusrajoitus (:alkuperainen-nopeusrajoitus jarjestely)
+          (merge {::tielupa/liikennemerkki (:liikennemerkki jarjestely)
+                  ::tielupa/alkuperainen-nopeusrajoitus (:alkuperainen-nopeusrajoitus jarjestely)
                   ::tielupa/alennettu-nopeusrajoitus (:alennettu-nopeusrajoitus jarjestely)
                   ::tielupa/nopeusrajoituksen-pituus (:nopeusrajoituksen-pituus jarjestely)}
                  (sijainti (:sijainti jarjestely))))

--- a/src/cljs/harja/views/tieluvat/tieluvat.cljs
+++ b/src/cljs/harja/views/tieluvat/tieluvat.cljs
@@ -507,7 +507,10 @@
    {:tyhja "Ei liikennemerkkijärjestelyitä"
     :tunniste identity}
    (concat
-     [{:otsikko "Al\u00ADku\u00ADpe\u00ADräi\u00ADnen no\u00ADpe\u00ADus\u00ADra\u00ADjoi\u00ADtus"
+     [{:otsikko "Lii\u00ADken\u00ADne\u00ADmerk\u00ADki"
+       :leveys 3
+       :nimi ::tielupa/liikennemerkki}
+      {:otsikko "Al\u00ADku\u00ADpe\u00ADräi\u00ADnen no\u00ADpe\u00ADus\u00ADra\u00ADjoi\u00ADtus"
        :leveys 3
        :nimi ::tielupa/alkuperainen-nopeusrajoitus}
       {:otsikko "A\u00ADlen\u00ADnet\u00ADtu no\u00ADpe\u00ADus\u00ADra\u00ADjoi\u00ADtus"

--- a/test/clj/harja/palvelin/integraatiot/api/sanomat/tielupa_sanoma_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/sanomat/tielupa_sanoma_test.clj
@@ -387,7 +387,8 @@
               :muut-liikennemerkit ""
               :jarjestelyt
               [{:jarjestely
-                {:alkuperainen-nopeusrajoitus "60"
+                {:liikennemerkki "Nopeusrajoitusmerkki"
+                 :alkuperainen-nopeusrajoitus "60"
                  :alennettu-nopeusrajoitus "30"
                  :nopeusrajoituksen-pituus "250"
                  :sijainti
@@ -415,7 +416,8 @@
                     :harja.domain.tielupa/losa nil
                     :harja.domain.tielupa/alennettu-nopeusrajoitus "30"
                     :harja.domain.tielupa/nopeusrajoituksen-pituus "250"
-                    :harja.domain.tielupa/kaista 1}]}]
+                    :harja.domain.tielupa/kaista 1
+                    :harja.domain.tielupa/liikennemerkki "Nopeusrajoitusmerkki"}]}]
     (is (= (tielupa-sanoma/tilapaiset-liikennemerkkijarjestelyt data) odotettu))))
 
 (deftest vesihuoltolupa

--- a/tietokanta/src/main/resources/db/migration/V1_839__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_839__.sql
@@ -1,0 +1,2 @@
+ALTER TYPE tieluvan_liikennemerkkijarjestely
+    ADD ATTRIBUTE "liikennemerkki" TEXT;


### PR DESCRIPTION
Tielupa-rajapintaan lisättiin uusi tieto: liikennemerkki.
Skeemamuutoksen lisäksi tehtiin käsittely uuden tiedon tallentamiseksi ja hakemiseksi sekä käyttöliittymämuutos tiedon esittämiseksi.