### PR TITLE
VHAR-4319 POT2 MHST-toimenpiteelle aina valituksi masuunikuona sideaine

### DIFF
--- a/dev-resources/less/pages/materiaalikirjasto.less
+++ b/dev-resources/less/pages/materiaalikirjasto.less
@@ -1,4 +1,8 @@
 .materiaalikirjasto-modal {
+    .modal-content {
+        height: 100%;
+        max-height: 100%;
+    }
     .livi-grid.panel.panel-default {
         .panel-heading, .panel-body {
             background-color: @white;

--- a/src/clj/harja/palvelin/raportointi/raportit.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit.clj
@@ -373,7 +373,7 @@
     :kuvaus       "Kulut tehtäväryhmittäin"
     :testiversio? true
     :suorita      #'harja.palvelin.raportointi.raportit.kulut-tehtavaryhmittain/suorita
-    :urakkatyyppi #{:hoito :teiden-hoito}}])
+    :urakkatyyppi #{:teiden-hoito}}])
 
 (def raportit-nimen-mukaan
   (into {} (map (juxt :nimi identity)) raportit))

--- a/src/clj/harja/palvelin/raportointi/raportit.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit.clj
@@ -85,7 +85,7 @@
     :kuvaus "Tehtävämäärät"
     :testiversio? true
     :suorita #'harja.palvelin.raportointi.raportit.tehtavamaarat/suorita
-    :urakkatyyppi #{:hoito :teiden-hoito}} ;; fixme: onko :hoito tässä ylimääräinen?
+    :urakkatyyppi #{:teiden-hoito}}
 
    ;; testidatasta huomoita: myös lapissa ivalon mhu-testiurakka
    ;; urakkatyypit: teiden-hoito = mh eli mhu, hoito = vanhan tyyliset

--- a/src/cljc/harja/domain/paallystys_ja_paikkaus.cljc
+++ b/src/cljc/harja/domain/paallystys_ja_paikkaus.cljc
@@ -49,7 +49,7 @@
     :aloitettu "Kesken"
     :valmis "Valmis käsiteltäväksi"
     :lukittu "Lukittu"
-    "-"))
+    "Aloittamatta"))
 
 (defn nayta-paatos [tila]
   (case tila

--- a/src/cljc/harja/domain/pot2.cljc
+++ b/src/cljc/harja/domain/pot2.cljc
@@ -20,6 +20,7 @@
 
 (def alusta-toimenpide-kaikki-lisaavaimet
   {:lisatty-paksuus {:nimi :lisatty-paksuus :otsikko "Lisätty paksuus" :yksikko "cm"
+                     :validoi [[:rajattu-numero-tai-tyhja 1 500 "Arvon tulee olla välillä 1-500cm"]]
                      :tyyppi :positiivinen-numero :kokonaisluku? true}
    :massamaara {:nimi :massamaara :otsikko "Massa\u00ADmäärä" :yksikko "kg/m²"
                 :tyyppi :positiivinen-numero :kokonaisluku? true}
@@ -27,6 +28,7 @@
             :tyyppi :valinta
             :valinta-arvo ::murske-id}
    :kasittelysyvyys {:nimi :kasittelysyvyys :otsikko "Käsittely\u00ADsyvyys" :yksikko "cm"
+                     :validoi [[:rajattu-numero-tai-tyhja 1 500 "Arvon tulee olla välillä 1-500cm"]]
                      :tyyppi :positiivinen-numero :kokonaisluku? true}
    :leveys {:nimi :leveys :otsikko "Leveys" :yksikko "m"
             :tyyppi :positiivinen-numero :kokonaisluku? true}

--- a/src/cljc/harja/domain/pot2.cljc
+++ b/src/cljc/harja/domain/pot2.cljc
@@ -89,11 +89,6 @@
                                                [:kasittelysyvyys
                                                 {:nimi :sideaine2
                                                  ;; MHST toimenpiteelle sideainetyypin on aina oltava Masuunikuona
-                                                 :hae (fn [rivi]
-                                                        (if (= +masuunihiekkastabilointi-tp-koodi+
-                                                               (:toimenpide rivi))
-                                                          +masuunikuonan-sideainetyyppi-koodi+
-                                                          (:sideaine2 rivi)))
                                                  :muokattava? (fn [rivi]
                                                                 (not= +masuunihiekkastabilointi-tp-koodi+
                                                                       (:toimenpide rivi)))}

--- a/src/cljs/harja/tiedot/urakka/paallystys.cljs
+++ b/src/cljs/harja/tiedot/urakka/paallystys.cljs
@@ -548,6 +548,7 @@
              :paallystysilmoitukset jarjestetyt-ilmoitukset)))
   TallennaPaallystysilmoitusEpaonnistui
   (process-event [{vastaus :vastaus} app]
+    (println "TallennaPaallystysilmoitusEpaonnistui: " (pr-str vastaus))
     (let [vastaus-virhe (cond
                           (get-in vastaus [:parse-error :original-text])
                           [(get-in vastaus [:parse-error :original-text])]

--- a/src/cljs/harja/tiedot/urakka/pot2/materiaalikirjasto.cljs
+++ b/src/cljs/harja/tiedot/urakka/pot2/materiaalikirjasto.cljs
@@ -28,7 +28,7 @@
 (defrecord TallennaLomake [data])
 (defrecord TallennaMassaOnnistui [vastaus])
 (defrecord TallennaMassaEpaonnistui [vastaus])
-(defrecord TyhjennaLomake [data])
+(defrecord TyhjennaLomake [])
 (defrecord PaivitaMassaLomake [data])
 (defrecord PaivitaAineenTieto [polku arvo])
 (defrecord LisaaSideaine [sideaineen-kayttotapa])
@@ -291,7 +291,7 @@
     app)
 
   TyhjennaLomake
-  (process-event [{data :data} app]
+  (process-event [_ app]
     (-> app
         (assoc :pot2-massa-lomake nil)))
 

--- a/src/cljs/harja/tiedot/urakka/pot2/pot2_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/pot2/pot2_tiedot.cljs
@@ -174,7 +174,8 @@
     (let [idt (keys @alustarivit-atom)
           pienin-id (apply min idt)
           uusi-id (or (:muokkaus-grid-id alustalomake)
-                      (if (pos? pienin-id)
+                      (if (or (nil? pienin-id)
+                              (pos? pienin-id))
                         -1
                         (dec pienin-id)))
           alusta-params (lomakkeen-muokkaus/ilman-lomaketietoja alustalomake)

--- a/src/cljs/harja/tiedot/urakka/pot2/pot2_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/pot2/pot2_tiedot.cljs
@@ -31,7 +31,6 @@
 (defrecord HaePot2TiedotEpaonnistui [vastaus])
 (defrecord TallennaPot2Tiedot [])
 (defrecord AvaaAlustalomake [lomake])
-(defrecord ValitseAlustatoimenpide [toimenpide])
 (defrecord PaivitaAlustalomake [alustalomake])
 (defrecord TallennaAlustalomake [alustalomake jatka?])
 (defrecord SuljeAlustalomake [])
@@ -157,11 +156,6 @@
   AvaaAlustalomake
   (process-event [{lomake :lomake} app]
     (assoc-in app [:paallystysilmoitus-lomakedata :alustalomake] lomake))
-
-  ValitseAlustatoimenpide
-  (process-event [{toimenpide :toimenpide} app]
-    (assoc-in app [:paallystysilmoitus-lomakedata :alustalomake]
-              {:toimenpide toimenpide}))
 
   PaivitaAlustalomake
   (process-event [{alustalomake :alustalomake} app]

--- a/src/cljs/harja/tiedot/urakka/pot2/pot2_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/pot2/pot2_tiedot.cljs
@@ -155,7 +155,10 @@
 
   AvaaAlustalomake
   (process-event [{lomake :lomake} app]
-    (assoc-in app [:paallystysilmoitus-lomakedata :alustalomake] lomake))
+    (let [lomake (if (empty? lomake)
+                   {:tr-numero (get-in app [:paallystysilmoitus-lomakedata :perustiedot :tr-numero])}
+                   lomake)]
+      (assoc-in app [:paallystysilmoitus-lomakedata :alustalomake] lomake)))
 
   PaivitaAlustalomake
   (process-event [{alustalomake :alustalomake} app]

--- a/src/cljs/harja/tiedot/urakka/pot2/pot2_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/pot2/pot2_tiedot.cljs
@@ -13,7 +13,8 @@
     [harja.tiedot.urakka.pot2.materiaalikirjasto :as mk-tiedot]
     [harja.ui.napit :as napit]
     [harja.ui.ikonit :as ikonit]
-    [harja.ui.viesti :as viesti])
+    [harja.ui.viesti :as viesti]
+    [harja.domain.yllapitokohde :as yllapitokohteet-domain])
 
   (:require-macros [reagent.ratom :refer [reaction]]
                    [cljs.core.async.macros :refer [go]]
@@ -84,6 +85,11 @@
                                                             (:massa rivi)))
                       %)
                    massat))))
+
+(defn jarjesta-rivit-tieos-mukaan [rivit]
+  (-> rivit
+      (yllapitokohteet-domain/jarjesta-yllapitokohteet)
+      (yllapitokohteet-domain/indeksoi-kohdeosat)))
 
 (extend-protocol tuck/Event
 
@@ -179,9 +185,9 @@
           ylimaaraiset-avaimet (pot2-domain/alusta-ylimaaraiset-lisaparams-avaimet alusta-params)
           alusta-params-ilman-ylimaaraisia (apply
                                              dissoc alusta-params ylimaaraiset-avaimet)
-          uusi-rivi {uusi-id alusta-params-ilman-ylimaaraisia}]
-      ;; TODO: sama järjestyslogiikka kuin taulukossa muutenkin
-      (swap! alustarivit-atom conj uusi-rivi)
+          uusi-rivi {uusi-id alusta-params-ilman-ylimaaraisia}
+          rivit (jarjesta-rivit-tieos-mukaan (vals (conj @alustarivit-atom uusi-rivi)))]
+      (reset! alustarivit-atom rivit)
       (-> app
           (assoc-in [:paallystysilmoitus-lomakedata :alustalomake]
                  (when jatka? (-> alusta-params

--- a/src/cljs/harja/ui/kentat.cljs
+++ b/src/cljs/harja/ui/kentat.cljs
@@ -302,9 +302,9 @@
                                               (validoi-kentta-fn v))
                                           (or (= v "")
                                               (when-not vaadi-ei-negatiivinen? (= v "-"))
-                                              ;; Halutaan että käyttäjä voi muokata desimaaliluvun esim ",0" muotoon,
-                                              ;; mutta tätä välivaihetta ei tallenneta dataan
-                                              (re-matches #"[0-9,.-]+" v)))
+                                              (re-matches (if kokonaisluku?
+                                                            kokonaisluku-re-pattern
+                                                            desimaaliluku-re-pattern) v)))
                                     (reset! teksti v)
 
                                     (let [numero (if kokonaisluku?

--- a/src/cljs/harja/views/urakka/paallystysilmoitukset.cljs
+++ b/src/cljs/harja/views/urakka/paallystysilmoitukset.cljs
@@ -42,7 +42,8 @@
             [harja.views.kartta :as kartta]
             [harja.views.urakka.yllapitokohteet :as yllapitokohteet]
             [harja.pvm :as pvm]
-            [harja.views.urakka.valinnat :as u-valinnat])
+            [harja.views.urakka.valinnat :as u-valinnat]
+            [harja.asiakas.kommunikaatio :as k])
   (:require-macros [reagent.ratom :refer [reaction]]
                    [cljs.core.async.macros :refer [go]]
                    [harja.atom :refer [reaction<!]]))
@@ -164,13 +165,14 @@
          [:div
           [:h3 {:style {:display "inline-block"}}
            "Päällystysilmoitukset"]
-          ;; HUOM! ei päästetä materiaalikirjastoa vielä tuotantoon, eli tämä oltava kommentoituna develop-haarassa
-          #_[napit/nappi "Muokkaa urakan materiaaleja"
-           #(e! (mk-tiedot/->NaytaModal true))
-           {:ikoni (ikonit/livicon-pen)
-            :luokka "napiton-nappi"
-            :style {:background-color "#fafafa"
-                    :margin-left "2rem"}}]]
+          ;; HUOM! ei päästetä materiaalikirjastoa vielä tuotantoon
+          (when (k/kehitysymparistossa?)
+            [napit/nappi "Muokkaa urakan materiaaleja"
+             #(e! (mk-tiedot/->NaytaModal true))
+             {:ikoni (ikonit/livicon-pen)
+              :luokka "napiton-nappi"
+              :style {:background-color "#fafafa"
+                      :margin-left "2rem"}}])]
 
 
          [paallystysilmoitukset-taulukko e! app]

--- a/src/cljs/harja/views/urakka/pot2/alusta.cljs
+++ b/src/cljs/harja/views/urakka/pot2/alusta.cljs
@@ -45,8 +45,9 @@
     (yllapitokohteet-domain/validoi-alustatoimenpide-teksti validoitu)))
 
 (defn- alustalomakkeen-lisakentat
-  [{:keys [toimenpide massat murskeet koodistot] :as alusta}]
-  (let [{massatyypit :massatyypit
+  [{:keys [alustalomake massat murskeet koodistot] :as alusta}]
+  (let [toimenpide (:toimenpide alustalomake)
+        {massatyypit :massatyypit
          mursketyypit :mursketyypit} koodistot
         mukautetut-lisakentat {:murske {:nimi :murske
                                         :valinta-nayta (fn [murske]
@@ -72,8 +73,6 @@
                                         valinnat-ja-nil (if pakollinen?
                                                           valinnat
                                                           (conj valinnat nil))]
-                                    (when (and (= tyyppi :valinta) (nil? valinnat-ja-nil))
-                                      (println "Kenttä " nimi " on valinta mutta ei sisällä valinnat"))
                                     (when (or (nil? jos)
                                               (some? (get alusta jos)))
                                       (lomake/rivi (merge kentta-metadata
@@ -82,10 +81,17 @@
                                                            :valinnat valinnat-ja-nil})))))]
     (map lisakentta-generaattori toimenpidespesifit-lisakentat)))
 
-(defn- alustalomakkeen-kentat [{:keys [alusta-toimenpiteet toimenpide] :as alusta}]
-  (let [toimenpide-kentta [{:otsikko "Toimen\u00ADpide" :nimi :toimenpide :palstoja 3
+(defn- alustalomakkeen-kentat [{:keys [alusta-toimenpiteet alustalomake] :as tiedot}]
+  (let [{toimenpide :toimenpide
+         murske :murske} alustalomake
+        toimenpide-kentta [{:otsikko "Toimen\u00ADpide" :nimi :toimenpide :palstoja 3 :pakollinen? true
                             :tyyppi :valinta :valinnat alusta-toimenpiteet :valinta-arvo ::pot2-domain/koodi
-                            :pakollinen? true
+                            :aseta (fn [rivi arvo]
+                                     (-> rivi
+                                         (assoc :toimenpide arvo)
+                                         ;; MHST toimenpiteelle sideainetyypin on aina oltava Masuunikuona
+                                         (assoc :sideaine2 (when (= pot2-domain/+masuunihiekkastabilointi-tp-koodi+ arvo)
+                                                             pot2-domain/+masuunikuonan-sideainetyyppi-koodi+))))
                             :valinta-nayta #(when %
                                               ;; Jos toimenpiteellä on lyhenne, näytetään LYHENNE (NIMI), muuten vain NIMI
                                               (str (or (::pot2-domain/lyhenne %) (::pot2-domain/nimi %))
@@ -120,7 +126,7 @@
                       :palstoja 1
                       :otsikko "Let"
                       :pakollinen? true :tyyppi :positiivinen-numero :kokonaisluku? true})]
-        lisakentat (alustalomakkeen-lisakentat alusta)]
+        lisakentat (alustalomakkeen-lisakentat tiedot)]
     (vec
       (concat toimenpide-kentta
               (when toimenpide tr-kentat)
@@ -170,8 +176,7 @@
                           {:disabled false
                            :luokka "pull-right"}]])}
           (alustalomakkeen-kentat {:alusta-toimenpiteet alusta-toimenpiteet
-                                   :toimenpide (:toimenpide alustalomake)
-                                   :murske (:murske alustalomake)
+                                   :alustalomake alustalomake
                                    :massat massat
                                    :murskeet murskeet
                                    :koodistot materiaalikoodistot})

--- a/src/cljs/harja/views/urakka/pot2/massat.cljs
+++ b/src/cljs/harja/views/urakka/pot2/massat.cljs
@@ -285,7 +285,7 @@
                                                                     :tallenna-fn #(e! (mk-tiedot/->TallennaLomake data))
                                                                     :voi-tallentaa? (or (not (ui-lomake/voi-tallentaa? data))
                                                                                         (not (empty? muut-validointivirheet)))
-                                                                    :peruuta-fn #(e! (mk-tiedot/->TyhjennaLomake data))
+                                                                    :peruuta-fn #(e! (mk-tiedot/->TyhjennaLomake))
                                                                     :poista-fn #(e! (mk-tiedot/->TallennaLomake (merge data {::pot2-domain/poistettu? true})))
                                                                     :tyyppi :massa
                                                                     :id massa-id

--- a/src/cljs/harja/views/urakka/pot2/materiaalikirjasto.cljs
+++ b/src/cljs/harja/views/urakka/pot2/materiaalikirjasto.cljs
@@ -63,7 +63,15 @@
    {:otsikko (str "Urakan materiaalikirjasto - " (:nimi @nav/valittu-urakka))
     :luokka "materiaalikirjasto-modal"
     :nakyvissa? @mk-tiedot/nayta-materiaalikirjasto?
-    :sulje-fn #(swap! mk-tiedot/nayta-materiaalikirjasto? not)}
+    :sulje-fn #(cond
+                 (:pot2-massa-lomake app)
+                 (e! (mk-tiedot/->TyhjennaLomake))
+
+                 (:pot2-murske-lomake app)
+                 (e! (mk-tiedot/->SuljeMurskeLomake))
+
+                 :else
+                 (swap! mk-tiedot/nayta-materiaalikirjasto? not))}
    [:div
     [materiaalikirjasto e! app]]])
 

--- a/src/cljs/harja/views/urakka/pot2/pot2_lomake.cljs
+++ b/src/cljs/harja/views/urakka/pot2/pot2_lomake.cljs
@@ -26,7 +26,8 @@
     [harja.views.urakka.pot2.murskeet :as murskeet]
     [harja.views.urakka.pot2.massat :as massat]
     [harja.ui.varmista-kayttajalta :as varmista-kayttajalta]
-    [harja.asiakas.kommunikaatio :as k])
+    [harja.asiakas.kommunikaatio :as k]
+    [harja.domain.paallystys-ja-paikkaus :as paallystys-ja-paikkaus])
   (:require-macros [reagent.ratom :refer [reaction]]
                    [cljs.core.async.macros :refer [go]]
                    [harja.atom :refer [reaction<!]]))
