### PR TITLE
VHAR-3934 Korjaa raporttia Kulut tehtäväryhmittäin

### DIFF
--- a/src/clj/harja/palvelin/komponentit/http_palvelin.clj
+++ b/src/clj/harja/palvelin/komponentit/http_palvelin.clj
@@ -360,7 +360,6 @@
                                           (conj ui-kasittelija))
                                       true)))
                        (catch [:virhe :todennusvirhe] _
-                         (log/warn "Ei voitu todentaa tunnusta -> palautetaan 403")
                          {:status 403 :body "Todennusvirhe"})
 
                        (finally

--- a/src/clj/harja/palvelin/raportointi/pdf.clj
+++ b/src/clj/harja/palvelin/raportointi/pdf.clj
@@ -124,6 +124,7 @@
   (case fmt
     ;; Jos halutaan tukea erityyppisiä sarakkeita,
     ;; pitää tänne lisätä formatter.
+    :kokonaisluku #(raportti-domain/yrita fmt/kokonaisluku-opt %)
     :numero #(raportti-domain/yrita fmt/desimaaliluku-opt % 1 true)
     :numero-3desim #(fmt/pyorista-ehka-kolmeen %)
     :prosentti #(raportti-domain/yrita fmt/prosentti-opt %)

--- a/src/clj/harja/palvelin/raportointi/pdf.clj
+++ b/src/clj/harja/palvelin/raportointi/pdf.clj
@@ -208,23 +208,30 @@
                       (when viimeinen-rivi-yhteenveto?
                         "Yhteenveto on laskettu kaikista riveistä"))]]]))
 
