### PR TITLE
VHAR-5358 Lisää raporttien suoritustietoihin urakka- ja organisaatioroolit

### DIFF
--- a/src/clj/harja/kyselyt/raportit.sql
+++ b/src/clj/harja/kyselyt/raportit.sql
@@ -3,17 +3,19 @@ select *, extract(epoch from rs.suoritus_valmis - rs.luotu) as kesto from raport
 
 -- name: luo-suoritustieto<!
 insert into 
-       raportti_suoritustieto (raportti, rooli, konteksti, suorittajan_organisaatio, 
-                                  parametrit, aikavali_alkupvm, aikavali_loppupvm, 
-                                  urakka_id, hallintayksikko_id, suoritustyyppi) 
-       values (:raportti, :rooli, :konteksti, :suorittajan_organisaatio, 
+       raportti_suoritustieto (raportti, rooli, urakkarooli, organisaatiorooli,
+                               konteksti, suorittajan_organisaatio,
+                               parametrit, aikavali_alkupvm, aikavali_loppupvm,
+                               urakka_id, hallintayksikko_id, suoritustyyppi)
+       values (:raportti, :rooli, :urakkarooli, :organisaatiorooli,
+               :konteksti, :suorittajan_organisaatio,
                :parametrit::jsonb, :aikavali_alkupvm, :aikavali_loppupvm, 
                :urakka_id, :hallintayksikko_id, :suoritustyyppi)
                returning raportti_suoritustieto.id;
 
 -- name: paivita-suorituksen-kesto<!
 update raportti_suoritustieto
-set suoritus_valmis = :valmispvm where id = :id;
+   set suoritus_valmis = NOW() where id = :id;
 
 -- name: paivita_raportti_cachet
 SELECT paivita_raportti_cachet();

--- a/test/clj/harja/palvelin/raportointi/tehtavamaarat_test.clj
+++ b/test/clj/harja/palvelin/raportointi/tehtavamaarat_test.clj
@@ -269,22 +269,24 @@
                             {:nimi       :tehtavamaarat
                              :konteksti  "urakka"
                              :parametrit {:alkupvm  (c/to-date (t/local-date 2016 10 1))
-                                          :loppupvm (c/to-date (t/local-date 2017 10 1))}})
-            [_ _ [_ _ _ rivit2]]
-            (kutsu-palvelua (:http-palvelin jarjestelma)
-                            :suorita-raportti
-                            +kayttaja-jvh+
-                            {:nimi       :tehtavamaarat
-                             :konteksti  "urakka"
-                             :urakka-id  82347592
-                             :parametrit {:alkupvm  (c/to-date (t/local-date 2016 10 1))
                                           :loppupvm (c/to-date (t/local-date 2017 10 1))}})]
+
         (is (empty? rivit) "Haetaan urakkaa ilman urakka-id")
-        (is (thrown? IllegalArgumentException (kutsu-palvelua (:http-palvelin jarjestelma)
-                                                              :suorita-raportti
-                                                              +kayttaja-jvh+
-                                                              {:nimi       :tehtavamaarat
-                                                               :konteksti  "urakka"
-                                                               :urakka-id  8234759283495
-                                                               :parametrit {:loppupvm (c/to-date (t/local-date 2017 10 1))}})) "Parametreja puuttuu")
-        (is (empty? rivit2) "Ei olemassa oleva id"))))
+
+            (is (thrown? SecurityException
+                         (kutsu-palvelua (:http-palvelin jarjestelma)
+                                         :suorita-raportti
+                                         +kayttaja-jvh+
+                                         {:nimi :tehtavamaarat
+                                          :konteksti "urakka"
+                                          :urakka-id 82347592
+                                          :parametrit {:alkupvm (c/to-date (t/local-date 2016 10 1))
+                                                       :loppupvm (c/to-date (t/local-date 2017 10 1))}})))
+
+        (is (thrown? SecurityException (kutsu-palvelua (:http-palvelin jarjestelma)
+                                                       :suorita-raportti
+                                                       +kayttaja-jvh+
+                                                       {:nimi       :tehtavamaarat
+                                                        :konteksti  "urakka"
+                                                        :urakka-id  8234759283495
+                                                        :parametrit {:loppupvm (c/to-date (t/local-date 2017 10 1))}})) "Parametreja puuttuu"))))

