### PR TITLE
VHAR-5278 Uudellemaalla päällystysurakan makkarat sekoittuvat hoitourakan geometriaan (urakkanumerot samat)

### DIFF
--- a/src/clj/harja/kyselyt/urakat.sql
+++ b/src/clj/harja/kyselyt/urakat.sql
@@ -1042,7 +1042,7 @@ WHERE urakka = :urakka
 UPDATE urakka
 SET alue   = ST_GeomFromText(:alue) :: GEOMETRY,
   muokattu = CURRENT_TIMESTAMP
-WHERE urakka.urakkanro = :urakkanro;
+WHERE urakka.urakkanro = :urakkanro AND urakka.tyyppi IN ('hoito', 'teiden-hoito');
 
 -- name: hae-urakka-id-alueurakkanumerolla
 -- single?: true

--- a/src/clj/harja/kyselyt/urakat.sql
+++ b/src/clj/harja/kyselyt/urakat.sql
@@ -189,7 +189,6 @@ SELECT
   WHEN (u.tyyppi IN ('hoito'::urakkatyyppi, 'teiden-hoito'::urakkatyyppi) AND au.alue IS NOT NULL)
     THEN -- Luodaan yhtenäinen polygon alueurakan alueelle (multipolygonissa voi olla reikiä)
       ST_SimplifyPreserveTopology(hoidon_alueurakan_geometria(u.urakkanro), 50)
-  ELSE ST_Simplify(au.alue, 50)
   END                                     AS alueurakan_alue
 
 FROM urakka u


### PR DESCRIPTION
-Kun päivitetään alueurakoiden alueita, varmista että kyseessä hoitourakka
-Älä nosta ei-hoitourakoille alueurakan_alue:tta

    Jos alueurakan_alue löytyy, sitä preferoidaan urakka-xf clj-koodissa
    Päällystysurakoille haluamme että alueurakan_alue on NULL, koska geometria
    asetetaan resultsetissä muuttujaan alue