### PR TITLE
vhar-5235 - api - paikkaustoteuman tierekisteriosoitteen validointi

### DIFF
--- a/laadunseuranta/clj-src/harja_laadunseuranta/tarkastusreittimuunnin/yhteiset.clj
+++ b/laadunseuranta/clj-src/harja_laadunseuranta/tarkastusreittimuunnin/yhteiset.clj
@@ -29,7 +29,7 @@
   [merkinta tie]
   (if-let [lahin-vastaava-projisio (laheisten-teiden-lahin-osuma-tielle merkinta tie)]
     (do
-      (log/debug "Projisoidaan merkintä tielle: " tie)
+      ;(log/debug "Projisoidaan merkintä tielle: " tie)
       (-> merkinta
           (assoc-in [:tr-osoite :tie] (:tie lahin-vastaava-projisio))
           (assoc-in [:tr-osoite :aosa] (:aosa lahin-vastaava-projisio))
@@ -37,7 +37,7 @@
           (assoc-in [:tr-osoite :losa] (:losa lahin-vastaava-projisio))
           (assoc-in [:tr-osoite :let] (:let lahin-vastaava-projisio))))
     (do
-      (log/debug (str "Ei voitu projisoida merkintää tielle: " tie ", ei ole riittävän lähellä"))
+      ;(log/debug (str "Ei voitu projisoida merkintää tielle: " tie ", ei ole riittävän lähellä"))
       (dissoc merkinta :tr-osoite))))
 
 (defn projisoi-merkinnat-edelliselle-tielle

--- a/laadunseuranta/clj-src/harja_laadunseuranta/tarkastusreittimuunnin/ymparikaantyminen.clj
+++ b/laadunseuranta/clj-src/harja_laadunseuranta/tarkastusreittimuunnin/ymparikaantyminen.clj
@@ -44,7 +44,7 @@
    ja K:n väliin jäävistä pisteistä se, joka on kaikista kauimpana
    K:sta (tätä pistettä aiemmin etäännyttiin K:sta ja eteenpäin aletaan lähentyä K:ta)"
   [kaikki-merkinnat merkinnat-nykyisesta-khon k-sijainti]
-  (log/debug "Määritetään ympärikääntymisen indeksi merkinnöistä (" (count merkinnat-nykyisesta-khon) "kpl)")
+  ;(log/debug "Määritetään ympärikääntymisen indeksi merkinnöistä (" (count merkinnat-nykyisesta-khon) "kpl)")
   (let [etaisyydet-khon (map #(math/pisteiden-etaisyys (:sijainti %)
                                                        k-sijainti)
                              merkinnat-nykyisesta-khon)
@@ -52,7 +52,7 @@
         kaukaisin-indeksi (.indexOf etaisyydet-khon kaukaisin)
         kaukaisin-merkinta (nth merkinnat-nykyisesta-khon kaukaisin-indeksi)
         ymparikaantymisen-indeksi (.indexOf kaikki-merkinnat kaukaisin-merkinta)]
-    (log/debug (str "Määritetty ympärikääntyminen indeksiin: " ymparikaantymisen-indeksi))
+    ;(log/debug (str "Määritetty ympärikääntyminen indeksiin: " ymparikaantymisen-indeksi))
     ymparikaantymisen-indeksi))
 
 (defn- k-nykyisessa-sijainnissa? [k-sijainti nykyinen-sijainti]
@@ -71,9 +71,9 @@
            seuraava-merkinta uusi-k-indeksi
            uusi-k-sijainti]}]
   (when (k-nykyisessa-sijainnissa? uusi-k-sijainti (:sijainti seuraava-merkinta))
-    (log/debug "--> K kohtasi nykyisen sijainnin!")
-    (log/debug "--> Käsiteltava indeksi: " kasiteltava-indeksi " ja uusi k indeksi: " uusi-k-indeksi)
-    (log/debug "--> Ympärikääntymisen piste täytyy löytä näiden välistä!")
+    ;(log/debug "--> K kohtasi nykyisen sijainnin!")
+    ;(log/debug "--> Käsiteltava indeksi: " kasiteltava-indeksi " ja uusi k indeksi: " uusi-k-indeksi)
+    ;(log/debug "--> Ympärikääntymisen piste täytyy löytä näiden välistä!")
     (maarita-ymparikaantymisen-indeksi
       kaikki-merkinnat
       (take (- kasiteltava-indeksi uusi-k-indeksi)
@@ -100,11 +100,11 @@
              ymparikaantyminen-indeksissa nil]
         (let [uusi-k-sijainti (:sijainti (nth (:lapikaydyt-merkinnat tulos) uusi-k-indeksi))]
           (if (= uusi-k-indeksi sopiva-merkinta-takana-indeksi)
-            (do (log/debug "K on sopivassa sijainnissa M metrin päässä.")
+            (do ;(log/debug "K on sopivassa sijainnissa M metrin päässä.")
                 {:sijainti (:sijainti sopiva-merkinta-takana)
                  :indeksi uusi-k-indeksi
                  :ymparikaantyminen-indeksi ymparikaantyminen-indeksissa})
-            (do (log/debug (str "Siirretään K:ta eteenpäin kohti indeksiä: " (inc uusi-k-indeksi)))
+            (do ;(log/debug (str "Siirretään K:ta eteenpäin kohti indeksiä: " (inc uusi-k-indeksi)))
                 (recur (inc uusi-k-indeksi)
                        (if ymparikaantyminen-indeksissa
                          ymparikaantyminen-indeksissa ;; Ympärikääntyminen havaittiin aiemmin
@@ -124,7 +124,7 @@
                (>= (math/pisteiden-etaisyys ensimmainen-sijainti
                                             seuraava-sijainti)
                    m))
-      (log/debug "Määritetään K ensimmäiseen pisteeseen")
+      ;(log/debug "Määritetään K ensimmäiseen pisteeseen")
       {:sijainti (:sijainti ensimmainen-sijainti)
        :indeksi 0})))
 
@@ -145,7 +145,7 @@
 
    On mahdollista, ettei uutta K:ta saada määritettyä, jos merkintöjen sijainti puuttuu."
   [{:keys [tulos seuraava-merkinta kasiteltava-indeksi k-indeksi m kaikki-merkinnat]}]
-  (log/debug "Käsitellään merkintä indeksissä: " kasiteltava-indeksi)
+  ;(log/debug "Käsitellään merkintä indeksissä: " kasiteltava-indeksi)
   (if (nil? (:k-indeksi tulos))
     ;; K:ta ei ole vielä määritelty, määrittele se ensimmäiseen pisteeseen
     ;; kunhan nykyinen käsiteltävä piste on riittävän kaukana

--- a/src/clj/harja/palvelin/integraatiot/api/tarkastukset.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/tarkastukset.clj
@@ -19,7 +19,7 @@
 
 (defn kirjaa-tarkastus [db liitteiden-hallinta kayttaja tyyppi {id :id} data]
   (let [urakka-id (Long/parseLong id)]
-    (log/debug (format "Kirjataan tarkastus tyyppiä: %s käyttäjän: %s toimesta. Data: %s" tyyppi (:kayttajanimi kayttaja) data))
+    ;(log/debug (format "Kirjataan tarkastus tyyppiä: %s käyttäjän: %s toimesta. Data: %s" tyyppi (:kayttajanimi kayttaja) data))
     (validointi/tarkista-urakka-ja-kayttaja db urakka-id kayttaja)
     (let [varoitukset (tarkastukset/luo-tai-paivita-tarkastukset db liitteiden-hallinta kayttaja tyyppi urakka-id data)]
       (tee-onnistunut-vastaus (join ", " varoitukset)))))
@@ -29,7 +29,7 @@
         ulkoiset-idt (-> data :tarkastusten-tunnisteet)
         kayttaja-id (:id kayttaja)
         kayttajanimi (:kayttajanimi kayttaja)]
-    (log/debug (format "Poistetaan tarkastus ulk.id %s tyyppiä: %s käyttäjän: %s toimesta. Data: %s"
+    #_ (log/debug (format "Poistetaan tarkastus ulk.id %s tyyppiä: %s käyttäjän: %s toimesta. Data: %s"
                        ulkoiset-idt
                        tyyppi
                        kayttajanimi

--- a/src/clj/harja/palvelin/integraatiot/api/tyokalut/kutsukasittely.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/tyokalut/kutsukasittely.clj
@@ -67,23 +67,23 @@
       body)))
 
 (defn lokita-kutsu [integraatioloki resurssi request body]
-  (log/debug "Vastaanotetiin kutsu resurssiin:" resurssi ".")
-  (log/debug "Kutsu:" request)
-  (log/debug "Parametrit: " (:params request))
-  (log/debug "Headerit: " (:headers request))
-  (log/debug "Sisältö:" (poista-liitteet-logituksesta body))
+  ;(log/debug "Vastaanotetiin kutsu resurssiin:" resurssi ".")
+  ;(log/debug "Kutsu:" request)
+  ;(log/debug "Parametrit: " (:params request))
+  ;(log/debug "Headerit: " (:headers request))
+  ;(log/debug "Sisältö:" (poista-liitteet-logituksesta body))
 
   (integraatioloki/kirjaa-alkanut-integraatio integraatioloki "api" (name resurssi) nil (tee-lokiviesti "sisään" body request)))
 
 (defn lokita-vastaus [integraatioloki resurssi response tapahtuma-id]
-  (log/debug "Lähetetään vastaus resurssiin:" resurssi "kutsuun.")
-  (log/debug "Vastaus:" response)
-  (log/debug "Headerit: " (:headers response))
-  (log/debug "Sisältö:" (:body response))
+  ;(log/debug "Lähetetään vastaus resurssiin:" resurssi "kutsuun.")
+  ;(log/debug "Vastaus:" response)
+  ;(log/debug "Headerit: " (:headers response))
+  ;(log/debug "Sisältö:" (:body response))
 
   (if (= 200 (:status response))
     (do
-      (log/debug "Kutsu resurssiin:" resurssi "onnistui. Palautetaan vastaus:" response)
+      ;(log/debug "Kutsu resurssiin:" resurssi "onnistui. Palautetaan vastaus:" response)
       (integraatioloki/kirjaa-onnistunut-integraatio
         integraatioloki
         (tee-lokiviesti "ulos" (:body response) response) nil tapahtuma-id nil))

--- a/src/clj/harja/palvelin/integraatiot/api/tyokalut/kutsukasittely.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/tyokalut/kutsukasittely.clj
@@ -191,7 +191,7 @@
   Validoi annetun kutsun JSON-datan ja mikäli data on validia, palauttaa datan Clojure dataksi muunnettuna.
   Jos annettu data ei ole validia, palautetaan nil."
   [skeema request body]
-  (log/debug "Luetaan kutsua")
+  ;(log/debug "Luetaan kutsua")
   (when (or (= :post (:request-method request))
             (= :put (:request-method request))
             (= :delete (:request-method request)))

--- a/src/clj/harja/palvelin/palvelut/yllapitokohteet.clj
+++ b/src/clj/harja/palvelin/palvelut/yllapitokohteet.clj
@@ -698,7 +698,7 @@
                     {:status :yha-virhe
                      :yllapitokohteet yllapitokohteet} yha-poistovirheet)
             (do
-              (log/debug "Tallennus suoritettu. Tuoreet ylläpitokohteet: " (pr-str yllapitokohteet))
+              ;(log/debug "Tallennus suoritettu. Tuoreet ylläpitokohteet: " (pr-str yllapitokohteet))
               {:status          :ok
                :yllapitokohteet yllapitokohteet}))))
       {:status            :validointiongelma

--- a/src/clj/harja/palvelin/palvelut/yllapitokohteet/paikkauskohteet.clj
+++ b/src/clj/harja/palvelin/palvelut/yllapitokohteet/paikkauskohteet.clj
@@ -11,6 +11,7 @@
             [ring.middleware.multipart-params :refer [wrap-multipart-params]]
             [specql.core :refer [fetch update! insert! upsert! delete!]]
             [harja.domain.oikeudet :as oikeudet]
+            [harja.domain.tierekisteri.validointi :as tr-validointi]
             [harja.domain.roolit :as roolit]
             [harja.domain.paikkaus :as paikkaus]
             [harja.domain.muokkaustiedot :as muokkaustiedot]
@@ -34,12 +35,6 @@
   (if (and (not (nil? alku)) (not (nil? loppu)) (.after alku loppu))
     (conj validointivirheet "Loppuaika tulee ennen alkuaikaa.")
     validointivirheet))
-
-(defn validit-tr_osat? [validointivirheet tie alkuosa loppuosa alkuetaisyys loppuetaisyys]
-  (if (and tie alkuosa alkuetaisyys loppuosa loppuetaisyys
-           (>= loppuosa alkuosa))
-    validointivirheet
-    (conj validointivirheet "Tierekisteriosoitteessa virhe.")))
 
 (defn- sallittu-tilamuutos? [uusi vanha rooli]
   (let [uusi-tila (:paikkauskohteen-tila uusi)
@@ -136,7 +131,7 @@
                                          (s/valid? ::loppupvm (:loppupvm kohde)))
                                   (validi-pvm-vali? virheet (:alkupvm kohde) (:loppupvm kohde))
                                   virheet)
-                                (validit-tr_osat? virheet (:tie kohde) (:aosa kohde) (:losa kohde) (:aet kohde) (:let kohde))
+                                (tr-validointi/validoi-tieosoite virheet (:tie kohde) (:aosa kohde) (:losa kohde) (:aet kohde) (:let kohde))
                                 (validi-paikkauskohteen-tilamuutos? virheet kohde vanha-kohde rooli))]
     validointivirheet))
 

