### PR TITLE
VHAR-4499 Ajorata ja kaista kadonneet POT1 lukutilasta alikohdetaulukossa

### DIFF
--- a/src/cljs/harja/ui/grid/muokkaus.cljs
+++ b/src/cljs/harja/ui/grid/muokkaus.cljs
@@ -249,7 +249,8 @@
                                                   tasaus-luokka
                                                   (grid-yleiset/tiivis-tyyli skeema))
                 fmt (if (and (= tyyppi :valinta)
-                             valinta-arvo valinta-nayta)
+                             valinta-arvo valinta-nayta
+                             (not kentta-arity-3?))
                       (sisalto-kun-rivi-disabloitu-oletus-fn sarake i)
                       arvo)]))))})))
 

--- a/src/cljs/harja/views/urakka/pot2/paallyste_ja_alusta_yhteiset.cljs
+++ b/src/cljs/harja/views/urakka/pot2/paallyste_ja_alusta_yhteiset.cljs
@@ -1,9 +1,11 @@
 (ns harja.views.urakka.pot2.paallyste-ja-alusta-yhteiset
-  (:require [harja.ui.napit :as napit]
+  (:require [reagent.core :refer [atom] :as r]
+            [harja.ui.napit :as napit]
             [harja.ui.ikonit :as ikonit]
             [harja.tiedot.urakka.pot2.pot2-tiedot :as pot2-tiedot]
             [harja.tiedot.urakka.yllapitokohteet :as yllapitokohteet]
-            [harja.ui.yleiset :as yleiset]))
+            [harja.ui.yleiset :as yleiset]
+            [harja.ui.viesti :as viesti]))
 
 (def hint-kopioi-kaistoille "Lisää rivit kaikille ajo\u00ADradan kaistoille, joita ei vielä ole taulukos\u00ADsa.")
 (def hint-pilko-osoitevali "Pilko tieosoite\u00ADväli kahdeksi eri riviksi")
@@ -18,49 +20,71 @@
    :tp-tiedot 8
    :toiminnot 3})
 
