### PR TITLE
VHAR-2419 MHU Kulujen kohdistaminen: lisää kuukausivalinta

### DIFF
--- a/dev-resources/images/harja-icons/action/copy-lane.svg
+++ b/dev-resources/images/harja-icons/action/copy-lane.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 24H0V0H2V24ZM22 24H24V0H22V24ZM13 17H11V24H13V17ZM13 0H11V7H13V0Z" fill="#004D99"/>
+<path d="M15.5 7.09998L14.1 8.49998L16.6 11H5V13H16.6L14.1 15.5L15.5 16.9L20.4 12L15.5 7.09998Z" fill="#004D99"/>
+</svg>

--- a/dev-resources/less/vayla/inputs-and-selects.less
+++ b/dev-resources/less/vayla/inputs-and-selects.less
@@ -147,7 +147,8 @@ label {
       .select-ul-yhteiset-arvot();
       border: solid 1px black;
 
-      > li {
+     > li,
+      > div > li {
         .select-li-yhteiset-arvot();
         display: flex;
         border-bottom: 1px solid @gray230;
@@ -229,7 +230,8 @@ label {
         margin-left: -1px;
         margin-right: -1px;
         border: solid 1px black;
-        > li {
+        > li,
+        > div > li {
           .select-li-yhteiset-arvot();
           display: flex;
           border-bottom: 1px solid @gray230;

--- a/resources/public/images/harja-icons/action/copy-lane.svg
+++ b/resources/public/images/harja-icons/action/copy-lane.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 24H0V0H2V24ZM22 24H24V0H22V24ZM13 17H11V24H13V17ZM13 0H11V7H13V0Z" fill="#004D99"/>
+<path d="M15.5 7.09998L14.1 8.49998L16.6 11H5V13H16.6L14.1 15.5L15.5 16.9L20.4 12L15.5 7.09998Z" fill="#004D99"/>
+</svg>

--- a/src/clj/harja/kyselyt/laskut.sql
+++ b/src/clj/harja/kyselyt/laskut.sql
@@ -122,30 +122,6 @@ where l.urakka = :urakka
   and l.laskun_numero = :laskun-numero
   and l.poistettu is not true;
 
--- name: hae-kaikki-urakan-laskuerittelyt
--- Hakee kaikki urakan laskut ja niihin liittyvät kohdistukset
-SELECT l.id                   as "id",
-       l.kokonaissumma        as "kokonaissumma",
-       l.erapaiva             as "erapaiva",
-       l.tyyppi               as "tyyppi",
-       l.laskun_numero        as "laskun-numero",
-       l.koontilaskun_kuukausi as "koontilaskun-kuukausi",
-       l.lisatieto            as "lisatieto",
-       lk.id                  as "kohdistus-id",
-       lk.rivi                as "rivi",
-       lk.summa               as "summa",
-       lk.toimenpideinstanssi as "toimenpideinstanssi",
-       lk.tehtavaryhma        as "tehtavaryhma",
-       lk.tehtava             as "tehtava",
-       lk.suoritus_alku       as "suoritus-alku",
-       lk.suoritus_loppu      as "suoritus-loppu",
-       lk.lisatyon_lisatieto  as "lisatyon-lisatieto",
-       lk.maksueratyyppi      as "maksueratyyppi"
-from lasku l
-       JOIN lasku_kohdistus lk on l.id = lk.lasku AND lk.poistettu IS NOT TRUE
-WHERE l.urakka = :urakka
-  AND l.poistettu IS NOT TRUE;
-
 -- name: hae-urakan-laskuerittelyt
 -- Hakee urakan laskut ja niihin liittyvät kohdistukset annetulta aikaväliltä
 SELECT l.id                   as "id",
@@ -168,8 +144,9 @@ SELECT l.id                   as "id",
 from lasku l
        JOIN lasku_kohdistus lk on l.id = lk.lasku AND lk.poistettu IS NOT TRUE
 WHERE l.urakka = :urakka
-  AND l.erapaiva BETWEEN :alkupvm ::DATE AND :loppupvm ::DATE
-  AND l.poistettu IS NOT TRUE;
+    AND (:alkupvm::DATE IS NULL OR :alkupvm::DATE <= l.erapaiva)
+    AND (:loppupvm::DATE IS NULL OR l.erapaiva <= :loppupvm::DATE)
+    AND l.poistettu IS NOT TRUE;
 
 -- name: linkita-lasku-ja-liite<!
 -- Linkittää liitteen ja laskun

--- a/src/clj/harja/palvelin/palvelut/laskut.clj
+++ b/src/clj/harja/palvelin/palvelut/laskut.clj
@@ -66,13 +66,6 @@
                                                kohdistukset)})))
     laskukohdistukset))
 