--- a/src/clj/harja/palvelin/raportointi/raportit/laskutusyhteenveto_mhu.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/laskutusyhteenveto_mhu.clj
@@ -279,7 +279,7 @@
                                                     :urakkatyyppi (:urakkatyyppi urakan-parametrit))
                                           (lyv-yhteiset/hae-laskutusyhteenvedon-tiedot db user urakan-parametrit)))
                                   urakoiden-parametrit)
-        _ (log/debug "laskutusyhteenvedot" (pr-str laskutusyhteenvedot))
+        ;_ (log/debug "laskutusyhteenvedot" (pr-str laskutusyhteenvedot))
 
         urakoiden-lahtotiedot (lyv-yhteiset/urakoiden-lahtotiedot laskutusyhteenvedot)
 

--- a/src/clj/harja/palvelin/raportointi/raportit/vesivaylien_laskutusyhteenveto.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/vesivaylien_laskutusyhteenveto.clj
@@ -131,7 +131,7 @@
                                    (map :toteutunut-maara (vals (:kokonaishintaiset tiedot))))))])
 
 (defn suorita [db user {:keys [urakka-id hallintayksikko-id alkupvm loppupvm] :as parametrit}]
-  (log/debug "suorita urakka id " urakka-id " hallintayksikkö id " hallintayksikko-id)
+  ;(log/debug "suorita urakka id " urakka-id " hallintayksikkö id " hallintayksikko-id)
   (let [konteksti (cond urakka-id :urakka
                         hallintayksikko-id :hallintayksikko
                         :default :urakka)

--- a/src/cljc/harja/domain/tierekisteri/validointi.cljc
+++ b/src/cljc/harja/domain/tierekisteri/validointi.cljc
@@ -19,6 +19,7 @@
                                 (if (and (>= loppuosa alkuosa))
                                   virheet
                                   (conj virheet "Tierekisteriosoitteen loppuosa pienempi kuin alkuosa. ")))
-        virheet (when-not (empty? virheet)
-                  (conj validointivirheet virheet))]
+        virheet (if-not (empty? virheet)
+                  (conj validointivirheet virheet)
+                  validointivirheet)]
     virheet))

