### PR TITLE
Vhar 3851 mhu laskutusyht akilliset hoitotyot

### DIFF
--- a/src/cljs/harja/views/urakka/toteumat/maarien_toteumat.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/maarien_toteumat.cljs
@@ -190,7 +190,10 @@
         [:th {:style {:width (:suunniteltu leveydet)}} "Suunniteltu"]
         [:th {:style {:width (:prosentti leveydet)}} "%"]]]
       (if (:toimenpiteet-lataa app)
-        [yleiset/ajax-loader "Haetaan..."]
+        [:tbody
+         [:tr
+          [:td {:colSpan "5"} [yleiset/ajax-loader "Haetaan..."]]]]
+
         [:tbody
          (doall
            (for [l ll]

--- a/test/clj/harja/kyselyt/maksuerat_test.clj
+++ b/test/clj/harja/kyselyt/maksuerat_test.clj
@@ -68,7 +68,7 @@
                ; MHU Ylläpito	20190	50
                ; MHU Korvausinvestointi	14300	51
                odotettu [{:tpi_id 45, :urakka_id 35, :kokonaishintainen 4207.8269412251655629246831000M}
-                         {:tpi_id 46, :urakka_id 35, :kokonaishintainen 1813.9635471854304635809971M}
+                         {:tpi_id 46, :urakka_id 35, :kokonaishintainen 6258.4035471854304635809971M}
                          {:tpi_id 47, :urakka_id 35, :kokonaishintainen 8801.94M}
                          {:tpi_id 48, :urakka_id 35, :kokonaishintainen 2030.60000000000000000000M}
                          {:tpi_id 49, :urakka_id 35, :kokonaishintainen 11001.94M}

--- a/tietokanta/src/main/resources/db/migration/R__Laskutusyhteenveto_mhu.sql
+++ b/tietokanta/src/main/resources/db/migration/R__Laskutusyhteenveto_mhu.sql
@@ -539,7 +539,7 @@ BEGIN
                                                 JOIN lasku_kohdistus lk ON lk.lasku = l.id
                                                 JOIN toimenpideinstanssi tpi
                                                      ON lk.toimenpideinstanssi = tpi.id AND tpi.id = t.tpi
-                                       WHERE lk.maksueratyyppi = 'kokonaishintainen' -- TODO: Sisältää kiinteähintaiset, kustannusarvioidut ja yksikkohintaiset työt
+                                       WHERE lk.maksueratyyppi != 'lisatyo' -- TODO: Sisältää kiinteähintaiset, kustannusarvioidut ja yksikkohintaiset työt
                                          AND lk.poistettu IS NOT TRUE
                                          AND l.erapaiva BETWEEN hk_alkupvm AND aikavali_loppupvm
                     LOOP


### PR DESCRIPTION
MHU laskutusyhteenvedossa otettiin hankintoihin mukaan vain kokonaishintaiset maksuerätyypit
Nyt muutettu niin, että lisätyöt edelleenkin tulee omana rivinään ja kaikki muut hankinnat riville.

Samalla korjattu:
Bugi: VHAR-3340 eli määrien toteumissa js warning.
Koska div on laitettu suoraa tablen sisään eikä td:n sisään.
