### PR TITLE
VHAR-2866 Yhteystietohaun urakan tarkistusen viilaus

### DIFF
--- a/resources/xsd/sahkoposti/esimerkit/sahkoposti_ja_liite.json
+++ b/resources/xsd/sahkoposti/esimerkit/sahkoposti_ja_liite.json
@@ -1,0 +1,4 @@
+{
+  :xml-viesti "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sah:sahkoposti xmlns:sah=\"http://www.liikennevirasto.fi/xsd/harja/sahkopostiLiite\"><viestiId>9a46f622-7645-4d5e-bcd5-0affd395bee8</viestiId><vastaanottajat><vastaanottaja>anna.esimerkki@urakoitsija.fi</vastaanottaja><vastaanottaja>aito.liite@virasto.fi</vastaanottaja><vastaanottaja>turku.liikennekeskus@tmfg.fi</vastaanottaja></vastaanottajat><lahettaja>harja@vayla.fi</lahettaja><otsikko>Harja: Tietyöilmoitus 29.10.202-0.11.2020 Kotikatu</otsikko><sisalto><![CDATA[Liitteenä on HARJA:ssa tehty tietyöilmoitus.]]></sisalto><liitetiedostonNimi>Tietyöilmoitus-29.10.2020-10.11.2020-Kotikatu.pdf</liitetiedostonNimi><vastaanotettu>Thu Oct 29 09:00:32 EET 2020</vastaanotettu></sah:sahkoposti>",
+  :pdf-liite -- Binääridata tähän
+}

--- a/src/clj/harja/kyselyt/urakat.sql
+++ b/src/clj/harja/kyselyt/urakat.sql
@@ -867,11 +867,13 @@ WHERE urakkanro = :urakkanro
       AND alkupvm <= current_date
       AND loppupvm >= current_date;
 
--- name: onko-olemassa-urakkanro?
+-- name: onko-kaynnissa-urakkanro?
 -- single?: true
 SELECT exists(SELECT id
               FROM urakka
-              WHERE urakkanro = :urakkanro);
+              WHERE urakkanro = :urakkanro
+                AND alkupvm <= current_date
+                AND loppupvm >= current_date);
 
 -- name: tuhoa-tekniset-laitteet-urakkadata!
 DELETE

--- a/src/clj/harja/palvelin/integraatiot/api/yhteystiedot.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/yhteystiedot.clj
@@ -23,7 +23,7 @@
              :virheet [{:koodi virheet/+kayttajalla-puutteelliset-oikeudet+
                         :viesti (format "Käyttäjällä ei oikeuksia urakkaan: %s" urakkanro)}]}))
   (when-not (urakat/onko-kaynnissa-urakkanro? db urakkanro)
-    (log/error (format "Yritettiin hakea yhteystiedot tuntemattomalle tai päättyneelle urakalle: %s." urakkanro))
+    (log/warn (format "Yritettiin hakea yhteystiedot tuntemattomalle tai päättyneelle urakalle: %s." urakkanro))
     (throw+ {:type virheet/+viallinen-kutsu+
              :virheet [{:koodi virheet/+tuntematon-urakka-koodi+
                         :viesti (format "Urakkanumerolla: %s ei löydy voimassa olevaa urakkaa Harjassa." urakkanro)}]})))

--- a/src/clj/harja/palvelin/integraatiot/api/yhteystiedot.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/yhteystiedot.clj
@@ -22,11 +22,11 @@
     (throw+ {:type virheet/+kayttajalla-puutteelliset-oikeudet+
              :virheet [{:koodi virheet/+kayttajalla-puutteelliset-oikeudet+
                         :viesti (format "Käyttäjällä ei oikeuksia urakkaan: %s" urakkanro)}]}))
-  (when-not (urakat/onko-olemassa-urakkanro? db urakkanro)
-    (log/error (format "Yritettiin hakea yhteystiedot tuntemattomalle urakalle: %s." urakkanro))
+  (when-not (urakat/onko-kaynnissa-urakkanro? db urakkanro)
+    (log/error (format "Yritettiin hakea yhteystiedot tuntemattomalle tai päättyneelle urakalle: %s." urakkanro))
     (throw+ {:type virheet/+viallinen-kutsu+
              :virheet [{:koodi virheet/+tuntematon-urakka-koodi+
-                        :viesti (format "Urakkanumerolla: %s ei löydy urakkaa Harjassa." urakkanro)}]})))
+                        :viesti (format "Urakkanumerolla: %s ei löydy voimassa olevaa urakkaa Harjassa." urakkanro)}]})))
 
 (defn hae-urakan-yhteystiedot [db fim {urakkanro :urakkanro} kayttaja]
   (log/debug (format "Haetaan urakan (urakkanro: %s) tiedot käyttäjälle: %s." urakkanro kayttaja))


### PR DESCRIPTION
Jos urakka ei ole enää käynnissä, virheilmoitus tuli vasta FIM-komponentissa. Lisäsin siksi urakan olemassaolon tarkistukseen mukaan voimassaoloajan.

Mukana asiaan liittymättömän esimerkkitiedoston lisäys.