--- a/src/cljc/harja/domain/tierekisteri/validointi.cljc
+++ b/src/cljc/harja/domain/tierekisteri/validointi.cljc
@@ -1,0 +1,24 @@
+(ns harja.domain.tierekisteri.validointi
+  "Yhteiset validointikäsittelyt frontille ja bäkkärille tierekisterin suhteen"
+  (:require [clojure.string :as str]
+            #?@(:clj [
+                      [clj-time.core :as t]])
+            #?@(:cljs [[cljs-time.core :as t]])))
+
+
+(defn validoi-tieosoite
+  "Lisää jo saatuihin virheisiin mahdolliset tierekisteriosoitteen virheet"
+  [validointivirheet tie alkuosa loppuosa alkuetaisyys loppuetaisyys]
+  (let [virheet (as-> #{} virheet
+                                (if (and tie alkuosa alkuetaisyys loppuosa loppuetaisyys)
+                                  virheet
+                                  (conj virheet "Osa tierekisteriosoitteesta puuttuu. "))
+                                (if (and (= alkuosa loppuosa) (>= alkuetaisyys loppuetaisyys))
+                                  (conj virheet "Tierekisteriosoitteen loppuetäisyys pienempi kuin alkuetäisyys. ")
+                                  virheet)
+                                (if (and (>= loppuosa alkuosa))
+                                  virheet
+                                  (conj virheet "Tierekisteriosoitteen loppuosa pienempi kuin alkuosa. ")))
+        virheet (when-not (empty? virheet)
+                  (conj validointivirheet virheet))]
+    virheet))