+(def tarjoa-undo? (atom nil))
+(def edellinen-tila (atom nil))
+
+(defn tarjoa-toiminnon-undo [vanha-tieto tyyppi index]
+  (reset! tarjoa-undo? {:tyyppi tyyppi :index index})
+  (reset! edellinen-tila vanha-tieto)
+  (yleiset/fn-viiveella #(reset! tarjoa-undo? nil) 5000))
+
 (defn rivin-toiminnot-sarake
   [rivi osa e! app kirjoitusoikeus? rivit-atom tyyppi voi-muokata?]
   (assert (#{:alusta :paallystekerros} tyyppi) "Tyypin on oltava päällystekerros tai alusta")
-  (let [kohdeosat-muokkaa! (fn [uudet-kohdeosat-fn]
+  (let [kohdeosat-muokkaa! (fn [uudet-kohdeosat-fn index]
                              (let [vanhat-kohdeosat @rivit-atom
                                    uudet-kohdeosat (uudet-kohdeosat-fn vanhat-kohdeosat)]
+                               (tarjoa-toiminnon-undo vanhat-kohdeosat tyyppi index)
                                (swap! rivit-atom (fn [_]
                                                        uudet-kohdeosat))))
         pilko-osa-fn (fn [index tyyppi]
                        (kohdeosat-muokkaa! (fn [vanhat-kohdeosat]
                                              (if (= tyyppi :paallystekerros)
                                                (yllapitokohteet/pilko-paallystekohdeosa vanhat-kohdeosat (inc index) {})
-                                               (yllapitokohteet/lisaa-uusi-pot2-alustarivi vanhat-kohdeosat (inc index) {})))))
+                                               (yllapitokohteet/lisaa-uusi-pot2-alustarivi vanhat-kohdeosat (inc index) {})))
+                                           index))
         poista-osa-fn (fn [index]
                         (kohdeosat-muokkaa! (fn [vanhat-kohdeosat]
-                                              (yllapitokohteet/poista-kohdeosa vanhat-kohdeosat (inc index)))))]
+                                              (yllapitokohteet/poista-kohdeosa vanhat-kohdeosat (inc index)))
+                                            index))]
     (fn [rivi {:keys [index]} e! app kirjoitusoikeus? rivit-atom tyyppi voi-muokata?]
       (let [nappi-disabled? (or (not voi-muokata?)
                                 (not kirjoitusoikeus?))]
         [:span.tasaa-oikealle.pot2-rivin-toiminnot
-         [yleiset/wrap-if true
-          [yleiset/tooltip {} :% hint-kopioi-kaistoille]
-          [napit/yleinen-ensisijainen ""
-          #(e! (pot2-tiedot/->KopioiToimenpiteetTaulukossa rivi rivit-atom))
-          {:ikoni (ikonit/copy-lane-svg)
-           :disabled? nappi-disabled?
-           :luokka "napiton-nappi btn-xs"
-           :toiminto-args [rivi rivit-atom]}]]
-         [yleiset/wrap-if true
-          [yleiset/tooltip {} :% hint-pilko-osoitevali]
-          [napit/yleinen-ensisijainen ""
-           pilko-osa-fn
-           {:ikoni (ikonit/action-add)
-            :disabled nappi-disabled?
-            :luokka "napiton-nappi btn-xs"
-            :toiminto-args [index tyyppi]}]]
-         [yleiset/wrap-if true
-          [yleiset/tooltip {} :% hint-poista-rivi]
-          [napit/yleinen-ensisijainen ""
-           poista-osa-fn
-           {:ikoni (ikonit/action-delete)
-            :disabled nappi-disabled?
-            :luokka "napiton-nappi btn-xs"
-            :toiminto-args [index]}]]]))))
+         ;; vain sille riville tarjotaan undo, missä on toimintoa painettu
+         (if (and (= tyyppi (:tyyppi @tarjoa-undo?))
+                  (= index (:index @tarjoa-undo?)))
+           [:div
+            [napit/yleinen-toissijainen "Peru toiminto"
+             #(do
+                (reset! rivit-atom @edellinen-tila)
+                (reset! tarjoa-undo? nil))]]
+           [:<>
+            [yleiset/wrap-if true
+             [yleiset/tooltip {} :% hint-kopioi-kaistoille]
+             [napit/yleinen-ensisijainen ""
+              #(do
+                 (tarjoa-toiminnon-undo @rivit-atom tyyppi index)
+                 (e! (pot2-tiedot/->KopioiToimenpiteetTaulukossa rivi rivit-atom)))
+              {:ikoni (ikonit/copy-lane-svg)
+               :disabled? nappi-disabled?
+               :luokka "napiton-nappi btn-xs"
+               :toiminto-args [rivi rivit-atom]}]]
+            [yleiset/wrap-if true
+             [yleiset/tooltip {} :% hint-pilko-osoitevali]
+             [napit/yleinen-ensisijainen ""
+              pilko-osa-fn
+              {:ikoni (ikonit/action-add)
+               :disabled nappi-disabled?
+               :luokka "napiton-nappi btn-xs"
+               :toiminto-args [index tyyppi]}]]
+            [yleiset/wrap-if true
+             [yleiset/tooltip {} :% hint-poista-rivi]
+             [napit/yleinen-ensisijainen ""
+              poista-osa-fn
+              {:ikoni (ikonit/action-delete)
+               :disabled nappi-disabled?
+               :luokka "napiton-nappi btn-xs"
+               :toiminto-args [index]}]]])]))))
 
 


### PR DESCRIPTION
Korjaa regression:
VHAR-4499  Ajorata ja kaista kadonneet POT1 lukutilasta alikohdetaulukossa

Mukana tulee hieman epätäydellinen undo-toiminto