@@ -37,7 +38,7 @@
                    (pot-yhteinen/paallystyskohteen-fmt perustiedot))]
    [:div
     [:div.inline-block.pot-tila {:class (when tila (name tila))}
-     (if-not tila "Aloittamatta" tila)]]])
+     (paallystys-ja-paikkaus/kuvaile-ilmoituksen-tila tila)]]])
 
 (defn tallenna
   [e! {:keys [tekninen-osa tila]}

--- a/src/cljs/harja/views/urakka/pot_yhteinen.cljs
+++ b/src/cljs/harja/views/urakka/pot_yhteinen.cljs
@@ -134,54 +134,60 @@
     (not (nil? (pakolliset-kentat kentta)))
     false))
 
+(def tee-asiatarkastus? (atom false))
+
 (defn asiatarkastus
   "Asiatarkastusosio konsultille."
   [urakka {:keys [tila asiatarkastus] :as perustiedot-nyt}
    lukittu? muokkaa! {{{:keys [tarkastusaika tarkastaja] :as asiatarkastus-validointi} :asiatarkastus} :perustiedot}]
-  (log "ASIATARKASTUS " (pr-str asiatarkastus))
-  (let [muokattava? (and
+  (let [pot-tila-lukittu? (= :lukittu tila)
+        asiatarkastus-sis-tietoja? (some #(some? (val %))
+                                         (lomake/ilman-lomaketietoja asiatarkastus))
+        muokattava? (and
                       (oikeudet/on-muu-oikeus? "asiatarkastus"
                                                oikeudet/urakat-kohdeluettelo-paallystysilmoitukset
                                                (:id urakka))
-                      (not= tila :lukittu)
+                      (not pot-tila-lukittu?)
                       (false? lukittu?))
-        pakolliset-kentat (-> asiatarkastus-validointi meta :pakolliset)
-        _ (js/console.log "asiatarkastus " (pr-str asiatarkastus))]
-
-    [:div.pot-asiatarkastus
-     [:h3 "Asiatarkastus"]
-
-     [lomake/lomake
-      {:otsikko ""
-       :muokkaa! (fn [uusi]
-                   (muokkaa! assoc-in [:perustiedot :asiatarkastus] uusi))
-       :validoi-alussa? true
-       :validoitavat-avaimet #{:pakollinen :validoi}
-       :voi-muokata? muokattava?
-       :data-cy "paallystysilmoitus-asiatarkastus"}
-      [{:otsikko "Tarkastettu"
-        :nimi :tarkastusaika
-        :pakollinen? (pakollinen-kentta? pakolliset-kentat :tarkastusaika)
-        :tyyppi :pvm
-        :huomauta tarkastusaika}
-       {:otsikko "Tarkastaja"
-        :nimi :tarkastaja
-        :pakollinen? (pakollinen-kentta? pakolliset-kentat :tarkastaja)
-        :tyyppi :string
-        :huomauta tarkastaja
-        :pituus-max 1024}
-       {:teksti "Hyväksytty"
-        :nimi :hyvaksytty
-        :tyyppi :checkbox
-        :fmt #(if % "Tekninen osa tarkastettu" "Teknistä osaa ei tarkastettu")}
-       {:otsikko "Lisätiedot"
-        :nimi :lisatiedot
-        :pakollinen? (pakollinen-kentta? pakolliset-kentat :lisatiedot)
-        :tyyppi :text
-        :koko [60 3]
-        :pituus-max 4096
-        :palstoja 2}]
-      asiatarkastus]]))
+        pakolliset-kentat (-> asiatarkastus-validointi meta :pakolliset)]
+    [:span
+     (when-not (or pot-tila-lukittu? asiatarkastus-sis-tietoja?)
+       [kentat/tee-kentta {:tyyppi :checkbox
+                           :teksti "Näytä asiatarkastus"} tee-asiatarkastus?])
+     (when (or @tee-asiatarkastus? pot-tila-lukittu? asiatarkastus-sis-tietoja?)
+       [:div.pot-asiatarkastus
+        [:h6 "Asiatarkastus"]
+        [lomake/lomake
+         {:otsikko ""
+          :muokkaa! (fn [uusi]
+                      (muokkaa! assoc-in [:perustiedot :asiatarkastus] uusi))
+          :validoi-alussa? true
+          :validoitavat-avaimet #{:pakollinen :validoi}
+          :voi-muokata? muokattava?
+          :data-cy "paallystysilmoitus-asiatarkastus"}
+         [{:otsikko "Tarkastettu"
+           :nimi :tarkastusaika
+           :pakollinen? (pakollinen-kentta? pakolliset-kentat :tarkastusaika)
+           :tyyppi :pvm
+           :huomauta tarkastusaika}
+          {:otsikko "Tarkastaja"
+           :nimi :tarkastaja
+           :pakollinen? (pakollinen-kentta? pakolliset-kentat :tarkastaja)
+           :tyyppi :string
+           :huomauta tarkastaja
+           :pituus-max 1024}
+          {:teksti "Hyväksytty"
+           :nimi :hyvaksytty
+           :tyyppi :checkbox
+           :fmt #(when-not % "Asiatarkastusta ei hyväksytty")}
+          {:otsikko "Lisätiedot"
+           :nimi :lisatiedot
+           :pakollinen? (pakollinen-kentta? pakolliset-kentat :lisatiedot)
+           :tyyppi :text
+           :koko [60 3]
+           :pituus-max 4096
+           :palstoja 2}]
+         asiatarkastus]])]))
 
 (defn kasittely
   "Ilmoituksen käsittelyosio, kun ilmoitus on valmis.
@@ -195,10 +201,9 @@
                       (not= tila :lukittu)
                       (false? lukittu?))]
     [:div.pot-kasittely
-
-     [:h3 "Käsittely"]
+     [:h6 "Käsittely, tekninen osa"]
      [lomake/lomake
-      {:otsikko "Tekninen osa"
+      {:otsikko ""
        :muokkaa! #(muokkaa! assoc-in [:perustiedot :tekninen-osa] %)
        :validoi-alussa? true
        :validoitavat-avaimet #{:pakollinen :validoi}
@@ -276,7 +281,7 @@
                                       kirjoitusoikeus?))]
         [:div.row.pot-perustiedot
          [:div.col-sm-12.col-md-6
-          [:h2 "Perustiedot"]
+          [:h6 "Perustiedot"]
           [lomake/lomake {:voi-muokata? muokattava?
                           :muokkaa! muokkaa-fn
                           :kutsu-muokkaa-renderissa? true

--- a/src/cljs/harja/views/urakka/pot_yhteinen.cljs
+++ b/src/cljs/harja/views/urakka/pot_yhteinen.cljs
@@ -138,7 +138,7 @@
 
 (defn asiatarkastus
   "Asiatarkastusosio konsultille."
-  [urakka {:keys [tila asiatarkastus] :as perustiedot-nyt}
+  [urakka {:keys [tila asiatarkastus versio] :as perustiedot-nyt}
    lukittu? muokkaa! {{{:keys [tarkastusaika tarkastaja] :as asiatarkastus-validointi} :asiatarkastus} :perustiedot}]
   (let [pot-tila-lukittu? (= :lukittu tila)
         asiatarkastus-sis-tietoja? (some #(some? (val %))
@@ -151,10 +151,10 @@
                       (false? lukittu?))
         pakolliset-kentat (-> asiatarkastus-validointi meta :pakolliset)]
     [:span
-     (when-not (or pot-tila-lukittu? asiatarkastus-sis-tietoja?)
+     (when-not (or (= 1 versio) pot-tila-lukittu? asiatarkastus-sis-tietoja?)
        [kentat/tee-kentta {:tyyppi :checkbox
                            :teksti "Näytä asiatarkastus"} tee-asiatarkastus?])
-     (when (or @tee-asiatarkastus? pot-tila-lukittu? asiatarkastus-sis-tietoja?)
+     (when (or (= 1 versio) @tee-asiatarkastus? pot-tila-lukittu? asiatarkastus-sis-tietoja?)
        [:div.pot-asiatarkastus
         [:h6 "Asiatarkastus"]
         [lomake/lomake


### PR DESCRIPTION
-Korjaa virheen käsittely ja näyttäminen kun pääll.kerros feilaa
-VHAR-4365 Korjaa Alustalistauksen järjestyslogiikka
-VHAR-4368 Esitäytä alustalomakkeeseen aina tie pääkohteen mukaan
-Lisää kohtuullisuus käs.syvyys ja lisätty paksuus kenttiin
-VHAR-4386 Kokonaisluku? validointi ei toimi numerokentässä
-VHAR-4319 POT2 MHST:lle aina valituksi masuunikuona sideaine
-Käsittele alustalomakkeen uuden rivin id oikein