### PR TITLE
Älä lokita XML sisältöä virheviesteissä

### DIFF
--- a/src/clj/harja/palvelin/integraatiot/tloik/sanomat/ilmoitustoimenpide_sanoma.clj
+++ b/src/clj/harja/palvelin/integraatiot/tloik/sanomat/ilmoitustoimenpide_sanoma.clj
@@ -47,7 +47,7 @@
         xml (xml/tee-xml-sanoma sisalto)]
     (if (xml/validi-xml? +xsd-polku+ "harja-tloik.xsd" xml)
       xml
-      (let [virheviesti (format "Ilmoitustoimenpidettä ei voida lähettää. XML ei ole validia. XML: %s." xml)]
+      (let [virheviesti "Ilmoitustoimenpidettä ei voida lähettää. XML ei ole validia."]
         (log/error virheviesti)
         (throw+ {:type virheet/+invalidi-xml+
                  :virheet [{:koodi :invalidi-ilmoitustoimenpide-xml

--- a/src/clj/harja/palvelin/integraatiot/turi/sanomat/turvallisuuspoikkeama.clj
+++ b/src/clj/harja/palvelin/integraatiot/turi/sanomat/turvallisuuspoikkeama.clj
@@ -235,19 +235,7 @@
         xml (xml/tee-xml-sanoma sisalto)]
     (if-let [virheet (xml/validoi-xml +xsd-polku+ "poikkeama-rest.xsd" xml)]
       (let [lokitettava-virhe (format "Turvallisuuspoikkeaman TURI-lähetyksen XML ei ole validia.\n
-      Validointivirheet: %s" virheet)
-            virheviesti (format (str lokitettava-virhe "\n
-                                 Muodostettu sanoma:\n
-                                 %s")
-                                (xml/tee-xml-sanoma
-                                  ;; Poistetaan tiedoston logitus sen takia, kun sen logitus voi jumittaa koko prosessin
-                                  (walk/prewalk (fn [osa]
-                                                  (if (and (vector? osa)
-                                                           (= :tiedosto (first osa)))
-                                                    [:tiedosto "<<EI LOKITETA TIEDOSTOA>>"]
-                                                    osa))
-                                                sisalto)))]
-        (log/error lokitettava-virhe)
+      Validointivirheet: %s" virheet)]
         (throw+ {:type :invalidi-turvallisuuspoikkeama-xml
-                 :error virheviesti}))
+                 :error lokitettava-virhe}))
       xml)))

--- a/src/clj/harja/palvelin/integraatiot/turi/sanomat/tyotunnit.clj
+++ b/src/clj/harja/palvelin/integraatiot/turi/sanomat/tyotunnit.clj
@@ -49,10 +49,8 @@
         xml (xml/tee-xml-sanoma sisalto)]
     (if-let [virheet (xml/validoi-xml "xsd/turi/" "tyotunnit-rest.xsd" xml)]
       (let [lokitettava-virhe (format "Työtuntien TURI-lähetyksen XML ei ole validia.\n
-                                 Validointivirheet: %s" virheet)
-            virheviesti (format (str lokitettava-virhe " Muodostettu sanoma: \n
-                                 %s") xml)]
+                                 Validointivirheet: %s" virheet)]
         (log/error lokitettava-virhe)
         (throw+ {:type :invalidi-tyotunti-xml
-                 :error virheviesti}))
+                 :error lokitettava-virhe}))
       xml)))


### PR DESCRIPTION
 - Virheviesteissä oli näkyvillä mm. käyttäjien nimiä, poistetaan näiden tulostaminen.