### PR TITLE
Yksikköhintaisen toteuman muokkaaminen

### DIFF
--- a/src/clj/harja/palvelin/palvelut/toteumat.clj
+++ b/src/clj/harja/palvelin/palvelut/toteumat.clj
@@ -169,7 +169,12 @@
     (do
       (when (not (:poistettu tehtava))
         (log/debug "Luodaan uusi tehtävä.")
-        (toteumat-q/luo-tehtava<! c (get-in toteuma [:toteuma :id]) (:toimenpidekoodi tehtava) (:maara tehtava) (:id user) nil (:urakka-id toteuma)))))
+        ;; Koska tälle funktiolle lähetetään kahdesta paikasta eri mäpin avaimessa toteuman id.
+        ;; Hyväksytään toteuman id jommasta kummasta avaimesta.
+        (toteumat-q/luo-tehtava<! c
+          (or (get-in toteuma [:toteuma :id])
+            (:toteuma-id toteuma))
+          (:toimenpidekoodi tehtava) (:maara tehtava) (:id user) nil (:urakka-id toteuma)))))
   (let [toteumatyyppi (name (:tyyppi toteuma))
         maksueratyyppi (case toteumatyyppi
                          "muutostyo" "muu"


### PR DESCRIPTION
Hyväksytään toteumatehtävän käsittelyssä toteuma-id:n antaminen kahdesta eri mäpin avaimesta.

Ongelmana oli muokkaaminen, kun käyttäjä oli tehnyt yksikköhintaisen toteumakirjauksen, niin toteuman id tallentui eri mäpin avaimeen, kuin mihin sen ajateltiin tallentuvan. Joten tässä on sallittu toteuma id:n käyttö kahdesta eri avaimesta.


