### PR TITLE
VHAR-5385 Raporttien PDF ja Excel vienti epäonnistuu koko maan ja elyn tasolla

### DIFF
--- a/src/clj/harja/palvelin/raportointi/excel.clj
+++ b/src/clj/harja/palvelin/raportointi/excel.clj
@@ -315,10 +315,10 @@
 
 (defmethod muodosta-excel :raportti [[_ raportin-tunnistetiedot & sisalto] workbook]
   (let [sisalto (mapcat #(if (seq? %) % [%]) sisalto)
-        tiedoston-nimi (clojure.string/join ", "
-                                            ((juxt :raportin-nimi :urakka (fn [rivi]
-                                                                            (str (:alkupvm rivi) "-" (:loppupvm rivi))))
-                                             (:raportin-yleiset-tiedot raportin-tunnistetiedot)))]
+        tiedoston-nimi (str/join ", "
+                                 ((juxt :raportin-nimi :urakka (fn [rivi]
+                                                                 (str (:alkupvm rivi) "-" (:loppupvm rivi))))
+                                  (:raportin-yleiset-tiedot raportin-tunnistetiedot)))]
     (doseq [elementti (remove nil? sisalto)]
       (muodosta-excel (liita-yleiset-tiedot elementti raportin-tunnistetiedot) workbook))
     tiedoston-nimi))

--- a/src/clj/harja/palvelin/raportointi/excel.clj
+++ b/src/clj/harja/palvelin/raportointi/excel.clj
@@ -314,10 +314,14 @@
       elementti)))
 
 (defmethod muodosta-excel :raportti [[_ raportin-tunnistetiedot & sisalto] workbook]
-  (let [sisalto (mapcat #(if (seq? %) % [%]) sisalto)]
+  (let [sisalto (mapcat #(if (seq? %) % [%]) sisalto)
+        tiedoston-nimi (clojure.string/join ", "
+                                            ((juxt :raportin-nimi :urakka (fn [rivi]
+                                                                            (str (:alkupvm rivi) "-" (:loppupvm rivi))))
+                                             (:raportin-yleiset-tiedot raportin-tunnistetiedot)))]
     (doseq [elementti (remove nil? sisalto)]
-      (muodosta-excel (liita-yleiset-tiedot elementti raportin-tunnistetiedot) workbook)))
-  (:nimi raportin-tunnistetiedot))
+      (muodosta-excel (liita-yleiset-tiedot elementti raportin-tunnistetiedot) workbook))
+    tiedoston-nimi))
 
 (defmethod muodosta-excel :default [elementti workbook]
   (log/debug "Excel ei tue elementtiä: " elementti)


### PR DESCRIPTION
-Hanskaa :raportin-yleiset-tiedot parsinnassa myös muut mahdolliset caset eli hallintayksikko ja koko maa

-Lisää Excel-raportin tiedostonimeen raportin tietoja