-(defn taulukko-header [optiot sarakkeet]
-  [:fo:table-header
-   (when-let [rivi-ennen (:rivi-ennen optiot)]
-     [:fo:table-row
-      (for [{:keys [teksti sarakkeita tasaa]} rivi-ennen]
-        [:fo:table-cell {:border reunan-tyyli :background-color raportin-tehostevari
-                         :color "#ffffff"
-                         :number-columns-spanned (or sarakkeita 1)
-                         :text-align (tasaus tasaa)}
-         [:fo:block teksti]])])
+(defn taulukko-header [{:keys [oikealle-tasattavat-kentat] :as optiot} sarakkeet]
+  (let [oikealle-tasattavat-kentat (or oikealle-tasattavat-kentat #{})]
+    [:fo:table-header
+     (when-let [rivi-ennen (:rivi-ennen optiot)]
+       [:fo:table-row
+        (for [{:keys [teksti sarakkeita tasaa]} rivi-ennen]
+          [:fo:table-cell {:border reunan-tyyli :background-color raportin-tehostevari
+                           :color "#ffffff"
+                           :number-columns-spanned (or sarakkeita 1)
+                           :text-align (tasaus tasaa)}
+           [:fo:block teksti]])])
 
-   [:fo:table-row
-    (for [otsikko (map :otsikko sarakkeet)]
-      [:fo:table-cell {:border "solid 0.1mm black" :background-color raportin-tehostevari
-                       :color "#ffffff"
-                       :font-weight "normal" :padding "1mm"}
-       [:fo:block (cdata otsikko)]])]])
+     [:fo:table-row
+      (map-indexed
+        (fn [i {:keys [otsikko fmt tasaa] :as rivi}]
+          [:fo:table-cell {:border "solid 0.1mm black" :background-color raportin-tehostevari
+                           :color "#ffffff"
+                           :text-align (if (or (oikealle-tasattavat-kentat i)
+                                               (raportti-domain/numero-fmt? fmt))
+                                         "right"
+                                         (tasaus tasaa))
+                           :font-weight "normal" :padding "1mm"}
+           [:fo:block (cdata otsikko)]])
+        sarakkeet)]]))
 
 (defn taulukko-body [sarakkeet data {:keys [viimeinen-rivi-yhteenveto? tyhja] :as optiot}]
   (let [rivien-maara (count data)

--- a/src/clj/harja/palvelin/raportointi/pdf.clj
+++ b/src/clj/harja/palvelin/raportointi/pdf.clj
@@ -183,7 +183,8 @@
                                (border-tyyli sarake)
                                {:padding "1mm"
                                 :font-weight "normal"
-                                :text-align (if (oikealle-tasattavat-kentat i)
+                                :text-align (if (or (oikealle-tasattavat-kentat i)
+                                                    (raportti-domain/numero-fmt? (:fmt sarake)))
                                               "right"
                                               (tasaus (:tasaa sarake)))}
                                yhteenveto?

--- a/src/clj/harja/palvelin/raportointi/raportit.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit.clj
@@ -91,12 +91,10 @@
    ;; urakkatyypit: teiden-hoito = mh eli mhu, hoito = vanhan tyyliset
    {:nimi :vemtr
     :parametrit [{:tyyppi "aikavali", :konteksti nil, :pakollinen true, :nimi "Aikaväli"}]
-    ;; fixme: takrkista konteksti
     :konteksti #{"hallintayksikko" "koko maa"}
     :kuvaus "Valtakunnalliset ja ELY-kohtaiset määrätoteumat"
     :testiversio? true
     :suorita #'harja.palvelin.raportointi.raportit.vemtr/suorita
-    ;; fixme: tarkista urakkatyyyppi
     :urakkatyyppi #{:hoito :teiden-hoito}}
 
    {:nimi         :laaduntarkastusraportti

--- a/src/clj/harja/palvelin/raportointi/raportit/kulut_tehtavaryhmittain.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/kulut_tehtavaryhmittain.clj
@@ -40,17 +40,7 @@
                    :tavoitehinta
                    (+ %1)) 0 hoitokaudet))))
 
-(def piste->pilkku
-  (comp (map str)
-        (map #(cstr/replace % #"(\d+)\.(\d+)" "$1,$2"))))
 
-(def muuta-pilkut-ja-poista-id
-  (map (fn [k]
-         (rest
-           (transduce
-             piste->pilkku
-             conj
-             k)))))
 
 (defn- kulut-urakalle
   [db {:keys [alkupvm urakka-id loppupvm]}]
@@ -131,10 +121,11 @@
         rivit-tassa-kuussa (into [] rivin-muodostaja kaikki-rivit-kuussa)
 
         otsikot [{:leveys 1 :otsikko "Tehtäväryhmä"}
-                 {:leveys 1 :otsikko (str "Hoitokauden alusta " (pvm/pvm alkupvm-hoitokausi) "-" (pvm/pvm loppupvm-hoitokausi))}
-                 {:leveys 1 :otsikko (cond
-                                       kuukausi-valittu? (str (pvm/kuukauden-nimi (pvm/kuukausi alkupvm-valittu-kuu-tai-vali)) " " (pvm/vuosi alkupvm-valittu-kuu-tai-vali))
-                                       :else (str "Jaksolla " (pvm/pvm alkupvm-valittu-kuu-tai-vali) "-" (pvm/pvm loppupvm-valittu-kuu-tai-vali)))}]
+                 {:leveys 1 :fmt :raha :otsikko (str "Hoitokauden alusta " (pvm/pvm alkupvm-hoitokausi) "-" (pvm/pvm loppupvm-hoitokausi))
+                  }
+                 {:leveys 1 :fmt :raha :otsikko (cond
+                                                  kuukausi-valittu? (str (pvm/kuukauden-nimi (pvm/kuukausi alkupvm-valittu-kuu-tai-vali)) " " (pvm/vuosi alkupvm-valittu-kuu-tai-vali))
+                                                  :else (str "Jaksolla " (pvm/pvm alkupvm-valittu-kuu-tai-vali) "-" (pvm/pvm loppupvm-valittu-kuu-tai-vali)))}]
         rivit (loop [rivit-hoitokausi rivit-hoitokauden-alusta
                      rivit-kuukausi rivit-tassa-kuussa
                      kaikki {}]
@@ -165,7 +156,8 @@
                              (+ (nth %1 2) (nth %2 3))])
                          ["Yhteensä" 0 0]
                          rivit)
-        rivit (into [] muuta-pilkut-ja-poista-id rivit)]
+        rivit (into [] (map (fn [k] (rest k))) rivit)]
+
     {:otsikot  otsikot
      :yhteensa yhteensa
      :rivit    rivit}))
@@ -187,20 +179,15 @@
       {:viimeinen-rivi-yhteenveto? true
        :otsikko                    (str "Kulut tehtäväryhmittäin ajalla " (pvm/pvm alkupvm) " - " (pvm/pvm loppupvm))}
       otsikot