-(defn hae-kaikki-urakan-laskuerittelyt
-  "Palauttaa urakan laskut laskuerittelyineen."
-  [db user hakuehdot]
-  (oikeudet/vaadi-lukuoikeus oikeudet/urakat-laskutus-laskunkirjoitus user (:urakka-id hakuehdot))
-  (let [laskukohdistukset (group-by :id (q/hae-kaikki-urakan-laskuerittelyt db {:urakka (:urakka-id hakuehdot)}))]
-    (kasittele-kohdistukset db laskukohdistukset)))
-
 (defn hae-urakan-laskuerittelyt
   "Palauttaa urakan laskut valitulta ajanjaksolta laskuerittelyineen."
   [db user hakuehdot]
@@ -316,9 +309,6 @@
       (julkaise-palvelu http :laskuerittelyt
                         (fn [user hakuehdot]
                           (hae-urakan-laskuerittelyt db user hakuehdot)))
-      (julkaise-palvelu http :kaikki-laskuerittelyt
-                        (fn [user hakuehdot]
-                          (hae-kaikki-urakan-laskuerittelyt db user hakuehdot)))
       (julkaise-palvelu http :lasku
                         (fn [user hakuehdot]
                           (hae-laskuerittely db user hakuehdot)))
@@ -348,7 +338,6 @@
     (poista-palvelut (:http-palvelin this) :laskut
                      :lasku
                      :laskuerittelyt
-                     :kaikki-laskuerittelyt
                      :tallenna-lasku
                      :poista-lasku
                      :poista-laskurivi

--- a/src/cljc/harja/fmt.cljc
+++ b/src/cljc/harja/fmt.cljc
@@ -677,3 +677,6 @@
     :tekniset-laitteet "tekniset laitteet"
 
     "Ei vielä formatointia ko. urakkatyypille"))
+
+(def fin-hk-alkupvm "01.10.")
+(def fin-hk-loppupvm "30.09.")

--- a/src/cljc/harja/fmt.cljc
+++ b/src/cljc/harja/fmt.cljc
@@ -677,6 +677,3 @@
     :tekniset-laitteet "tekniset laitteet"
 
     "Ei vielä formatointia ko. urakkatyypille"))
-
-(def fin-hk-alkupvm "01.10.")
-(def fin-hk-loppupvm "30.09.")

--- a/src/cljs/harja/tiedot/urakka/mhu_laskutus.cljs
+++ b/src/cljs/harja/tiedot/urakka/mhu_laskutus.cljs
@@ -569,8 +569,7 @@
 
   PaivitaLomake
   (process-event [{polut-ja-arvot :polut-ja-arvot optiot :optiot} app]
-    (let [
-          app (update app :lomake lomakkeen-paivitys polut-ja-arvot optiot)
+    (let [app (update app :lomake lomakkeen-paivitys polut-ja-arvot optiot)
           lomake (:lomake app)
           {validoi-fn :validoi} (meta lomake)
           validoitu-lomake (validoi-fn lomake)
@@ -701,11 +700,10 @@
   AsetaHakukuukausi
   (process-event
     [{:keys [kuukausi]} app]
-    (let []
-      (-> app
-          (assoc-in [:parametrit :haun-alkupvm] nil)
-          (assoc-in [:parametrit :haun-loppupvm] nil)
-          (assoc-in [:parametrit :haun-kuukausi] kuukausi))))
+    (-> app
+        (assoc-in [:parametrit :haun-alkupvm] nil)
+        (assoc-in [:parametrit :haun-loppupvm] nil)
+        (assoc-in [:parametrit :haun-kuukausi] kuukausi)))
 
   AsetaHakuparametri
   (process-event

--- a/src/cljs/harja/tiedot/urakka/mhu_laskutus.cljs
+++ b/src/cljs/harja/tiedot/urakka/mhu_laskutus.cljs
@@ -24,6 +24,7 @@
 (defrecord NakymastaPoistuttiin [])
 (defrecord PoistaKulu [id])
 (defrecord PoistoOnnistui [tulos])
+(defrecord AsetaHakukuukausi [kuukausi])
 (defrecord AsetaHakuparametri [polku arvo])
 
 (defrecord LiiteLisatty [liite])
@@ -495,11 +496,6 @@
                                                  {:tehtavaryhmat []
                                                   :toimenpiteet  []}
                                                  (sort-by :jarjestys kasitelty))]
-      (tuck-apurit/post! :kaikki-laskuerittelyt
-                         {:urakka-id (-> @tila/tila :yleiset :urakka :id)}
-                         {:onnistui           ->LaskuhakuOnnistui
-                          :epaonnistui        ->KutsuEpaonnistui
-                          :paasta-virhe-lapi? true})
       (assoc app
         :toimenpiteet toimenpiteet
         :tehtavaryhmat tehtavaryhmat)))
@@ -528,19 +524,19 @@
                           :epaonnistui        ->KutsuEpaonnistui
                           :epaonnistui-parametrit [{:viesti "Urakan maksuerien haku epäonnistui"}]
                           :paasta-virhe-lapi? true}))
