### PR TITLE
VHAR-4362 Alustataulukkoon Mahdollisuus järjestää sisältöä

### DIFF
--- a/dev-resources/less/grid.less
+++ b/dev-resources/less/grid.less
@@ -695,3 +695,18 @@ span.ajax-loader-pisteet {
 .gridin-fonttikoko {
   font-size: @fontin-koko-leipateksti;
 }
+.muokkaus-grid-sort-nappi {
+  &.nappi-ikoni {
+    width: unset;
+    border: none;
+  }
+  &.valittu-sort {
+    border: 1px solid @black;
+  }
+  padding: 0;
+  margin-left: 8px;
+  > span > img {
+    width: 1rem;
+    height: 1rem;
+  }
+}

--- a/src/clj/harja/palvelin/palvelut/yllapitokohteet/pot2.clj
+++ b/src/clj/harja/palvelin/palvelut/yllapitokohteet/pot2.clj
@@ -55,8 +55,7 @@
 
 (defn hae-urakan-massat-ja-murskeet [db user {:keys [urakka-id]}]
   (oikeudet/vaadi-lukuoikeus oikeudet/urakat-kohdeluettelo-paallystysilmoitukset user urakka-id)
-  (let [_ (println "hae-urakan-pot2-massat :: urakka-id" (pr-str urakka-id))
-        massat
+  (let [massat
         (->> (fetch db
                     ::pot2-domain/pot2-mk-urakan-massa
                     #{::pot2-domain/massa-id

--- a/src/cljc/harja/domain/yllapitokohde.cljc
+++ b/src/cljc/harja/domain/yllapitokohde.cljc
@@ -548,6 +548,18 @@ yllapitoluokkanimi->numero
           vec
           sort))))
 
+(defn sailyta-idt-jos-sama-tr-osoite
+  [rivi-ja-kopiot rivit-atomista]
+  (let [rivit (map (fn [rivi]
+                     (let [vastaava-rivi (some #(when (tr-domain/sama-tr-osoite? rivi %)
+                                                  %)
+                                               rivit-atomista)]
+                       (assoc rivi :kohdeosa-id (:kohdeosa-id vastaava-rivi)
+                                   :pot2a_id (:pot2a_id vastaava-rivi)
+                                   :pot2p_id (:pot2p_id vastaava-rivi)
+                                   :nimi (:nimi vastaava-rivi))))
+                   rivi-ja-kopiot)]
+    rivit))
 
 (defn validoi-kohde
   "Tarkistaa, että annettu pääkohde on validi."

--- a/src/cljc/harja/domain/yllapitokohde.cljc
+++ b/src/cljc/harja/domain/yllapitokohde.cljc
@@ -549,11 +549,14 @@ yllapitoluokkanimi->numero
           sort))))
 
 (defn sailyta-idt-jos-sama-tr-osoite
+  "Funktiota käytetään kun kopioidaan rivejä eri kaistoille. Jos tunnistetaan että ko. rivi on jo taulukossa (tasan sama TR-osoite), säilytetään keskeiset tiedot eli avaimet ja alikohteen nimi."
   [rivi-ja-kopiot rivit-atomista]
   (let [rivit (map (fn [rivi]
                      (let [vastaava-rivi (some #(when (tr-domain/sama-tr-osoite? rivi %)
                                                   %)
                                                rivit-atomista)]
+                       ;; funktio on siksi geneerinen, että se toimii sekä päällyste- että alustariveille
+                       ;; on turvallista assocata päällysteriveille alustaid:ksi nil ja vice versa.
                        (assoc rivi :kohdeosa-id (:kohdeosa-id vastaava-rivi)
                                    :pot2a_id (:pot2a_id vastaava-rivi)
                                    :pot2p_id (:pot2p_id vastaava-rivi)

--- a/src/cljs/harja/tiedot/urakka/pot2/materiaalikirjasto.cljs
+++ b/src/cljs/harja/tiedot/urakka/pot2/materiaalikirjasto.cljs
@@ -177,7 +177,7 @@
   "Materiaalin nimi voidaan esittää joko Reagent-komponenttina tai stringinä (default), käyttötapauksesta riippuen."
   [{:keys [ydin tarkennukset fmt toiminto-fn]}]
   (if (= :komponentti fmt)
-    [(if toiminto-fn :div :span) ;; Jos toiminto-fn annetaan, kääritään kompoinentti diviin, muuten spaniin.
+    [(if toiminto-fn :div :span) ;; Jos toiminto-fn annetaan, kääritään komponentti diviin, muuten spaniin.
      {:on-click #(when toiminto-fn
                    (do
                      (.stopPropagation %)

--- a/src/cljs/harja/tiedot/urakka/pot2/materiaalikirjasto.cljs
+++ b/src/cljs/harja/tiedot/urakka/pot2/materiaalikirjasto.cljs
@@ -173,9 +173,11 @@
 (def uusi-murske-map
   {::pot2-domain/murskeen-nimi uuden-materiaalin-nimen-vihje})
 
-(defn- materiaalin-nimen-komp [{:keys [ydin tarkennukset fmt toiminto-fn]}]
+(defn- materiaalin-nimen-komp
+  "Materiaalin nimi voidaan esittää joko Reagent-komponenttina tai stringinä (default), käyttötapauksesta riippuen."
+  [{:keys [ydin tarkennukset fmt toiminto-fn]}]
   (if (= :komponentti fmt)
-    [(if toiminto-fn :div :span)
+    [(if toiminto-fn :div :span) ;; Jos toiminto-fn annetaan, kääritään kompoinentti diviin, muuten spaniin.
      {:on-click #(when toiminto-fn
                    (do
                      (.stopPropagation %)

--- a/src/cljs/harja/tiedot/urakka/pot2/pot2_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/pot2/pot2_tiedot.cljs
@@ -54,6 +54,13 @@
 (defn onko-alustatoimenpide-verkko? [koodi]
   (= koodi 3))
 
+(defn toimenpiteen-teksti
+  [rivi materiaalikoodistot alusta-toimenpiteet]
+  (if (onko-alustatoimenpide-verkko? (:toimenpide rivi))
+    (pot2-domain/ainetyypin-koodi->nimi (:verkon-tyypit materiaalikoodistot) (:verkon-tyyppi rivi))
+    (pot2-domain/ainetyypin-koodi->lyhenne alusta-toimenpiteet (:toimenpide rivi))))
+
+
 (defn toimenpiteen-tiedot
   [{:keys [koodistot]} rivi]
   (fn [{:keys [koodistot]} rivi]
@@ -101,10 +108,18 @@
                         %)
                      massat)))))
 
-(defn jarjesta-rivit-tieos-mukaan [rivit]
+(defn- jarjesta-rivit-tieos-mukaan [rivit]
   (-> rivit
       (yllapitokohteet-domain/jarjesta-yllapitokohteet)
       (yllapitokohteet-domain/indeksoi-kohdeosat)))
+
+(defn jarjesta-ja-indeksoi-atomin-rivit
+  [rivit-atom sort-fn]
+  (reset! rivit-atom
+          (yllapitokohteet-domain/indeksoi-kohdeosat
+            (sort-by sort-fn (vals @rivit-atom)))))
+
+(def valittu-alustan-sort (atom :tieosoite))
 
 (extend-protocol tuck/Event
 

--- a/src/cljs/harja/tiedot/urakka/pot2/pot2_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/pot2/pot2_tiedot.cljs
@@ -101,18 +101,13 @@
                         %)
                      massat)))))
 
-(defn- jarjesta-rivit-tieos-mukaan [rivit]
-  (-> rivit
-      (yllapitokohteet-domain/jarjesta-yllapitokohteet)
-      (yllapitokohteet-domain/indeksoi-kohdeosat)))
-
 (defn jarjesta-ja-indeksoi-atomin-rivit
   [rivit-atom sort-fn]
   (reset! rivit-atom
           (yllapitokohteet-domain/indeksoi-kohdeosat
             (sort-by sort-fn (vals @rivit-atom)))))
 
-(defn- jarjesta-rivit-fn-mukaan-rivit [sort-fn rivit]
+(defn- jarjesta-rivit-fn-mukaan [sort-fn rivit]
   (yllapitokohteet-domain/indeksoi-kohdeosat
     (sort-by sort-fn rivit)))
 
@@ -274,7 +269,7 @@
           rivit-ja-kopiot (->> haettavat-rivit
                                (into {})
                                vals
-                               (jarjesta-rivit-fn-mukaan-rivit
+                               (jarjesta-rivit-fn-mukaan
                                  (fn [rivi]
                                    (jarjesta-valitulla-sort-funktiolla @valittu-alustan-sort {:massat (:massat app)
                                                                           :murskeet (:murskeet app)
@@ -312,7 +307,7 @@
           alusta-params-ilman-ylimaaraisia (apply
                                              dissoc alusta-params ylimaaraiset-avaimet)
           uusi-rivi {uusi-id alusta-params-ilman-ylimaaraisia}
-          rivit (jarjesta-rivit-fn-mukaan-rivit
+          rivit (jarjesta-rivit-fn-mukaan
                   (fn [rivi]
                     (jarjesta-valitulla-sort-funktiolla @valittu-alustan-sort {:massat (:massat app)
                                                                                :murskeet (:murskeet app)

--- a/src/cljs/harja/ui/grid/muokkaus.cljs
+++ b/src/cljs/harja/ui/grid/muokkaus.cljs
@@ -414,14 +414,21 @@
    [:tr
     (if rivinumerot? [:th {:width "40px"} " "])
     (map-indexed
-      (fn [i {:keys [otsikko yksikko leveys nimi tasaa]}]
+      (fn [i {:keys [otsikko yksikko leveys nimi tasaa sarake-sort]}]
         ^{:key (str i nimi)}
         [:th {:width (or leveys "5%")
               :class (y/luokat (y/tasaus-luokka tasaa)
                                (grid-yleiset/tiivis-tyyli skeema))}
          otsikko
          (when yksikko
-           [:span.kentan-yksikko yksikko])]) skeema)
+           [:span.kentan-yksikko yksikko])
+         (when sarake-sort
+           [napit/nappi "" (:fn sarake-sort)
+            {:luokka (y/luokat "muokkaus-grid-sort-nappi"
+                               (:luokka sarake-sort))
+             :ikoninappi? true
+             :ikoni [ikonit/navigation-down]}])])
+      skeema)
     (when-not piilota-toiminnot?
       [:th.toiminnot {:width "40px"} " "])]])
 

--- a/src/cljs/harja/views/urakka/pot2/alusta.cljs
+++ b/src/cljs/harja/views/urakka/pot2/alusta.cljs
@@ -180,9 +180,6 @@
                                    :koodistot materiaalikoodistot})
           alustalomake]]))))
 
-
-(def +nil-materiaalin-sort-str+ "zzz") ;; alustarivit joista materiaali puuttuu, menevät taulukon hännille
-
 (defn alusta
   "Alikohteiden päällysteiden alustakerroksen rivien muokkaus"
   [e! {:keys [kirjoitusoikeus? perustiedot alustalomake tr-osien-pituudet] :as app}
@@ -216,18 +213,27 @@
         :tyyppi :string :leveys (:toimenpide pot2-yhteiset/gridin-leveydet)
         :sarake-sort {:fn (fn [rivi]
                             (reset! pot2-tiedot/valittu-alustan-sort :toimenpide)
-                            (pot2-tiedot/jarjesta-ja-indeksoi-atomin-rivit alustarivit-atom
-                                                                           (fn [rivi]
-                                                                             (pot2-tiedot/toimenpiteen-teksti rivi materiaalikoodistot alusta-toimenpiteet))))
+                            (pot2-tiedot/jarjesta-ja-indeksoi-atomin-rivit
+                              alustarivit-atom
+                              (fn [rivi]
+                                (pot2-tiedot/jarjesta-valitulla-sort-funktiolla @pot2-tiedot/valittu-alustan-sort {:massat massat
+                                                                                               :murskeet murskeet
+                                                                                               :materiaalikoodistot materiaalikoodistot}
+                                                                                rivi))))
                       :luokka (when (= @pot2-tiedot/valittu-alustan-sort :toimenpide) "valittu-sort")}
-        :hae #(pot2-tiedot/toimenpiteen-teksti % materiaalikoodistot alusta-toimenpiteet)
+        :hae #(pot2-tiedot/toimenpiteen-teksti % materiaalikoodistot)
         :validoi [[:ei-tyhja "Anna arvo"]]}
        {:otsikko "Tie" :tyyppi :positiivinen-numero :tasaa :oikea :kokonaisluku? true
         :leveys (:perusleveys pot2-yhteiset/gridin-leveydet) :nimi :tr-numero :validoi (:tr-numero validointi)
         :sarake-sort {:fn (fn [rivi]
                             (reset! pot2-tiedot/valittu-alustan-sort :tieosoite)
-                            (pot2-tiedot/jarjesta-ja-indeksoi-atomin-rivit alustarivit-atom
-                                                                           yllapitokohteet-domain/yllapitokohteen-jarjestys))
+                            (pot2-tiedot/jarjesta-ja-indeksoi-atomin-rivit
+                              alustarivit-atom
+                              (fn [rivi]
+                                (pot2-tiedot/jarjesta-valitulla-sort-funktiolla @pot2-tiedot/valittu-alustan-sort {:massat massat
+                                                                                               :murskeet murskeet
+                                                                                               :materiaalikoodistot materiaalikoodistot}
+                                                                                rivi))))
                       :luokka (when (= @pot2-tiedot/valittu-alustan-sort :tieosoite) "valittu-sort")}}
        {:otsikko "Ajor." :nimi :tr-ajorata :tyyppi :valinta :leveys (:perusleveys pot2-yhteiset/gridin-leveydet) :elementin-id "alustan-ajor"
         :valinnat pot/+ajoradat-numerona+ :valinta-arvo :koodi
@@ -257,17 +263,16 @@
         :tyyppi :komponentti :muokattava? (constantly false)
         :sarake-sort {:fn (fn [rivi]
                             (reset! pot2-tiedot/valittu-alustan-sort :materiaali)
-                            (pot2-tiedot/jarjesta-ja-indeksoi-atomin-rivit alustarivit-atom
-                                                                           (fn [rivi]
-                                                                             (if-let [materiaali (mm-yhteiset/tunnista-materiaali rivi massat murskeet)]
-                                                                               (mk-tiedot/materiaalin-rikastettu-nimi {:tyypit ((if (::pot2-domain/murske-id materiaali)
-                                                                                                                                  :mursketyypit
-                                                                                                                                  :massatyypit) materiaalikoodistot)
-                                                                                                                       :materiaali materiaali})
-                                                                               +nil-materiaalin-sort-str+))))
+                            (pot2-tiedot/jarjesta-ja-indeksoi-atomin-rivit
+                              alustarivit-atom
+                              (fn [rivi]
+                                (pot2-tiedot/jarjesta-valitulla-sort-funktiolla @pot2-tiedot/valittu-alustan-sort {:massat massat
+                                                                                               :murskeet murskeet
+                                                                                               :materiaalikoodistot materiaalikoodistot}
+                                                                                rivi))))
                       :luokka (when (= @pot2-tiedot/valittu-alustan-sort :materiaali) "valittu-sort")}
         :komponentti (fn [rivi]
-                       (when-let [materiaali (mm-yhteiset/tunnista-materiaali rivi massat murskeet)]
+                       (when-let [materiaali (pot2-tiedot/tunnista-materiaali rivi massat murskeet)]
                          [mm-yhteiset/materiaalin-tiedot materiaali
                           {:materiaalikoodistot materiaalikoodistot}
                           #(e! (pot2-tiedot/->NaytaMateriaalilomake rivi true))]))}

--- a/src/cljs/harja/views/urakka/pot2/massa_ja_murske_yhteiset.cljs
+++ b/src/cljs/harja/views/urakka/pot2/massa_ja_murske_yhteiset.cljs
@@ -170,3 +170,18 @@
                   [napit/muokkaa "Muokkaa"
                    #(yleiset/fn-viiveella muokkaa-fn)
                    {:luokka "napiton-nappi"}])})
+
+(defn tunnista-materiaali
+  "Tunnistaa rivin, massojen ja murskeiden avulla, mikä massa tai murske on kyseessä."
+  [rivi massat murskeet]
+  (let [massa-id (or (:massa rivi) (:massa-id rivi))
+        murske-id (:murske rivi)]
+    (cond
+      massa-id
+      (materiaali massat {:massa-id massa-id})
+
+      murske-id
+      (materiaali murskeet {:murske-id murske-id})
+
+      :else
+      nil)))

--- a/src/cljs/harja/views/urakka/pot2/massa_ja_murske_yhteiset.cljs
+++ b/src/cljs/harja/views/urakka/pot2/massa_ja_murske_yhteiset.cljs
@@ -157,12 +157,6 @@
         :ikoninappi? true
         :ikoni (ikonit/action-copy)}]]]))
 
-(defn materiaali
-  [massat-tai-murskeet {:keys [massa-id murske-id]}]
-  (first (filter #(or (= (::pot2-domain/massa-id %) massa-id)
-                      (= (::pot2-domain/murske-id %) murske-id))
-                 massat-tai-murskeet)))
-
 (defn muokkaa-nappi [muokkaa-fn]
   {:nimi ::pot2-domain/muokkaus :otsikko "" :tyyppi :komponentti :palstoja 3
    :piilota-label? true
@@ -170,18 +164,3 @@
                   [napit/muokkaa "Muokkaa"
                    #(yleiset/fn-viiveella muokkaa-fn)
                    {:luokka "napiton-nappi"}])})
-
-(defn tunnista-materiaali
-  "Tunnistaa rivin, massojen ja murskeiden avulla, mikä massa tai murske on kyseessä."
-  [rivi massat murskeet]
-  (let [massa-id (or (:massa rivi) (:massa-id rivi))
-        murske-id (:murske rivi)]
-    (cond
-      massa-id
-      (materiaali massat {:massa-id massa-id})
-
-      murske-id
-      (materiaali murskeet {:murske-id murske-id})
-
-      :else
-      nil)))

--- a/src/cljs/harja/views/urakka/pot2/paallyste_ja_alusta_yhteiset.cljs
+++ b/src/cljs/harja/views/urakka/pot2/paallyste_ja_alusta_yhteiset.cljs
@@ -54,11 +54,11 @@
                         (kohdeosat-muokkaa! (fn [vanhat-kohdeosat]
                                               (yllapitokohteet/poista-kohdeosa vanhat-kohdeosat (inc index)))
                                             ;; Jos poistetaan ylin rivi (index 0), lisätään yksi, jotta undo tarjotaan riville 1
-                                            (if (= index 0)
-                                              index
-                                              ;; Jos poistetaan muu rivi, vähennetään indeksiä jotta undo ilmestyy edeltävälle riville
-                                              (dec index))))]
-    (fn [rivi {:keys [index]} e! app kirjoitusoikeus? rivit-atom tyyppi voi-muokata?]
+                                            (if (= index (- (count (keys @rivit-atom)) 1))
+                                              ;; Jos poistetaan alin rivi, vähennetään indeksiä jotta undo ilmestyy edeltävälle riville (muuten ei näkyisi ollenkaan)
+                                              (dec index)
+                                              index)))]
+    (fn [rivi {:keys [index] :as osa} e! app kirjoitusoikeus? rivit-atom tyyppi voi-muokata?]
       (let [nappi-disabled? (or (not voi-muokata?)
                                 (not kirjoitusoikeus?))]
         [:span.tasaa-oikealle.pot2-rivin-toiminnot

--- a/src/cljs/harja/views/urakka/pot2/pot2_lomake.cljs
+++ b/src/cljs/harja/views/urakka/pot2/pot2_lomake.cljs
@@ -119,6 +119,7 @@
                      (e! (paallystys/->HaeTrOsienPituudet tr-numero tr-alkuosa tr-loppuosa))
                      (e! (paallystys/->HaeTrOsienTiedot tr-numero tr-alkuosa tr-loppuosa))
                      (e! (mk-tiedot/->HaePot2MassatJaMurskeet))
+                     (reset! pot2-tiedot/valittu-alustan-sort :tieosoite)
                      (reset! pot2-tiedot/kohdeosat-atom
                              (-> (:paallystekerros paallystysilmoitus-lomakedata)
                                  (pot2-domain/lisaa-paallystekerroksen-jarjestysnro 1)

--- a/test/clj/harja/domain/kohteiden_validointi_test.clj
+++ b/test/clj/harja/domain/kohteiden_validointi_test.clj
@@ -522,6 +522,78 @@
                                                           tr-tieto
                                                           false))))))
 
