### PR TITLE
Vhar 4970 kustannusten seuranta vain MHU

### DIFF
--- a/src/clj/harja/kyselyt/kustannusten_seuranta.sql
+++ b/src/clj/harja/kyselyt/kustannusten_seuranta.sql
@@ -9,7 +9,7 @@ WITH urakan_toimenpideinstanssi_23150 AS
                maksuera m
           WHERE tpi.urakka = :urakka
             AND m.toimenpideinstanssi = tpi.id
-            AND tpk2.koodi = '23150')
+            AND tpk2.koodi = '23150' limit 1)
 -- Haetaan budjetoidut hankintakustannukset kustannusarvioitu-työ taulusta
 SELECT kt.summa                                  AS budjetoitu_summa,
        0                                         AS toteutunut_summa,

--- a/src/cljs/harja/tiedot/urakka/kulut/mhu_kustannusten_seuranta.cljs
+++ b/src/cljs/harja/tiedot/urakka/kulut/mhu_kustannusten_seuranta.cljs
@@ -54,19 +54,20 @@
                    aikavali-alkupvm :aikavali-alkupvm aikavali-loppupvm :aikavali-loppupvm} app]
     (do
       (hae-kustannukset (-> @tila/yleiset :urakka :id) hoitokauden-alkuvuosi aikavali-alkupvm aikavali-loppupvm)
-      app))
+      (assoc app :haku-kaynnissa? true)))
 
   KustannustenHakuOnnistui
   (process-event [{vastaus :vastaus} app]
     (let [data (kustannusten-seuranta/jarjesta-tehtavat vastaus)]
       (-> app
           (assoc-in [:kustannukset-yhteensa] (:yhteensa data))
-          (assoc-in [:kustannukset] (:taulukon-rivit data)))))
+          (assoc-in [:kustannukset] (:taulukon-rivit data))
+          (assoc :haku-kaynnissa? false))))
 
   KustannustenHakuEpaonnistui
   (process-event [{vastaus :vastaus} app]
     (viesti/nayta! "Haku epäonnistui!" :danger)
-    app)
+    (assoc app :haku-kaynnissa? false))
 
   HaeBudjettitavoite
   (process-event [_ app]
@@ -106,6 +107,7 @@
       (hae-kustannukset urakka vuosi nil nil)
       (-> app
           (assoc :valittu-kuukausi nil)
+          (assoc :haku-kaynnissa? true)
           (assoc :hoitokauden-alkuvuosi vuosi))))
 
   ValitseKuukausi
@@ -121,6 +123,7 @@
             (e! (->HaeBudjettitavoite))))
         (hae-kustannukset urakka vuosi (first valittu-kuukausi) (second valittu-kuukausi))
         (-> app
+            (assoc :haku-kaynnissa? true)
             (assoc-in [:valittu-kuukausi] kuukausi))))))
 
 (defn- muuta-hoitokausivuosi-jarjestysnumeroksi

--- a/src/cljs/harja/views/urakka/kulut/mhu_kustannusten_seuranta.cljs
+++ b/src/cljs/harja/views/urakka/kulut/mhu_kustannusten_seuranta.cljs
@@ -347,7 +347,7 @@
 (defn kustannukset
   "Kustannukset listattuna taulukkoon"
   [e! app]
-  (let [{:keys [alkupvm]} (-> @tila/tila :yleiset :urakka)  ;; Ota urakan alkamis päivä
+  (let [{:keys [alkupvm]} (-> @tila/tila :yleiset :urakka) ;; Ota urakan alkamis päivä
         vuosi (pvm/vuosi alkupvm)
         hoitokaudet (into [] (range vuosi (+ 5 vuosi)))
         taulukon-rivit (:kustannukset app)
@@ -411,9 +411,11 @@
                                                 :loppupvm haun-loppupvm})}]
          [:button {:type "submit"
                    :class #{"button-secondary-default" "suuri"}} "Tallenna Excel"]]]]]
-
-     [kustannukset-taulukko e! app taulukon-rivit]
-     [yhteenveto-laatikko e! app taulukon-rivit]]))
+     (if (:haku-kaynnissa? app)
+       [:div {:style {:padding-left "20px"}} [yleiset/ajax-loader "Haetaan käynnissä"]]
+       [:div
+        [kustannukset-taulukko e! app taulukon-rivit]
+        [yhteenveto-laatikko e! app taulukon-rivit]])]))
 
 (defn kustannusten-seuranta* [e! app]
   (komp/luo

--- a/src/cljs/harja/views/urakka/laskutus.cljs
+++ b/src/cljs/harja/views/urakka/laskutus.cljs
@@ -42,6 +42,7 @@
 
           "Kustannusten seuranta"
           :kustannusten-seuranta
-          ^{:key "kustannusten-seuranta"}
-          [kustannusten-seuranta/kustannusten-seuranta]
+          (when mhu-urakka?
+            ^{:key "kustannusten-seuranta"}
+            [kustannusten-seuranta/kustannusten-seuranta])
           ]]))))


### PR DESCRIPTION
Estettiin Kustannusten seurannan näkyminen muille kuin MHU tyyppisille urakoille.
Samalla lisättiin ajax-loaderi hakuun, koska haku voi viedä jopa sekunnin, niin on parempi, kun kerrotaan käyttäjälle hausta.
Subqueryyn lisättiin limit 1 ehto, jotta moneen kertaan lisätyt toimenpiteet eivät aiheuttaisi tietokantaerroreita. Tämä tosin taitaa tapahtua vain hoito urakoille, mutta parantaa kuitenkin haun varmuutta.