### PR TITLE
Vhar 5383 toteumien tierekisteriosoite

### DIFF
--- a/src/cljs/harja/ui/kentat.cljs
+++ b/src/cljs/harja/ui/kentat.cljs
@@ -1266,7 +1266,7 @@
        (when virhe
          [:div virhe])]
       (when karttavalinta
-        [:div {:style {:display "flex" :flex-direction "column"}}
+        [:div {:style {:flex-grow "1"}}
          [:div.karttavalinta
           karttavalinta]])])))
 


### PR DESCRIPTION
Pikakorjaus käsin syötettävän sijainnin syöttämiseen.
Divi oli input kenttien päällä.