+(defn- tietyn-kaistan-rivi [rivit kaista]
+  (first (filter #(= (:tr-kaista %) kaista) rivit)))
+
+(deftest pot2-paallysterivin-idn-sailytys-jos-tr-matsaa
+  (testing "Jos POT2 päällysterivi kopioidaan, säilytä id:t jos on olemassa rivi jonka tierekisteriosoite on full match"
+    (let [rivi-ja-kopiot [{:kohdeosa-id 12, :tr-kaista 11, :leveys 3, :kokonaismassamaara 5000, :tr-ajorata 1, :pinta_ala 8283, :tr-loppuosa 1, :jarjestysnro 1, :tr-alkuosa 1, :massamenekki 333, :tr-loppuetaisyys 3827, :nimi "Tärkeä kohdeosa kaista 12", :materiaali 2, :tr-alkuetaisyys 1066, :piennar false, :tr-numero 20, :toimenpide 23, :pot2p_id 2} {:kohdeosa-id 12, :tr-kaista 12, :leveys 3, :kokonaismassamaara 5000, :tr-ajorata 1, :pinta_ala 8283, :tr-loppuosa 1, :jarjestysnro 1, :tr-alkuosa 1, :massamenekki 333, :tr-loppuetaisyys 3827, :nimi "Tärkeä kohdeosa kaista 12", :materiaali 2, :tr-alkuetaisyys 1066, :piennar false, :tr-numero 20, :toimenpide 23, :pot2p_id 2}]
+          kaikki-rivit [{:kohdeosa-id 11, :tr-kaista 11, :leveys 3, :kokonaismassamaara 5000, :tr-ajorata 1, :pinta_ala 8283, :tr-loppuosa 1, :jarjestysnro 1, :tr-alkuosa 1, :massamenekki 333, :tr-loppuetaisyys 3827, :nimi "Tärkeä kohdeosa kaista 11", :materiaali 1, :tr-alkuetaisyys 1066, :piennar true, :tr-numero 20, :toimenpide 22, :pot2p_id 1} {:kohdeosa-id 12, :tr-kaista 12, :leveys 3, :kokonaismassamaara 5000, :tr-ajorata 1, :pinta_ala 8283, :tr-loppuosa 1, :jarjestysnro 1, :tr-alkuosa 1, :massamenekki 333, :tr-loppuetaisyys 3827, :nimi "Tärkeä kohdeosa kaista 12", :materiaali 2, :tr-alkuetaisyys 1066, :piennar false, :tr-numero 20, :toimenpide 23, :pot2p_id 2}]
+          laskettu-tulos (yllapitokohteet/sailyta-idt-jos-sama-tr-osoite rivi-ja-kopiot kaikki-rivit)
+          odotettu-tulos [{:kohdeosa-id 11, :tr-kaista 11, :leveys 3, :kokonaismassamaara 5000, :tr-ajorata 1, :pinta_ala 8283, :tr-loppuosa 1, :jarjestysnro 1, :tr-alkuosa 1, :massamenekki 333, :tr-loppuetaisyys 3827, :nimi "Tärkeä kohdeosa kaista 11", :materiaali 2, :tr-alkuetaisyys 1066, :piennar false, :tr-numero 20, :toimenpide 23, :pot2a_id nil, :pot2p_id 1} {:kohdeosa-id 12, :tr-kaista 12, :leveys 3, :kokonaismassamaara 5000, :tr-ajorata 1, :pinta_ala 8283, :tr-loppuosa 1, :jarjestysnro 1, :tr-alkuosa 1, :massamenekki 333, :tr-loppuetaisyys 3827, :nimi "Tärkeä kohdeosa kaista 12", :materiaali 2, :tr-alkuetaisyys 1066, :piennar false, :tr-numero 20, :toimenpide 23, :pot2a_id nil, :pot2p_id 2}]]
+      (is (= (tietyn-kaistan-rivi laskettu-tulos 11) (tietyn-kaistan-rivi odotettu-tulos 11)) "POT2 kaistan 11  kopioitu oikein")
+      (is (= (tietyn-kaistan-rivi laskettu-tulos 12) (tietyn-kaistan-rivi odotettu-tulos 12)) "POT2 kaistan 12 päällyste kopioitu oikein"))))
+
+(deftest pot2-paallysterivin-idn-nillaus-jos-tr-ei-matsaa
+  (testing "Jos POT2 päällysterivi kopioidaan, älä säilytä id:itä jos tr ei mätsää"
+    (let [rivi-ja-kopiot [{:kohdeosa-id 12, :tr-kaista 11, :leveys 3, :kokonaismassamaara 5000, :tr-ajorata 1, :pinta_ala 8283, :tr-loppuosa 1, :jarjestysnro 1, :tr-alkuosa 1, :massamenekki 333, :tr-loppuetaisyys 3827, :nimi "Tärkeä kohdeosa kaista 12", :materiaali 2, :tr-alkuetaisyys 1066, :piennar false, :tr-numero 20, :toimenpide 23, :pot2p_id 2} {:kohdeosa-id 12, :tr-kaista 12, :leveys 3, :kokonaismassamaara 5000, :tr-ajorata 1, :pinta_ala 8283, :tr-loppuosa 1, :jarjestysnro 1, :tr-alkuosa 1, :massamenekki 333, :tr-loppuetaisyys 3827, :nimi "Tärkeä kohdeosa kaista 12", :materiaali 2, :tr-alkuetaisyys 1066, :piennar false, :tr-numero 20, :toimenpide 23, :pot2p_id 2}]
+          kaikki-rivit [{:kohdeosa-id 11, :tr-kaista 11, :leveys 3, :kokonaismassamaara 5000, :tr-ajorata 1, :pinta_ala 8283, :tr-loppuosa 1, :jarjestysnro 1, :tr-alkuosa 1, :massamenekki 333, :tr-loppuetaisyys 2400, :nimi "Tärkeä kohdeosa kaista 11", :materiaali 1, :tr-alkuetaisyys 1066, :piennar true, :tr-numero 20, :toimenpide 22, :pot2p_id 1} {:kohdeosa-id 12, :tr-kaista 12, :leveys 3, :kokonaismassamaara 5000, :tr-ajorata 1, :pinta_ala 8283, :tr-loppuosa 1, :jarjestysnro 1, :tr-alkuosa 1, :massamenekki 333, :tr-loppuetaisyys 3827, :nimi "Tärkeä kohdeosa kaista 12", :materiaali 2, :tr-alkuetaisyys 1066, :piennar false, :tr-numero 20, :toimenpide 23, :pot2p_id 2}]
+          laskettu-tulos (yllapitokohteet/sailyta-idt-jos-sama-tr-osoite rivi-ja-kopiot kaikki-rivit)
+          odotettu-tulos [{:jarjestysnro 1
+                           :kohdeosa-id nil
+                           :kokonaismassamaara 5000
+                           :leveys 3
+                           :massamenekki 333
+                           :materiaali 2
+                           :nimi nil
+                           :piennar false
+                           :pinta_ala 8283
+                           :pot2a_id nil
+                           :pot2p_id nil
+                           :toimenpide 23
+                           :tr-ajorata 1
+                           :tr-alkuetaisyys 1066
+                           :tr-alkuosa 1
+                           :tr-kaista 11
+                           :tr-loppuetaisyys 3827
+                           :tr-loppuosa 1
+                           :tr-numero 20}
+                          {:kohdeosa-id 12, :tr-kaista 12, :leveys 3, :kokonaismassamaara 5000, :tr-ajorata 1, :pinta_ala 8283, :tr-loppuosa 1, :jarjestysnro 1, :tr-alkuosa 1, :massamenekki 333, :tr-loppuetaisyys 3827, :nimi "Tärkeä kohdeosa kaista 12", :materiaali 2, :tr-alkuetaisyys 1066, :piennar false, :tr-numero 20, :toimenpide 23, :pot2a_id nil, :pot2p_id 2}]]
+      (is (= (tietyn-kaistan-rivi laskettu-tulos 11) (tietyn-kaistan-rivi odotettu-tulos 11)) "POT2 kaistan 11  kopioitu oikein")
+      (is (= (tietyn-kaistan-rivi laskettu-tulos 12) (tietyn-kaistan-rivi odotettu-tulos 12)) "POT2 kaistan 12 päällyste kopioitu oikein"))))
+
+(deftest pot2-alustarivin-id-sailyy-jos-tr-matsaa
+  (testing "Jos POT2 alustarivi kopioidaan, säilytä id:t jos on olemassa rivi jonka tierekisteriosoite on full match"
+    (let [rivi-ja-kopiot [{:tr-kaista 11, :leveys nil, :kokonaismassamaara nil, :murske nil, :massa nil, :tr-ajorata 1, :massamaara nil, :verkon-tarkoitus 1, :tr-loppuosa 1, :tr-alkuosa 1, :pinta-ala nil, :kasittelysyvyys nil, :tr-loppuetaisyys 2000, :lisatty-paksuus nil, :verkon-tyyppi 1, :sideaine2 nil, :sideainepitoisuus nil, :tr-alkuetaisyys 1066, :tr-numero 20, :sideaine nil, :toimenpide 3, :verkon-sijainti 1, :pot2a_id 2} {:tr-kaista 12, :leveys nil, :kokonaismassamaara nil, :murske nil, :massa nil, :tr-ajorata 1, :massamaara nil, :verkon-tarkoitus 1, :tr-loppuosa 1, :tr-alkuosa 1, :pinta-ala nil, :kasittelysyvyys nil, :tr-loppuetaisyys 2000, :lisatty-paksuus nil, :verkon-tyyppi 1, :sideaine2 nil, :sideainepitoisuus nil, :tr-alkuetaisyys 1066, :tr-numero 20, :sideaine nil, :toimenpide 3, :verkon-sijainti 1, :pot2a_id 2}]
+          kaikki-rivit [{:tr-kaista 11, :leveys nil, :kokonaismassamaara nil, :murske nil, :massa nil, :tr-ajorata 1, :massamaara nil, :verkon-tarkoitus 1, :tr-loppuosa 1, :tr-alkuosa 1, :pinta-ala nil, :kasittelysyvyys nil, :tr-loppuetaisyys 2000, :lisatty-paksuus nil, :verkon-tyyppi 1, :sideaine2 nil, :sideainepitoisuus nil, :tr-alkuetaisyys 1066, :tr-numero 20, :sideaine nil, :toimenpide 3, :verkon-sijainti 1, :pot2a_id 7} {:tr-kaista 12, :leveys nil, :kokonaismassamaara nil, :murske nil, :massa nil, :tr-ajorata 1, :massamaara nil, :verkon-tarkoitus 1, :tr-loppuosa 1, :tr-alkuosa 1, :pinta-ala nil, :kasittelysyvyys nil, :tr-loppuetaisyys 2000, :lisatty-paksuus nil, :verkon-tyyppi 1, :sideaine2 nil, :sideainepitoisuus nil, :tr-alkuetaisyys 1066, :tr-numero 20, :sideaine nil, :toimenpide 3, :verkon-sijainti 1, :pot2a_id 2}]
+          laskettu-tulos (yllapitokohteet/sailyta-idt-jos-sama-tr-osoite rivi-ja-kopiot kaikki-rivit)
+          odotettu-tulos [{:kohdeosa-id nil, :tr-kaista 11, :leveys nil, :kokonaismassamaara nil, :murske nil, :massa nil, :tr-ajorata 1, :massamaara nil, :verkon-tarkoitus 1, :tr-loppuosa 1, :tr-alkuosa 1, :pinta-ala nil, :kasittelysyvyys nil, :tr-loppuetaisyys 2000, :nimi nil, :lisatty-paksuus nil, :verkon-tyyppi 1, :sideaine2 nil, :sideainepitoisuus nil, :tr-alkuetaisyys 1066, :tr-numero 20, :sideaine nil, :toimenpide 3, :verkon-sijainti 1, :pot2a_id 7, :pot2p_id nil} {:kohdeosa-id nil, :tr-kaista 12, :leveys nil, :kokonaismassamaara nil, :murske nil, :massa nil, :tr-ajorata 1, :massamaara nil, :verkon-tarkoitus 1, :tr-loppuosa 1, :tr-alkuosa 1, :pinta-ala nil, :kasittelysyvyys nil, :tr-loppuetaisyys 2000, :nimi nil, :lisatty-paksuus nil, :verkon-tyyppi 1, :sideaine2 nil, :sideainepitoisuus nil, :tr-alkuetaisyys 1066, :tr-numero 20, :sideaine nil, :toimenpide 3, :verkon-sijainti 1, :pot2a_id 2, :pot2p_id nil}]]
+(is (= (tietyn-kaistan-rivi laskettu-tulos 11) (tietyn-kaistan-rivi odotettu-tulos 11)) "POT2 kaistan 11 alusta kopioitu oikein")
+      (is (= (tietyn-kaistan-rivi laskettu-tulos 12) (tietyn-kaistan-rivi odotettu-tulos 12)) "POT2 kaistan 12 alusta kopioitu oikein"))))
+
+(deftest pot2-alustarivin-id-nillataan-jos-tr-ei-matsaa
+  (testing "Jos POT2 alustarivi kopioidaan, älä säilytä id:itä jos tr ei mätsää"
+    (let [rivi-ja-kopiot [{:tr-kaista 11, :leveys nil, :kokonaismassamaara nil, :murske nil, :massa nil, :tr-ajorata 1, :massamaara nil, :verkon-tarkoitus 1, :tr-loppuosa 1, :tr-alkuosa 1, :pinta-ala nil, :kasittelysyvyys nil, :tr-loppuetaisyys 2000, :lisatty-paksuus nil, :verkon-tyyppi 1, :sideaine2 nil, :sideainepitoisuus nil, :tr-alkuetaisyys 1066, :tr-numero 20, :sideaine nil, :toimenpide 3, :verkon-sijainti 1, :pot2a_id 2} {:tr-kaista 12, :leveys nil, :kokonaismassamaara nil, :murske nil, :massa nil, :tr-ajorata 1, :massamaara nil, :verkon-tarkoitus 1, :tr-loppuosa 1, :tr-alkuosa 1, :pinta-ala nil, :kasittelysyvyys nil, :tr-loppuetaisyys 2000, :lisatty-paksuus nil, :verkon-tyyppi 1, :sideaine2 nil, :sideainepitoisuus nil, :tr-alkuetaisyys 1066, :tr-numero 20, :sideaine nil, :toimenpide 3, :verkon-sijainti 1, :pot2a_id 2}]
+          kaikki-rivit [{:tr-kaista 11, :leveys nil, :kokonaismassamaara nil, :murske 1, :massa nil, :tr-ajorata 1, :massamaara nil, :verkon-tarkoitus nil, :tr-loppuosa 1, :tr-alkuosa 1, :pinta-ala nil, :kasittelysyvyys nil, :tr-loppuetaisyys 3827, :lisatty-paksuus 10, :verkon-tyyppi nil, :sideaine2 nil, :sideainepitoisuus nil, :tr-alkuetaisyys 1066, :tr-numero 20, :sideaine nil, :toimenpide 23, :verkon-sijainti nil, :pot2a_id 1} {:tr-kaista 12, :leveys nil, :kokonaismassamaara nil, :murske nil, :massa nil, :tr-ajorata 1, :massamaara nil, :verkon-tarkoitus 1, :tr-loppuosa 1, :tr-alkuosa 1, :pinta-ala nil, :kasittelysyvyys nil, :tr-loppuetaisyys 2000, :lisatty-paksuus nil, :verkon-tyyppi 1, :sideaine2 nil, :sideainepitoisuus nil, :tr-alkuetaisyys 1066, :tr-numero 20, :sideaine nil, :toimenpide 3, :verkon-sijainti 1, :pot2a_id 2}]
+          laskettu-tulos (yllapitokohteet/sailyta-idt-jos-sama-tr-osoite rivi-ja-kopiot kaikki-rivit)
+          odotettu-tulos [{:kohdeosa-id nil, :tr-kaista 11, :leveys nil, :kokonaismassamaara nil, :murske nil, :massa nil, :tr-ajorata 1, :massamaara nil, :verkon-tarkoitus 1, :tr-loppuosa 1, :tr-alkuosa 1, :pinta-ala nil, :kasittelysyvyys nil, :tr-loppuetaisyys 2000, :nimi nil, :lisatty-paksuus nil, :verkon-tyyppi 1, :sideaine2 nil, :sideainepitoisuus nil, :tr-alkuetaisyys 1066, :tr-numero 20, :sideaine nil, :toimenpide 3, :verkon-sijainti 1, :pot2a_id nil, :pot2p_id nil} {:kohdeosa-id nil, :tr-kaista 12, :leveys nil, :kokonaismassamaara nil, :murske nil, :massa nil, :tr-ajorata 1, :massamaara nil, :verkon-tarkoitus 1, :tr-loppuosa 1, :tr-alkuosa 1, :pinta-ala nil, :kasittelysyvyys nil, :tr-loppuetaisyys 2000, :nimi nil, :lisatty-paksuus nil, :verkon-tyyppi 1, :sideaine2 nil, :sideainepitoisuus nil, :tr-alkuetaisyys 1066, :tr-numero 20, :sideaine nil, :toimenpide 3, :verkon-sijainti 1, :pot2a_id 2, :pot2p_id nil}]]
+      (is (= (tietyn-kaistan-rivi laskettu-tulos 11) (tietyn-kaistan-rivi odotettu-tulos 11)) "POT2 kaistan 11 alusta kopioitu oikein")
+      (is (= (tietyn-kaistan-rivi laskettu-tulos 12) (tietyn-kaistan-rivi odotettu-tulos 12)) "POT2 kaistan 12 alusta kopioitu oikein"))))
+
+
+(deftest pot2-paallysterivin-id-nillataan-jos-tr-ei-matsaa
+  (testing "Jos POT2 alustarivi kopioidaan, älä säilytä id:itä jos tr ei mätsää"
+    (let [rivi-ja-kopiot [{:kohdeosa-id 52, :tr-kaista 11, :leveys 1, :kokonaismassamaara 2, :tr-ajorata 1, :pinta_ala 1000, :tr-loppuosa 1, :jarjestysnro 1, :tr-alkuosa 1, :massamenekki 3, :tr-loppuetaisyys 3000, :nimi nil, :materiaali 2, :tr-alkuetaisyys 2000, :piennar false, :tr-numero 20, :toimenpide 12, :pot2p_id 4}
+                          {:kohdeosa-id 52, :tr-kaista 12, :leveys 1, :kokonaismassamaara 2, :tr-ajorata 1, :pinta_ala 1000, :tr-loppuosa 1, :jarjestysnro 1, :tr-alkuosa 1, :massamenekki 3, :tr-loppuetaisyys 3000, :nimi nil, :materiaali 2, :tr-alkuetaisyys 2000, :piennar false, :tr-numero 20, :toimenpide 12, :pot2p_id 4}]
+          kaikki-rivit [{:kohdeosa-id 11, :tr-kaista 11, :leveys 3, :kokonaismassamaara 5000, :tr-ajorata 1, :pinta_ala 2802, :tr-loppuosa 1, :jarjestysnro 1, :tr-alkuosa 1, :massamenekki 333, :tr-loppuetaisyys 2000, :nimi "Tärkeä kohdeosa kaista 11", :materiaali 1, :tr-alkuetaisyys 1066, :piennar false, :tr-numero 20, :toimenpide 23, :pot2p_id 1}
+                        {:kohdeosa-id 12, :tr-kaista 12, :leveys 3, :kokonaismassamaara 5000, :tr-ajorata 1, :pinta_ala 2802, :tr-loppuosa 1, :jarjestysnro 1, :tr-alkuosa 1, :massamenekki 333, :tr-loppuetaisyys 2000, :nimi "Tärkeä kohdeosa kaista 12", :materiaali 1, :tr-alkuetaisyys 1066, :piennar false, :tr-numero 20, :toimenpide 23, :pot2p_id 2}
+                        {:kohdeosa-id 52, :tr-kaista 12, :leveys 1, :kokonaismassamaara 2, :tr-ajorata 1, :pinta_ala 1000, :tr-loppuosa 1, :jarjestysnro 1, :tr-alkuosa 1, :massamenekki 3, :tr-loppuetaisyys 3000, :nimi nil, :materiaali 2, :tr-alkuetaisyys 2000, :piennar false, :tr-numero 20, :toimenpide 12, :pot2p_id 4}]
+          laskettu-tulos (yllapitokohteet/sailyta-idt-jos-sama-tr-osoite rivi-ja-kopiot kaikki-rivit)
+          odotettu-tulos [{:kohdeosa-id nil, :tr-kaista 11, :leveys 1, :kokonaismassamaara 2, :tr-ajorata 1, :pinta_ala 1000, :tr-loppuosa 1, :jarjestysnro 1, :tr-alkuosa 1, :massamenekki 3, :tr-loppuetaisyys 3000, :nimi nil, :materiaali 2, :tr-alkuetaisyys 2000, :piennar false, :tr-numero 20, :toimenpide 12, :pot2a_id nil, :pot2p_id nil} {:kohdeosa-id 52, :tr-kaista 12, :leveys 1, :kokonaismassamaara 2, :tr-ajorata 1, :pinta_ala 1000, :tr-loppuosa 1, :jarjestysnro 1, :tr-alkuosa 1, :massamenekki 3, :tr-loppuetaisyys 3000, :nimi nil, :materiaali 2, :tr-alkuetaisyys 2000, :piennar false, :tr-numero 20, :toimenpide 12, :pot2a_id nil, :pot2p_id 4}]]
+      (is (= (tietyn-kaistan-rivi laskettu-tulos 11) (tietyn-kaistan-rivi odotettu-tulos 11)) "POT2 kaistan 11 alusta kopioitu oikein")
+      (is (= (tietyn-kaistan-rivi laskettu-tulos 12) (tietyn-kaistan-rivi odotettu-tulos 12)) "POT2 kaistan 12 alusta kopioitu oikein"))))
+
+
 ;; TODO korja feilaavat vanhat ja uudet testit
 #_(deftest validoi-kaikki
   (let [tr-osoite {:tr-numero 22 :tr-alkuosa 3 :tr-alkuetaisyys 0 :tr-loppuosa 6 :tr-loppuetaisyys 10000}


### PR DESCRIPTION
VHAR-4362 Alustataulukkoon Mahdollisuus järjestää sisältöä: toimenpiteen, tieosoitteen tai materiaalin mukaan

Korjaa bugi VHAR-4749 POT2 alustan ja päällysteen kaistoille kopiointi kopioi myös rivin id:n --> jää tallentumatta