### PR TITLE
Kasvata status-tarkastusten timeout-aikoja.

### DIFF
--- a/src/clj/harja/palvelin/main.clj
+++ b/src/clj/harja/palvelin/main.clj
@@ -791,7 +791,7 @@
                                                                                 (jms/aloita-jms (:sonja uudelleen-kaynnistetty-jarjestelma))
                                                                                 (when (ominaisuus-kaytossa? :itmf)
                                                                                   (jms/aloita-jms (:itmf uudelleen-kaynnistetty-jarjestelma)))
-                                                                                (if (jarjestelma/kaikki-ok? uudelleen-kaynnistetty-jarjestelma (* 1000 10))
+                                                                                (if (jarjestelma/kaikki-ok? uudelleen-kaynnistetty-jarjestelma (* 1000 20))
                                                                                   (event-apurit/julkaise-tapahtuma :harjajarjestelman-restart-onnistui tapahtumien-tulkkaus/tyhja-arvo)
                                                                                   (event-apurit/julkaise-tapahtuma :harjajarjestelman-restart-epaonnistui tapahtumien-tulkkaus/tyhja-arvo))
                                                                                 uudelleen-kaynnistetty-jarjestelma)

--- a/src/clj/harja/palvelin/palvelut/status.clj
+++ b/src/clj/harja/palvelin/palvelut/status.clj
@@ -76,7 +76,7 @@
 
 (defn tietokannan-tila [komponenttien-tila]
   (async/go
-    (let [timeout-ms 10000
+    (let [timeout-ms 20000
           yhteys-ok? (async/<! (dbn-tila-ok? timeout-ms (get komponenttien-tila :komponenttien-tila)))]
       {:ok? yhteys-ok?
        :komponentti :db
@@ -85,7 +85,7 @@
 
 (defn replikoinnin-tila [komponenttien-tila]
   (async/go
-    (let [timeout-ms 10000
+    (let [timeout-ms 20000
           replikoinnin-tila-ok? (async/<! (replikoinnin-tila-ok? timeout-ms (get komponenttien-tila :komponenttien-tila)))]
       {:ok? replikoinnin-tila-ok?
        :komponentti :db-replica
@@ -116,7 +116,7 @@
 
 (defn harjan-tila [komponenttien-tila]
   (async/go
-    (let [timeout-ms 10000
+    (let [timeout-ms 20000
           kaikki-ok? (async/<! (harjan-tila-ok? timeout-ms (get komponenttien-tila :komponenttien-tila)))]
       {:ok? kaikki-ok?
        :komponentti :harja

--- a/test/clj/harja/palvelin/palvelut/status_test.clj
+++ b/test/clj/harja/palvelin/palvelut/status_test.clj
@@ -95,7 +95,7 @@
     (with-redefs [status/dbn-tila-ok? (fn [& _] (async/go false))]
       (let [vastaus (tyokalut/get-kutsu ["/status"] +kayttaja-jvh+ nil {:timeout 1000} portti)]
         (is (= (-> vastaus :body (cheshire/decode true))
-               {:viesti (str "Ei saatu yhteyttä kantaan 10 sekunnin kuluessa.")
+               {:viesti (str "Ei saatu yhteyttä kantaan 20 sekunnin kuluessa.")
                 :harja-ok? true
                 :sonja-yhteys-ok? true
                 :itmf-yhteys-ok? true


### PR DESCRIPTION
Tuplaa harjan, tietokannan, replikoinnin ja uudelleenkäynnistyksen tarkastusten timeoutit 10s -> 20s.