### PR TITLE
VHAR-5355 Siirtymä kartalta infopaneelista POT:iin ei toimi

### DIFF
--- a/src/cljs/harja/tiedot/urakka/siirtymat.cljs
+++ b/src/cljs/harja/tiedot/urakka/siirtymat.cljs
@@ -11,6 +11,7 @@
             [harja.loki :refer [log]]
             [harja.pvm :as pvm]
             [harja.tiedot.urakka.paallystys :as paallystys]
+            [harja.tiedot.urakka.pot2.pot2-tiedot :as pot2-tiedot]
             [harja.tiedot.urakka.urakka :as urakka-tila]
             [harja.domain.oikeudet :as oikeudet]
             [harja.tiedot.ilmoitukset.tietyoilmoitukset :as tietyoilmoitukset]
@@ -113,7 +114,10 @@
     (let [{:keys [yllapitokohde-id urakka-id hallintayksikko-id] :as vastaus}
           (<! (hae-paallystysilmoituksen-tiedot {:paallystyskohde-id paallystyskohde-id
                                                  :urakka-id kohteen-urakka-id}))
-          vastaus (paallystys/muotoile-osoitteet-ja-alustatoimet vastaus)
+          pot-versio (:versio vastaus)
+          vastaus (if (= 1 pot-versio)
+                    (paallystys/muotoile-osoitteet-ja-alustatoimet vastaus)
+                    (pot2-tiedot/pot2-haun-vastaus->lomakedata vastaus kohteen-urakka-id))
           nykyinen-valilehti-taso1 @nav/valittu-sivu
           nykyinen-valilehti-taso2 (nav/valittu-valilehti :urakat)
           nykyinen-valilehti-taso3 (nav/valittu-valilehti :kohdeluettelo-paallystys)]
@@ -147,7 +151,10 @@
     (let [vastaus (<! (hae-paallystysilmoituksen-tiedot {:paallystyskohde-id paallystyskohde-id
                                                          :urakka-id kohteen-urakka-id
                                                          :paikkauskohde? true}))
-          vastaus (paallystys/muotoile-osoitteet-ja-alustatoimet vastaus)
+          pot-versio (:versio vastaus)
+          vastaus (if (= 1 pot-versio)
+                    (paallystys/muotoile-osoitteet-ja-alustatoimet vastaus)
+                    (pot2-tiedot/pot2-haun-vastaus->lomakedata vastaus kohteen-urakka-id))
           perustiedot (select-keys vastaus paallystys/perustiedot-avaimet)
           muut-tiedot (apply dissoc vastaus paallystys/perustiedot-avaimet)
           vastaus (-> vastaus

--- a/src/cljs/harja/tiedot/urakka/siirtymat.cljs
+++ b/src/cljs/harja/tiedot/urakka/siirtymat.cljs
@@ -155,13 +155,8 @@
           vastaus (if (= 1 pot-versio)
                     (paallystys/muotoile-osoitteet-ja-alustatoimet vastaus)
                     (pot2-tiedot/pot2-haun-vastaus->lomakedata vastaus kohteen-urakka-id))
-          perustiedot (select-keys vastaus paallystys/perustiedot-avaimet)
           muut-tiedot (apply dissoc vastaus paallystys/perustiedot-avaimet)
-          vastaus (-> vastaus
-                      (assoc :perustiedot perustiedot)
-                      (assoc-in [:perustiedot :tr-osoite]
-                                (select-keys perustiedot paallystys/tr-osoite-avaimet))
-                      (merge muut-tiedot))]
+          vastaus (merge vastaus muut-tiedot)]
       ;; Aseta oikea välilehti
       (nav/aseta-valittu-valilehti! :kohdeluettelo-paikkaukset :paikkausten-paallystysilmoitukset)
       ;; Päivitetään app-stateen pot lomakkeen tiedot, jotka on mukiloitu letissä oikeaksi

--- a/src/cljs/harja/ui/kentat.cljs
+++ b/src/cljs/harja/ui/kentat.cljs
@@ -977,11 +977,11 @@
                                 (pvm/->pvm nykyinen-teksti)
                                 nykyinen-pvm
                                 (pvm-tyhjana rivi))
-               input-komponentti [:input {:class (str (when-not (or kentan-tyylit vayla-tyyli?) "pvm")
-                                 (cond
-                                   kentan-tyylit (apply str kentan-tyylit)
-                                   vayla-tyyli? (str "input-" (if virhe? "error-" "") "default ")
-                                   lomake? "form-control"))
+               input-komponentti [:input {:class (yleiset/luokat (when-not (or kentan-tyylit vayla-tyyli?) "pvm")
+                                                                 (cond
+                                                                   kentan-tyylit (apply str kentan-tyylit)
+                                                                   vayla-tyyli? (str "input-" (if virhe? "error-" "") "default ")
+                                                                   lomake? "form-control"))
                          :placeholder (or placeholder "pp.kk.vvvv")
                          :value nykyinen-teksti
                          :on-focus #(do (when on-focus (on-focus)) (reset! auki true) %)

--- a/src/cljs/harja/views/urakka/pot_yhteinen.cljs
+++ b/src/cljs/harja/views/urakka/pot_yhteinen.cljs
@@ -272,7 +272,7 @@
         :tyyppi :pvm ::lomake/col-luokka "col-sm-6"
         :huomauta kasittelyaika}
        {:otsikko "Päätös"
-        :nimi :paatos :kaariva-luokka "paatos"
+        :nimi :paatos
         :tyyppi :valinta ::lomake/col-luokka "col-sm-6"
         :valinnat [:hyvaksytty :hylatty]
         :huomauta paatos


### PR DESCRIPTION
Korjattiin siirtymäkoodia tunnistamaan POT-versio, ja sen mukaisesti muotoilemaan palvelimelta saatu vastaus oikeaan muotoon. Korjattiin samalla myös paikkauskohteiden hallinnan pot-siirtymään.