### PR TITLE
VHAR-5570 Kasvata indeksikertoimen desimaalien määrää

### DIFF
--- a/src/clj/harja/palvelin/palvelut/budjettisuunnittelu.clj
+++ b/src/clj/harja/palvelin/palvelut/budjettisuunnittelu.clj
@@ -296,9 +296,9 @@
                                                                                (>= vuosi urakan-loppuvuosi)))
                                                                      (map (fn [{:keys [arvo vuosi]}]
                                                                             {:vuosi vuosi
-                                                                             ;; Halutaan numero kahdeksan desimaalin tarkkuudella. Pelataan sen varaan, että indeksikerroin
-                                                                             ;; Ei nouse yli kymmenen, jolloin with-precision 9 riittää.
-                                                                             :indeksikerroin (pyorista (with-precision 9 (/ arvo perusluku)) 8)})))
+                                                                             ;; Halutaan numero kymmenen desimaalin tarkkuudella. Pelataan sen varaan, että indeksikerroin
+                                                                             ;; Ei nouse yli kymmenen, jolloin with-precision 11 riittää.
+                                                                             :indeksikerroin (pyorista (with-precision 11 (/ arvo perusluku)) 10)})))
                                                                (i-q/hae-indeksi db {:nimi indeksi}))
                                   urakan-indeksien-maara (count indeksiluvut-urakan-aikana)]
                               (if (= 5 urakan-indeksien-maara)

--- a/test/clj/harja/palvelin/palvelut/budjettisuunnittelu_test.clj
+++ b/test/clj/harja/palvelin/palvelut/budjettisuunnittelu_test.clj
@@ -236,7 +236,7 @@
 
     ;; Hae Rovaniemen ensimmäisen hoitovuoden indeksi apurilla
     ;; TODO: Tarkasta meneekö tämä assert läpi aina vaikka urakat muuttuu testidatassa dynaamisesti taustalla?
-    (is (= 1.06842508 (bs/indeksikerroin rovaniemen-indeksit 1)))))
+    (is (= 1.0684250765 (bs/indeksikerroin rovaniemen-indeksit 1)))))
 
 (deftest indeksikorjauksen-laskenta
   (is (= 112.603394 (bs/indeksikorjaa 1.12345 100.230))))


### PR DESCRIPTION
Yhdeksäs desimaali oli sittenkin vielä merkitsevä. Lisäsin vielä yhden virhemarginaaliksi.