### PR TITLE
Määrittele tr_osoite-tyyppi paikkaus-domainiin.

### DIFF
--- a/src/cljc/harja/domain/paikkaus.cljc
+++ b/src/cljc/harja/domain/paikkaus.cljc
@@ -17,6 +17,7 @@
 
 (define-tables
   ["tr_osoite_laajennettu" ::tr-osoite-laajennettu]
+  ["tr_osoite" ::tr-osoite]
   ["paikkauskohde" ::paikkauskohde
    {"luoja-id" ::muokkaustiedot/luoja-id
     "luotu" ::muokkaustiedot/luotu

--- a/src/cljc/harja/domain/paikkaus.cljc
+++ b/src/cljc/harja/domain/paikkaus.cljc
@@ -4,6 +4,7 @@
     [clojure.string :as str]
     [harja.domain.muokkaustiedot :as muokkaustiedot]
     [harja.kyselyt.specql :as harja-specql]
+    [harja.domain.tierekisteri :as tr]
     [harja.pvm :as pvm]
 
     #?@(:clj  [
@@ -17,7 +18,7 @@
 
 (define-tables
   ["tr_osoite_laajennettu" ::tr-osoite-laajennettu]
-  ["tr_osoite" ::tr-osoite]
+  ["tr_osoite" ::tr/tr-osoite]
   ["paikkauskohde" ::paikkauskohde
    {"luoja-id" ::muokkaustiedot/luoja-id
     "luotu" ::muokkaustiedot/luotu


### PR DESCRIPTION
Uncaught Error: Unable to resolve spec: :specql.data-types/tr_osoite
    at cljs$spec$alpha$the_spec (alpha.js:sourcemap:289)
    at Function.cljs$core$IFn$_invoke$arity$5 (alpha.js:sourcemap:1692)
    at cljs$spec$alpha$spec_impl (alpha.js:sourcemap:1666)
    at Function.cljs$core$IFn$_invoke$arity$4 (alpha.js:sourcemap:1676)
    at cljs$spec$alpha$spec_impl (alpha.js:sourcemap:1662)
    at cljs$spec$alpha$def_impl (alpha.js:sourcemap:1043)
    at paikkaus.js:sourcemap:188
    
    Tämä virhe on alkanut ilmentyä jonkin uuden muutoksen myötä ja rikkoo esim. kustannussuunnitelman cypress-testit.

Korjaus: Määritellään tr_osoite paikkaus-domainiin.