### PR TITLE
VHAR-4342
Näytä materiaalikirjastoon lisätty materiaali lukutilassa, kuten POT-lomakkeella

### DIFF
--- a/cypress/integration/pot_lomake.js
+++ b/cypress/integration/pot_lomake.js
@@ -5,8 +5,8 @@ let valitseVuosi = function (vuosi) {
     // paallystysilmoituksien näkymistä guilla ennen kuin valitaan 2017 vuosi.
     cy.get('[data-cy=paallystysilmoitukset-grid] .ajax-loader', {timeout: 10000}).should('not.be.visible')
     cy.get('[data-cy=valinnat-vuosi]').valinnatValitse({valinta: vuosi.toString()})
-    cy.get('[data-cy=paallystysilmoitukset-grid] .ajax-loader', {timeout: 10000}).should('be.visible')
-    cy.get('[data-cy=paallystysilmoitukset-grid] .ajax-loader', {timeout: 10000}).should('not.exist')
+    cy.get('[data-cy=paallystysilmoitukset-grid] .ajax-loader', {timeout: 30000}).should('be.visible')
+    cy.get('[data-cy=paallystysilmoitukset-grid] .ajax-loader').should('not.exist')
 };
 
 let avaaPaallystysIlmoitus = function (vuosi, urakka, kohteenNimi, kohteenTila) {

--- a/cypress/integration/pot_lomake.js
+++ b/cypress/integration/pot_lomake.js
@@ -5,8 +5,8 @@ let valitseVuosi = function (vuosi) {
     // paallystysilmoituksien näkymistä guilla ennen kuin valitaan 2017 vuosi.
     cy.get('[data-cy=paallystysilmoitukset-grid] .ajax-loader', {timeout: 10000}).should('not.be.visible')
     cy.get('[data-cy=valinnat-vuosi]').valinnatValitse({valinta: vuosi.toString()})
-    cy.get('[data-cy=paallystysilmoitukset-grid] .ajax-loader').should('be.visible')
-    cy.get('[data-cy=paallystysilmoitukset-grid] .ajax-loader').should('not.exist')
+    cy.get('[data-cy=paallystysilmoitukset-grid] .ajax-loader', {timeout: 10000}).should('be.visible')
+    cy.get('[data-cy=paallystysilmoitukset-grid] .ajax-loader', {timeout: 10000}).should('not.exist')
 };
 
 let avaaPaallystysIlmoitus = function (vuosi, urakka, kohteenNimi, kohteenTila) {

--- a/src/cljs/harja/ui/modal.cljs
+++ b/src/cljs/harja/ui/modal.cljs
@@ -66,7 +66,9 @@
              otsikko]
             (when otsikon-alle-komp
               [otsikon-alle-komp])])
-         [:hr.modal-header-body-space]
+         (when-not (and (empty? otsikko)
+                        (nil? otsikon-alle-komp))
+           [:hr.modal-header-body-space])
          [:div.modal-body {:style body-tyyli} sisalto]
          (when footer [:div.modal-footer footer])]]]
 

--- a/src/cljs/harja/views/urakka/pot2/alusta.cljs
+++ b/src/cljs/harja/views/urakka/pot2/alusta.cljs
@@ -51,17 +51,17 @@
         mukautetut-lisakentat {:murske {:nimi :murske
                                         :valinta-nayta (fn [murske]
                                                          (if murske
-                                                           [mm-yhteiset/materiaalin-rikastettu-nimi {:tyypit mursketyypit
-                                                                                                     :materiaali murske
-                                                                                                     :fmt :komponentti}]
+                                                           [mk-tiedot/materiaalin-rikastettu-nimi {:tyypit mursketyypit
+                                                                                                   :materiaali murske
+                                                                                                   :fmt :komponentti}]
                                                            "-"))
                                         :valinnat murskeet}
                                :massa {:nimi :massa
                                        :valinta-nayta (fn [massa]
                                                         (if massa
-                                                          [mm-yhteiset/materiaalin-rikastettu-nimi {:tyypit massatyypit
-                                                                                                    :materiaali massa
-                                                                                                    :fmt :komponentti}]
+                                                          [mk-tiedot/materiaalin-rikastettu-nimi {:tyypit massatyypit
+                                                                                                  :materiaali massa
+                                                                                                  :fmt :komponentti}]
                                                           "-"))
                                        :valinnat massat}}
         toimenpidespesifit-lisakentat (pot2-domain/alusta-toimenpidespesifit-metadata alustalomake)