-    (update-in app [:parametrit :haetaan] + 2))
+    (update-in app [:parametrit :haetaan] + 1))
   HaeUrakanLaskut
-  (process-event [{{:keys [id alkupvm loppupvm]} :hakuparametrit} app]
-    (tuck-apurit/post! (if (and alkupvm loppupvm)
-                         :laskuerittelyt
-                         :kaikki-laskuerittelyt)
-                       (cond-> {:urakka-id id}
-                               (and alkupvm loppupvm) (assoc :alkupvm alkupvm
-                                                             :loppupvm loppupvm))
-                       {:onnistui           ->LaskuhakuOnnistui
-                        :epaonnistui        ->KutsuEpaonnistui
-                        :epaonnistui-parametrit [{:viesti "Urakan laskujen haku epäonnistui"}]
-                        :paasta-virhe-lapi? true})
+  (process-event [{{:keys [id alkupvm loppupvm kuukausi]} :hakuparametrit} app]
+    (let [alkupvm (or alkupvm (first kuukausi))
+          loppupvm (or loppupvm (second kuukausi))]
+      (tuck-apurit/post! :laskuerittelyt
+                         {:urakka-id id
+                          :alkupvm alkupvm
+                          :loppupvm loppupvm}
+                         {:onnistui ->LaskuhakuOnnistui
+                          :epaonnistui ->KutsuEpaonnistui
+                          :epaonnistui-parametrit [{:viesti "Urakan laskujen haku epäonnistui"}]
+                          :paasta-virhe-lapi? true}))
     (update-in app [:parametrit :haetaan] inc))
   HaeUrakanToimenpiteetJaTehtavaryhmat
   (process-event
@@ -702,15 +698,26 @@
                         :epaonnistui ->KutsuEpaonnistui
                         :epaonnistui-parametrit [{:viesti "Aliurakoitsijan luonti epäonistui"}]})
     (update-in app [:parametrit :haetaan] inc))
+  AsetaHakukuukausi
+  (process-event
+    [{:keys [kuukausi]} app]
+    (let []
+      (-> app
+          (assoc-in [:parametrit :haun-alkupvm] nil)
+          (assoc-in [:parametrit :haun-loppupvm] nil)
+          (assoc-in [:parametrit :haun-kuukausi] kuukausi))))
+
   AsetaHakuparametri
   (process-event
     [{:keys [polku arvo]} app]
     (let [arvo (if (nil? arvo)
                  (-> @tila/yleiset :urakka polku)
                  arvo)]
-      (assoc-in app [:parametrit (case polku
-                                   :alkupvm :haun-alkupvm
-                                   :loppupvm :haun-loppupvm)] arvo)))
+      (-> app
+          (assoc-in [:parametrit :haun-kuukausi] nil)
+          (assoc-in [:parametrit (case polku
+                                       :alkupvm :haun-alkupvm
+                                       :loppupvm :haun-loppupvm)] arvo))))
 
   ;; FORMITOIMINNOT
 

--- a/src/cljs/harja/tiedot/urakka/mhu_laskutus.cljs
+++ b/src/cljs/harja/tiedot/urakka/mhu_laskutus.cljs
@@ -35,7 +35,7 @@
 
 (defrecord HaeUrakanToimenpiteetJaTehtavaryhmat [urakka])
 (defrecord HaeUrakanLaskut [hakuparametrit])