-      (conj rivit (transduce piste->pilkku
-                             conj
-                             yhteensa))]
+      (conj rivit yhteensa)]
      [:taulukko
       {:otsikko                    "Urakkavuoden alusta"
        :viimeinen-rivi-yhteenveto? true}
-      [{:leveys 1 :otsikko ""} {:leveys 1 :otsikko ""}]
-      (map #(transduce piste->pilkku
-                       conj
-                       %)
-           [["Urakkavuoden alusta tav.hintaan kuuluvia: " (str yhteensa-hoitokauden-alusta)]
-            ["Tavoitehinta: " (if (some? tavoitehinta)
-                                (str tavoitehinta)
-                                "Tavoitehintaa ei saatu")]
-            ["Jäljellä: " (if (some? tavoitehinta)
-                            (str (- tavoitehinta yhteensa-hoitokauden-alusta))
-                            "Tavoitehintaa ei saatu - jäljellä olevaa ei voitu laskea")]])]]))
+      [{:leveys 1 :otsikko ""} {:leveys 1 :otsikko "" :fmt :raha}]
+      [["Tavoitehinta: " (if (some? tavoitehinta)
+                           tavoitehinta
+                           "Tavoitehintaa ei saatu")]
+       ["Urakkavuoden alusta tav.hintaan kuuluvia: " yhteensa-hoitokauden-alusta]
+       ["Jäljellä: " (if (some? tavoitehinta)
+                       (- tavoitehinta yhteensa-hoitokauden-alusta)
+                       "Tavoitehintaa ei saatu - jäljellä olevaa ei voitu laskea")]]]]))

--- a/src/clj/harja/palvelin/raportointi/raportit/kulut_tehtavaryhmittain.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/kulut_tehtavaryhmittain.clj
@@ -119,13 +119,14 @@
                                     (:summa %)])))
         rivit-hoitokauden-alusta (into [] rivin-muodostaja kaikki-rivit-alusta)
         rivit-tassa-kuussa (into [] rivin-muodostaja kaikki-rivit-kuussa)
-
+        aikavalin-otsikko (if kuukausi-valittu?
+                            (pvm/koko-kuukausi-ja-vuosi alkupvm-valittu-kuu-tai-vali true)
+                            (str "Jaksolla " (pvm/pvm alkupvm-valittu-kuu-tai-vali) "-" (pvm/pvm loppupvm-valittu-kuu-tai-vali)))
         otsikot [{:leveys 1 :otsikko "Tehtäväryhmä"}
-                 {:leveys 1 :fmt :raha :otsikko (str "Hoitokauden alusta " (pvm/pvm alkupvm-hoitokausi) "-" (pvm/pvm loppupvm-hoitokausi))
-                  }
-                 {:leveys 1 :fmt :raha :otsikko (cond
-                                                  kuukausi-valittu? (str (pvm/kuukauden-nimi (pvm/kuukausi alkupvm-valittu-kuu-tai-vali)) " " (pvm/vuosi alkupvm-valittu-kuu-tai-vali))
-                                                  :else (str "Jaksolla " (pvm/pvm alkupvm-valittu-kuu-tai-vali) "-" (pvm/pvm loppupvm-valittu-kuu-tai-vali)))}]
+                 {:leveys 1 :fmt :raha
+                  :otsikko (str "Hoitokauden alusta " (pvm/pvm alkupvm-hoitokausi) "-"
+                                (pvm/pvm loppupvm-hoitokausi))}
+                 {:leveys 1 :fmt :raha :otsikko aikavalin-otsikko}]
         rivit (loop [rivit-hoitokausi rivit-hoitokauden-alusta
                      rivit-kuukausi rivit-tassa-kuussa
                      kaikki {}]

--- a/src/clj/harja/palvelin/raportointi/raportit/pohjavesialueiden_suolat.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/pohjavesialueiden_suolat.clj
@@ -39,20 +39,21 @@
      "")])
 
 (defn sarakkeet []
-  [{:leveys 3 :otsikko "Tie"}
-   {:leveys 2 :otsikko "Alkuosa"}
-   {:leveys 2 :otsikko "Alkuetäisyys"}
-   {:leveys 2 :otsikko "Loppuosa"}
-   {:leveys 2 :otsikko "Loppuetäisyys"}
-   {:leveys 3 :otsikko "Pituus"}
-   {:leveys 5 :otsikko "Toteutunut talvisuola yhteensä t"}
-   {:leveys 5 :otsikko "Toteutunut talvisuola t/km"}
-   {:leveys 5 :otsikko "Käyttöraja t/km"}])
+  [{:leveys 3 :fmt :kokonaisluku :otsikko "Tie"}
+   {:leveys 2 :fmt :kokonaisluku :otsikko "Alku\u00ADosa"}
+   {:leveys 2 :fmt :kokonaisluku :otsikko "Alku\u00ADetäisyys"}
+   {:leveys 2 :fmt :kokonaisluku :otsikko "Loppu\u00ADosa"}
+   {:leveys 2 :fmt :kokonaisluku :otsikko "Loppu\u00ADetäisyys"}
+   {:leveys 3 :fmt :numero :otsikko "Pituus"}
+   {:leveys 5 :fmt :numero :otsikko "Tot. talvisuola yhteensä (t)"}
+   {:leveys 5 :fmt :numero :otsikko "Tot. talvisuola (t/km)"}
+   {:leveys 5 :fmt :numero :otsikko "Käyttö\u00ADraja (t/km)"}])
 
 (defn pohjavesialueen-taulukko [rivit]
   (let [eka (first rivit)]
     [:taulukko {:otsikko (str (:tunnus eka) "-" (:nimi eka))
-                :viimeinen-rivi-yhteenveto? true}
+                :viimeinen-rivi-yhteenveto? true
+                :tyhja (if (empty? rivit) "Ei raportoitavia suolatoteumia.")}
      (sarakkeet)
      (into [] (map rivi-xf (loppusumma rivit)))]))
 