--- a/src/cljs/harja/views/urakka/pot2/alusta.cljs
+++ b/src/cljs/harja/views/urakka/pot2/alusta.cljs
@@ -259,7 +259,7 @@
                                                              :else
                                                              nil)
                             {:materiaalikoodistot materiaalikoodistot}
-                            #(e! (pot2-tiedot/->NaytaMateriaalilomake rivi))])))}
+                            #(e! (pot2-tiedot/->NaytaMateriaalilomake rivi true))])))}
        {:otsikko "Toimenpiteen tie\u00ADdot" :nimi :toimenpiteen-tiedot :leveys (:tp-tiedot pot2-yhteiset/gridin-leveydet)
         :tyyppi :komponentti :muokattava? (constantly false)
         :komponentti (fn [rivi]

--- a/src/cljs/harja/views/urakka/pot2/massa_ja_murske_yhteiset.cljs
+++ b/src/cljs/harja/views/urakka/pot2/massa_ja_murske_yhteiset.cljs
@@ -17,35 +17,6 @@
 
 (def materiaali-jo-kaytossa-str "Materiaali jo käytössä: ei voida poistaa.")
 
-(defn- materiaalin-nimen-komp [{:keys [ydin tarkennukset fmt toiminto-fn]}]
-  (if (= :komponentti fmt)
-    [(if toiminto-fn :div :span)
-     {:on-click #(when toiminto-fn
-                   (do
-                     (.stopPropagation %)
-                     (toiminto-fn)))
-      :style {:cursor "pointer"}}
-     [:span.bold ydin]
-     ;; Toistaiseksi Tean kanssa sovittu 23.2.2021 ettei näytetä tarkennuksia suluissa
-     [:span tarkennukset]]
-    (str ydin tarkennukset)))
-
-(defn materiaalin-rikastettu-nimi
-  "Formatoi massan tai murskeen nimen. Jos haluat Reagent-komponentin, anna fmt = :komponentti, muuten anna :string"
-  [{:keys [tyypit materiaali fmt toiminto-fn]}]
-  ;; esim AB16 (AN15, RC40, 2020/09/1234) tyyppi (raekoko, nimen tarkenne, DoP, Kuulamyllyluokka, RC%)
-  (let [tyyppi (mk-tiedot/massatyypit-vai-mursketyypit? tyypit)
-        [ydin tarkennukset] ((if (= :massa tyyppi)
-                               pot2-domain/massan-rikastettu-nimi
-                               pot2-domain/murskeen-rikastettu-nimi)
-                             tyypit materiaali)
-        params {:ydin ydin
-                :tarkennukset tarkennukset
-                :fmt fmt :toiminto-fn toiminto-fn}]
-    (if (= fmt :komponentti)
-      [materiaalin-nimen-komp params]
-      (materiaalin-nimen-komp params))))
-
 (defn- rivityyppi-fmt [tyyppi]
   (case tyyppi
     "paallyste" "päällyste"
@@ -159,11 +130,11 @@
     [:div.pot2-materiaalin-tiedot.valinta-ja-linkki-container
      [napit/nappi "" toiminto-fn {:luokka "nappi-ikoni valinnan-vierusnappi napiton-nappi"
                                   :ikoni (ikonit/livicon-external)}]
-     [materiaalin-rikastettu-nimi {:tyypit ((if (::pot2-domain/murske-id materiaali)
-                                              :mursketyypit
-                                              :massatyypit) materiaalikoodistot)
-                                   :materiaali materiaali
-                                   :fmt :komponentti :toiminto-fn toiminto-fn}]]))
+     [mk-tiedot/materiaalin-rikastettu-nimi {:tyypit ((if (::pot2-domain/murske-id materiaali)
+                                                        :mursketyypit
+                                                        :massatyypit) materiaalikoodistot)
+                                             :materiaali materiaali
+                                             :fmt :komponentti :toiminto-fn toiminto-fn}]]))
 
 (defn materiaalirivin-toiminnot [e! rivi]
   (let [muokkaus-event (if (contains? rivi :harja.domain.pot2/murske-id)

--- a/src/cljs/harja/views/urakka/pot2/massa_lomake.cljs
+++ b/src/cljs/harja/views/urakka/pot2/massa_lomake.cljs
@@ -297,6 +297,7 @@
           [:div.massa-lomake
            [lomake/lomake
             {:muokkaa! #(e! (mk-tiedot/->PaivitaMassaLomake (lomake/ilman-lomaketietoja %)))
+             :tarkkaile-ulkopuolisia-muutoksia? true ;; massan nimen dynaaminen päivitys
              :luokka (when sivulle? "overlay-oikealla overlay-leveampi") :voi-muokata? voi-muokata?
              :sulje-fn (when sivulle? #(e! (pot2-tiedot/->SuljeMateriaalilomake)))
              :otsikko-komp (fn [data]
@@ -323,13 +324,7 @@
                                                                      :voi-muokata? voi-muokata?}])
              :vayla-tyyli? true}
             [{:otsikko "" :muokattava? (constantly false) :nimi ::pot2-domain/massan-nimi :tyyppi :string :palstoja 3
-              :piilota-label? true :vayla-tyyli? true :kentan-arvon-luokka "fontti-20"
-              :hae (fn [rivi]
-                     (if-not (::pot2-domain/tyyppi rivi)
-                       "Nimi muodostuu automaattisesti lomakkeeseen täytettyjen tietojen perusteella"
-                       (mm-yhteiset/materiaalin-rikastettu-nimi {:tyypit massatyypit
-                                                                 :materiaali rivi
-                                                                 :fmt :string})))}
+              :piilota-label? true :vayla-tyyli? true :kentan-arvon-luokka "fontti-20"}
              (when (and (not voi-muokata?)
                         (not materiaali-lukittu?))
                (mm-yhteiset/muokkaa-nappi #(e! (mk-tiedot/->AloitaMuokkaus :pot2-massa-lomake))))

--- a/src/cljs/harja/views/urakka/pot2/massat_taulukko.cljs
+++ b/src/cljs/harja/views/urakka/pot2/massat_taulukko.cljs
@@ -81,9 +81,9 @@
                              :luokka "nappi-ensisijainen"}}}
    [{:otsikko "Nimi" :tyyppi :komponentti :leveys 6
      :komponentti (fn [rivi]
-                    [mm-yhteiset/materiaalin-rikastettu-nimi {:tyypit (:massatyypit materiaalikoodistot)
-                                                              :materiaali rivi
-                                                              :fmt :komponentti}])}
+                    [mk-tiedot/materiaalin-rikastettu-nimi {:tyypit (:massatyypit materiaalikoodistot)
+                                                            :materiaali rivi
+                                                            :fmt :komponentti}])}
     {:otsikko "KM-lk." :nimi ::pot2-domain/kuulamyllyluokka :leveys 2}
     {:otsikko "RC%" :nimi ::pot2-domain/rc% :leveys 2
      :hae (fn [massa]

--- a/src/cljs/harja/views/urakka/pot2/massat_taulukko.cljs
+++ b/src/cljs/harja/views/urakka/pot2/massat_taulukko.cljs
@@ -72,7 +72,7 @@
     :tyhja (if (nil? massat)
              [ajax-loader "Haetaan massatyyppejä..."]
              "Urakalle ei ole vielä lisätty massoja")
-    :rivi-klikattu #(e! (mk-tiedot/->MuokkaaMassaa % false))
+    :rivi-klikattu #(e! (pot2-tiedot/->NaytaMateriaalilomake % false))
     :voi-lisata? false :voi-kumota? false
     :voi-poistaa? (constantly false) :voi-muokata? true
     :custom-toiminto {:teksti "Lisää massa"

--- a/src/cljs/harja/views/urakka/pot2/materiaalikirjasto.cljs
+++ b/src/cljs/harja/views/urakka/pot2/materiaalikirjasto.cljs
@@ -54,30 +54,32 @@
   "Voit käyttää materiaalikirjastoon lisättyjä massoja ja murskeita kaikissa urakan päällystysilmoituksissa.")
 
 (defn materiaalikirjasto-modal [e! app]
-  [modal/modal
-   {:otsikko "Materiaalikirjasto"
-    :otsikon-alle-komp (fn []
-                         [:span
-                          [:div.fontti-14-vaaleampi {:style {:margin-bottom "24px"}}
-                           (str (:nimi @nav/valittu-urakka))]
-                          [:div.fontti-14 materiaalikirjaston-otsikon-text]])
-    :luokka "materiaalikirjasto-modal"
-    :nakyvissa? @mk-tiedot/nayta-materiaalikirjasto?
-    :sulje-ruksista-fn #(cond
-                          (:pot2-massa-lomake app)
-                          (e! (mk-tiedot/->TyhjennaLomake))
+  (let [lomake-auki? (or (:pot2-massa-lomake app)
+                         (:pot2-murske-lomake app))]
+    [modal/modal
+     {:otsikko (if lomake-auki?
+                 ""
+                 "Materiaalikirjasto")
+      :otsikon-alle-komp (when-not lomake-auki?
+                           (fn []
+                             [:span
+                              [:div.fontti-14-vaaleampi {:style {:margin-bottom "24px"}}
+                               (str (:nimi @nav/valittu-urakka))]
+                              [:div.fontti-14 materiaalikirjaston-otsikon-text]]))
+      :luokka "materiaalikirjasto-modal"
+      :nakyvissa? @mk-tiedot/nayta-materiaalikirjasto?
+      :sulje-ruksista-fn #(cond
+                            (:pot2-massa-lomake app)
+                            (e! (mk-tiedot/->TyhjennaLomake))
 
-                          (:pot2-murske-lomake app)
-                          (e! (mk-tiedot/->SuljeMurskeLomake))
+                            (:pot2-murske-lomake app)
+                            (e! (mk-tiedot/->SuljeMurskeLomake))
 
-                          :else
-                          (swap! mk-tiedot/nayta-materiaalikirjasto? not))
-    :sulje-fn #(when
-                 (and (not (:pot2-massa-lomake app))
-                      (not (:pot2-murske-lomake app)))
-
-                 (swap! mk-tiedot/nayta-materiaalikirjasto? not))}
-   [:div
-    [materiaalikirjasto e! app]]])
+                            :else
+                            (swap! mk-tiedot/nayta-materiaalikirjasto? not))
+      :sulje-fn #(when-not lomake-auki?
+                   (swap! mk-tiedot/nayta-materiaalikirjasto? not))}
+     [:div
+      [materiaalikirjasto e! app]]]))
 
 