-(defrecord HaeUrakanLaskutJaTiedot [hakuparametrit])
+(defrecord HaeUrakanToimenpiteetJaMaksuerat [hakuparametrit])
 (defrecord OnkoLaskunNumeroKaytossa [laskun-numero])
 
 (defrecord KutsuEpaonnistui [tulos parametrit])
@@ -509,7 +509,7 @@
 
   ;; HAUT
 
-  HaeUrakanLaskutJaTiedot
+  HaeUrakanToimenpiteetJaMaksuerat
   (process-event [{:keys [hakuparametrit]} app]
     (varmista-kasittelyjen-jarjestys
       (tuck-apurit/post! :tehtavaryhmat-ja-toimenpiteet

--- a/src/cljs/harja/tiedot/urakka/urakka.cljs
+++ b/src/cljs/harja/tiedot/urakka/urakka.cljs
@@ -212,7 +212,8 @@
 (def kustannusten-seuranta-nakymassa? (atom false))
 
 
-(def kulut-default {:parametrit  {:haetaan 0}
+(def kulut-default {:parametrit  {:haetaan 0
+                                  :haun-kuukausi (pvm/kuukauden-aikavali (pvm/nyt))}
                     :taulukko    nil
                     :lomake      kulut-lomake-default
                     :kulut       []

--- a/src/cljs/harja/ui/kentat.cljs
+++ b/src/cljs/harja/ui/kentat.cljs
@@ -8,7 +8,7 @@
             [harja.ui.ikonit :as ikonit]
             [harja.ui.tierekisteri :as tr]
             [harja.ui.sijaintivalitsin :as sijaintivalitsin]
-            [harja.ui.yleiset :refer [linkki ajax-loader livi-pudotusvalikko nuolivalinta valinta-ul-max-korkeus-px]]
+            [harja.ui.yleiset :refer [linkki ajax-loader livi-pudotusvalikko nuolivalinta valinta-ul-max-korkeus-px] :as yleiset]
             [harja.ui.napit :as napit]
             [harja.loki :refer [log logt tarkkaile!]]
             [harja.tiedot.navigaatio :as nav]
@@ -1660,6 +1660,9 @@
   :rajauksen-alkupvm / -loppupvm antavat maksimi raja-arvot päivämäärille
   "
   [{:keys [ikoni rajauksen-alkupvm rajauksen-loppupvm] :as _optiot}]
+  ;; TODO: Tämä aikavali-kentta on käytössä vain yhdessä paikassa Harjaa (kulut). Muualla (12 usages) käytetään harja.ui.valinnat/aikavali komponenttia
+  ;; Tavoitteena pitäisi olla yhdistää nämä kaksi maailmaa siten, että jäljelle jää yksi komponentti ja sille halutun kaltainen toiminnallisuus
+  ;; Jos tähän komponenttiin alkaa kohdistua bugeja tai muutostarpeita, kannattaa mielestäni lähteä maksamaan tämä tekninen velka samalla
   (let [auki? (r/atom false)
         fokus-vaerit {:outline-color  "#0068B3"
                       :outline-width  "3px"
@@ -1739,9 +1742,11 @@
         (let [{:keys [valittu-pvm syottobufferi koskettu?]} @sisaiset]
           [:div.aikavali
            [vayla-lomakekentta
-            "Aikaväli"
+            ""
+            :tyylit {:kontti #{"aikavalikentta"}}
+            :otsikko-tag :span
             :ikoni ikoni
-            :placeholder "-valitse-"
+            :placeholder yleiset/valitse-text
             :value (or (when (and pvm-alku pvm-loppu)
                          (str (pvm/pvm pvm-alku) "-" (pvm/pvm pvm-loppu)))
                        "")

--- a/src/cljs/harja/ui/valinnat.cljs
+++ b/src/cljs/harja/ui/valinnat.cljs
@@ -77,8 +77,17 @@
                             :valitse-fn valitse-fn}
        hoitokaudet]])))
 
-(defn kuukausi [{:keys [disabled nil-valinta disabloi-tulevat-kk?] :or {disabloi-tulevat-kk? false}} kuukaudet valittu-kuukausi-atom]
-  (let [nyt (pvm/nyt)
+(defn kuukausi
+  "Kuukausivalinnan komponentti. Mahdollista käytön sekä atomin että ei-atomin (tuck) kanssa."
+  [{:keys [disabled nil-valinta disabloi-tulevat-kk? valitse-fn vayla-tyyli?] :or {disabloi-tulevat-kk? false}}
+                kuukaudet valittu-kuukausi]
+  (assert (or (instance? reagent.ratom/Reaction valittu-kuukausi)
+              (vector? valittu-kuukausi)
+              (nil? valittu-kuukausi)) "valittu-kuukausi oltava vektori (tai nil jos arvo asettamatta) tai reaktio")
+  (let [atomi? (not (or (vector? valittu-kuukausi)
+                        (nil? valittu-kuukausi)))
+        _ (assert (or atomi? valitse-fn) "Jos et anna atomia, on annettava valitse-fn")
+        nyt (pvm/nyt)
         format-fn (r/partial
                     (fn [kuukausi]
                       (if kuukausi
@@ -86,20 +95,25 @@
                               kk-teksti (pvm/kuukauden-nimi (pvm/kuukausi alkupvm))]
                           (str (str/capitalize kk-teksti) " " (pvm/vuosi alkupvm)))
                         (or nil-valinta "Kaikki"))))
-        valitse-fn (r/partial
-                     (fn [kuukausi]
-                       (reset! valittu-kuukausi-atom kuukausi)))
+        valitse-fn (or valitse-fn
+                       (when atomi?
+                         (r/partial
+                           (fn [kuukausi]
+                             (reset! valittu-kuukausi kuukausi)))))
         disabled-vaihtoehdot (when disabloi-tulevat-kk?
                                (into #{}
                                      (filter #(pvm/jalkeen? (first %) nyt))
                                      kuukaudet))]
     [:div.label-ja-alasveto.kuukausi
      [:span.alasvedon-otsikko "Kuukausi"]
-     [livi-pudotusvalikko {:valinta @valittu-kuukausi-atom
+     [livi-pudotusvalikko {:valinta (if atomi?
+                                      @valittu-kuukausi
+                                      valittu-kuukausi)
                            :disabled disabled
                            :disabled-vaihtoehdot disabled-vaihtoehdot
                            :format-fn format-fn
-                           :valitse-fn valitse-fn}
+                           :valitse-fn valitse-fn
+                           :vayla-tyyli? vayla-tyyli?}
       kuukaudet]]))
 
 (defn hoitokauden-kuukausi

--- a/src/cljs/harja/ui/yleiset.cljs
+++ b/src/cljs/harja/ui/yleiset.cljs
@@ -766,3 +766,5 @@ jatkon."
    (fn-viiveella fn-to-run 10))
   ([fn-to-run ms]
    (js/setTimeout (fn [] (fn-to-run)) ms)))
+
+(def valitse-text "-valitse-")

--- a/src/cljs/harja/views/urakka/kulut.cljs
+++ b/src/cljs/harja/views/urakka/kulut.cljs
@@ -758,7 +758,7 @@
   [e! app]
   (komp/luo
     (komp/piirretty (fn [this]
-                      (e! (tiedot/->HaeUrakanLaskutJaTiedot (select-keys (-> @tila/yleiset :urakka) [:id :alkupvm :loppupvm])))
+                      (e! (tiedot/->HaeUrakanToimenpiteetJaMaksuerat (select-keys (-> @tila/yleiset :urakka) [:id :alkupvm :loppupvm])))
                       (e! (tiedot/->HaeUrakanLaskut {:id (-> @tila/yleiset :urakka :id)
                                                      :alkupvm (first (pvm/kuukauden-aikavali (pvm/nyt)))
                                                      :loppupvm (second (pvm/kuukauden-aikavali (pvm/nyt)))}))))

--- a/src/cljs/harja/views/urakka/kulut.cljs
+++ b/src/cljs/harja/views/urakka/kulut.cljs
@@ -808,11 +808,6 @@
               :luokka "suuri"}]]
 
            [:div.flex-row {:style {:justify-content "flex-start"}}
-            #_[kentat/vayla-lomakekentta
-               "Kirjoita tähän halutessasi lisätietoa"
-               "Kirjoita tähän halutessasi lisätietoa"
-               :on-change #(e! (tiedot/->AsetaHakuTeksti (-> % .-target .-value)))
-               :arvo hakuteksti]
             [valinnat/kuukausi {:nil-valinta yleiset/valitse-text
                                 :vayla-tyyli? true
                                 :valitse-fn #(do

--- a/src/cljs/harja/views/urakka/kulut.cljs
+++ b/src/cljs/harja/views/urakka/kulut.cljs
@@ -23,7 +23,10 @@
             [harja.asiakas.kommunikaatio :as k]
             [harja.transit :as t]
             [harja.pvm :as pvm]
-            [clojure.string :as string])
+            [clojure.string :as string]
+            [harja.ui.valinnat :as valinnat]
+            [harja.tiedot.urakka :as u]
+            [harja.fmt :as fmt])
   (:require-macros [harja.ui.taulukko.tyokalut :refer [muodosta-taulukko]]))
 
 (defn- hallinnollisen-otsikointi [ryhma]
@@ -755,64 +758,82 @@
   [e! app]
   (komp/luo
     (komp/piirretty (fn [this]
-                      (e! (tiedot/->HaeUrakanLaskutJaTiedot (select-keys (-> @tila/yleiset :urakka) [:id :alkupvm :loppupvm])))))
+                      (e! (tiedot/->HaeUrakanLaskutJaTiedot (select-keys (-> @tila/yleiset :urakka) [:id :alkupvm :loppupvm])))
+                      (e! (tiedot/->HaeUrakanLaskut {:id (-> @tila/yleiset :urakka :id)
+                                                     :alkupvm (first (pvm/kuukauden-aikavali (pvm/nyt)))
+                                                     :loppupvm (second (pvm/kuukauden-aikavali (pvm/nyt)))}))))
     (komp/ulos #(e! (tiedot/->NakymastaPoistuttiin)))
-    (fn [e! {taulukko :taulukko syottomoodi :syottomoodi {:keys [hakuteksti haun-alkupvm haun-loppupvm]} :parametrit lomake :lomake tehtavaryhmat :tehtavaryhmat :as app}]
-      [:div#vayla
-       (if syottomoodi
-         [:div
-          [kulujen-syottolomake e! app]]
-         [:div
-          [:div.flex-row
-           [:h2 "Kulujen kohdistus"]
-           ^{:key "raporttixls"}
-           [:form {:style  {:margin-left "auto"}
-                   :target "_blank" :method "POST"
-                   :action (k/excel-url :kulut)}
-            [:input {:type  "hidden" :name "parametrit"
-                     :value (t/clj->transit {:urakka-id   (-> @tila/yleiset :urakka :id)
-                                             :urakka-nimi (-> @tila/yleiset :urakka :nimi)
-                                             :alkupvm     haun-alkupvm
-                                             :loppupvm    haun-loppupvm})}]
-            [:button {:type  "submit"
-                      :class #{"button-secondary-default" "suuri"}} "Tallenna Excel"]]
-           ^{:key "raporttipdf"}
-           [:form {:style  {:margin-left  "16px"
+    (fn [e! {taulukko :taulukko syottomoodi :syottomoodi {:keys [hakuteksti haun-kuukausi haun-alkupvm haun-loppupvm]} :parametrit lomake :lomake tehtavaryhmat :tehtavaryhmat :as app}]
+      (let [[hk-alkupvm hk-loppupvm] (pvm/paivamaaran-hoitokausi (pvm/nyt))
+            kuukaudet (pvm/aikavalin-kuukausivalit
+                        [hk-alkupvm
+                         hk-loppupvm])]
+        [:div#vayla
+         [debug/debug app]
+        (if syottomoodi
+          [:div
+           [kulujen-syottolomake e! app]]
+          [:div
+           [:div.flex-row
+            [:h2 "Kulujen kohdistus"]
+            ^{:key "raporttixls"}
+            [:form {:style {:margin-left "auto"}
+                    :target "_blank" :method "POST"
+                    :action (k/excel-url :kulut)}
+             [:input {:type "hidden" :name "parametrit"
+                      :value (t/clj->transit {:urakka-id (-> @tila/yleiset :urakka :id)
+                                              :urakka-nimi (-> @tila/yleiset :urakka :nimi)
+                                              :kuukausi haun-kuukausi
+                                              :alkupvm haun-alkupvm
+                                              :loppupvm haun-loppupvm})}]
+             [:button {:type "submit"
+                       :class #{"button-secondary-default" "suuri"}} "Tallenna Excel"]]
+            ^{:key "raporttipdf"}
+            [:form {:style {:margin-left "16px"
                             :margin-right "64px"}
-                   :target "_blank" :method "POST"
-                   :action (k/pdf-url :kulut)}
-            [:input {:type  "hidden" :name "parametrit"
-                     :value (t/clj->transit {:urakka-id   (-> @tila/yleiset :urakka :id)
-                                             :urakka-nimi (-> @tila/yleiset :urakka :nimi)
-                                             :alkupvm     haun-alkupvm
-                                             :loppupvm    haun-loppupvm})}]
-            [:button {:type  "submit"
-                      :class #{"button-secondary-default" "suuri"}} "Tallenna PDF"]]
-           [napit/yleinen-ensisijainen
-            "Uusi kulu"
-            #(e! (tiedot/->KulujenSyotto (not syottomoodi)))
-            {:vayla-tyyli? true
-             :luokka       "suuri"}]]
+                    :target "_blank" :method "POST"
+                    :action (k/pdf-url :kulut)}
+             [:input {:type "hidden" :name "parametrit"
+                      :value (t/clj->transit {:urakka-id (-> @tila/yleiset :urakka :id)
+                                              :urakka-nimi (-> @tila/yleiset :urakka :nimi)
+                                              :kuukausi haun-kuukausi
+                                              :alkupvm haun-alkupvm
+                                              :loppupvm haun-loppupvm})}]
+             [:button {:type "submit"
+                       :class #{"button-secondary-default" "suuri"}} "Tallenna PDF"]]
+            [napit/yleinen-ensisijainen
+             "Uusi kulu"
+             #(e! (tiedot/->KulujenSyotto (not syottomoodi)))
+             {:vayla-tyyli? true
+              :luokka "suuri"}]]
 
-          [:div.flex-row
-           #_[kentat/vayla-lomakekentta
-              "Kirjoita tähän halutessasi lisätietoa"
-              :on-change #(e! (tiedot/->AsetaHakuTeksti (-> % .-target .-value)))
-              :arvo hakuteksti]
-           [kentat/aikavali
-            {:valinta-fn               #(e! (tiedot/->AsetaHakuparametri %1 %2))
-             :pvm-alku                 (or haun-alkupvm
-                                           (-> @tila/yleiset :urakka :alkupvm))
-             :rajauksen-alkupvm        (-> @tila/yleiset :urakka :alkupvm)
-             :rajauksen-loppupvm       (-> @tila/yleiset :urakka :loppupvm)
-             :pvm-loppu                (or haun-loppupvm
-                                           (-> @tila/yleiset :urakka :loppupvm))
-             :ikoni                    ikonit/calendar
-             :sumeutus-kun-molemmat-fn #(e! (tiedot/->HaeUrakanLaskut {:id       (-> @tila/yleiset :urakka :id)
-                                                                       :alkupvm  %1
-                                                                       :loppupvm %2}))}]]
-          (when taulukko
-            [p/piirra-taulukko taulukko])])])))
+           [:div.flex-row {:style {:justify-content "flex-start"}}
+            #_[kentat/vayla-lomakekentta
+               "Kirjoita tähän halutessasi lisätietoa"
+               "Kirjoita tähän halutessasi lisätietoa"
+               :on-change #(e! (tiedot/->AsetaHakuTeksti (-> % .-target .-value)))
+               :arvo hakuteksti]
+            [valinnat/kuukausi {:nil-valinta yleiset/valitse-text
+                                :vayla-tyyli? true
+                                :valitse-fn #(do
+                                               (e! (tiedot/->AsetaHakukuukausi %))
+                                               (e! (tiedot/->HaeUrakanLaskut {:id (-> @tila/yleiset :urakka :id)
+                                                                              :kuukausi %})))}
+             kuukaudet haun-kuukausi]
+            [:div.label-ja-alasveto.aikavali
+             [:span.alasvedon-otsikko "Aikaväli"]
+             [kentat/aikavali
+              {:valinta-fn #(e! (tiedot/->AsetaHakuparametri %1 %2))
+               :pvm-alku haun-alkupvm
+               :rajauksen-alkupvm (-> @tila/yleiset :urakka :alkupvm)
+               :rajauksen-loppupvm (-> @tila/yleiset :urakka :loppupvm)
+               :pvm-loppu haun-loppupvm
+               :ikoni ikonit/calendar
+               :sumeutus-kun-molemmat-fn #(e! (tiedot/->HaeUrakanLaskut {:id (-> @tila/yleiset :urakka :id)
+                                                                         :alkupvm %1
+                                                                         :loppupvm %2}))}]]]
+           (when taulukko
+             [p/piirra-taulukko taulukko])])]))))
 
 (defn kohdistetut-kulut
   []

--- a/src/cljs/harja/views/urakka/kulut/mhu_kustannusten_seuranta.cljs
+++ b/src/cljs/harja/views/urakka/kulut/mhu_kustannusten_seuranta.cljs
@@ -20,7 +20,8 @@
             [harja.tiedot.urakka.kulut.mhu-kustannusten-seuranta :as kustannusten-seuranta-tiedot]
             [harja.domain.kulut.kustannusten-seuranta :as kustannusten-seuranta]
             [harja.domain.skeema :refer [+tyotyypit+]]
-            [harja.tyokalut.big :as big])
+            [harja.tyokalut.big :as big]
+            [harja.fmt :as fmt])
   (:require-macros [cljs.core.async.macros :refer [go]]
                    [reagent.ratom :refer [reaction run!]]
                    [harja.atom :refer [reaction<!]]))
@@ -355,13 +356,11 @@
                              2019
                              (:hoitokauden-alkuvuosi app))
         valittu-kuukausi (:valittu-kuukausi app)
-        fin-hk-alkupvm "01.10."
-        fin-hk-loppupvm "30.09."
         db-hk-alkupvm "-10-01"
         db-hk-loppupvm "-09-30"
         hoitokauden-kuukaudet (pvm/aikavalin-kuukausivalit
-                                [(pvm/->pvm (str fin-hk-alkupvm valittu-hoitokausi))
-                                 (pvm/->pvm (str fin-hk-loppupvm (inc valittu-hoitokausi)))])
+                                [(pvm/->pvm (str fmt/fin-hk-alkupvm valittu-hoitokausi))
+                                 (pvm/->pvm (str fmt/fin-hk-loppupvm (inc valittu-hoitokausi)))])
         haun-alkupvm (if valittu-kuukausi
                        (first valittu-kuukausi)
                        (str valittu-hoitokausi db-hk-alkupvm))
@@ -384,7 +383,7 @@
         [yleiset/livi-pudotusvalikko {:valinta valittu-hoitokausi
                                       :vayla-tyyli? true
                                       :valitse-fn #(e! (kustannusten-seuranta-tiedot/->ValitseHoitokausi (:id @nav/valittu-urakka) %))
-                                      :format-fn #(str fin-hk-alkupvm % "-" fin-hk-loppupvm (inc %))
+                                      :format-fn #(str fmt/fin-hk-alkupvm % "-" fmt/fin-hk-loppupvm (inc %))
                                       :klikattu-ulkopuolelle-params {:tarkista-komponentti? true}}
          hoitokaudet]]
        [:div.col-xs-6.col-md-3.filtteri

--- a/src/cljs/harja/views/urakka/kulut/mhu_kustannusten_seuranta.cljs
+++ b/src/cljs/harja/views/urakka/kulut/mhu_kustannusten_seuranta.cljs
@@ -20,8 +20,7 @@
             [harja.tiedot.urakka.kulut.mhu-kustannusten-seuranta :as kustannusten-seuranta-tiedot]
             [harja.domain.kulut.kustannusten-seuranta :as kustannusten-seuranta]
             [harja.domain.skeema :refer [+tyotyypit+]]
-            [harja.tyokalut.big :as big]
-            [harja.fmt :as fmt])
+            [harja.tyokalut.big :as big])
   (:require-macros [cljs.core.async.macros :refer [go]]
                    [reagent.ratom :refer [reaction run!]]
                    [harja.atom :refer [reaction<!]]))

--- a/test/clj/harja/palvelin/palvelut/laskut_test.clj
+++ b/test/clj/harja/palvelin/palvelut/laskut_test.clj
@@ -20,7 +20,7 @@
   (testit)
   (alter-var-root #'jarjestelma component/stop))
 
-(use-fixtures :once (compose-fixtures
+(use-fixtures :each (compose-fixtures
                       jarjestelma-fixture
                       urakkatieto-fixture))
 


### PR DESCRIPTION
Poista palvelu :kaikki-laskuerittelyt koska :laskuerittelyt osaa tehdä samat asiat
Poista SQL kysely hae-kaikki-urakan-laskuerittelyt, koska hae-urakan-laskuerittelyt
osaa tehdä samat asiat

Korjaa tyylejä tilanteessa, jossa alasvetovalinnan listassa on väliryhmittely

Tarjoa kuukausivalinnan komponentista versio atomin kanssa ja ilman (Tuck).