@@ -78,11 +79,12 @@
         otsikko (raportin-otsikko
                   (:nimi (first (urakat-q/hae-urakka db urakka-id)))
                   raportin-nimi alkupvm loppupvm)]
-    (log/debug "löytyi " (count tulos) " toteumaa")
     (vec
      (concat
       [:raportti {:orientaatio :landscape
                   :nimi otsikko}]
-      (mapv pohjavesialueen-taulukko (sort-by #(->> % first :nimi)
-                                              (map #(sort-by (juxt :tie :alkuosa :alkuet) %)
-                                                   (vals (group-by :tunnus tulos)))))))))
+      (if (empty? tulos)
+        [:teksti yleinen/ei-tuloksia-aikavalilla-str]
+        (mapv pohjavesialueen-taulukko (sort-by #(->> % first :nimi)
+                                                (map #(sort-by (juxt :tie :alkuosa :alkuet) %)
+                                                     (vals (group-by :tunnus tulos))))))))))

--- a/src/clj/harja/palvelin/raportointi/raportit/tehtavamaarat.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/tehtavamaarat.clj
@@ -223,7 +223,7 @@
                       :leveys 1 :fmt :numero}
                      {:otsikko "Toteuma" :leveys 1 :fmt :numero}
                      {:otsikko "Toteuma-%" :leveys 1 :fmt :prosentti-0desim}
-                     {:otsikko "Toteutunut materiaalimäärä" :leveys 1 :fmt :numero}])}))
+                     {:otsikko "Toteutunut materiaali\u00ADmäärä" :leveys 1 :fmt :numero}])}))
 
 (defn db-haku-fn
   [db params]

--- a/src/clj/harja/palvelin/raportointi/raportit/yleinen.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/yleinen.clj
@@ -229,3 +229,6 @@
                      %
                      [%])
                   (drop 2 raportti))))
+
+(def ei-tuloksia-aikavalilla-str
+  "Tietoja ei löytynyt valitulta aikaväliltä.")

--- a/src/cljc/harja/domain/raportointi.cljc
+++ b/src/cljc/harja/domain/raportointi.cljc
@@ -119,3 +119,6 @@
     (apply (partial fn arvo) args)
     #?(:cljs (catch js/Object _ arvo))
     #?(:clj (catch Exception _ arvo))))
