### PR TITLE
Korjaa virheellisen materiaalin näkyminen pot2-lomakkeen gridissä.

### DIFF
--- a/src/cljs/harja/tiedot/urakka/pot2/pot2_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/pot2/pot2_tiedot.cljs
@@ -118,8 +118,10 @@
 
 (defn- materiaali
   [massat-tai-murskeet {:keys [massa-id murske-id]}]
-  (first (filter #(or (= (::pot2-domain/massa-id %) massa-id)
-                      (= (::pot2-domain/murske-id %) murske-id))
+  (first (filter #(or (and (not (nil? massa-id))
+                           (= (::pot2-domain/massa-id %) massa-id))
+                      (and (not (nil? murske-id))
+                           (= (::pot2-domain/murske-id %) murske-id)))
                  massat-tai-murskeet)))
 
 (defn tunnista-materiaali

--- a/src/cljs/harja/tiedot/urakka/pot2/pot2_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/pot2/pot2_tiedot.cljs
@@ -118,9 +118,9 @@
 
 (defn- materiaali
   [massat-tai-murskeet {:keys [massa-id murske-id]}]
-  (first (filter #(or (and (not (nil? massa-id))
+  (first (filter #(or (and (some? massa-id)
                            (= (::pot2-domain/massa-id %) massa-id))
-                      (and (not (nil? murske-id))
+                      (and (some? murske-id)
                            (= (::pot2-domain/murske-id %) murske-id)))
                  massat-tai-murskeet)))
 


### PR DESCRIPTION
Oikean materiaalin sijasta näkyi massa-listan ensimmäinen elementti.
Tämä sen takia, että massoilla ei ole murske-id:tä, ja funktiolle annettu murske-id oli nil. Eli filtteriksi meni (= nil nil)