### PR TITLE
VHAR-3128 Näytä Paikkaus-välilehti MH-urakoille

### DIFF
--- a/src/cljs/harja/views/urakka.cljs
+++ b/src/cljs/harja/views/urakka.cljs
@@ -61,7 +61,7 @@
                         (u-domain/vesivaylaurakkatyyppi? tyyppi)
                         (istunto/ominaisuus-kaytossa? :vesivayla))
     :paikkaukset (and (oikeudet/urakat-paikkaukset id)
-                      (#{:hoito :paallystys} tyyppi))
+                      (#{:hoito :teiden-hoito :paallystys} tyyppi))
     :aikataulu (and (oikeudet/urakat-aikataulu id) (or (= tyyppi :paallystys)
                                                        (= tyyppi :tiemerkinta)))
     :kohdeluettelo-paallystys (and (or (oikeudet/urakat-kohdeluettelo-paallystyskohteet id)


### PR DESCRIPTION
Paikkaus-välilehden näkyvyys laajennettiin koskemaan myös MH-urakoita (urakkatyyppi: teiden-hoito).