+
+(defn numero-fmt? [fmt]
+  (boolean (#{:numero :numero-3desim :prosentti :prosentti-0desim :raha} fmt)))

--- a/src/cljc/harja/domain/raportointi.cljc
+++ b/src/cljc/harja/domain/raportointi.cljc
@@ -121,4 +121,4 @@
     #?(:clj (catch Exception _ arvo))))
 
 (defn numero-fmt? [fmt]
-  (boolean (#{:numero :numero-3desim :prosentti :prosentti-0desim :raha} fmt)))
+  (boolean (#{:kokonaisluku :numero :numero-3desim :prosentti :prosentti-0desim :raha} fmt)))

--- a/src/cljc/harja/fmt.cljc
+++ b/src/cljc/harja/fmt.cljc
@@ -524,6 +524,13 @@
      ""
      (desimaaliluku luku tarkkuus ryhmitelty?))))
 
+(defn kokonaisluku-opt
+  [luku]
+  (assert (number? luku) "Luvun on oltava numerotyyppinen.")
+  (if luku
+    (int luku)
+    ""))
+
 (defn pyorista-ehka-kolmeen [arvo]
   (let [desimaalit-seq (s/split (str arvo) #"\.")
         desimaalit (if (> (count desimaalit-seq) 1)

--- a/src/cljc/harja/pvm.cljc
+++ b/src/cljc/harja/pvm.cljc
@@ -28,6 +28,11 @@
                   "Touko" "Kesä" "Heinä" "Elo"
                   "Syys" "Loka" "Marras" "Joulu"])
 
+(def +kuukaudet-pitka-muoto+
+  ["Tammikuu" "Helmikuu" "Maaliskuu" "Huhtikuu"
+   "Toukokuu" "Kesäkuu" "Heinäkuu" "Elokuu"
+   "Syyskuu" "Lokakuu" "Marraskuu" "Joulukuu"])
+
 (defn kk-fmt [kk]
   (get +kuukaudet+ (dec kk)))
 
@@ -609,8 +614,13 @@
 
 (defn koko-kuukausi-ja-vuosi
   "Formatoi pvm:n muotoon: MMMM yyyy. Esim. Touko 2017."
-  [pvm]
-  (str (nth +kuukaudet+ (dec (kuukausi pvm))) " " (vuosi pvm)))
+  ([pvm]
+   (koko-kuukausi-ja-vuosi pvm false))
+  ([pvm pitka-muoto?]
+   (str (nth (if pitka-muoto?
+               +kuukaudet-pitka-muoto+
+               +kuukaudet+)
+             (dec (kuukausi pvm))) " " (vuosi pvm))))
 
 (defn paiva
   "Palauttaa annetun DateTime päivän."

--- a/src/cljs/harja/ui/raportti.cljs
+++ b/src/cljs/harja/ui/raportti.cljs
@@ -69,9 +69,6 @@
     :pvm #(raportti-domain/yrita fmt/pvm-opt %)
     str))
 
-(defn- numero-fmt? [fmt]
-  (boolean (#{:numero :numero-3desim :prosentti :prosentti-0desim :raha} fmt)))
-
 (defmethod muodosta-html :taulukko [[_ {:keys [otsikko viimeinen-rivi-yhteenveto?
                                                rivi-ennen
                                                tyhja
@@ -108,7 +105,7 @@
                              :komponentti
                              :string)
                    :tasaa (if (or (oikealle-tasattavat-kentat i)
-                                  (numero-fmt? (:fmt sarake)))
+                                  (raportti-domain/numero-fmt? (:fmt sarake)))
                             :oikea
                             (:tasaa sarake))}
                  (when raporttielementteja?

--- a/src/cljs/harja/ui/raportti.cljs
+++ b/src/cljs/harja/ui/raportti.cljs
@@ -61,6 +61,7 @@
 
 (defn- formatoija-fmt-mukaan [fmt]
   (case fmt
+    :kokonaisluku #(raportti-domain/yrita fmt/kokonaisluku-opt %)
     :numero #(raportti-domain/yrita fmt/desimaaliluku-opt % 2 true)
     :numero-3desim #(fmt/pyorista-ehka-kolmeen %)
     :prosentti #(raportti-domain/yrita fmt/prosentti-opt % 1)

--- a/test/clj/harja/palvelin/raportointi/kulut_tehtavaryhmittain_test.clj
+++ b/test/clj/harja/palvelin/raportointi/kulut_tehtavaryhmittain_test.clj
@@ -43,6 +43,8 @@
                                  :urakka-id  @oulun-maanteiden-hoitourakan-2019-2024-id
                                  :parametrit {:alkupvm  (c/to-date (t/local-date 2019 12 1))
                                               :loppupvm (c/to-date (t/local-date 2020 8 30))}})
+        odotettu-vastaus [:raportti {:nimi "Kulut tehtäväryhmittäin"} [:taulukko {:viimeinen-rivi-yhteenveto? true, :otsikko "Kulut tehtäväryhmittäin ajalla 01.12.2019 - 30.08.2020"} [{:leveys 1, :otsikko "Tehtäväryhmä"} {:leveys 1, :fmt :raha, :otsikko "Hoitokauden alusta 01.10.2019-30.08.2020"} {:leveys 1, :fmt :raha, :otsikko "Jaksolla 01.12.2019-30.08.2020"}] [(list "Talvihoito (A)" 6601.94M 3300.40M) (list "Talvisuola (B1)" 0 0) (list  "KFo, NaFo (B2)" 0 0) (list "Hiekoitus (B3)" 0 0) (list "Liikennemerkit ja liikenteenohjauslaitteet (L)" 0 0) (list "Puhtaanapito (P)" 111.11M 0) (list "Vesakonraivaukset ja puun poisto (V)" 333.33M 0) (list "Nurmetukset ja muut vihertyöt (N)" 222.22M 0) (list "Kuivatusjärjestelmät (K)" 2222.22M 0) (list "Rummut, päällystetiet (R)" 0 0) (list "Rummut, soratiet (S)" 0 0) (list "Kaiteet, aidat ja kivetykset (U)" 0 0) (list "Kuumapäällyste (Y1)" 11001.94M 5500.40M) (list "Kylmäpäällyste (Y2)" 0 0) (list "Käsipaikkaus pikapaikkausmassalla (Y4)" 0 0) (list "Puhallus-SIP (Y5)" 0 0) (list "Saumojen juottaminen bitumilla (Y6)" 0 0) (list "Valu (Y7)" 0 0) (list "Siltapäällysteet (H)" 0 0) (list "Sorapientareet (O)" 0 0) (list "Sorastus (M)" 8801.94M 4400.40M) (list "Sillat ja laiturit (I)" 0 0) (list "Sorateiden hoito (C)" 0 0) (list "Kesäsuola, materiaali (D)" 0 0) (list "Äkilliset hoitotyöt, Soratiet (T1)" 0 0) (list "Vahinkojen korjaukset, Soratiet (T2)" 0 0) (list "Avo-ojitus, päällystetyt tiet (X)" 0 0) (list "Avo-ojitus, soratiet (Z)" 15401.94M 7700.40M) (list "RKR-korjaus (Q)" 13201.94M 6600.40M) (list "Muut (F)" 0 0) (list "ELY-rahoitteiset, liikenneympäristön hoito (E)" 0 0) (list "ELY-rahoitteiset, ylläpito (E)" 0 0) (list "Tilaajan rahavaraus (T3)" 0 0) (list "Hoidonjohtopalkkio (G)" 10.20M 10.20M) (list "Johto- ja hallintokorvaus (J)" 310.20M 260.20M) (list "Erillishankinnat (W)" 344.20M 294.20M) (list "Alataso Lisätyöt" 0 0) ["Yhteensä" 58563.18M 28066.60M]]] [:taulukko {:otsikko "Urakkavuoden alusta", :viimeinen-rivi-yhteenveto? true} [{:leveys 1, :otsikko ""} {:leveys 1, :otsikko "", :fmt :raha}] [["Tavoitehinta: " 250000M] ["Urakkavuoden alusta tav.hintaan kuuluvia: " 58563.18M]  ["Jäljellä: " 191436.82M]]]]
+
         vastaus-ulkopuolella (kutsu-palvelua (:http-palvelin jarjestelma)
                                 :suorita-raportti
                                 +kayttaja-jvh+
@@ -55,34 +57,28 @@
                        (-> vastaus
                            (nth 2)
                            (nth 3)))
-        pilkku->piste #(cstr/replace % #"(\d+),(\d+)" "$1.$2")
-        numeroksi (fn [arvo]
-                    (if (string? arvo)
-                      (-> arvo
-                          pilkku->piste
-                          Float/parseFloat)
-                      arvo))
-        eka-luku (numeroksi (second yhteensa))
-        toka-luku (numeroksi (nth yhteensa 2))
+        eka-luku (second yhteensa)
+        toka-luku (nth yhteensa 2)
         raportti-avainsana (first vastaus)
         taulukot (nth vastaus 2)
         taulukko-avainsana (first taulukot)
         taulukon-rivit (-> vastaus
                            (nth 2)
                            (nth 3))]
-
     (is (vector? vastaus) "Raportille palautuu tavaraa")
     (is (and (= :raportti raportti-avainsana)
              (= :taulukko taulukko-avainsana)
              (vector? taulukon-rivit)
              (> (count taulukon-rivit)
                 0)) "Vastaus näyttää raportilta")
+(is (= vastaus odotettu-vastaus))
+
     (is (and
           (> toka-luku 0)
           (> eka-luku 0)) "Raportille lasketaan summat oikein (jos testidata muuttuu, tää voi kosahtaa)")
-    (is (every? #(let [eka (numeroksi (second %))
-                       toka (numeroksi (nth % 2))]
-                   (= 0.0 eka toka))
+    (is (every? #(let [eka (second %)
+                       toka (nth % 2)]
+                   (= 0 eka toka))
                 (-> vastaus-ulkopuolella
                     (nth 2)
                     (nth 3))) "Raportille ei tule väärää tavaraa")))

--- a/test/clj/harja/palvelin/raportointi/pdf_test.clj
+++ b/test/clj/harja/palvelin/raportointi/pdf_test.clj
@@ -38,8 +38,7 @@
     ;; PENDING: tämä testaa *TODELLA* tarkkaan, että rakenne on tismalleen oikein
     ;; XSL-FO generointia on hankala testata muuten, koska ei voi lopputulos PDF:n
     ;; visuaalista rakennetta oikein assertoida.
-    (log/debug "Palautus: " fo)
-    (is (= fo `[:fo:block
+    (is (= fo ` [:fo:block
                 {:space-before "1em", :font-size "8pt", :font-weight "bold"}
                 "Taulukko"
                 [:fo:table
@@ -54,21 +53,24 @@
                       :background-color "#0066cc",
                       :color "#ffffff",
                       :font-weight "normal",
-                      :padding "1mm"}
+                      :padding "1mm"
+                      :text-align "left"}
                      [:fo:block "<![CDATA[Eka]]>"]]
                     [:fo:table-cell
                      {:border "solid 0.1mm black",
                       :background-color "#0066cc",
                       :color "#ffffff",
                       :font-weight "normal",
-                      :padding "1mm"}
+                      :padding "1mm"
+                      :text-align "left"}
                      [:fo:block "<![CDATA[Toka]]>"]]
                     [:fo:table-cell
                      {:border "solid 0.1mm black",
                       :background-color "#0066cc",
                       :color "#ffffff",
                       :font-weight "normal",
-                      :padding "1mm"}
+                      :padding "1mm"
+                      :text-align "left"}
                      [:fo:block "<![CDATA[Kolmas]]>"]])]]
                  [:fo:table-body
                   nil

--- a/test/clj/harja/palvelin/raportointi/pohjavesialueiden_suolat_test.clj
+++ b/test/clj/harja/palvelin/raportointi/pohjavesialueiden_suolat_test.clj
@@ -39,15 +39,15 @@
 (defn tarkista-sarakkeet [taulukko]
   (apurit/tarkista-taulukko-sarakkeet
     taulukko
-    {:otsikko "Tie"}
-    {:otsikko "Alkuosa"}
-    {:otsikko "Alkuetäisyys"}
-    {:otsikko "Loppuosa"}
-    {:otsikko "Loppuetäisyys"}
-    {:otsikko "Pituus"}
-    {:otsikko "Toteutunut talvisuola yhteensä t"}
-    {:otsikko "Toteutunut talvisuola t/km"}
-    {:otsikko "Käyttöraja t/km"}))
+    {:leveys 3 :fmt :kokonaisluku :otsikko "Tie"}
+    {:leveys 2 :fmt :kokonaisluku :otsikko "Alku\u00ADosa"}
+    {:leveys 2 :fmt :kokonaisluku :otsikko "Alku\u00ADetäisyys"}
+    {:leveys 2 :fmt :kokonaisluku :otsikko "Loppu\u00ADosa"}
+    {:leveys 2 :fmt :kokonaisluku :otsikko "Loppu\u00ADetäisyys"}
+    {:leveys 3 :fmt :numero :otsikko "Pituus"}
+    {:leveys 5 :fmt :numero :otsikko "Tot. talvisuola yhteensä (t)"}
+    {:leveys 5 :fmt :numero :otsikko "Tot. talvisuola (t/km)"}
+    {:leveys 5 :fmt :numero :otsikko "Käyttö\u00ADraja (t/km)"}))
 
 (deftest raportin-suoritus-urakalle-toimii
   (let [nyt (java.util.Date.)
@@ -71,26 +71,63 @@
 
       (is (= vastaus
              [:raportti
-              {:orientaatio :landscape,
-               :nimi
-               (str "Aktiivinen Oulu Testi, Pohjavesialueiden suolatoteumat ajalta "
-                    (apply str (interpose "."
-                                          [(format "%02d" p) (format "%02d" kk) (dec v)]))
-                    " - "
-                    (apply str (interpose "."
-                                          [(format "%02d" p) (format "%02d" kk) (inc v)])))}
+              {:nimi "Aktiivinen Oulu Testi, Pohjavesialueiden suolatoteumat ajalta 13.04.2020 - 13.04.2022"
+               :orientaatio :landscape}
               [:taulukko
-               {:otsikko "11244001-Kempeleenharju",
+               {:otsikko "11244001-Kempeleenharju"
+                :tyhja nil
                 :viimeinen-rivi-yhteenveto? true}
-               [{:leveys 3, :otsikko "Tie"}
-                {:leveys 2, :otsikko "Alkuosa"}
-                {:leveys 2, :otsikko "Alkuetäisyys"}
-                {:leveys 2, :otsikko "Loppuosa"}
-                {:leveys 2, :otsikko "Loppuetäisyys"}
-                {:leveys 3, :otsikko "Pituus"}
-                {:leveys 5, :otsikko "Toteutunut talvisuola yhteensä t"}
-                {:leveys 5, :otsikko "Toteutunut talvisuola t/km"}
-                {:leveys 5, :otsikko "Käyttöraja t/km"}]
-               [["846" "1" "0" "1" "1016" "1389,3" "3,0" "2,2" ""]
-                ["18637" "1" "0" "1" "8953" "9324,4" "5,0" "0,5" ""]
-                ["Yhteensä" "" "" "" "" "" "8,0" "" ""]]]])))))
+               [{:fmt :kokonaisluku
+                 :leveys 3
+                 :otsikko "Tie"}
+                {:fmt :kokonaisluku
+                 :leveys 2
+                 :otsikko "Alku­osa"}
+                {:fmt :kokonaisluku
+                 :leveys 2
+                 :otsikko "Alku­etäisyys"}
+                {:fmt :kokonaisluku
+                 :leveys 2
+                 :otsikko "Loppu­osa"}
+                {:fmt :kokonaisluku
+                 :leveys 2
+                 :otsikko "Loppu­etäisyys"}
+                {:fmt :numero
+                 :leveys 3
+                 :otsikko "Pituus"}
+                {:fmt :numero
+                 :leveys 5
+                 :otsikko "Tot. talvisuola yhteensä (t)"}
+                {:fmt :numero
+                 :leveys 5
+                 :otsikko "Tot. talvisuola (t/km)"}
+                {:fmt :numero
+                 :leveys 5
+                 :otsikko "Käyttö­raja (t/km)"}]
+               [["846"
+                 "1"
+                 "0"
+                 "1"
+                 "1016"
+                 "1389,3"
+                 "3,0"
+                 "2,2"
+                 ""]
+                ["18637"
+                 "1"
+                 "0"
+                 "1"
+                 "8953"
+                 "9324,4"
+                 "5,0"
+                 "0,5"
+                 ""]
+                ["Yhteensä"
+                 ""
+                 ""
+                 ""
+                 ""
+                 ""
+                 "8,0"
+                 ""
+                 ""]]]])))))


### PR DESCRIPTION
Tasaa luvut oikealle
Lisää raha-formatterin käyttö rahakentille
Korjaa stringit numerotyypeiksi, jotta :fmt formatteri toimii
Paranna yksikkötestejä, assertoi palautettu tulos
Siirrä numero-fmt? raportointi.cljc:hen