### PR TITLE
VHAR-3349 Korjaa alasvetovalikkojen click-käsittelijät POT-lomakkeella

### DIFF
--- a/src/cljs/harja/ui/yleiset.cljs
+++ b/src/cljs/harja/ui/yleiset.cljs
@@ -319,10 +319,10 @@ joita kutsutaan kun niiden näppäimiä paineetaan."
             [:div.valittu (or naytettava-arvo (format-fn valinta))]
             (if @auki?
               ^{:key :auki}
-              [:span.livicon-chevron-up {:id (str "chevron-up-btn-" (hash vaihtoehdot))
+              [:span.livicon-chevron-up {:id (str "chevron-up-btn-" (or elementin-id "") "-" (hash vaihtoehdot))
                                          :class (when disabled "disabled")}]
               ^{:key :kiinni}
-              [:span.livicon-chevron-down {:id (str "chevron-up-btn-" (hash vaihtoehdot))
+              [:span.livicon-chevron-down {:id (str "chevron-up-btn-" (or elementin-id "") "-" (hash vaihtoehdot))
                                            :class (when disabled "disabled")}])]
            [alasvetolista (merge (select-keys asetukset #{:nayta-ryhmat :ryhman-otsikko :li-luokka-fn :itemit-komponentteja?
                                                           :disabled-vaihtoehdot :vayla-tyyli? :skrollattava?})

--- a/src/cljs/harja/views/urakka/paallystysilmoitukset.cljs
+++ b/src/cljs/harja/views/urakka/paallystysilmoitukset.cljs
@@ -638,12 +638,12 @@
                              (if rivi
                                 (:nimi rivi)
                                 "- Valitse Ajorata -"))
-            :pituus-max    256
+            :pituus-max    256 :elementin-id "alustan-ajorata"
             :validoi       (:tr-ajorata alustatoimien-validointi)
             :tasaa         :oikea
             :kokonaisluku? true}
            {:otsikko       "Kaista" :nimi :tr-kaista :tyyppi :valinta :leveys 10
-            :pituus-max    256
+            :pituus-max    256 :elementin-id "alustan-kaista"
             :valinnat      pot/+kaistat+
             :valinta-arvo  :koodi
             :valinta-nayta (fn [rivi]


### PR DESCRIPTION
Kahdelle alasvetovalintakentälle syntyi samat id:t sekä buttoniin että spaniin
Korjataan valuttamalla elementin-id parametri pohjaan saakka ja antamalla
se alustatoimenpiteiden ajorata ja tr-kaista valinnoille, koska samassa näkymässä
on samannimiset valinnat pot-lomakkeen Tierekisteriosoitteet-taulukossa.