--- a/src/cljs/harja/views/urakka/pot2/murske_lomake.cljs
+++ b/src/cljs/harja/views/urakka/pot2/murske_lomake.cljs
@@ -44,6 +44,7 @@
           [:div.murske-lomake
            [ui-lomake/lomake
             {:muokkaa! #(e! (mk-tiedot/->PaivitaMurskeLomake (ui-lomake/ilman-lomaketietoja %)))
+             :tarkkaile-ulkopuolisia-muutoksia? true ;; murskeen nimen dynaaminen päivitys
              :luokka (when sivulle? "overlay-oikealla overlay-leveampi") :voi-muokata? voi-muokata?
              :sulje-fn (when sivulle? #(e! (mk-tiedot/->SuljeMurskeLomake)))
              :otsikko-komp (fn [data]
@@ -69,13 +70,7 @@
                                                                      :voi-muokata? voi-muokata?}])
              :vayla-tyyli? true}
             [{:otsikko "" :piilota-label? true :muokattava? (constantly false) :nimi ::pot2-domain/murskeen-nimi :tyyppi :string :palstoja 3
-              :luokka "bold" :vayla-tyyli? true :kentan-arvon-luokka "fontti-20"
-              :hae (fn [rivi]
-                     (if-not (::pot2-domain/tyyppi rivi)
-                       "Nimi muodostuu automaattisesti lomakkeeseen täytettyjen tietojen perusteella"
-                       (mm-yhteiset/materiaalin-rikastettu-nimi {:tyypit mursketyypit
-                                                                 :materiaali rivi
-                                                                 :fmt :string})))}
+              :luokka "bold" :vayla-tyyli? true :kentan-arvon-luokka "fontti-20"}
              (when (and (not voi-muokata?)
                         (not materiaali-lukittu?))
                (mm-yhteiset/muokkaa-nappi #(e! (mk-tiedot/->AloitaMuokkaus :pot2-murske-lomake))))

--- a/src/cljs/harja/views/urakka/pot2/murskeet_taulukko.cljs
+++ b/src/cljs/harja/views/urakka/pot2/murskeet_taulukko.cljs
@@ -12,7 +12,8 @@
             [harja.views.urakka.pot2.massa-ja-murske-yhteiset :as mm-yhteiset]
 
             [harja.loki :refer [log logt tarkkaile!]]
-            [harja.ui.komponentti :as komp])
+            [harja.ui.komponentti :as komp]
+            [harja.tiedot.urakka.pot2.pot2-tiedot :as pot2-tiedot])
   (:require-macros [reagent.ratom :refer [reaction]]
                    [cljs.core.async.macros :refer [go]]
                    [harja.atom :refer [reaction<!]]))