--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_toteumat.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_toteumat.cljs
@@ -238,8 +238,7 @@
       (e! (t-toteumalomake/->SuljeToteumaLomake))
       ;; Tässä hallitaan app-statea olemassa olevien tuck eventtien kautta ja niiden app-staten päivitys
       ;;ottaa muutaman millisekunnin. Joten lisätään pieni viive, jotta saadaan varmasti päivitetty lomake auki
-      (js/setTimeout #(e! (t-toteumalomake/->AvaaToteumaLomake toteumalomake nil)) 5)
-      )))
+      (js/setTimeout #(e! (t-toteumalomake/->AvaaToteumaLomake toteumalomake nil)) 5))))
 
 (defn- yksikko-avain [yksikko]
   (cond
@@ -283,20 +282,20 @@
                      pvm/pvm-aika-klo-suluissa
                      pvm/pvm-opt)}]
             (if (or urapaikkaus? levittimella-tehty?)
-              (yllapitokohteet/tierekisteriosoite-sarakkeet 4 tierekisteriosoite-sarakkeet))
-            [{:otsikko "Tie\u00ADnu\u00ADme\u00ADro" :nimi ::tierekisteri/tie
-              :tyyppi :positiivinen-numero :leveys 4 :tasaa :oikea :kokonaisluku? true}
-             {:otsikko "Ajo\u00ADrata" :nimi ::tierekisteri/ajorata
-              :tyyppi :positiivinen-numero
-              :leveys 4 :tasaa :oikea}
-             {:otsikko "Aosa" :nimi ::tierekisteri/aosa :leveys 4 :tyyppi :positiivinen-numero
-              :tasaa :oikea :kokonaisluku? true}
-             {:otsikko "Aet" :nimi ::tierekisteri/aet :leveys 4 :tyyppi :positiivinen-numero
-              :tasaa :oikea :kokonaisluku? true}
-             {:otsikko "Losa" :nimi ::tierekisteri/losa :leveys 4 :tyyppi :positiivinen-numero
-              :tasaa :oikea :kokonaisluku? true}
-             {:otsikko "Let" :nimi ::tierekisteri/let :leveys 4 :tyyppi :positiivinen-numero
-              :tasaa :oikea :kokonaisluku? true}]
+              (yllapitokohteet/tierekisteriosoite-sarakkeet 4 tierekisteriosoite-sarakkeet)
+              [{:otsikko "Tie\u00ADnu\u00ADme\u00ADro" :nimi ::tierekisteri/tie
+                :tyyppi :positiivinen-numero :leveys 4 :tasaa :oikea :kokonaisluku? true}
+               {:otsikko "Ajo\u00ADrata" :nimi ::tierekisteri/ajorata
+                :tyyppi :positiivinen-numero
+                :leveys 4 :tasaa :oikea}
+               {:otsikko "Aosa" :nimi ::tierekisteri/aosa :leveys 4 :tyyppi :positiivinen-numero
+                :tasaa :oikea :kokonaisluku? true}
+               {:otsikko "Aet" :nimi ::tierekisteri/aet :leveys 4 :tyyppi :positiivinen-numero
+                :tasaa :oikea :kokonaisluku? true}
+               {:otsikko "Losa" :nimi ::tierekisteri/losa :leveys 4 :tyyppi :positiivinen-numero
+                :tasaa :oikea :kokonaisluku? true}
+               {:otsikko "Let" :nimi ::tierekisteri/let :leveys 4 :tyyppi :positiivinen-numero
+                :tasaa :oikea :kokonaisluku? true}])
             (when (or levittimella-tehty? urapaikkaus?)
               [{:otsikko "Leveys\u00AD (m)"
                 :leveys 5

--- a/test/clj/harja/kyselyt/asiakastyytyvaisyysbonus_test.clj
+++ b/test/clj/harja/kyselyt/asiakastyytyvaisyysbonus_test.clj
@@ -44,7 +44,7 @@
         sop @oulun-alueurakan-2014-2019-paasopimuksen-id
         maksupvm (ffirst (q (str "select pvm from erilliskustannus
         WHERE tyyppi = 'asiakastyytyvaisyysbonus' AND rahasumma = 1000 AND sopimus = " sop)))
-        _ (log/debug "maksupvm" maksupvm)
+        ;_ (log/debug "maksupvm" maksupvm)
         ind_nimi (ffirst (q (str "select indeksin_nimi from erilliskustannus
         WHERE tyyppi = 'asiakastyytyvaisyysbonus' AND rahasumma = 1000 AND sopimus = " sop)))
         summa (ffirst (q (str "select rahasumma from erilliskustannus

--- a/test/clj/harja/kyselyt/urakan_hoitokaudet_test.clj
+++ b/test/clj/harja/kyselyt/urakan_hoitokaudet_test.clj
@@ -34,7 +34,7 @@
       (let [hoitokaudet (q (str "SELECT * FROM urakan_hoitokaudet(" urakka-id ")"))]
         (is (= 3 (count hoitokaudet)))
         (mapv (fn [hoitokausi]
-                (log/debug "HOITOKAUSI: " hoitokausi)
+                ;(log/debug "HOITOKAUSI: " hoitokausi)
                 (let [alkupvm (paikallinen-aika (first hoitokausi))
                       loppupvm (paikallinen-aika (second hoitokausi))]
                   (is (= 1 (time/day alkupvm)))

--- a/test/clj/harja/palvelin/integraatiot/api/laatupoikkeaman_kirjaus_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/laatupoikkeaman_kirjaus_test.clj
@@ -33,9 +33,9 @@
           liite-id (ffirst (q (str "SELECT id FROM liite WHERE nimi = 'testihavainto36934853.jpg';")))
           laatupoikkeama-id (ffirst (q (str "SELECT id FROM laatupoikkeama WHERE kohde = 'testikohde36934853';")))
           kommentti-id (ffirst (q (str "SELECT id FROM kommentti WHERE kommentti = 'Testikommentti323353435';")))]
-      (log/debug "liite-id: " liite-id)
-      (log/debug "laatupoikkeama-id: " laatupoikkeama-id)
-      (log/debug "kommentti-id: " kommentti-id)
+      ;(log/debug "liite-id: " liite-id)
+      ;(log/debug "laatupoikkeama-id: " laatupoikkeama-id)
+      ;(log/debug "kommentti-id: " kommentti-id)
 
       (is (= (+ laatupoikkeamat-kannassa-ennen-pyyntoa 1) laatupoikkeamat-kannassa-pyynnon-jalkeen))
       (is (number? liite-id))

--- a/test/clj/harja/palvelin/integraatiot/api/siltatarkastuksien_kirjaus_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/siltatarkastuksien_kirjaus_test.clj
@@ -53,17 +53,17 @@
                                                     (.replace "__SUKUNIMI__" tarkastaja-sukunimi)
                                                     (.replace "__SILTATUNNUS__" (str siltatunnus))
                                                     (.replace "__TARKASTUSAIKA__" tarkastusaika)))]
-    (log/debug "Vastaus: " vastaus-lisays)
+    ;(log/debug "Vastaus: " vastaus-lisays)
     (is (= 200 (:status vastaus-lisays)))
     (let [siltatarkastus-kannassa (first (q (str "SELECT id, ulkoinen_id, tarkastaja, tarkastusaika FROM siltatarkastus WHERE ulkoinen_id = '" ulkoinen-id "';")))
           siltatarkastus-kannassa-id (first siltatarkastus-kannassa)]
       (is (not (nil? siltatarkastus-kannassa)))
       (is (= (nth siltatarkastus-kannassa 1) (str ulkoinen-id)))
       (is (= (nth siltatarkastus-kannassa 2) (str tarkastaja-etunimi " " tarkastaja-sukunimi)))
-      (log/debug (str "TARKASTUS KANNASSA " siltatarkastus-kannassa-id))
+      ;(log/debug (str "TARKASTUS KANNASSA " siltatarkastus-kannassa-id))
 
       (let [kohteet-kannassa (q (str "SELECT kohde, tulos::char[], lisatieto FROM siltatarkastuskohde WHERE siltatarkastus = " siltatarkastus-kannassa-id ";"))]
-        (log/debug (str "KOHTEET KANNASSA " kohteet-kannassa))
+        ;(log/debug (str "KOHTEET KANNASSA " kohteet-kannassa))
         (is (= (count kohteet-kannassa) 24))
         (doseq [kohde kohteet-kannassa]
           (is (= (konv/pgarray->vector (second kohde)) (odotettu-kohdetulos (first kohde)))))

--- a/test/clj/harja/palvelin/integraatiot/api/urakan_haku_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/urakan_haku_test.clj
@@ -49,7 +49,7 @@
         encoodattu-body (cheshire/decode (:body vastaus) true)
         materiaalien-lkm (ffirst (q
                                    (str "SELECT count(*) FROM materiaalikoodi")))]
-    (log/debug "Urakan haku id:llä: " encoodattu-body)
+    ;(log/debug "Urakan haku id:llä: " encoodattu-body)
     (is (= 200 (:status vastaus)))
     (is (not (nil? (:urakka encoodattu-body))))
     (is (= (get-in encoodattu-body [:urakka :tiedot :id]) urakka))
@@ -72,10 +72,10 @@
   (let [ytunnus "1565583-5"
         vastaus (api-tyokalut/get-kutsu ["/api/urakat/haku/" ytunnus] kayttaja portti)
         encoodattu-body (cheshire/decode (:body vastaus) true)]
-    (log/debug "Urakan haku ytunnuksella löytyi " (count (:urakat encoodattu-body)) " urakkaa: " (:body vastaus))
+    ;(log/debug "Urakan haku ytunnuksella löytyi " (count (:urakat encoodattu-body)) " urakkaa: " (:body vastaus))
     (is (= 200 (:status vastaus)))
     (is (>= (count (:urakat encoodattu-body)) 2))
-    (log/debug "Urakka: " (first (:urakat encoodattu-body)))
+    ;(log/debug "Urakka: " (first (:urakat encoodattu-body)))
     (is (= (get-in (first (:urakat encoodattu-body)) [:urakka :tiedot :urakoitsija :ytunnus]) ytunnus))))
 
 (deftest urakan-haku-ytunnuksella-ei-toimi-ilman-oikeuksia

--- a/test/clj/harja/palvelin/integraatiot/api/varusteet_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/varusteet_test.clj
@@ -33,7 +33,7 @@
       [(str +testi-tierekisteri-url+ tierekisteri-resurssi) vastaus-xml
        (str "http://localhost:" portti validi-kutsu) :allow]
       (let [vastaus (api-tyokalut/get-kutsu [validi-kutsu] kayttaja portti)]
-        (log/debug "Vastaus saatiin: " (pr-str vastaus))
+        ;(log/debug "Vastaus saatiin: " (pr-str vastaus))
         (is (= 200 (:status vastaus)) "Haku onnistui validilla kutsulla")))))
 
 (deftest tarkista-tietolajin-virheellinen-haku

--- a/test/clj/harja/palvelin/integraatiot/api/yllapitokohteet_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/yllapitokohteet_test.clj
@@ -62,8 +62,6 @@
         leppajarven-ramppi-2018 (first (filter #(= (:nimi %) "Leppäjärven ramppi 2018")
                                                yllapitokohteet))]
 
-    (log/debug "leppajarven-ramppi-2018 " leppajarven-ramppi-2018)
-
     (is (= 200 (:status vastaus)))
     (is (= 12 (count yllapitokohteet))
         "Palautuu kaikkien vuosien kohteet (2017 & 2018)")

--- a/test/clj/harja/palvelin/integraatiot/sampo/kasittely/toimenpiteet_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/sampo/kasittely/toimenpiteet_test.clj
@@ -51,8 +51,7 @@
     (is (some #(= (first %) "Varuste ja laite (ohjelmoidut korjaukset): Bonukset") nimet))
     (is (some #(= (first %) "Varuste ja laite (ohjelmoidut korjaukset): Sakot") nimet))
     (is (some #(= (first %) "Varuste ja laite (ohjelmoidut korjaukset): Äkilliset hoitotyöt") nimet))
-    (is (some #(= (first %) "Varuste ja laite (ohjelmoidut korjaukset): Muut") nimet))
-    (log/debug "nimet: " nimet))
+    (is (some #(= (first %) "Varuste ja laite (ohjelmoidut korjaukset): Muut") nimet)))
 
   (poista-toimenpide))
 

--- a/test/clj/harja/palvelin/integraatiot/sampo/sanomat/kustannussuunnitelma_sanoma_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/sampo/sanomat/kustannussuunnitelma_sanoma_test.clj
@@ -75,7 +75,7 @@
                      {:alkupvm  "2019-01-01T02:00:00.0",
                       :loppupvm "2019-09-30T00:00:00.0",
                       :summa    0}])]
-    (log/debug segmentit)
+
     (is (= 6 (count segmentit)) "Segmentit on jaoteltu 3 vuodelle")
 
     (let [segmentti (second (second segmentit))]

--- a/test/clj/harja/palvelin/integraatiot/turi/sanomat/turvallisuuspoikkeama_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/turi/sanomat/turvallisuuspoikkeama_test.clj
@@ -96,7 +96,7 @@
 
 (deftest sanomien-muodostus-toimii-kaikille-turpoille
   (let [turpo-idt (sort (flatten (q "SELECT id FROM turvallisuuspoikkeama")))]
-    (log/debug "Validoidaan turpo-idt: " (pr-str turpo-idt))
+    ;(log/debug "Validoidaan turpo-idt: " (pr-str turpo-idt))
     (doseq [id turpo-idt]
       (testaa-turpon-sanoman-muodostus id))))
 

--- a/test/clj/harja/palvelin/palvelut/kokonaishintaiset_tyot_test.clj
+++ b/test/clj/harja/palvelin/palvelut/kokonaishintaiset_tyot_test.clj
@@ -50,7 +50,7 @@
 
         urakoitsijan-urakanvalvoja (oulun-2005-urakan-urakoitsijan-urakkavastaava)
         ei-ole-taman-urakan-urakoitsijan-urakanvalvoja (ei-ole-oulun-urakan-urakoitsijan-urakkavastaava)
-        _ (log/debug  "URAKOITSIJAN URAKANVALVOJA" urakoitsijan-urakanvalvoja "; O AU ID " @oulun-alueurakan-2005-2010-id)
+        ;_ (log/debug  "URAKOITSIJAN URAKANVALVOJA" urakoitsijan-urakanvalvoja "; O AU ID " @oulun-alueurakan-2005-2010-id)
         kokonaishintaiset-tyot-kutsujana-urakoitsija
         (filter #(= oulun-alueurakan-sopimus (:sopimus %))
                 (kutsu-palvelua (:http-palvelin jarjestelma) :kokonaishintaiset-tyot

--- a/test/clj/harja/palvelin/palvelut/laskutusyhteenveto_test.clj
+++ b/test/clj/harja/palvelin/palvelut/laskutusyhteenveto_test.clj
@@ -50,9 +50,9 @@
           haetut-tiedot-oulu-talvihoito (first (filter #(= (:tuotekoodi %) "23100") haetut-tiedot-oulu))
           haetut-tiedot-oulu-liikenneymparisto (first (filter #(= (:tuotekoodi %) "23110") haetut-tiedot-oulu))
           haetut-tiedot-oulu-soratiet (first (filter #(= (:tuotekoodi %) "23120") haetut-tiedot-oulu))
-          _ (log/debug "haetut-tiedot-oulu-talvihoito" haetut-tiedot-oulu-talvihoito)
-          _ (log/debug "haetut-tiedot-oulu-liikenneymparisto" haetut-tiedot-oulu-liikenneymparisto)
-          _ (log/debug "haetut-tiedot-oulu-soratiet" haetut-tiedot-oulu-soratiet)
+          ;_ (log/debug "haetut-tiedot-oulu-talvihoito" haetut-tiedot-oulu-talvihoito)
+          ;_ (log/debug "haetut-tiedot-oulu-liikenneymparisto" haetut-tiedot-oulu-liikenneymparisto)
+          ;_ (log/debug "haetut-tiedot-oulu-soratiet" haetut-tiedot-oulu-soratiet)
 
           odotetut-talvihoito
           {:bonukset_laskutettu_ind_korotettuna               0.0M

--- a/test/clj/harja/palvelin/palvelut/muokkauslukko_test.clj
+++ b/test/clj/harja/palvelin/palvelut/muokkauslukko_test.clj
@@ -49,7 +49,7 @@
         lukko (kutsu-palvelua (:http-palvelin jarjestelma)
                               :lukitse
                               +kayttaja-jvh+ {:id "tyhmanakyma_123"})]
-    (log/debug "Lukko: " (pr-str lukko))
+    ;(log/debug "Lukko: " (pr-str lukko))
     (is (not (= :ei-lukittu lukko)))
     (is (= (:id lukko) "tyhmanakyma_123"))
     (is (= (:kayttaja lukko) (:id +kayttaja-jvh+)))
@@ -64,7 +64,7 @@
         lukko (kutsu-palvelua (:http-palvelin jarjestelma)
                               :hae-lukko-idlla
                               +kayttaja-jvh+ {:id "tyhmalukko_666"})]
-    (log/debug "Lukko: " (pr-str lukko))
+    ;(log/debug "Lukko: " (pr-str lukko))
     (is (not (= :ei-lukittu lukko)))
     (is (= (:id lukko) "tyhmalukko_666"))))
 

--- a/test/clj/harja/palvelin/palvelut/turvallisuuspoikkeamat_test.clj
+++ b/test/clj/harja/palvelin/palvelut/turvallisuuspoikkeamat_test.clj
@@ -73,7 +73,7 @@
 
 (defn poista-tp-taulusta
   [kuvaus]
-  (log/debug "Poistetaan testi-turpo")
+  ;(log/debug "Poistetaan testi-turpo")
   (let [id (ffirst (q (str "SELECT id FROM turvallisuuspoikkeama WHERE kuvaus='" kuvaus "'")))]
     (u (str "DELETE FROM korjaavatoimenpide WHERE turvallisuuspoikkeama=" id))
     (u (str "DELETE FROM turvallisuuspoikkeama_kommentti WHERE turvallisuuspoikkeama=" id))

--- a/test/clj/harja/palvelin/palvelut/valitavoitteet_test.clj
+++ b/test/clj/harja/palvelin/palvelut/valitavoitteet_test.clj
@@ -32,7 +32,7 @@
   (let [vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
                                 :hae-urakan-valitavoitteet +kayttaja-jvh+ (hae-oulun-alueurakan-2014-2019-id))]
 
-    (log/debug vastaus)
+    ;(log/debug vastaus)
     (is (>= (count vastaus) 4)))
 
   (let [vastaus (kutsu-palvelua (:http-palvelin jarjestelma)

--- a/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
+++ b/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
@@ -491,7 +491,7 @@
 
 (defn- tallenna-vaara-paallystysilmoitus
   [paallystyskohde-id paallystysilmoiuts vuosi odotettu]
-  (log/debug "Yritän tallentaa väärä päällystysilmotus " paallystyskohde-id)
+  ;(log/debug "Yritän tallentaa väärä päällystysilmotus " paallystyskohde-id)
   (is (some? paallystyskohde-id))
   (let [paallystysilmoitus (-> paallystysilmoiuts
                                (assoc :paallystyskohde-id paallystyskohde-id)

--- a/test/clj/harja/tyokalut/json_validointi_test.clj
+++ b/test/clj/harja/tyokalut/json_validointi_test.clj
@@ -20,7 +20,7 @@
       (json-skeemat/virhevastaus json-data)
       (assert false "Invalidi JSON ei aiheuttanut oletettua poikkeusta")
       (catch [:type virheet/+invalidi-json+] {:keys [virheet]}
-        (log/debug "VIRHEET:" virheet)
+        ;(log/debug "VIRHEET:" virheet)
         (is (.contains (:viesti (first virheet)) "JSON ei ole validia"))))))
 
 (deftest tarkista-syntaksiltaan-virheellinen-json
@@ -29,7 +29,7 @@
      (json-skeemat/virhevastaus json-data)
      (assert false "Invalidi JSON ei aiheuttanut oletettua poikkeusta")
      (catch [:type virheet/+invalidi-json+] {:keys [virheet]}
-       (log/debug "VIRHEET:" virheet)
+       ;(log/debug "VIRHEET:" virheet)
        (is (.contains (:viesti (first virheet)) "JSON ei ole validia"))))))
 
 (deftest urakkahaun-vastaus

--- a/test/clj/tarkkailija/palvelin/komponentit/uudelleen_kaynnistaja_test.clj
+++ b/test/clj/tarkkailija/palvelin/komponentit/uudelleen_kaynnistaja_test.clj
@@ -112,7 +112,7 @@
                                                                                                               (when (= palvelin event-apurit/host-nimi)
                                                                                                                 (alter-var-root #'jarjestelma
                                                                                                                                 (fn [harja-jarjestelma]
-                                                                                                                                  (log/debug "harjajarjestelman-restart")
+                                                                                                                                  ;(log/debug "harjajarjestelman-restart")
                                                                                                                                   (try (let [uudelleen-kaynnistetty-jarjestelma (jarjestelma/system-restart harja-jarjestelma payload)]
                                                                                                                                          (jms/aloita-jms (:itmf uudelleen-kaynnistetty-jarjestelma))
                                                                                                                                          (if (jarjestelma/kaikki-ok? uudelleen-kaynnistetty-jarjestelma (* 1000 10))

--- a/test/resurssit/api/paikkausten-kirjaus-vaara-pituus.json
+++ b/test/resurssit/api/paikkausten-kirjaus-vaara-pituus.json
@@ -1,0 +1,57 @@
+{
+  "otsikko": {
+    "lahettaja": {
+      "jarjestelma": "Urakoitsijan järjestelmä",
+      "organisaatio": {
+        "nimi": "Urakoitsija",
+        "ytunnus": "1234567-8"
+      }
+    },
+    "viestintunniste": {
+      "id": 123
+    },
+    "lahetysaika": "2018-01-30T12:00:00Z"
+  },
+  "paikkaukset": [
+    {
+      "paikkaus": {
+        "tunniste": {
+          "id": <PAIKKAUSTUNNISTE>
+        },
+        "paikkauskohde": {
+          "nimi": "Testipaikkauskohde",
+          "tunniste": {
+            "id": <KOHDETUNNISTE>
+          }
+        },
+        "alkuaika": "2018-01-30T12:00:00Z",
+        "loppuaika": "2018-01-30T18:00:00Z",
+        "sijainti": {
+          "tie": 924,
+          "aosa": 13,
+          "aet": 2972,
+          "losa": 13,
+          "let": 2764
+        },
+        "tyomenetelma": "UREM",
+        "massatyyppi": "AB, Asfalttibetoni",
+        "leveys": 1.6,
+        "massamenekki": 62,
+        "raekoko": 11,
+        "kuulamylly": "AN19",
+        "kivi-ja-sideaineet": [
+          {
+            "kivi-ja-sideaine": {
+              "esiintyma": "testi",
+              "km-arvo": "testi",
+              "muotoarvo": "testi",
+              "sideainetyyppi": "20/30",
+              "pitoisuus": 1.2,
+              "lisa-aineet": "lisäaineet"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tietokanta/testidata/paikkaukset.sql
+++ b/tietokanta/testidata/paikkaukset.sql
@@ -374,12 +374,19 @@ insert into paikkauskohde (nimi, luotu, "luoja-id", "urakka-id", alkupvm, loppup
  ROW (926, 9, 3364, 12, 3964, 0, NULL, NULL, NULL, NULL)::tr_osoite_laajennettu,
  400, 400, 'jm', 'Keskustelujen jälkeen päädyttiin siihen, että tätä kohtaa ei tarvitse paikata.');
 
+-- Lisätään UREM kohde ja sille yksi toteuma
 insert into paikkauskohde ("ulkoinen-id", nimi, luotu, "luoja-id", "urakka-id",
                            alkupvm, loppupvm, tyomenetelma, tierekisteriosoite_laajennettu,
                            "paikkauskohteen-tila", "suunniteltu-maara", "suunniteltu-hinta", yksikko, lisatiedot)  VALUES
 (999888777, 'Muokattava testikohde', current_timestamp, 3, 36, '2021-01-01', '2021-01-02', 8,
- ROW(926, 9, 3364, 12, 3964, 1, NULL, NULL, NULL, NULL)::tr_osoite_laajennettu, 'ehdotettu',
+ ROW(926, 9, 3364, 12, 3964, 1, NULL, NULL, NULL, NULL)::tr_osoite_laajennettu, 'tilattu',
  1000, 1000, 'jm', 'muokattava testikohde');
+
+INSERT INTO paikkaus ("urakka-id", "paikkauskohde-id", "ulkoinen-id", alkuaika, loppuaika, tierekisteriosoite,
+                      tyomenetelma, massatyyppi, leveys, raekoko, kuulamylly, massamaara)
+VALUES (36,(select id from paikkauskohde where nimi = 'Muokattava testikohde'),1113, '2021-01-01 00:00:00',
+        '2021-01-01 01:00:00', ROW(926, 9, 3364, 12, 3964, NULL)::tr_osoite, 8, 'AB, Asfalttibetoni', 7.1, 5, 'AN5', 1234);
+
 
 
 -- Koska todella monessa paikkauksessa ei alunperin lisätty paikkauskohteelle paikkauskohde-tila arvoa eikä työmenetelmää


### PR DESCRIPTION
Estetään apin kautta tulevan paikkaustoteuman iterekisteriosoitteen pituuden negatiivisuus.
Samalla lisätty yksikkötestiä, jolla jo tullutta paikkaustoteumaan muutetaan.

Korjataan samalla paikkauskohteiden toteumien välilehden urem toteuman tierekisterin näkyminen, kun oli kahteen kertaan listassa samat tiedot. 
Edellisen mahdollistamiseksi lisätty testidataa testitietokantaan.