### PR TITLE
VHAR-2905 Printta kunnolla kuukaudet joissa on kirjain "ä"

### DIFF
--- a/src/cljc/harja/pvm.cljc
+++ b/src/cljc/harja/pvm.cljc
@@ -471,7 +471,9 @@
     "huhtikuu" 4
     "toukokuu" 5
     "kesäkuu" 6
+    "kesakuu" 6
     "heinäkuu" 7
+    "heinakuu" 7
     "elokuu" 8
     "syyskuu" 9
     "lokakuu" 10

--- a/src/cljs/harja/ui/pvm.cljs
+++ b/src/cljs/harja/ui/pvm.cljs
@@ -169,8 +169,8 @@
                                     (.preventDefault %)
                                     (.stopPropagation %)
                                     (when (or (not (some? valittava?-fn))
-                                              (valittava?-fn pvm/nyt))
-                                      (valitse pvm/nyt)))}
+                                              (valittava?-fn (pvm/nyt)))
+                                      (valitse (pvm/nyt))))}
                    "Tänään"]]]]])))))
 
 (def ^:const

--- a/src/cljs/harja/views/urakka/kulut.cljs
+++ b/src/cljs/harja/views/urakka/kulut.cljs
@@ -155,7 +155,7 @@
                     (if (nil? a)
                       "Ei valittu"
                       (let [[kk hv] (str/split a #"/")]
-                        (str (if (pvm/kuukauden-numero kk) (str/capitalize kk) (str "VÄÄRÄ KUUKAUSI " kk)) " - "
+                        (str (pvm/kuukauden-nimi (pvm/kuukauden-numero kk) true) " - "
                              (get lasku/hoitovuodet-strs (keyword hv))))))}
    (for [hv (range 1 6)
          kk kuukaudet]
@@ -463,7 +463,7 @@
                           (:summa k))]])
    [:div.flex-row (str "Koontilaskun kuukausi: "
                        (let [[kk hv] (str/split koontilaskun-kuukausi #"/")]
-                         (str (if (pvm/kuukauden-numero kk) (str/capitalize kk) (str "VÄÄRÄ KUUKAUSI " kk)) " - "
+                         (str (pvm/kuukauden-nimi (pvm/kuukauden-numero kk) true) " - "
                               (get lasku/hoitovuodet-strs (keyword hv)))))]
    [:div.flex-row (str "Laskun päivämäärä: "
                        laskun-pvm)]

--- a/test/clj/harja/pvm_test.clj
+++ b/test/clj/harja/pvm_test.clj
@@ -93,6 +93,13 @@
   (is (true? (pvm/sama-kuukausi? (pvm/->pvm-date-timeksi "3.4.2020")
                                  (t/local-date 2020 4 25)))))
 
+(deftest kuukauden-numero-toimii-myos-umlautilla
+  (is (= 6 (pvm/kuukauden-numero "kesäkuu")))
+  (is (= 6 (pvm/kuukauden-numero "kesakuu")))
+  (is (= 7 (pvm/kuukauden-numero "heinäkuu")))
+  (is (= 7 (pvm/kuukauden-numero "heinakuu")))
+  (is (nil? (pvm/kuukauden-numero "täyskuu"))))
+
 (deftest valissa?
   (is (true? (pvm/valissa? nyt nyt nyt)))
   (is (true? (pvm/valissa? nyt


### PR DESCRIPTION
Myös korjattu pikku bugi kalentteri "tänään" toiminnallisuudessa. 