@@ -24,7 +25,7 @@
     :tyhja (if (nil? murskeet)
              [ajax-loader "Haetaan urakan murskeita..."]
              "Urakalle ei ole vielä lisätty murskeita")
-    :rivi-klikattu #(e! (mk-tiedot/->MuokkaaMursketta % false))
+    :rivi-klikattu #(e! (pot2-tiedot/->NaytaMateriaalilomake % false))
     :voi-lisata? false :voi-kumota? false
     :voi-poistaa? (constantly false) :voi-muokata? true
     :custom-toiminto {:teksti "Lisää murske"

--- a/src/cljs/harja/views/urakka/pot2/murskeet_taulukko.cljs
+++ b/src/cljs/harja/views/urakka/pot2/murskeet_taulukko.cljs
@@ -34,9 +34,9 @@
                              :luokka "nappi-ensisijainen"}}}
    [{:otsikko "Nimi" :tyyppi :komponentti :leveys 8
      :komponentti (fn [rivi]
-                    [mm-yhteiset/materiaalin-rikastettu-nimi {:tyypit (:mursketyypit materiaalikoodistot)
-                                                              :materiaali rivi
-                                                              :fmt :komponentti}])}
+                    [mk-tiedot/materiaalin-rikastettu-nimi {:tyypit (:mursketyypit materiaalikoodistot)
+                                                            :materiaali rivi
+                                                            :fmt :komponentti}])}
     {:otsikko "Tyyppi" :tyyppi :string :muokattava? (constantly false) :leveys 6
      :hae (fn [rivi]
             (or

--- a/src/cljs/harja/views/urakka/pot2/paallystekerros.cljs
+++ b/src/cljs/harja/views/urakka/pot2/paallystekerros.cljs
@@ -109,7 +109,7 @@
       {:otsikko "Pääl\u00ADlyste" :nimi :materiaali :leveys (:materiaali pot2-yhteiset/gridin-leveydet) :tayta-alas? pot2-tiedot/tayta-alas?-fn
        :tyyppi :valinta :valinnat massat :valinta-arvo ::pot2-domain/massa-id
        :linkki-fn (fn [arvo]
-                    (e! (pot2-tiedot/->NaytaMateriaalilomake {::pot2-domain/massa-id arvo})))
+                    (e! (pot2-tiedot/->NaytaMateriaalilomake {::pot2-domain/massa-id arvo} true)))
        :linkki-icon (ikonit/livicon-external)
        :valinta-nayta (fn [rivi]
                         (if (empty? massat)

--- a/src/cljs/harja/views/urakka/pot2/paallystekerros.cljs
+++ b/src/cljs/harja/views/urakka/pot2/paallystekerros.cljs
@@ -115,9 +115,9 @@
                         (if (empty? massat)
                           [:div.neutraali-tausta "Lisää massa"]
                           [:div.pot2-paallyste
-                           [mm-yhteiset/materiaalin-rikastettu-nimi {:tyypit (:massatyypit materiaalikoodistot)
-                                                                     :materiaali (pot2-tiedot/rivi->massa-tai-murske rivi {:massat massat})
-                                                                     :fmt :komponentti}]]))
+                           [mk-tiedot/materiaalin-rikastettu-nimi {:tyypit (:massatyypit materiaalikoodistot)
+                                                                   :materiaali (pot2-tiedot/rivi->massa-tai-murske rivi {:massat massat})
+                                                                   :fmt :komponentti}]]))
        :validoi [[:ei-tyhja "Anna arvo"]]}
       {:otsikko "Leveys (m)" :nimi :leveys :tyyppi :positiivinen-numero :tasaa :oikea
        :tayta-alas? pot2-tiedot/tayta-alas?-fn :desimaalien-maara 1

--- a/tietokanta/README.md
+++ b/tietokanta/README.md
@@ -16,6 +16,9 @@ sitten psql komento:
 
 > psql -h localhost -p 7777 -U flyway harja
 
+## Tietokantojen salasanat
+
+Kyselepä tiimiläisiltä. Saatat päästä eteenpäin myös tällä: HAR-4599
 
 ## Tietokannan lokitus paikallisessa Docker-kontissa. Tällä sisään kantakoneelle:
 > docker exec -it harjadb /bin/bash


### PR DESCRIPTION
Tämä pullero sisältää käytännössä kaksi taskia
-VHAR 4342 tarjoaa materiaalikirjaston massa- ja murskelomakkeiden tarkastelun lukutilassa. Tätä varten NaytaMateriaalilomake Tuck-eventtiä on modattu tukemaan sivulle? parametriä, koska mat. kirjaston tapauksessa lomake avataan keskelle modaalia isona, kun taas pot-lomakkeella se avataan sivulle kapeana.
-VHAR 4346 tekee pienen mutta tärkeän muutoksen: massan / murskeen nimi päivitetään dynaamisesti lomakkeen täytön aikana. Nimi on kombinaatio lomakkeen tiedoista, ja on hyvä että käyttäjä näkee reaaliajassa mikä nimeksi tulee muodostumaan, ja tallennuksen jälkeen nimi vastaa sitten otsikossa koko ajan ajantasalla olevaa nimeä