### PR TITLE
VHAR-4555 Korjaa POT2 YHA-lähetyksestä löydetyt virheet: kuulamyllyluokka, raekoko ja pinta-ala

### DIFF
--- a/src/clj/harja/kyselyt/paallystys.sql
+++ b/src/clj/harja/kyselyt/paallystys.sql
@@ -161,13 +161,15 @@ SELECT
     pot2p.toimenpide as "pot2-tyomenetelma",
     pot2p.leveys,
     pot2p.massamenekki,
-    pot2p.pinta_ala,
+    pot2p.pinta_ala as "pinta-ala",
     pot2p.kokonaismassamaara,
     pot2p.piennar,
     pot2p.lisatieto,
     pot2p.jarjestysnro,
     um.nimen_tarkenne as "nimen-tarkenne",
     um.tyyppi as "paallystetyyppi",
+    um.max_raekoko as raekoko,
+    um.kuulamyllyluokka,
     (SELECT massaprosentti FROM pot2_mk_massan_runkoaine asfrouhe WHERE
             asfrouhe.pot2_massa_id = um.id AND
             pot2p.pot2_id = :pot2_id AND

--- a/src/clj/harja/kyselyt/paallystys.sql
+++ b/src/clj/harja/kyselyt/paallystys.sql
@@ -168,7 +168,7 @@ SELECT
     pot2p.jarjestysnro,
     um.nimen_tarkenne as "nimen-tarkenne",
     um.tyyppi as "paallystetyyppi",
-    um.max_raekoko as raekoko,
+    um.max_raekoko as "max-raekoko",
     um.kuulamyllyluokka,
     (SELECT massaprosentti FROM pot2_mk_massan_runkoaine asfrouhe WHERE
             asfrouhe.pot2_massa_id = um.id AND

--- a/src/clj/harja/palvelin/integraatiot/yha/yha_komponentti.clj
+++ b/src/clj/harja/palvelin/integraatiot/yha/yha_komponentti.clj
@@ -2,6 +2,7 @@
   (:require [com.stuartsierra.component :as component]
             [hiccup.core :refer [html]]
             [taoensso.timbre :as log]
+            [harja.domain.paallystysilmoitus :as pot-domain]
             [harja.palvelin.integraatiot.integraatiotapahtuma :as integraatiotapahtuma]
             [harja.palvelin.integraatiot.yha.sanomat
              [urakoiden-hakuvastaussanoma :as urakoiden-hakuvastaus]
@@ -150,7 +151,10 @@
 (defn hae-alikohteet [db kohde-id paallystysilmoitus]
   (let [alikohteet (q-yha-tiedot/hae-yllapitokohteen-kohdeosat db {:yllapitokohde kohde-id})
         osoitteet (if (= (:versio paallystysilmoitus) 2)
-                    (q-paallystys/hae-pot2-paallystekerrokset db {:pot2_id (:id paallystysilmoitus)})
+                    (map
+                      (fn [rivi]
+                        (assoc rivi :kuulamylly (pot-domain/kuulamylly-koodi-nimella (:kuulamyllyluokka rivi))))
+                      (q-paallystys/hae-pot2-paallystekerrokset db {:pot2_id (:id paallystysilmoitus)}))
                     (get-in paallystysilmoitus [:ilmoitustiedot :osoitteet]))]
     (mapv (fn [alikohde]
             (let [id (:id alikohde)

--- a/src/clj/harja/palvelin/integraatiot/yha/yha_komponentti.clj
+++ b/src/clj/harja/palvelin/integraatiot/yha/yha_komponentti.clj
@@ -153,7 +153,8 @@
         osoitteet (if (= (:versio paallystysilmoitus) 2)
                     (map
                       (fn [rivi]
-                        (assoc rivi :kuulamylly (pot-domain/kuulamylly-koodi-nimella (:kuulamyllyluokka rivi))))
+                        (assoc rivi :kuulamylly (pot-domain/kuulamylly-koodi-nimella (:kuulamyllyluokka rivi))
+                                    :raekoko (:max-raekoko rivi)))
                       (q-paallystys/hae-pot2-paallystekerrokset db {:pot2_id (:id paallystysilmoitus)}))
                     (get-in paallystysilmoitus [:ilmoitustiedot :osoitteet]))]
     (mapv (fn [alikohde]

--- a/test/clj/harja/palvelin/integraatiot/yha/urakan_kohteen_lahetys_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/yha/urakan_kohteen_lahetys_test.clj
@@ -179,7 +179,24 @@
            (is (= (xml/luetun-xmln-tagien-sisalto alikohteet
                                                   {:tagi :alikohde :positio 1} :paallystystoimenpide :paallystetyomenetelma)
                   ["23"]))
-
+           (is (= (xml/luetun-xmln-tagien-sisalto alikohteet
+                                                  {:tagi :alikohde :positio 0} :paallystystoimenpide :raekoko)
+                  ["16"]))
+           (is (= (xml/luetun-xmln-tagien-sisalto alikohteet
+                                                  {:tagi :alikohde :positio 1} :paallystystoimenpide :raekoko)
+                  ["16"]))
+           (is (= (xml/luetun-xmln-tagien-sisalto alikohteet
+                                                  {:tagi :alikohde :positio 0} :paallystystoimenpide :kuulamylly)
+                  ["4"])) ;; AN14
+           (is (= (xml/luetun-xmln-tagien-sisalto alikohteet
+                                                  {:tagi :alikohde :positio 1} :paallystystoimenpide :kuulamylly)
+                  ["2"])) ;; AN7
+           (is (= (xml/luetun-xmln-tagien-sisalto alikohteet
+                                                  {:tagi :alikohde :positio 0} :paallystystoimenpide :pinta-ala)
+                  ["8283"]))
+           (is (= (xml/luetun-xmln-tagien-sisalto alikohteet
+                                                  {:tagi :alikohde :positio 1} :paallystystoimenpide :pinta-ala)
+                  ["8283"]))
            (is (= (xml/luetun-xmln-tagien-sisalto alikohteet
                                                   {:tagi :alikohde :positio 0} :paallystystoimenpide :massamenekki)
                   ["333"]))


### PR DESCRIPTION
Puuttui kolme tärkeää kenttää - nyt lisätty, testit perään.