--- a/test/clj/harja/palvelin/raportointi_test.clj
+++ b/test/clj/harja/palvelin/raportointi_test.clj
@@ -80,3 +80,36 @@
     (is (some? (kutsu-palvelua +kayttaja-jvh+)))
     ;; ei heitä virhettä tilaajan urakanvalvojalle
     (is (some? (kutsu-palvelua +kayttaja-tero+)))))
+
+(deftest raportin-suoritustietojen-roolien-parsinta
+  (let [roolit-jvh #{"Jarjestelmavastaava"}
+        roolit-kaksi-roolia #{"Tilaajan_Asiantuntija" "Jarjestelmavastaava"}
+        roolit-tyhja {}
+
+        urakkaroolit-vastuuhlo-ja-laadunvalvoja {35 #{"vastuuhenkilo" "Laadunvalvoja"}, 7 #{"vastuuhenkilo"}}
+        urakkaroolit-urakanvalvoja {35 #{"ELY_Urakanvalvoja"}}
+        urakkaroolit-tyhja {}
+
+        organisaatioroolit-kayttaja-ja-vaihtaja {21 #{"Kayttaja" "Vaipanvaihtaja"}}
+        organisaatioroolit-tyhja {}
+        ]
+    (is (= (r/parsi-roolit roolit-jvh) "Jarjestelmavastaava"))
+    (is (= (r/parsi-roolit roolit-kaksi-roolia) "Tilaajan_Asiantuntija,Jarjestelmavastaava"))
+    (is (nil? (r/parsi-roolit roolit-tyhja)) "Ei rooleja, tultava nil")
+
+    (is (= (r/parsi-urakka-tai-organisaatioroolit urakkaroolit-vastuuhlo-ja-laadunvalvoja) "vastuuhenkilo,Laadunvalvoja"))
+    (is (= (r/parsi-urakka-tai-organisaatioroolit urakkaroolit-urakanvalvoja) "ELY_Urakanvalvoja"))
+    (is (nil? (r/parsi-urakka-tai-organisaatioroolit urakkaroolit-tyhja)) "Ei rooleja, tultava nil")
+
+    (is (= (r/parsi-urakka-tai-organisaatioroolit organisaatioroolit-kayttaja-ja-vaihtaja) "Kayttaja,Vaipanvaihtaja"))
+    (is (nil? (r/parsi-urakka-tai-organisaatioroolit organisaatioroolit-tyhja)) "Ei rooleja, tultava nil")))
+
+(deftest raportin-suoritustietojen-urakka-idn-tarkistus
+  (let [oulun-alueurakan-2014-2019-id (hae-oulun-alueurakan-2014-2019-id)]
+    (is (thrown? SecurityException (r/vaadi-urakka-on-olemassa (:db jarjestelma) 666123)) "Urakkaa ei olemassa")
+    (is (nil? (r/vaadi-urakka-on-olemassa (:db jarjestelma) oulun-alueurakan-2014-2019-id)) "Urakka on olemassa")))
+
+(deftest raportin-suoritustietojen-org-idn-tarkistus
+  (let [pohjois-pohjanmaan-hallintayksikon-id (hae-pohjois-pohjanmaan-hallintayksikon-id)]
+    (is (thrown? SecurityException (r/vaadi-hallintayksikko-on-olemassa (:db jarjestelma) 666123)) "Hallintayksikköä ei olemassa")
+    (is (nil? (r/vaadi-hallintayksikko-on-olemassa (:db jarjestelma) pohjois-pohjanmaan-hallintayksikon-id)) "Hallintayksikkö on olemassa")))

--- a/tietokanta/src/main/resources/db/migration/V1_897__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_897__.sql
@@ -1,0 +1,3 @@
+ALTER TABLE raportti_suoritustieto ALTER COLUMN rooli DROP NOT NULL;
+ALTER TABLE raportti_suoritustieto ADD COLUMN urakkarooli TEXT;
+ALTER TABLE raportti_suoritustieto ADD COLUMN organisaatiorooli TEXT;


### PR DESCRIPTION
* Lisää tietokantaan sarakkeet urakka- ja organisaatiorooleille.
* Pudota rooli-sarakkeen NOT NULL.
* Parsi urakka- ja organisaatioroolit mukaan raportin suoritustietoihin
* Käytä samaa kelloa kun tallennetaan raportin suorituksen alku- ja lähtöaika