### PR TITLE
Korjaa flaky budjettisuunnittelutesti

### DIFF
--- a/src/clj/harja/palvelin/palvelut/budjettisuunnittelu.clj
+++ b/src/clj/harja/palvelin/palvelut/budjettisuunnittelu.clj
@@ -327,9 +327,10 @@
 
   (let [ylitetyt-kattohinnat (remove nil? (map
                                             (fn [{:keys [hoitokausi tavoitehinta kattohinta]}]
-                                              (when (and kattohinta
+                                              (when (and kattohinta tavoitehinta
                                                       ;; Sallitaan kattohinnan arvoksi nolla mikäli tavoitehintakin on nolla.
-                                                      (not (and (zero? kattohinta)
+                                                      (not (and
+                                                             (zero? kattohinta)
                                                              (zero? tavoitehinta)))
                                                       (<= kattohinta tavoitehinta))
                                                 hoitokausi))

--- a/src/clj/harja/palvelin/palvelut/budjettisuunnittelu.clj
+++ b/src/clj/harja/palvelin/palvelut/budjettisuunnittelu.clj
@@ -329,7 +329,8 @@
                                             (fn [{:keys [hoitokausi tavoitehinta kattohinta]}]
                                               (when (and kattohinta
                                                       ;; Sallitaan kattohinnan arvoksi nolla mikäli tavoitehintakin on nolla.
-                                                      (not (zero? kattohinta)) (not (zero? tavoitehinta))
+                                                      (not (and (zero? kattohinta)
+                                                             (zero? tavoitehinta)))
                                                       (<= kattohinta tavoitehinta))
                                                 hoitokausi))
                                             tavoitteet))]

--- a/test/clj/harja/palvelin/palvelut/budjettisuunnittelu_test.clj
+++ b/test/clj/harja/palvelin/palvelut/budjettisuunnittelu_test.clj
@@ -763,7 +763,7 @@
              {:urakka-id urakka-id
               :tavoitteet (mapv (fn [tavoite]
                                   (-> tavoite
-                                    (assoc :tavoitehinta (* 2 uusi-tavoitehinta))
+                                    (assoc :tavoitehinta (+ 10 uusi-tavoitehinta))
                                     (assoc :kattohinta uusi-tavoitehinta)))
                             tallennettavat-tavoitteet)})
            (is false "Budjettitavoitteen tallennus onnistui vaikka tavoitehinta ylitti kattohinnan")


### PR DESCRIPTION
Helppo tapa testata:
Replissä budjettisuunnittelu-namespacessa: 
```
(remove nil? (map (fn [_]
       (let [th (clojure.spec.gen.alpha/generate (s/gen ::bs-p/tavoitehinta))]
         (let [vastaus (try
                         (tallenna-urakan-tavoite db
                           user
                           {:urakka-id 39
                            :tavoitteet [{:hoitokausi 1
                                          :tavoitehinta (+ 2 th)
                                          :kattohinta th}]}
                           )
                         th
                         (catch IllegalArgumentException e
                           nil))]
           vastaus)
         )) (range 1000)))
```
Lopputuloksen pitäisi olla tyhjä, ennen korjausta testiä vastaava toteutus, jossa tavoitehinta kerrotaan ynnäämisen sijasta, palauttaa muutaman kerran 0 tai -0.0, mikä olisi testissä ollut epäonnistuminen.