### PR TITLE
VHAR-4393 Opasta käyttäjää materiaalikirjastoon, jos ei ole yhtään massaa eikä mursketta tehtynä

### DIFF
--- a/cypress/integration/aikataulunakyma.js
+++ b/cypress/integration/aikataulunakyma.js
@@ -23,7 +23,7 @@ describe('Aikataulunäkymien avaaminen päällystysurakassa', function () {
 
     it("Aikataulun avaaminen toimii päällystyksessä", function () {
         cy.contains('.klikattava', 'Aikataulu', {timeout: 40000}).click()
-        cy.get('.livicon-chevron.livicon-chevron-right', {timeout: 40000}).first().click()
+        cy.get('.navigation-ympyrassa', {timeout: 40000}).first().click()
         // Ei saa näkyä alikohteet omassa taulukossaan
         cy.contains('.panel-title', 'Kohteen tierekisteriosoitteet').should('not.visible')
         cy.contains('.panel-title', 'Muut tierekisteriosoitteet').should('not.visible')

--- a/cypress/integration/aikataulunakyma.js
+++ b/cypress/integration/aikataulunakyma.js
@@ -1,19 +1,19 @@
-// describe('Aikataulunäkymien avaaminen tiemerkintäurakassa', function () {
-//     beforeEach(function () {
-//         cy.visit("http://localhost:3000/#urakat/yleiset?&hy=12&u=12")
-//     })
-//
-//     it("Aikataulun avaaminen toimii tiemerkinnässä", function () {
-//         cy.contains('.klikattava', 'Aikataulu').click()
-//         cy.get('.alasveto-vuosi').click()
-//         cy.get('a').contains('2018').click()
-//         cy.get('.livicon-chevron.livicon-chevron-right', {timeout: 40000}).first().click()
-//         // Pitää näkyä alikohteet omassa taulukossaan
-//         cy.contains('.panel-title', 'Kohteen tierekisteriosoitteet')
-//         cy.contains('.panel-title', 'Muut tierekisteriosoitteet')
-//         cy.contains('.panel-title', 'Kohteen päällystysurakan tarkka aikataulu')
-//     })
-// })
+describe('Aikataulunäkymien avaaminen tiemerkintäurakassa', function () {
+    beforeEach(function () {
+        cy.visit("http://localhost:3000/#urakat/yleiset?&hy=12&u=12")
+    })
+
+    it("Aikataulun avaaminen toimii tiemerkinnässä", function () {
+        cy.contains('.klikattava', 'Aikataulu').click()
+        cy.get('.alasveto-vuosi').click()
+        cy.get('a').contains('2018').click()
+        cy.get('.navigation-right', {timeout: 40000}).first().click()
+        // Pitää näkyä alikohteet omassa taulukossaan
+        cy.contains('.panel-title', 'Kohteen tierekisteriosoitteet')
+        cy.contains('.panel-title', 'Muut tierekisteriosoitteet')
+        cy.contains('.panel-title', 'Kohteen päällystysurakan tarkka aikataulu')
+    })
+})
 
 
 describe('Aikataulunäkymien avaaminen päällystysurakassa', function () {
@@ -23,7 +23,7 @@ describe('Aikataulunäkymien avaaminen päällystysurakassa', function () {
 
     it("Aikataulun avaaminen toimii päällystyksessä", function () {
         cy.contains('.klikattava', 'Aikataulu', {timeout: 40000}).click()
-        cy.get('.navigation-ympyrassa', {timeout: 40000}).first().click()
+        cy.get('.navigation-right', {timeout: 40000}).first().click()
         // Ei saa näkyä alikohteet omassa taulukossaan
         cy.contains('.panel-title', 'Kohteen tierekisteriosoitteet').should('not.visible')
         cy.contains('.panel-title', 'Muut tierekisteriosoitteet').should('not.visible')

--- a/cypress/integration/nakymien_avaus_spec.js
+++ b/cypress/integration/nakymien_avaus_spec.js
@@ -8,4 +8,31 @@ describe('Päänäkymien avaamiset', function () {
         cy.contains('.haku-lista-item', 'Aktiivinen Oulu Testi').click()
         cy.contains('Aktiivinen Oulu Testi')
     })
+
+    it("Raportit välilehti toimii", function () {
+        cy.contains('ul#sivut a span', 'Raportit').click()
+        cy.contains('div.valittu', 'Valitse').click()
+        cy.contains('.harja-alasvetolistaitemi a', "Ilmoitusraportti").click()
+        cy.contains('span.raksiboksi-teksti', "Valittu aikaväli").should('exist')
+        cy.contains('span.raksiboksi-teksti', "Näytä urakka-alueet eriteltynä").should('exist')
+        cy.contains('Hupsista').should('not.exist')
+    })
+
+    it("Tilannekuva välilehti toimii", function () {
+        cy.contains('ul#sivut a span', 'Tilannekuva').click()
+        cy.contains('div#tk-suodattimet a.klikattava', "Nykytilanne").should('exist')
+        cy.contains('Hupsista').should('not.exist')
+    })
+
+    it("Ilmoitukset välilehti toimii", function () {
+        cy.contains('ul#sivut a span', 'Ilmoitukset').click()
+        cy.contains('div.livi-grid th', "Urakka").should('exist')
+        cy.contains('Hupsista').should('not.exist')
+    })
+
+    it("Tienpidon luvat välilehti toimii", function () {
+        cy.contains('ul#sivut a span', 'Tienpidon luvat').click()
+        cy.contains('button', "Hae lupia").should('exist')
+        cy.contains('Hupsista').should('not.exist')
+    })
 })

--- a/cypress/integration/pot_lomake.js
+++ b/cypress/integration/pot_lomake.js
@@ -207,11 +207,11 @@ describe('Aloita päällystysilmoitus vanha', function () {
             })
             cy.get('[data-cy=paallystystoimenpiteen-tiedot]').then(($ptGrid) => {
                 expect($ptGrid.find('.panel-heading span').text()).to.contain('Tarkista kohteen tr-osoite ennen tallentamista')
-                expect($ptGrid.find('input').eq(0)).to.be.disabled;
+                expect($ptGrid.find('td.ei-muokattava').eq(0));
             })
             cy.get('[data-cy=kiviaines-ja-sideaine]').then(($ksGrid) => {
                 expect($ksGrid.find('.panel-heading span').text()).to.contain('Tarkista kohteen tr-osoite ennen tallentamista')
-                expect($ksGrid.find('input').eq(0)).to.be.disabled;
+                expect($ksGrid.find('td.ei-muokattava').eq(0));
             })
             cy.get('[data-cy=pot-tallenna]').should('be.disabled')
         })

--- a/dev-resources/less/bootstrap/modals.less
+++ b/dev-resources/less/bootstrap/modals.less
@@ -34,6 +34,10 @@
     .transition-transform(~"0.3s ease-out");
   }
   &.in .modal-dialog { .translate(0, 0) }
+  hr.modal-header-body-space {
+    margin-left: 15px;
+    margin-right: 15px;
+  }
 }
 .modal-open .modal {
   overflow-x: hidden;
@@ -78,7 +82,6 @@
 // Top section of the modal w/ title and dismiss
 .modal-header {
   padding: @modal-title-padding;
-  border-bottom: 1px solid @modal-header-border-color;
   min-height: (@modal-title-padding + @modal-title-line-height);
 }
 // Close icon
@@ -88,7 +91,7 @@
 
 // Title text within header
 .modal-title {
-  margin: 0;
+  margin-bottom: 8px;
   line-height: @modal-title-line-height;
 }
 

--- a/dev-resources/less/grid.less
+++ b/dev-resources/less/grid.less
@@ -12,9 +12,10 @@
 
 @livitaulukon-rivi-korkeus: 36px;
 @livitaulukon-input-korkeus: @livitaulukon-rivi-korkeus;
-@livi-taulukon-padding: 1px 16px;
-@livi-taulukon-padding-tiivis: 1px 12px;
-@livi-taulukon-padding-melko-tiivis: 1px 12px;
+@taulukon-vertical-padding: 8px;
+@livi-taulukon-padding: @taulukon-vertical-padding 16px;
+@livi-taulukon-padding-tiivis: @taulukon-vertical-padding 12px;
+@livi-taulukon-padding-melko-tiivis: @taulukon-vertical-padding 12px;
 @infolaatikko-leveys: 300px;
 @hento-korostusvari: @blue-lighter;
 
@@ -54,6 +55,7 @@
     font-size: @fontin-koko-taulukko;
     word-break: break-all;
     td {
+      vertical-align: top;
       input:not([type="checkbox"]), select {
         width: 100%;
         z-index: 10;

--- a/dev-resources/less/grid.less
+++ b/dev-resources/less/grid.less
@@ -12,9 +12,9 @@
 
 @livitaulukon-rivi-korkeus: 36px;
 @livitaulukon-input-korkeus: @livitaulukon-rivi-korkeus;
-@livi-taulukon-padding: 0 16px;
-@livi-taulukon-padding-tiivis: 0 12px;
-@livi-taulukon-padding-melko-tiivis: 0 12px;
+@livi-taulukon-padding: 1px 16px;
+@livi-taulukon-padding-tiivis: 1px 12px;
+@livi-taulukon-padding-melko-tiivis: 1px 12px;
 @infolaatikko-leveys: 300px;
 @hento-korostusvari: @blue-lighter;
 
@@ -248,7 +248,7 @@
   }
   tr.klikattava:hover:not(.gridin-collapsoitava-valiotsikko) {
     cursor: pointer;
-    background-color: #D2CFCE;
+    background-color: @blue-lighter;
   }
   .ei-arvoa {
     color: @varoitus;
@@ -257,6 +257,21 @@
   tr.muokataan {
     height: @livitaulukon-rivi-korkeus;
     padding: @livi-taulukon-padding-tiivis;
+    &.klikattava:hover td.ei-muokattava {
+      background-color: @blue-lighter;
+    }
+    &:focus-within {
+      background-color: @blue-lighter;
+      > td.ei-muokattava {
+        background-color: @blue-lighter;
+      }
+      > td.rivinumero {
+        background-color: @blue-lighter;
+      }
+      > td.muokattava {
+        background-color: transparent;
+      }
+    }
     &.parillinen {
       input[disabled].disabled {
         background-color: @harmaa10;

--- a/dev-resources/less/grid.less
+++ b/dev-resources/less/grid.less
@@ -10,13 +10,13 @@
   width: 100%;
 }
 
-@livitaulukon-rivi-korkeus: 36px;
-@livitaulukon-input-korkeus: @livitaulukon-rivi-korkeus;
+@livitaulukon-input-korkeus: @input-korkeus;
 @taulukon-vertical-padding: 8px;
 @livi-taulukon-padding: @taulukon-vertical-padding 16px;
 @livi-taulukon-padding-tiivis: @taulukon-vertical-padding 4px;
 @livi-taulukon-padding-melko-tiivis: @taulukon-vertical-padding 12px;
 @kalenterin-pvm-padding: 0 10px;
+@kalenterin-pvm-korkeus: 36px;
 @infolaatikko-leveys: 300px;
 @hento-korostusvari: @blue-lighter;
 
@@ -60,7 +60,6 @@
       input:not([type="checkbox"]), select {
         width: 100%;
         z-index: 10;
-        height: @livitaulukon-input-korkeus;
       }
       input[type="radio"] {
         width: auto;
@@ -97,14 +96,10 @@
     thead {
       background-color: @harmaa13;
       word-break: normal;
-      > tr {
-        height: @livitaulukon-rivi-korkeus;
-      }
     }
     tbody {
       > tr {
         border-bottom: 1px solid @harmaa-vaalea;
-        height: @livitaulukon-rivi-korkeus;
       }
     }
 
@@ -225,7 +220,6 @@
     display: inline-block;
     .livicon-trash {
       margin-left: 2px;
-      line-height: @livitaulukon-input-korkeus;
     }
   }
 
@@ -261,7 +255,6 @@
   }
 
   tr.muokataan {
-    height: @livitaulukon-rivi-korkeus;
     padding: @livi-taulukon-padding-tiivis;
     &.klikattava:hover td.ei-muokattava {
       background-color: @blue-lighter;
@@ -343,7 +336,7 @@
             text-align: right;
           }
           .livicon-chevron-down, .livicon-chevron-up {
-            right: 0;
+            right: 2px;
           }
         }
       }
@@ -351,7 +344,10 @@
         border: none;
       }
       > span.grid-kentta-wrapper input {
-        border: none;
+        border-top: 4px solid @valkoinen;
+        border-bottom: 5px solid @valkoinen;
+        border-left: none;
+        border-right: none;
       }
       .nappi-alasveto {
         border: none;

--- a/dev-resources/less/grid.less
+++ b/dev-resources/less/grid.less
@@ -13,8 +13,8 @@
 @livitaulukon-rivi-korkeus: 36px;
 @livitaulukon-input-korkeus: @livitaulukon-rivi-korkeus;
 @livi-taulukon-padding: 0 16px;
-@livi-taulukon-padding-tiivis: 0 2px;
-@livi-taulukon-padding-melko-tiivis: 0 4px;
+@livi-taulukon-padding-tiivis: 0 12px;
+@livi-taulukon-padding-melko-tiivis: 0 12px;
 @infolaatikko-leveys: 300px;
 @hento-korostusvari: @blue-lighter;
 

--- a/dev-resources/less/grid.less
+++ b/dev-resources/less/grid.less
@@ -546,8 +546,14 @@ tr.otsikko {
 
 .gridin-collapsoitava-valiotsikko {
   > td {
+    > .navigation-ympyrassa {
+      position: relative;
+      top: 27px;
+      right: 4px;
+      text-align: center;
+    }
     h5 {
-      margin-left: 20px;
+      margin-left: 30px;
     }
 
     span[class^="livicon-chevron"] {

--- a/dev-resources/less/grid.less
+++ b/dev-resources/less/grid.less
@@ -16,6 +16,7 @@
 @livi-taulukon-padding: @taulukon-vertical-padding 16px;
 @livi-taulukon-padding-tiivis: @taulukon-vertical-padding 12px;
 @livi-taulukon-padding-melko-tiivis: @taulukon-vertical-padding 12px;
+@kalenterin-pvm-padding: 0 10px;
 @infolaatikko-leveys: 300px;
 @hento-korostusvari: @blue-lighter;
 
@@ -89,6 +90,9 @@
         .virhe-tai-varoitus-grid(@huomautus, @valkoinen);
       }
     }
+    .gridin-collapsoitava-valiotsikko > td {
+      padding: @kalenterin-pvm-padding;
+    }
 
     thead {
       background-color: @harmaa13;
@@ -148,6 +152,7 @@
   }
   td.vetolaatikon-tila {
     text-align: center;
+    vertical-align: middle;
   }
   tr, td, th {
     padding: @livi-taulukon-padding;
@@ -541,9 +546,7 @@ tr.otsikko {
 }
 
 .gridin-collapsoitava-valiotsikko {
-  td {
-    position: relative;
-
+  > td {
     h5 {
       margin-left: 20px;
     }

--- a/dev-resources/less/grid.less
+++ b/dev-resources/less/grid.less
@@ -24,6 +24,9 @@
 
 .livi-grid {
   color: @harmaa1;
+  &.panel {
+    margin-bottom: 34px;
+  }
   // pienen napin sisässä on pientä tekstiä, tämä estää esim. panel headerin kasvattamasta ikoneita
   // tämähän on vähän nastya, vaihtoehtona poistaa bs:n panel-heading luokka gridistä.
   .panel-heading {
@@ -33,6 +36,7 @@
     // anna padding top ja bottom tulla BS:stä
     padding-left: 0;
     padding-right: 0;
+    margin-bottom: 16px;
     button {
       padding: 4px 8px;
     }
@@ -179,7 +183,7 @@
     margin-bottom: 1px;
   }
   .muokkaustoiminnot {
-    margin-bottom: 4px;
+    margin-bottom: 9px;
     button {
       margin-right: 1em;
     }

--- a/dev-resources/less/grid.less
+++ b/dev-resources/less/grid.less
@@ -12,6 +12,7 @@
 
 @livitaulukon-input-korkeus: @input-korkeus;
 @taulukon-vertical-padding: 8px;
+@taulukon-vertical-padding-muokattava-kentta: 4px;
 @livi-taulukon-padding: @taulukon-vertical-padding 16px;
 @livi-taulukon-padding-tiivis: @taulukon-vertical-padding 4px;
 @livi-taulukon-padding-melko-tiivis: @taulukon-vertical-padding 12px;
@@ -258,6 +259,10 @@
     padding: @livi-taulukon-padding-tiivis;
     &.klikattava:hover td.ei-muokattava {
       background-color: @blue-lighter;
+    }
+    > td.muokattava {
+      padding-top: @taulukon-vertical-padding-muokattava-kentta;
+      padding-bottom: @taulukon-vertical-padding-muokattava-kentta;
     }
     &:focus-within {
       background-color: @blue-lighter;

--- a/dev-resources/less/grid.less
+++ b/dev-resources/less/grid.less
@@ -14,7 +14,7 @@
 @livitaulukon-input-korkeus: @livitaulukon-rivi-korkeus;
 @taulukon-vertical-padding: 8px;
 @livi-taulukon-padding: @taulukon-vertical-padding 16px;
-@livi-taulukon-padding-tiivis: @taulukon-vertical-padding 12px;
+@livi-taulukon-padding-tiivis: @taulukon-vertical-padding 4px;
 @livi-taulukon-padding-melko-tiivis: @taulukon-vertical-padding 12px;
 @kalenterin-pvm-padding: 0 10px;
 @infolaatikko-leveys: 300px;
@@ -152,7 +152,6 @@
   }
   td.vetolaatikon-tila {
     text-align: center;
-    vertical-align: middle;
   }
   tr, td, th {
     padding: @livi-taulukon-padding;

--- a/dev-resources/less/livicons.less
+++ b/dev-resources/less/livicons.less
@@ -21,6 +21,10 @@
     -moz-osx-font-smoothing: grayscale;
 }
 .navigation-ympyrassa {
+    background-color: @blue-light;
+    height: 20px;
+    width: 20px;
+    border-radius: 50%;
     > img {
         width: 16px;
         height: 13px;

--- a/dev-resources/less/livicons.less
+++ b/dev-resources/less/livicons.less
@@ -20,6 +20,14 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 }
+.navigation-ympyrassa {
+    > img {
+        width: 16px;
+        height: 12px;
+        position: relative;
+        left: 2px;
+    }
+}
 
 .livicon-arrow-beginning:before {
     content: "\e600";

--- a/dev-resources/less/livicons.less
+++ b/dev-resources/less/livicons.less
@@ -23,9 +23,17 @@
 .navigation-ympyrassa {
     > img {
         width: 16px;
-        height: 12px;
+        height: 13px;
         position: relative;
-        left: 2px;
+        &.navigation-right,
+        &.navigation-left {
+
+        }
+        &.navigation-up,
+        &.navigation-down {
+
+        }
+
     }
 }
 

--- a/dev-resources/less/lomake.less
+++ b/dev-resources/less/lomake.less
@@ -358,6 +358,10 @@ fieldset.lomake-osa {
   line-height: 20px;
   .fontti-yhteiset();
 }
+.fontti-14-vaaleampi {
+  .fontti-14();
+  color: @black-light;
+}
 .fontti-20 {
   font-size: 20px;
   line-height: 24px;

--- a/dev-resources/less/pages/materiaalikirjasto.less
+++ b/dev-resources/less/pages/materiaalikirjasto.less
@@ -35,9 +35,6 @@
         button.nappi-ensisijainen {
             margin-right: 24px;
         }
-        .yleinen-pikkuvihje .vihjeen-sisalto {
-            margin: 0;
-        }
         border: none;
         input {
             height: 40px;

--- a/dev-resources/less/pages/materiaalikirjasto.less
+++ b/dev-resources/less/pages/materiaalikirjasto.less
@@ -3,7 +3,12 @@
         height: 100%;
         max-height: 100%;
     }
+    .massa-taulukko {
+        margin-bottom: 51px;
+        margin-top: 83px;
+    }
     .livi-grid.panel.panel-default {
+        background-color: @white;
         .panel-heading, .panel-body {
             background-color: @white;
         }
@@ -18,10 +23,21 @@
             }
         }
     }
+    .materiaalitoiminnot {
+        div:not(:last-child) > button.nappi-ikoni {
+            margin-right: 4px;
+        }
+    }
 }
 // POT2:sta avaamme massa- ja murskelomakkeen myös sivulle overlayhin ilman materiaalikirjaston modaalia
 .massa-lomake, .murske-lomake {
     .lomake {
+        button.nappi-ensisijainen {
+            margin-right: 24px;
+        }
+        .yleinen-pikkuvihje .vihjeen-sisalto {
+            margin: 0;
+        }
         border: none;
         input {
             height: 40px;

--- a/dev-resources/less/pages/materiaalikirjasto.less
+++ b/dev-resources/less/pages/materiaalikirjasto.less
@@ -39,8 +39,6 @@
                 margin-top: -12px;
                 margin-left: 35px;
                 margin-bottom: 5px;
-            }
-            .sideaine-komponentti {
                 .select-default > ul {
                     position: absolute;
                     width: 350px;

--- a/dev-resources/less/pvm-valinta.less
+++ b/dev-resources/less/pvm-valinta.less
@@ -13,10 +13,10 @@
   .pvm-kontrollit, .pvm-paivat {
     tr {
       td, th {
-        height: @livitaulukon-rivi-korkeus;
+        height: @kalenterin-pvm-korkeus;
         vertical-align: middle;
       }
-      height: @livitaulukon-rivi-korkeus;
+      height: @kalenterin-pvm-korkeus;
     }
   }
 

--- a/dev-resources/less/pvm-valinta.less
+++ b/dev-resources/less/pvm-valinta.less
@@ -8,13 +8,13 @@
   text-align: center;
   min-width: 200px;
   max-width: 200px;
-
   background-color: #ffffff;
 
   .pvm-kontrollit, .pvm-paivat {
     tr {
       td, th {
         height: @livitaulukon-rivi-korkeus;
+        vertical-align: middle;
       }
       height: @livitaulukon-rivi-korkeus;
     }
@@ -30,7 +30,7 @@
 
   td.pvm-paiva {
     border: 1px solid @harmaa-vaalea;
-    padding: @livi-taulukon-padding-tiivis;
+    padding: @kalenterin-pvm-padding;
     &:hover {
       background-color: wheat;
     }

--- a/dev-resources/less/vayla/typography.less
+++ b/dev-resources/less/vayla/typography.less
@@ -43,6 +43,8 @@
   margin: 0; // Ylikirjoittaa selaimen lisäämän marginin.
   font-size: @koko;
   line-height: @korkeus;
+  margin-bottom: 16px;
+  margin-top: 16px;
 }
 
 h1 {

--- a/dev-resources/less/yleiset.less
+++ b/dev-resources/less/yleiset.less
@@ -349,6 +349,11 @@ button > .ajax-loader {
     .livicon-info-circle {
       color: @sininen5;
     }
+    > span > span {
+      margin-left: 8px;
+      position: relative;
+      top: 2px;
+    }
   }
   margin-right: 1em;
 

--- a/src/cljc/harja/domain/pot2.cljc
+++ b/src/cljc/harja/domain/pot2.cljc
@@ -371,7 +371,6 @@
              (remove nil? (mapv val (select-keys rivi avaimet))))))
 
 (defn murskeen-rikastettu-nimi [mursketyypit murske]
-  ; (str ydin (when-not (empty? tarkennukset) (str "(" tarkennukset ")")))
   (let [ydin (str (ainetyypin-koodi->lyhenne mursketyypit (::tyyppi murske)) " "
                   (rivin-avaimet->str murske #{::nimen-tarkenne}))
         tarkennukset (rivin-avaimet->str murske #{::dop-nro} ", ")
@@ -389,7 +388,7 @@
       (str "RC" (:runkoaine/massaprosentti asfalttirouhe)))))
 
 (defn massan-rikastettu-nimi
-  "Formatoi massan nimen. Jos haluat Reagent-komponentin, anna fmt = :komponentti, muuten anna :string"
+  "Formatoi massan nimen"
   [massatyypit massa]
   ;; esim AB16 (AN15, RC40, 2020/09/1234) tyyppi (raekoko, nimen tarkenne, DoP, Kuulamyllyluokka, RC%)
   (let [massa (assoc massa ::rc% (massan-rc-pitoisuus massa))

--- a/src/cljc/harja/domain/pot2.cljc
+++ b/src/cljc/harja/domain/pot2.cljc
@@ -372,6 +372,9 @@
 
 (defn murskeen-rikastettu-nimi [mursketyypit murske]
   (let [ydin (str (ainetyypin-koodi->lyhenne mursketyypit (::tyyppi murske)) " "
+                  (when (and (::tyyppi-tarkenne murske)
+                             (empty? (::nimen-tarkenne murske)))
+                    (str (::tyyppi-tarkenne murske) " "))
                   (rivin-avaimet->str murske #{::nimen-tarkenne}))
         tarkennukset (rivin-avaimet->str murske #{::dop-nro} ", ")
         tarkennukset-teksti (when (seq tarkennukset) (str " (" tarkennukset ")"))]

--- a/src/cljc/harja/domain/pot2.cljc
+++ b/src/cljc/harja/domain/pot2.cljc
@@ -385,13 +385,13 @@
   (when-let [runkoaineet (::runkoaineet rivi)]
     (when-let [asfalttirouhe (first (filter #(= (:runkoaine/tyyppi %) asfalttirouheen-tyypin-id)
                                             runkoaineet))]
-      (str "RC" (:runkoaine/massaprosentti asfalttirouhe)))))
+      (:runkoaine/massaprosentti asfalttirouhe))))
 
 (defn massan-rikastettu-nimi
   "Formatoi massan nimen"
   [massatyypit massa]
   ;; esim AB16 (AN15, RC40, 2020/09/1234) tyyppi (raekoko, nimen tarkenne, DoP, Kuulamyllyluokka, RC%)
-  (let [massa (assoc massa ::rc% (massan-rc-pitoisuus massa))
+  (let [massa (assoc massa ::rc% (str "RC" (massan-rc-pitoisuus massa)))
         ydin (str (ainetyypin-koodi->lyhenne massatyypit (::tyyppi massa))
                   (rivin-avaimet->str massa [::max-raekoko
                                              ::nimen-tarkenne]))

--- a/src/cljs/harja/ui/grid/muokkaus.cljs
+++ b/src/cljs/harja/ui/grid/muokkaus.cljs
@@ -152,7 +152,8 @@
                tasaus-luokka (y/tasaus-luokka tasaa)
                tayta-alas (:tayta-alas? sarake)
                elementin-id (str rivi-index elementin-id)]
-           (if (or (nil? muokattava?) (muokattava? rivi i))
+           (if (and (or (nil? muokattava?) (muokattava? rivi i))
+                    voi-muokata?)
              [:td {:class (y/luokat "muokattava"
                                     tasaus-luokka
                                     (grid-yleiset/tiivis-tyyli skeema)
@@ -240,8 +241,8 @@
   (let [rivi-disabloitu? (and disabloi-rivi? (disabloi-rivi? rivi))]
     [:tr.muokataan {:class (y/luokat
                              (if (even? (+ i 1))
-                               "parillinen "
-                               "pariton ")
+                               "parillinen"
+                               "pariton")
                              (when rivi-disabloitu? "disabloitu-rivi")
                              (when rivi-klikattu "klikattava"))
                     :on-click #(when rivi-klikattu

--- a/src/cljs/harja/ui/grid/perus.cljs
+++ b/src/cljs/harja/ui/grid/perus.cljs
@@ -496,8 +496,8 @@
                        (- colspan (:col-span komponentti-otsikon-sisaan)))}
        (when salli-valiotsikoiden-piilotus?
          (if (@piilotetut-valiotsikot valiotsikko-id)
-           (ikonit/livicon-chevron-right)
-           (ikonit/livicon-chevron-down)))
+           [ikonit/navigation-ympyrassa :right]
+           [ikonit/navigation-ympyrassa :down]))
        [:h5 teksti]]
       (when (and (:sisalto komponentti-otsikon-sisaan)
                  (:col-span komponentti-otsikon-sisaan))

--- a/src/cljs/harja/ui/grid/protokollat.cljs
+++ b/src/cljs/harja/ui/grid/protokollat.cljs
@@ -159,5 +159,5 @@ Annettu rivin-tiedot voi olla tyhjä tai se voi alustaa kenttien arvoja.")
                            (avaa-tai-sulje-vetolaatikko! ohjaus id)))}
      (when vetolaatikko?
        (if (vetolaatikko-auki? ohjaus id)
-         (ikonit/livicon-chevron-down)
-         (ikonit/livicon-chevron-right)))]))
+         [ikonit/navigation-ympyrassa :down]
+         [ikonit/navigation-ympyrassa :right]))]))

--- a/src/cljs/harja/ui/grid/yleiset.cljs
+++ b/src/cljs/harja/ui/grid/yleiset.cljs
@@ -30,8 +30,8 @@
                    [harja.makrot :refer [fnc]]
                    [harja.tyokalut.ui :refer [for*]]))
 
-(def tiiviin-tyylin-sarakemaara 11)
-(def melko-tiiviin-tyylin-sarakemaara 6)
+(def tiiviin-tyylin-sarakemaara 15)
+(def melko-tiiviin-tyylin-sarakemaara 8)
 
 (defn tiivis-tyyli [skeema]
   (cond

--- a/src/cljs/harja/ui/ikonit.cljs
+++ b/src/cljs/harja/ui/ikonit.cljs
@@ -626,10 +626,6 @@
 
 (defn navigation-ympyrassa [suunta]
   [:div.navigation-ympyrassa
-   {:style {:background-color "#E6F0FA"
-            :height "20px"
-            :width "20px"
-            :border-radius "50%"}}
    (case suunta
      :up (navigation-up)
      :right (navigation-right)

--- a/src/cljs/harja/ui/ikonit.cljs
+++ b/src/cljs/harja/ui/ikonit.cljs
@@ -615,14 +615,14 @@
 (defn nelio-info []
   [:img {:src "images/harja-icons/status/info.svg" :alt "info"}])
 
-(defn navigation-top []
-  [:img {:src "images/harja-icons/navigation/top.svg" :alt "top"}])
+(defn navigation-up []
+  [:img.navigation-up {:src "images/harja-icons/navigation/up.svg" :alt "up"}])
 (defn navigation-right []
-  [:img {:src "images/harja-icons/navigation/right.svg" :alt "right"}])
+  [:img.navigation-right {:src "images/harja-icons/navigation/right.svg" :alt "right"}])
 (defn navigation-down []
-  [:img {:src "images/harja-icons/navigation/down.svg" :alt "down"}])
+  [:img.navigation-down {:src "images/harja-icons/navigation/down.svg" :alt "down"}])
 (defn navigation-left []
-  [:img {:src "images/harja-icons/navigation/left.svg" :alt "left"}])
+  [:img.navigation-left {:src "images/harja-icons/navigation/left.svg" :alt "left"}])
 
 (defn navigation-ympyrassa [suunta]
   [:div.navigation-ympyrassa
@@ -631,7 +631,7 @@
             :width "20px"
             :border-radius "50%"}}
    (case suunta
-     :top (navigation-top)
+     :up (navigation-up)
      :right (navigation-right)
      :down (navigation-down)
      :left (navigation-left)

--- a/src/cljs/harja/ui/ikonit.cljs
+++ b/src/cljs/harja/ui/ikonit.cljs
@@ -615,6 +615,18 @@
 (defn nelio-info []
   [:img {:src "images/harja-icons/status/info.svg" :alt "info"}])
 
+(defn navigation [suunta]
+  (assert (#{:right :down :left :top} suunta) "Suunnan oltava :right, :down, :left tai :top")
+  [:img {:src (str "images/harja-icons/navigation/" (name suunta)".svg")
+         :alt (name suunta)}])
+
+(defn navigation-ympyrassa [suunta]
+  [:div {:style {:background-color "#E6F0FA"
+                 :height "20px"
+                 :width "20px"
+                 :border-radius "50%"}}
+   (navigation-ympyrassa suunta)])
+
 (defn ikoni-ja-teksti [ikoni teksti]
   [:span
    ikoni
@@ -623,8 +635,13 @@
 (defn ikoni-ja-elementti [ikoni elementti]
   [:span
    ikoni
-   [:span " "]
-   elementti])
+   ;; tämä tyyli on tehty [yleiset/vihje] komponentin ehdoilla. Ao. parametreilla ikoni ja teksti
+   ;; asettuvat kivasti oikealle etäisyydelle ja korkeuteen. Jos tämä ei toimi sinulle, ole hyvä
+   ;; ja implementoi tyyli-parametri tälle komponentille
+   [:span {:style {:margin-left "16px"
+                   :position "relative"
+                   :top "2px"}}
+    elementti]])
 
 (defn teksti-ja-ikoni [teksti ikoni]
   [:span

--- a/src/cljs/harja/ui/ikonit.cljs
+++ b/src/cljs/harja/ui/ikonit.cljs
@@ -615,17 +615,28 @@
 (defn nelio-info []
   [:img {:src "images/harja-icons/status/info.svg" :alt "info"}])
 
-(defn navigation [suunta]
-  (assert (#{:right :down :left :top} suunta) "Suunnan oltava :right, :down, :left tai :top")
-  [:img {:src (str "images/harja-icons/navigation/" (name suunta)".svg")
-         :alt (name suunta)}])
+(defn navigation-top []
+  [:img {:src "images/harja-icons/navigation/top.svg" :alt "top"}])
+(defn navigation-right []
+  [:img {:src "images/harja-icons/navigation/right.svg" :alt "right"}])
+(defn navigation-down []
+  [:img {:src "images/harja-icons/navigation/down.svg" :alt "down"}])
+(defn navigation-left []
+  [:img {:src "images/harja-icons/navigation/left.svg" :alt "left"}])
 
 (defn navigation-ympyrassa [suunta]
-  [:div {:style {:background-color "#E6F0FA"
-                 :height "20px"
-                 :width "20px"
-                 :border-radius "50%"}}
-   (navigation-ympyrassa suunta)])
+  [:div.navigation-ympyrassa
+   {:style {:background-color "#E6F0FA"
+            :height "20px"
+            :width "20px"
+            :border-radius "50%"}}
+   (case suunta
+     :top (navigation-top)
+     :right (navigation-right)
+     :down (navigation-down)
+     :left (navigation-left)
+
+     nil)])
 
 (defn ikoni-ja-teksti [ikoni teksti]
   [:span
@@ -635,13 +646,8 @@
 (defn ikoni-ja-elementti [ikoni elementti]
   [:span
    ikoni
-   ;; tämä tyyli on tehty [yleiset/vihje] komponentin ehdoilla. Ao. parametreilla ikoni ja teksti
-   ;; asettuvat kivasti oikealle etäisyydelle ja korkeuteen. Jos tämä ei toimi sinulle, ole hyvä
-   ;; ja implementoi tyyli-parametri tälle komponentille
-   [:span {:style {:margin-left "16px"
-                   :position "relative"
-                   :top "2px"}}
-    elementti]])
+   [:span " "]
+   elementti])
 
 (defn teksti-ja-ikoni [teksti ikoni]
   [:span

--- a/src/cljs/harja/ui/leijuke.cljs
+++ b/src/cljs/harja/ui/leijuke.cljs
@@ -93,7 +93,7 @@
        [:div.vihjeen-sisalto {:on-click #(reset! nakyvissa? true)}
         (if @nakyvissa?
           [leijuke (merge
-                     {:otsikko [ikonit/ikoni-ja-teksti (ikonit/livicon-info-sign) "Vihje"]
+                     {:otsikko [ikonit/ikoni-ja-teksti (ikonit/nelio-info) "Vihje"]
                       :sulje! #(reset! nakyvissa? false)}
                      optiot)
            [:div {:style {:min-width "300px"}}

--- a/src/cljs/harja/ui/leijuke.cljs
+++ b/src/cljs/harja/ui/leijuke.cljs
@@ -89,7 +89,7 @@
 (defn vihjeleijuke [optiot leijuke-sisalto]
   (let [nakyvissa? (atom false)]
     (fn [optiot leijuke-sisalto]
-      [:div.inline-block.yleinen-pikkuvihje.klikattava
+      [:div.inline-block.yleinen-pikkuvihje.klikattava {:style {:margin-left "16px"}}
        [:div.vihjeen-sisalto {:on-click #(reset! nakyvissa? true)}
         (if @nakyvissa?
           [leijuke (merge
@@ -98,10 +98,9 @@
                      optiot)
            [:div {:style {:min-width "300px"}}
             leijuke-sisalto]]
-          [:span
-           (harja.ui.ikonit/livicon-info-sign)
-           [:span " "] ;; TODO Anna olla noin kuukausi, sen jälkeen "Vihje" teksti pois (17.2.2018)
-           [:a "Vihje"]])]])))
+          [ikonit/ikoni-ja-teksti
+           (ikonit/nelio-info)
+           "Ohje"])]])))
 
 (defn otsikko-ja-vihjeleijuke [otsikko-taso otsikko leijuke-optiot leijuke-sisalto]
   [:div

--- a/src/cljs/harja/ui/modal.cljs
+++ b/src/cljs/harja/ui/modal.cljs
@@ -23,6 +23,7 @@
     teksti]))
 
 (def modal-sisalto (atom {:otsikko nil
+                          :otsikon-alle-komp nil
                           :sisalto nil
                           :footer nil
                           :luokka nil
@@ -37,7 +38,8 @@
   (swap! modal-sisalto assoc :nakyvissa? false))
 
 (defn- modal-container* [optiot sisalto]
-  (let [{:keys [otsikko otsikko-tyyli footer nakyvissa? luokka leveys sulje-fn content-tyyli body-tyyli modal-luokka]} optiot
+  (let [{:keys [otsikko otsikon-alle-komp otsikko-tyyli footer nakyvissa? luokka
+                leveys sulje-fn content-tyyli body-tyyli modal-luokka]} optiot
         sulje!  #(do
                   ;; estää file-open dialogin poistamisen
                   #_(.preventDefault %)
@@ -53,18 +55,17 @@
        [:div (merge {:class (str "modal-dialog modal-sm " (or luokka ""))}
                     (when leveys
                       {:style {:max-width leveys}}))
-        [:div.modal-content {:on-click #(do
-                                          ;; estää file-open dialogin poistamisen
-                                          #_(.preventDefault %)
-                                          ;; syödään eventti että modalin sisällön click ei sulje
-                                          (.stopPropagation %))
+        [:div.modal-content {:on-click #(.stopPropagation %)
                              :style content-tyyli}
          (when otsikko
            [:div.modal-header
             [ikonit/sulje-ruksi sulje! {:style {:margin 0}}]
-            [:h2.modal-title {:class (when (= otsikko-tyyli :virhe)
+            [:h1.modal-title {:class (when (= otsikko-tyyli :virhe)
                                        "modal-otsikko-virhe")}
-             otsikko]])
+             otsikko]
+            (when otsikon-alle-komp
+              [otsikon-alle-komp])])
+         [:hr.modal-header-body-space]
          [:div.modal-body {:style body-tyyli} sisalto]
          (when footer [:div.modal-footer footer])]]]
 
@@ -77,8 +78,10 @@
   (let [optiot-ja-sisalto @modal-sisalto]
     [modal-container* optiot-ja-sisalto (:sisalto optiot-ja-sisalto)]))
 
-(defn nayta! [{:keys [sulje otsikko sulje-fn otsikko-tyyli footer luokka leveys content-tyyli body-tyyli modal-luokka]} sisalto]
+(defn nayta! [{:keys [sulje otsikko otsikon-alle-komp sulje-fn otsikko-tyyli
+                      footer luokka leveys content-tyyli body-tyyli modal-luokka]} sisalto]
   (reset! modal-sisalto {:otsikko otsikko
+                         :otsikon-alle-komp otsikon-alle-komp
                          :otsikko-tyyli otsikko-tyyli
                          :footer footer
                          :sisalto sisalto

--- a/src/cljs/harja/ui/modal.cljs
+++ b/src/cljs/harja/ui/modal.cljs
@@ -39,14 +39,15 @@
 
 (defn- modal-container* [optiot sisalto]
   (let [{:keys [otsikko otsikon-alle-komp otsikko-tyyli footer nakyvissa? luokka
-                leveys sulje-fn content-tyyli body-tyyli modal-luokka]} optiot
+                leveys sulje-fn sulje-ruksista-fn content-tyyli body-tyyli modal-luokka]} optiot
         sulje!  #(do
                   ;; estää file-open dialogin poistamisen
                   #_(.preventDefault %)
                   (.stopPropagation %)
                   (when sulje-fn
                     (sulje-fn))
-                  (piilota!))]
+                  (piilota!))
+        sulje-ruksista! (or sulje-ruksista-fn sulje!)]
     (if nakyvissa?
       ^{:key "modaali"}
       [:div.modal.fade.in.harja-modal {:class modal-luokka
@@ -59,7 +60,7 @@
                              :style content-tyyli}
          (when otsikko
            [:div.modal-header
-            [ikonit/sulje-ruksi sulje! {:style {:margin 0}}]
+            [ikonit/sulje-ruksi sulje-ruksista! {:style {:margin 0}}]
             [:h1.modal-title {:class (when (= otsikko-tyyli :virhe)
                                        "modal-otsikko-virhe")}
              otsikko]
@@ -78,7 +79,7 @@
   (let [optiot-ja-sisalto @modal-sisalto]
     [modal-container* optiot-ja-sisalto (:sisalto optiot-ja-sisalto)]))
 
-(defn nayta! [{:keys [sulje otsikko otsikon-alle-komp sulje-fn otsikko-tyyli
+(defn nayta! [{:keys [sulje otsikko otsikon-alle-komp sulje-ruksista-fn sulje-fn otsikko-tyyli
                       footer luokka leveys content-tyyli body-tyyli modal-luokka]} sisalto]
   (reset! modal-sisalto {:otsikko otsikko
                          :otsikon-alle-komp otsikon-alle-komp
@@ -86,6 +87,7 @@
                          :footer footer
                          :sisalto sisalto
                          :luokka luokka
+                         :sulje-ruksista-fn sulje-ruksista-fn
                          :sulje-fn sulje-fn
                          :sulje sulje
                          :nakyvissa? true

--- a/src/cljs/harja/ui/napit.cljs
+++ b/src/cljs/harja/ui/napit.cljs
@@ -294,6 +294,7 @@
 
 (defn sulje
   ([toiminto] (yleinen-toissijainen "Sulje" toiminto {}))
+  ([teksti toiminto] (yleinen-toissijainen teksti toiminto {}))
   ([teksti toiminto {:keys [luokka vayla-tyyli? teksti-nappi?] :as optiot}]
    [nappi teksti toiminto (merge
                             optiot

--- a/src/cljs/harja/ui/yleiset.cljs
+++ b/src/cljs/harja/ui/yleiset.cljs
@@ -623,7 +623,7 @@ lisätään eri kokoluokka jokaiselle mäpissä mainitulle koolle."
    [:div {:class
           (str "yleinen-pikkuvihje " (or luokka ""))}
     [:div.vihjeen-sisalto
-     (ikonit/ikoni-ja-teksti (harja.ui.ikonit/livicon-info-sign) teksti)]]))
+     (ikonit/ikoni-ja-teksti (ikonit/nelio-info) teksti)]]))
 
 (defn vihje-elementti
   ([elementti] (vihje-elementti elementti nil))
@@ -631,7 +631,7 @@ lisätään eri kokoluokka jokaiselle mäpissä mainitulle koolle."
    [:div {:class
           (str "yleinen-pikkuvihje " (or luokka ""))}
     [:div.vihjeen-sisalto
-     (ikonit/ikoni-ja-elementti (harja.ui.ikonit/livicon-info-sign) elementti)]]))
+     (ikonit/ikoni-ja-elementti (ikonit/nelio-info) elementti)]]))
 
 (def +tehtavien-hinta-vaihtoehtoinen+ "Urakan tehtävillä voi olla joko yksikköhinta tai muutoshinta")
 

--- a/src/cljs/harja/views/urakka/paallystysilmoitukset.cljs
+++ b/src/cljs/harja/views/urakka/paallystysilmoitukset.cljs
@@ -168,14 +168,8 @@
           [:h3.inline-block "Päällystysilmoitukset"]
           ;; HUOM! ei päästetä materiaalikirjastoa vielä tuotantoon
           (when (k/kehitysymparistossa?)
-            [napit/nappi "Muokkaa urakan materiaaleja"
-             #(e! (mk-tiedot/->NaytaModal true))
-             {:ikoni (ikonit/livicon-pen)
-              :luokka "napiton-nappi"
-              :style {:background-color "#fafafa"
-                      :margin-left "2rem"}}])]
-
-
+           [pot2-lomake/avaa-materiaalikirjasto-nappi #(e! (mk-tiedot/->NaytaModal true))
+            {:margin-left "24px"}])]
          [paallystysilmoitukset-taulukko e! app]
          [:h3 "YHA-lähetykset"]
          [yleiset/vihje "Ilmoituksen täytyy olla merkitty valmiiksi ja kokonaisuudessaan hyväksytty ennen kuin se voidaan lähettää YHAan."]

--- a/src/cljs/harja/views/urakka/paallystysilmoitukset.cljs
+++ b/src/cljs/harja/views/urakka/paallystysilmoitukset.cljs
@@ -162,9 +162,10 @@
       (let [urakka-id (:id urakka)
             sopimus-id (first valittu-sopimusnumero)]
         [:div
-         [:div
-          [:h3 {:style {:display "inline-block"}}
-           "Päällystysilmoitukset"]
+         [:div {:style {:display "inline-block"
+                        :position "relative"
+                        :top "28px"}}
+          [:h3.inline-block "Päällystysilmoitukset"]
           ;; HUOM! ei päästetä materiaalikirjastoa vielä tuotantoon
           (when (k/kehitysymparistossa?)
             [napit/nappi "Muokkaa urakan materiaaleja"

--- a/src/cljs/harja/views/urakka/pot2/massa_ja_murske_yhteiset.cljs
+++ b/src/cljs/harja/views/urakka/pot2/massa_ja_murske_yhteiset.cljs
@@ -15,7 +15,7 @@
                    [cljs.core.async.macros :refer [go]]))
 
 
-(def materiaali-jo-kaytossa-str "Materiaali on jo käytössä, eikä sitä voi enää poistaa.")
+(def materiaali-jo-kaytossa-str "Materiaali jo käytössä: ei voida poistaa.")
 
 (defn- materiaalin-nimen-komp [{:keys [ydin tarkennukset fmt toiminto-fn]}]
   (if (= :komponentti fmt)
@@ -104,7 +104,7 @@
                  [:div (str "Haluatko varmasti tallentaa muutokset? Voit myös halutessasi luoda " materiaalista-str " kopion ja muokata sitä.")]]
                 :toiminto-fn toiminto-fn
                 :hyvaksy "Tallenna"})))))
-     {:luokka "medium"
+     {:luokka "medium pull-left"
       :disabled (or disabled lukittu?)}]))
 
 (defn poista-materiaali-nappi
@@ -113,7 +113,7 @@
   (let [lukittu? (some #(str/includes? % "lukittu")
                        (map :tila materiaali-kaytossa))
         materiaalin-str (if (= :murske tyyppi) "Murskeen" "Massan")]
-    [:div {:style {:width "160px"}}
+    [:div.inline-block
      [napit/poista
       "Poista"
       (fn []
@@ -124,7 +124,7 @@
            :toiminto-fn toiminto-fn
            :hyvaksy "Kyllä"}))
       {:disabled (not (empty? materiaali-kaytossa))
-       :luokka "medium"}]
+       :luokka "medium pull-left"}]
      (when (and (not lukittu?)
                 (not (empty? materiaali-kaytossa)))
        [yleiset/vihje materiaali-jo-kaytossa-str])]))
@@ -134,17 +134,15 @@
               peruuta-fn poista-fn tyyppi id materiaali-kaytossa voi-muokata?]}]
   [:div
    [puutelistaus (ui-lomake/puuttuvat-pakolliset-kentat data) validointivirheet]
-   [:div.flex-row {:style {:align-items "start"}}
-    [:div.tallenna-peruuta
-     (when voi-muokata?
-       [tallenna-materiaali-nappi materiaali-kaytossa tallenna-fn
-        voi-tallentaa?
-        tyyppi])
-     [napit/yleinen (if voi-muokata? "Peruuta" "Sulje") :toissijainen peruuta-fn
-      {:luokka "medium"}]]
-
+   [:div
+    (when voi-muokata?
+      [tallenna-materiaali-nappi materiaali-kaytossa tallenna-fn
+       voi-tallentaa?
+       tyyppi])
     (when (and id voi-muokata?)
-      [poista-materiaali-nappi materiaali-kaytossa poista-fn tyyppi])]
+      [poista-materiaali-nappi materiaali-kaytossa poista-fn tyyppi])
+    [napit/yleinen (if voi-muokata? "Peruuta" "Sulje") :toissijainen peruuta-fn
+     {:luokka "medium pull-right"}]]
    [materiaalin-kaytto materiaali-kaytossa]])
 
 (defn materiaalin-tiedot [materiaali {:keys [materiaalikoodistot]} toiminto-fn]
@@ -163,7 +161,7 @@
   (let [muokkaus-event (if (contains? rivi :harja.domain.pot2/murske-id)
                          mk-tiedot/->MuokkaaMursketta
                          mk-tiedot/->MuokkaaMassaa)]
-    [:span.pull-right
+    [:span.pull-right.materiaalitoiminnot
      [yleiset/wrap-if true
       [yleiset/tooltip {} :% "Muokkaa"]
       [napit/nappi ""

--- a/src/cljs/harja/views/urakka/pot2/massat.cljs
+++ b/src/cljs/harja/views/urakka/pot2/massat.cljs
@@ -411,16 +411,17 @@
   [grid/grid
    {:otsikko "Massat"
     :tunniste ::pot2-domain/massa-id
+    :luokat ["massa-taulukko"]
     :tyhja (if (nil? massat)
              [ajax-loader "Haetaan massatyyppejä..."]
              "Urakalle ei ole vielä lisätty massoja")
     :rivi-klikattu #(e! (mk-tiedot/->MuokkaaMassaa % false))
     :voi-lisata? false :voi-kumota? false
     :voi-poistaa? (constantly false) :voi-muokata? true
-    :custom-toiminto {:teksti "Luo uusi massa"
+    :custom-toiminto {:teksti "Lisää massa"
                       :toiminto #(e! (mk-tiedot/->UusiMassa))
                       :opts {:ikoni (ikonit/livicon-plus)
-                             :luokka "napiton-nappi"}}}
+                             :luokka "nappi-ensisijainen"}}}
    [{:otsikko "Nimi" :tyyppi :komponentti :leveys 6
      :komponentti (fn [rivi]
                     [mm-yhteiset/materiaalin-rikastettu-nimi {:tyypit (:massatyypit materiaalikoodistot)

--- a/src/cljs/harja/views/urakka/pot2/massat.cljs
+++ b/src/cljs/harja/views/urakka/pot2/massat.cljs
@@ -79,6 +79,7 @@
        (when (contains? #{3} aineen-koodi)
          {:otsikko "Tyyppi" :valinnat pot2-domain/erikseen-lisattava-fillerikiviaines
           :tyyppi :valinta :pakollinen? true
+          :valinta-nayta #(or % yleiset/valitse-text)
           :arvo fillerityyppi :leveys "150px"
           :polku (conj polun-avaimet :runkoaine/fillerityyppi)})
        (when-not (contains? #{3 7} aineen-koodi)
@@ -94,7 +95,7 @@
           :validoi-kentta-fn (fn [numero] (v/validoi-numero numero 0 40 1))
           :polku (conj polun-avaimet :runkoaine/litteysluku)})
        (when (contains? #{7} aineen-koodi)
-         {:otsikko "Kuvaus" :placeholder "Anna ainetta kuvaava nimi"
+         {:otsikko "Kuvaus" :placeholder "Aineen nimi"
           :tyyppi :string :pakollinen? true
           :arvo kuvaus :leveys "160px"
           :polku (conj polun-avaimet :runkoaine/kuvaus)})

--- a/src/cljs/harja/views/urakka/pot2/massat.cljs
+++ b/src/cljs/harja/views/urakka/pot2/massat.cljs
@@ -439,4 +439,7 @@
     {:otsikko "" :nimi :toiminnot :tyyppi :komponentti :leveys 3
      :komponentti (fn [rivi]
                     [mm-yhteiset/materiaalirivin-toiminnot e! rivi])}]
-   massat])
+   (sort-by (fn [massa]
+              (pot2-domain/massan-rikastettu-nimi (:massatyypit materiaalikoodistot)
+                                                  massa))
+            massat)])

--- a/src/cljs/harja/views/urakka/pot2/massat.cljs
+++ b/src/cljs/harja/views/urakka/pot2/massat.cljs
@@ -427,6 +427,10 @@
                     [mm-yhteiset/materiaalin-rikastettu-nimi {:tyypit (:massatyypit materiaalikoodistot)
                                                               :materiaali rivi
                                                               :fmt :komponentti}])}
+    {:otsikko "KM-lk." :nimi ::pot2-domain/kuulamyllyluokka :leveys 2}
+    {:otsikko "RC%" :nimi ::pot2-domain/rc% :leveys 2
+     :hae (fn [massa]
+            (pot2-domain/massan-rc-pitoisuus massa))}
     {:otsikko "Runkoaineet" :nimi ::pot2-domain/runkoaineet :fmt #(or % "-") :tyyppi :komponentti :leveys 6
      :komponentti (fn [rivi]
                     [massan-runkoaineet rivi (:runkoainetyypit materiaalikoodistot)])}

--- a/src/cljs/harja/views/urakka/pot2/materiaalikirjasto.cljs
+++ b/src/cljs/harja/views/urakka/pot2/materiaalikirjasto.cljs
@@ -37,7 +37,8 @@
    [murskeet/murskeet-taulukko e! app]
    ;; spacer, jotta alimpien rivien pop up ei piiloudu. Voi olla että voidaan poistaa kunhan murskeiden hallionta on tehty
    [:div {:style {:height "100px"}}]
-   [napit/sulje #(swap! mk-tiedot/nayta-materiaalikirjasto? not)]])
+   [napit/sulje "Sulje kirjasto"
+    #(swap! mk-tiedot/nayta-materiaalikirjasto? not)]])
 
 (defn materiaalikirjasto [e! app]
   (komp/luo
@@ -58,9 +59,17 @@
          [urakan-materiaalit e! app])
        [debug app {:otsikko "TUCK STATE"}]])))
 
+(def materiaalikirjaston-otsikon-text
+  "Voit käyttää materiaalikirjastoon lisättyjä massoja ja murskeita kaikissa urakan päällystysilmoituksissa.")
+
 (defn materiaalikirjasto-modal [e! app]
   [modal/modal
-   {:otsikko (str "Urakan materiaalikirjasto - " (:nimi @nav/valittu-urakka))
+   {:otsikko "Materiaalikirjasto"
+    :otsikon-alle-komp (fn []
+                         [:span
+                          [:div.fontti-14-vaaleampi {:style {:margin-bottom "24px"}}
+                           (str (:nimi @nav/valittu-urakka))]
+                          [:div.fontti-14 materiaalikirjaston-otsikon-text]])
     :luokka "materiaalikirjasto-modal"
     :nakyvissa? @mk-tiedot/nayta-materiaalikirjasto?
     :sulje-fn #(cond

--- a/src/cljs/harja/views/urakka/pot2/materiaalikirjasto.cljs
+++ b/src/cljs/harja/views/urakka/pot2/materiaalikirjasto.cljs
@@ -72,14 +72,19 @@
                           [:div.fontti-14 materiaalikirjaston-otsikon-text]])
     :luokka "materiaalikirjasto-modal"
     :nakyvissa? @mk-tiedot/nayta-materiaalikirjasto?
-    :sulje-fn #(cond
-                 (:pot2-massa-lomake app)
-                 (e! (mk-tiedot/->TyhjennaLomake))
+    :sulje-ruksista-fn #(cond
+                          (:pot2-massa-lomake app)
+                          (e! (mk-tiedot/->TyhjennaLomake))
 
-                 (:pot2-murske-lomake app)
-                 (e! (mk-tiedot/->SuljeMurskeLomake))
+                          (:pot2-murske-lomake app)
+                          (e! (mk-tiedot/->SuljeMurskeLomake))
 
-                 :else
+                          :else
+                          (swap! mk-tiedot/nayta-materiaalikirjasto? not))
+    :sulje-fn #(when
+                 (and (not (:pot2-massa-lomake app))
+                      (not (:pot2-murske-lomake app)))
+
                  (swap! mk-tiedot/nayta-materiaalikirjasto? not))}
    [:div
     [materiaalikirjasto e! app]]])

--- a/src/cljs/harja/views/urakka/pot2/murskeet.cljs
+++ b/src/cljs/harja/views/urakka/pot2/murskeet.cljs
@@ -173,4 +173,7 @@
     {:otsikko "" :nimi :toiminnot :tyyppi :komponentti :leveys 4
      :komponentti (fn [rivi]
                     [mm-yhteiset/materiaalirivin-toiminnot e! rivi])}]
-   murskeet])
+   (sort-by (fn [murske]
+              (pot2-domain/murskeen-rikastettu-nimi (:mursketyypit materiaalikoodistot)
+                                                    murske))
+            murskeet)])

--- a/src/cljs/harja/views/urakka/pot2/murskeet.cljs
+++ b/src/cljs/harja/views/urakka/pot2/murskeet.cljs
@@ -169,7 +169,6 @@
     {:otsikko "Kiviaines\u00ADesiintymä" :nimi ::pot2-domain/esiintyma :tyyppi :string :muokattava? (constantly false) :leveys 8}
     {:otsikko "Rakei\u00ADsuus" :nimi ::pot2-domain/rakeisuus :tyyppi :string :muokattava? (constantly false) :leveys 4}
     {:otsikko "Iskun\u00ADkestävyys" :nimi ::pot2-domain/iskunkestavyys :tyyppi :string :muokattava? (constantly false) :leveys 4}
-    {:otsikko "DoP" :nimi ::pot2-domain/dop-nro :tyyppi :string :muokattava? (constantly false) :leveys 4}
     {:otsikko "" :nimi :toiminnot :tyyppi :komponentti :leveys 4
      :komponentti (fn [rivi]
                     [mm-yhteiset/materiaalirivin-toiminnot e! rivi])}]

--- a/src/cljs/harja/views/urakka/pot2/murskeet.cljs
+++ b/src/cljs/harja/views/urakka/pot2/murskeet.cljs
@@ -166,7 +166,10 @@
     {:otsikko "Tyyppi" :tyyppi :string :muokattava? (constantly false) :leveys 6
      :hae (fn [rivi]
             (pot2-domain/ainetyypin-koodi->nimi (:mursketyypit materiaalikoodistot) (::pot2-domain/tyyppi rivi)))}
-    {:otsikko "Kiviaines\u00ADesiintymä" :nimi ::pot2-domain/esiintyma :tyyppi :string :muokattava? (constantly false) :leveys 8}
+    {:otsikko "Esiintymä / Lähde" :nimi :esiintyma-tai-lahde :tyyppi :string :muokattava? (constantly false) :leveys 8
+     :hae (fn [rivi]
+            (or (::pot2-domain/esiintyma rivi)
+                (::pot2-domain/lahde rivi)))}
     {:otsikko "Rakei\u00ADsuus" :nimi ::pot2-domain/rakeisuus :tyyppi :string :muokattava? (constantly false) :leveys 4}
     {:otsikko "Iskun\u00ADkestävyys" :nimi ::pot2-domain/iskunkestavyys :tyyppi :string :muokattava? (constantly false) :leveys 4}
     {:otsikko "" :nimi :toiminnot :tyyppi :komponentti :leveys 4

--- a/src/cljs/harja/views/urakka/pot2/murskeet.cljs
+++ b/src/cljs/harja/views/urakka/pot2/murskeet.cljs
@@ -154,10 +154,10 @@
     :rivi-klikattu #(e! (mk-tiedot/->MuokkaaMursketta % false))
     :voi-lisata? false :voi-kumota? false
     :voi-poistaa? (constantly false) :voi-muokata? true
-    :custom-toiminto {:teksti "Luo uusi murske"
+    :custom-toiminto {:teksti "Lisää murske"
                       :toiminto #(e! (mk-tiedot/->UusiMurske))
                       :opts {:ikoni (ikonit/livicon-plus)
-                             :luokka "napiton-nappi"}}}
+                             :luokka "nappi-ensisijainen"}}}
    [{:otsikko "Nimi" :tyyppi :komponentti :leveys 8
      :komponentti (fn [rivi]
                     [mm-yhteiset/materiaalin-rikastettu-nimi {:tyypit (:mursketyypit materiaalikoodistot)

--- a/src/cljs/harja/views/urakka/pot2/murskeet.cljs
+++ b/src/cljs/harja/views/urakka/pot2/murskeet.cljs
@@ -165,7 +165,10 @@
                                                               :fmt :komponentti}])}
     {:otsikko "Tyyppi" :tyyppi :string :muokattava? (constantly false) :leveys 6
      :hae (fn [rivi]
-            (pot2-domain/ainetyypin-koodi->nimi (:mursketyypit materiaalikoodistot) (::pot2-domain/tyyppi rivi)))}
+            (or
+              (::pot2-domain/tyyppi-tarkenne rivi)
+              (pot2-domain/ainetyypin-koodi->nimi (:mursketyypit materiaalikoodistot)
+                                                  (::pot2-domain/tyyppi rivi))))}
     {:otsikko "Esiintymä / Lähde" :nimi :esiintyma-tai-lahde :tyyppi :string :muokattava? (constantly false) :leveys 8
      :hae (fn [rivi]
             (or (::pot2-domain/esiintyma rivi)

--- a/src/cljs/harja/views/urakka/pot2/pot2_lomake.cljs
+++ b/src/cljs/harja/views/urakka/pot2/pot2_lomake.cljs
@@ -104,16 +104,34 @@
                                     :tr-loppuosa :tr-loppuosa
                                     :tr-loppuetaisyys :tr-loppuetaisyys}}]}})
 
+(def materiaalikirjasto-tyhja-txt
+  "Päällystysilmoitusta on uudistettu. Nyt urakoissa käytetyt massat ja murkseet syötetään ensin materiaalikirjastoon.
+  Sen jälkeen niitä voi lisätä kulutuskerroksen ja alustan riveille. Aloita siis menemällä materiaalikirjastoon ao. painikkeesta, kiitos.")
+
+(def materiaalikirjasto-napin-tooltip
+  "Urakan materiaalikirjastoon syötetään urakan päällystystöissä käytetyt massat ja murskeet.")
+
+(defn avaa-materiaalikirjasto-nappi [toiminto tyyli]
+  [yleiset/wrap-if true
+   [yleiset/tooltip {} :% materiaalikirjasto-napin-tooltip]
+   [napit/nappi "Muokkaa urakan materiaaleja"
+   toiminto
+   {:ikoni (ikonit/livicon-pen)
+    :luokka "nappi-toissijainen"
+    :style (merge {:margin-left "0"}
+                  tyyli)}]])
+
 (defn- toimenpiteet-ja-materiaalit-otsikkorivi
   "Toimenpiteiden ja materiaalien otsikkorivi, jossa joitakin toimintoja"
-  [e!]
-  [:div
-   [napit/nappi "Muokkaa urakan materiaaleja"
-    #(e! (mk-tiedot/->NaytaModal true))
-    {:ikoni (ikonit/livicon-pen)
-     :luokka "napiton-nappi"
-     :style {:background-color "#fafafa"
-             :margin-left "0"}}]])
+  [e! massat murskeet]
+  (let [materiaalikirjasto-tyhja? (and (empty? massat)
+                                       (empty? murskeet))]
+    [:div
+     (when materiaalikirjasto-tyhja?
+       [:div {:style {:margin-top "24px"
+                      :margin-bottom "24px"}}
+        [yleiset/vihje materiaalikirjasto-tyhja-txt]])
+     [avaa-materiaalikirjasto-nappi #(e! (mk-tiedot/->NaytaModal true))]]))
 
 (defn lisatiedot
   [e! lisatiedot-atom]
@@ -194,7 +212,7 @@
            [pot-yhteinen/paallystysilmoitus-perustiedot
             e! perustiedot-app urakka false muokkaa! pot2-validoinnit huomautukset]
            [:hr]
-           [toimenpiteet-ja-materiaalit-otsikkorivi e!]
+           [toimenpiteet-ja-materiaalit-otsikkorivi e! massat murskeet]
            [yleiset/valitys-vertical]
            [paallystekerros/paallystekerros e! paallystekerros-app {:massat massat
                                                                     :materiaalikoodistot materiaalikoodistot

--- a/src/cljs/harja/views/urakka/pot2/pot2_lomake.cljs
+++ b/src/cljs/harja/views/urakka/pot2/pot2_lomake.cljs
@@ -105,7 +105,7 @@
                                     :tr-loppuetaisyys :tr-loppuetaisyys}}]}})
 
 (def materiaalikirjasto-tyhja-txt
-  "Päällystysilmoitusta on uudistettu. Nyt urakoissa käytetyt massat ja murkseet syötetään ensin materiaalikirjastoon.
+  "Päällystysilmoitusta on uudistettu. Urakoissa käytetyt massat ja murkseet syötetään ensin materiaalikirjastoon.
   Sen jälkeen niitä voi lisätä kulutuskerroksen ja alustan riveille. Aloita siis menemällä materiaalikirjastoon ao. painikkeesta, kiitos.")
 
 (def materiaalikirjasto-napin-tooltip

--- a/tietokanta/src/main/resources/db/migration/V1_878__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_878__.sql
@@ -1,0 +1,2 @@
+DELETE FROM pot2_mk_massatyyppi WHERE nimi =  'Pehmeät asfalttibetonit';
+DELETE FROM pot2_mk_massatyyppi WHERE nimi =  'Kovat asfalttibetonit';


### PR DESCRIPTION
VHAR-4393
Opasta käyttäjää materiaalikirjastoon, jos ei ole yhtään massaa eikä mursketta tehtynä


VHAR-4361
Läpi Harjan taulkoiden: Taulukon riveillä pystytasaus solun yläreunaan (ei keskitystä)

 VHAR-4363 Alustataul. riveille hover kohtaan, josta lomake aukeaa

 VHAR-4358 Korosta solun lisäksi myös rivi, jolle kirjoitetaan

VHAR-4375 Harja taulukot: padding 16px, tiheille 12px

 VHAR-4336 Ulkopuolelle klikkaamisen ei pitäisi sulkea editoitavaa lomaketta