### PR TITLE
VHAR-4271: Status-rajapintojen parannuksia

### DIFF
--- a/src/clj/harja/palvelin/palvelut/status.clj
+++ b/src/clj/harja/palvelin/palvelut/status.clj
@@ -182,7 +182,12 @@
       (GET "/app_status" _
         (let [testit (async/merge
                        [(harjan-tila komponenttien-tila)])
-              {:keys [status] :as lahetettava-viesti} (koko-status testit)]
+              {:keys [status] :as lahetettava-viesti} (koko-status testit)
+              ;; Lähetä "Harja ok" tyhjän viestin sijasta, mikäli harjan tila on OK.
+              ;;  Jos jotakin on pielessä, niin koko-status fn kokoaa virheviestit lähetettäväksi.
+              lahetettava-viesti  (if (= 200 status)
+                                    (assoc lahetettava-viesti :viesti "Harja ok")
+                                    lahetettava-viesti)]
           {:status status
            :headers {"Content-Type" "application/json; charset=UTF-8"}
            :body (encode
@@ -196,7 +201,8 @@
           {:status (if harja-ok? 200 503)
            :headers {"Content-Type" "application/json; charset=UTF-8"}
            :body (encode
-                   {:viesti "Harja ok"})})))
+                   ;; Jos harja ei ole OK, lähetä vain tyhjä viesti.
+                   {:viesti (if harja-ok? "Harja ok" "")})})))
     this)
 
   (stop [{http :http-palvelin :as this}]

--- a/test/clj/harja/palvelin/palvelut/status_test.clj
+++ b/test/clj/harja/palvelin/palvelut/status_test.clj
@@ -112,3 +112,48 @@
               :yhteys-master-kantaan-ok? true
               :replikoinnin-tila-ok? true}))
       (is (= (get vastaus :status) 200)))))
+
+
+(deftest toimiiko-app-status
+  (testing "Kaikki hienosti"
+    (let [vastaus (tyokalut/get-kutsu ["/app_status"] +kayttaja-jvh+ nil {:timeout 1000} portti)]
+      (is (= (-> vastaus :body (cheshire/decode true))
+            {:viesti "Harja ok"}))
+      (is (= (get vastaus :status) 200))))
+  (testing "harja ei ole ok"
+    (with-redefs [status/harjan-tila-ok? (fn [& _] (async/go false))]
+      (println (swap! (-> jarjestelma :komponenttien-tila :komponenttien-tila)
+                 (fn [tila]
+                   (-> tila
+                     (assoc-in [tapahtuma-apurit/host-nimi :harja :kaikki-ok?] false)
+                     (assoc-in [tapahtuma-apurit/host-nimi :harja :viesti] "poks")))))
+      (let [vastaus (tyokalut/get-kutsu ["/app_status"] +kayttaja-jvh+ nil {:timeout 1000} portti)]
+        (is (= (-> vastaus :body (cheshire/decode true))
+              {:viesti (format "HOST: %s\nVIESTI: poks\nHOST: testihost\nVIESTI: kaik kivast" tapahtuma-apurit/host-nimi)}))
+        (is (= (get vastaus :status) 503)))
+      (println (swap! (-> jarjestelma :komponenttien-tila :komponenttien-tila)
+                 assoc-in
+                 [tapahtuma-apurit/host-nimi :harja :kaikki-ok?]
+                 true)))))
+
+
+(deftest toimiiko-app-status-local
+  (testing "Kaikki hienosti"
+    (let [vastaus (tyokalut/get-kutsu ["/app_status_local"] +kayttaja-jvh+ nil {:timeout 1000} portti)]
+      (is (= (-> vastaus :body (cheshire/decode true))
+            {:viesti "Harja ok"}))
+      (is (= (get vastaus :status) 200))))
+  ;; Testi poistettu käytöstä, koska rajapinnan sisäinen timeout failure-responsen lähettämiselle on liian korkea (10 sec)
+  #_(testing "harja ei ole ok"
+    (println (swap! (-> jarjestelma :komponenttien-tila :komponenttien-tila)
+               (fn [tila]
+                 (-> tila
+                   (assoc-in [tapahtuma-apurit/host-nimi :harja :kaikki-ok?] false)))))
+    (let [vastaus (tyokalut/get-kutsu ["/app_status_local"] +kayttaja-jvh+ nil {:timeout 20000} portti)]
+      (is (= (-> vastaus :body (cheshire/decode true))
+            {:viesti ""}))
+      (is (= (get vastaus :status) 503)))
+    (println (swap! (-> jarjestelma :komponenttien-tila :komponenttien-tila)
+               assoc-in
+               [tapahtuma-apurit/host-nimi :harja :kaikki-ok?]
+               true))))


### PR DESCRIPTION
Lähetä app_status rajapinnasta "Harja ok" viesti, jos kaikki on ok.
* Korjattu lisäksi app_status_local-rajapinnasta ajatusvirhe:
  * Jos harja ei ole OK, niin ei lähetetä enää "Harja ok"-viestiä, vaan
tyhjä string.
  * app_status_local-rajapintaa ei tämän hetken tietojen mukaan
monitoroida.
* Lisätty testejä app_status ja app_status_local rajapinnoille.