### PR TITLE
Lisätään 'Johto- ja hallintokorvaus (J)' tehtäväryhmä kuukausihakuun

### DIFF
--- a/tietokanta/src/main/resources/db/migration/R__Laskutusyhteenveto_mhu.sql
+++ b/tietokanta/src/main/resources/db/migration/R__Laskutusyhteenveto_mhu.sql
@@ -336,7 +336,8 @@ BEGIN
                                FROM kustannusarvioitu_tyo kt
                                WHERE kt.toimenpideinstanssi = t_instanssi
                                  AND kt.sopimus = sopimus_id
-                                 AND kt.tehtava = toimistotarvike_koodi -- Kustannussuunnitelmassa "Muut kulut" on toimistotarvikekuluja
+                                 AND (kt.tehtava = toimistotarvike_koodi OR -- Kustannussuunnitelmassa "Muut kulut" on toimistotarvikekuluja
+                                      kt.tehtavaryhma = tehtavaryhma_id) -- Tietokantaan saa myös 'Johto- ja hallintokorvaus (J)' tehtäväryhmälle suunniteltua kuluja
                                  AND (SELECT (date_trunc('MONTH',
                                                          format('%s-%s-%s', kt.vuosi, kt.kuukausi, 1)::DATE))) BETWEEN aikavali_alkupvm AND aikavali_loppupvm
 


### PR DESCRIPTION
Kun laskutusyhteenvetoraportille haetaan kuukausittaiset summat ja hoitokauden alusta summa, niin kuukausittaisista puuttui tehtäväryhmä