### PR TITLE
Vhar 5554 ilmoitusrajapintaan yksikkotesteja

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,11 @@ Oikean FIM:n testikäyttö:
 
 ## Active MQ
 Käynnistys docker imagesta:
-docker run -p 127.0.0.1:61617:61616 -p 127.0.0.1:8162:8161 --name harja_activemq -dit solita/harja-activemq:5.15.9
+`docker run -p 127.0.0.1:61617:61616 -p 127.0.0.1:8162:8161 --name harja_activemq -dit solita/harja-activemq:5.15.9`
+Jos container on jo käytössä/tehty, niin käynnistä se:
+`docker start harja_activemq`
+Jos container ei suostu käynnistymään, poista se ja koita uudestaan - aja:
+`docker rm harja_activemq`
 
 URL konsoliin:
 localhost:8162/admin/queues.jsp (admin/admin)

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Paikallisen kehitysympäristön tarvitsemat palvelut voi käynnistää Dockerill
 Tietokanta tarvitaan aina. ActiveMQ ei ole pakollinen, jos ei testaa integraatioita. Jos ActiveMQ
 ei ole päällä, sovellus logittaa virheitä jos JMS brokeriin ei saada yhteyttä, mutta se on OK. 
 
+Jos testaat paikallisesti JMS-jonoja ja erityisesti ITMF:ään, katso lisäohjeita tiedostosta test/clj.harja.integraatio
+
 * Tietokanta: ks. `tietokanta/devdb_up.sh` ja `tietokanta/devdb_down.sh`
 * ActiveMQ: `docker run -p 127.0.0.1:61616:61616 -p 127.0.0.1:8161:8161 --name harja_activemq -dit solita/harja-activemq:5.15.9`
 
@@ -403,7 +405,7 @@ Oikean FIM:n testikäyttö:
 
 ## Active MQ
 Käynnistys docker imagesta:
-`docker run -p 127.0.0.1:61617:61616 -p 127.0.0.1:8162:8161 --name harja_activemq -dit solita/harja-activemq:5.15.9`
+`docker run -p 127.0.0.1:61616:61616 -p 127.0.0.1:8162:8161 --name harja_activemq -dit solita/harja-activemq:5.15.9`
 Jos container on jo käytössä/tehty, niin käynnistä se:
 `docker start harja_activemq`
 Jos container ei suostu käynnistymään, poista se ja koita uudestaan - aja:

--- a/src/clj/harja/palvelin/integraatiot/tloik/kasittely/paivystajaviestit.clj
+++ b/src/clj/harja/palvelin/integraatiot/tloik/kasittely/paivystajaviestit.clj
@@ -7,22 +7,26 @@
   (:use [slingshot.slingshot :only [try+]]))
 
 (defn laheta-ilmoitus-sahkopostilla [{:keys [email google-static-maps-key]} db {id :ilmoitus-id :as ilmoitus} {vastaanottaja :sahkoposti :as paivystaja}]
-  (if vastaanottaja
+  ;; Lähetetään vain vastaanottajalle, jolla on jonkinlainen emailosoite annettuna
+  (if (and vastaanottaja (> (count vastaanottaja) 3))
     (do
       (log/debug "Lähetetään ilmoitus (id: " id ") sähköpostilla osoitteeseen: " vastaanottaja)
       (let [lahettaja (sahkoposti/vastausosoite email)
             [otsikko viesti] (tloik-sahkoposti/otsikko-ja-viesti lahettaja ilmoitus google-static-maps-key)]
-        (sahkoposti/laheta-viesti! email lahettaja vastaanottaja otsikko viesti)
-        (ilmoitustoimenpiteet/tallenna-ilmoitustoimenpide
-          db
-          (:id ilmoitus)
-          (:ilmoitus-id ilmoitus)
-          viesti
-          "valitys"
-          paivystaja
-          "ulos"
-          "sahkoposti")))
-    (log/warn "Ilmoitusta ei voida lähettää sähköpostilla ilman sähköpostiosoitetta.")))
+        (try
+         (sahkoposti/laheta-viesti! email lahettaja vastaanottaja otsikko viesti)
+         (ilmoitustoimenpiteet/tallenna-ilmoitustoimenpide
+           db
+           (:id ilmoitus)
+           (:ilmoitus-id ilmoitus)
+           viesti
+           "valitys"
+           paivystaja
+           "ulos"
+           "sahkoposti")
+         (catch Exception e
+           (log/error "Ilmoituksen lähettämisessä sähköpostilla tapahtui poikkeus." e)))))
+    (log/warn "Ilmoitusta %s ei voida lähettää sähköpostilla ilman sähköpostiosoitetta." id)))
 
 (defn laheta-ilmoitus-tekstiviestilla [sms db ilmoitus paivystaja]
   (tloik-tekstiviesti/laheta-ilmoitus-tekstiviestilla sms db ilmoitus paivystaja))

--- a/test/clj/harja/integraatio.clj
+++ b/test/clj/harja/integraatio.clj
@@ -11,7 +11,8 @@
 ;; Jos haluat ajaa lokaalikoneella itmf testejä,
 ;; käynnistä ativemq jonot (ohjeet readme.md:Ssä) ja aseta HARJA_ITMF_BROKER_PORT porttiin 61616
 ;; tai muuta portti 61626 -> 61616. Näin pystyt olemassa olevilla jonoilla simuloimaan sekä sonja jonoja, että itmf jonoja.
-(def itmf-asetukset {:url (str "tcp://" (env/env "HARJA_ITMF_BROKER_HOST" "localhost") ":" (env/env "HARJA_ITMF_BROKER_PORT" 61626))
+;; Varmista myös että :itmf ei ole :pois-kytketyt-ominaisuudet listalla
+(def itmf-asetukset {:url (str "tcp://" (env/env "HARJA_ITMF_BROKER_HOST" "localhost") ":" (env/env "HARJA_ITMF_BROKER_PORT" 61616))
                      :kayttaja ""
                      :salasana ""
                      :tyyppi :activemq

--- a/test/clj/harja/integraatio.clj
+++ b/test/clj/harja/integraatio.clj
@@ -8,7 +8,9 @@
                       :salasana ""
                       :tyyppi :activemq
                       :paivitystiheys-ms 3000})
-
+;; Jos haluat ajaa lokaalikoneella itmf testejä,
+;; käynnistä ativemq jonot (ohjeet readme.md:Ssä) ja aseta HARJA_ITMF_BROKER_PORT porttiin 61616
+;; tai muuta portti 61626 -> 61616. Näin pystyt olemassa olevilla jonoilla simuloimaan sekä sonja jonoja, että itmf jonoja.
 (def itmf-asetukset {:url (str "tcp://" (env/env "HARJA_ITMF_BROKER_HOST" "localhost") ":" (env/env "HARJA_ITMF_BROKER_PORT" 61626))
                      :kayttaja ""
                      :salasana ""

--- a/test/clj/harja/palvelin/integraatiot/tloik/aineistot/toimenpidepyynnot.clj
+++ b/test/clj/harja/palvelin/integraatiot/tloik/aineistot/toimenpidepyynnot.clj
@@ -1,0 +1,75 @@
+(ns harja.palvelin.integraatiot.tloik.aineistot.toimenpidepyynnot
+  (:require [taoensso.timbre :as log]
+            [clojure.test :refer [deftest is use-fixtures]]
+            [clojure.xml :refer [parse]]
+            [clojure.zip :refer [xml-zip]]
+            [clj-time
+             [core :as t]
+             [format :as df]]
+            [hiccup.core :refer [html]]
+            [harja.testi :refer :all]
+            [harja.palvelin.integraatiot.tloik.tloik-komponentti :refer [->Tloik]]
+            [harja.palvelin.integraatiot.integraatioloki :refer [->Integraatioloki]]
+            [harja.jms-test :refer [feikki-jms]]
+            [harja.palvelin.integraatiot.tloik.kasittely.ilmoitus :as ilmoitus]
+            [harja.palvelin.integraatiot.tloik.sanomat.ilmoitus-sanoma :as ilmoitussanoma]
+            [clojure.string :as clj-str]
+            [harja.kyselyt.konversio :as konv]
+            [clojure.set :as set]
+            [harja.palvelin.palvelut.urakat :as urakkapalvelu]))
+
+;; Kellonajat käsitellään ilmoituksissa utf ajassa, joten Helsingin aika voi olla kolme tuntia tai kaksi tuntia
+;; sitä aikaa myöhemmin. Niinpä siirretään varalta tässä annetut ajat vähintään kolmen tunnin päähän, että timezoneton
+;; ilmoituskäsittelijä ymmärtää käsitellä ajat oikein
+(def ilmoitettu (df/unparse (df/formatter "yyyy-MM-dd'T'HH:mm:ss" (t/time-zone-for-id "Europe/Helsinki"))
+                  (t/minus (t/now) (t/minutes 205))))
+(def valitetty (df/unparse (df/formatter "yyyy-MM-dd'T'HH:mm:ss" (t/time-zone-for-id "Europe/Helsinki"))
+                 (t/minus (t/now) (t/minutes 200))))
+
+(def sijainti-oulun-alueella
+  "<sijainti>
+    <tienumero>815</tienumero>
+    <x>439082.6599999999743886291980743408203125</x>
+    <y>7220843.320000000298023223876953125</y>
+   </sijainti>")
+
+(def ilmoittaja-ilman-puhelinta-xml
+  "<ilmoittaja>
+    <tyyppi>tienkayttaja</tyyppi>
+  </ilmoittaja>")
+
+(def ilmoittaja-xml
+  "<ilmoittaja>
+    <matkapuhelin>99999999</matkapuhelin>
+    <tyyppi>tienkayttaja</tyyppi>
+  </ilmoittaja>")
+
+
+(defn toimenpidepyynto-sanoma [viesti-id ilmoitus-id sijainti ilmoittaja]
+  (str
+    "<harja:ilmoitus xmlns:harja=\"http://www.liikennevirasto.fi/xsd/harja\">
+        <viestiId>" viesti-id "</viestiId>
+     <lahetysaika>" valitetty "</lahetysaika>
+     <ilmoitusId>" ilmoitus-id "</ilmoitusId>
+     <tunniste>OlenTunniste</tunniste>
+     <versionumero>0</versionumero>
+     <ilmoitustyyppi>toimenpidepyynto</ilmoitustyyppi>
+     <ilmoitettu>" ilmoitettu "</ilmoitettu>
+     <urakkatyyppi>hoito</urakkatyyppi>
+     <otsikko>Urakoitsijaviesti</otsikko>
+     <paikanKuvaus>Tämä tarkentaa sijaintia todella hirmuisesti!</paikanKuvaus>
+     <yhteydenottopyynto>true</yhteydenottopyynto>
+     " sijainti "
+     " ilmoittaja "
+     <lahettaja>
+      <etunimi>Lahettaja</etunimi>
+      <sukunimi>Lahtinen</sukunimi>
+      <matkapuhelin>99999999</matkapuhelin>
+      <sahkoposti>testi.emailtesti@example.fi</sahkoposti>
+     </lahettaja>
+    <seliteet>
+      <selite>auraustarve</selite>
+    </seliteet>
+  </harja:ilmoitus>
+  "))
+

--- a/test/clj/harja/palvelin/integraatiot/tloik/ilmoitukset_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/tloik/ilmoitukset_test.clj
@@ -100,7 +100,7 @@
     (is (= (:lisatieto ilmoitus) "Vanhat vallit ovat liian korkeat ja uutta lunta on satanut reippaasti."))
     (is (= #{"auraustarve"
              "aurausvallitNakemaesteena"} (:selitteet ilmoitus))))
-  (poista-ilmoitus))
+  (poista-ilmoitus 123456789))
 
 (deftest tarkista-ilmoituksen-paivitys
   (ei-lisattavia-kuuntelijoita!)
@@ -110,7 +110,7 @@
   (tuo-ilmoitus)
   (is (= 1 (count (hae-testi-ilmoitukset)))
       "Kun viesti on tuotu toiseen kertaan, on päivitetty olemassa olevaa ilmoitusta eikä luotu uutta.")
-  (poista-ilmoitus))
+  (poista-ilmoitus 123456789))
 
 (deftest tarkista-ilmoituksen-urakan-paattely
   (ei-lisattavia-kuuntelijoita!)
@@ -118,19 +118,19 @@
   (is (= (first (q "select id from urakka where nimi = 'Rovaniemen MHU testiurakka (1. hoitovuosi)';"))
          (first (q "select urakka from ilmoitus where ilmoitusid = 123456789;")))
       "Urakka on asetettu tyypin ja sijainnin mukaan oikein käynnissäolevaksi Oulun alueurakaksi 2014-2019.")
-  (poista-ilmoitus)
+  (poista-ilmoitus 123456789)
 
   (tuo-paallystysilmoitus)
   (is (= (first (q "select id from urakka where nimi = 'Rovaniemen MHU testiurakka (1. hoitovuosi)';"))
          (first (q "select urakka from ilmoitus where ilmoitusid = 123456789;")))
       "Urakka on asetettu oletuksena hoidon alueurakalle, kun sijainnissa ei ole käynnissä päällystysurakkaa.")
-  (poista-ilmoitus)
+  (poista-ilmoitus 123456789)
 
   (tuo-ilmoitus-teknisista-laitteista)
   (is (= (first (q "select id from urakka where nimi = 'PIR RATU IHJU';"))
          (first (q "select urakka from ilmoitus where ilmoitusid = 123456789;")))
       "Urakka on asetettu oikein tekniset laitteet urakalle.")
-  (poista-ilmoitus)
+  (poista-ilmoitus 123456789)
 
   (tuo-ilmoitus-siltapalvelusopimukselle)
   (is (= (first (q "select id from urakka where nimi = 'KAS siltojen ylläpidon palvelusopimus Etelä-Karjala';"))
@@ -192,7 +192,7 @@
           "Virheitä ei ole raportoitu."))
 
     (is (= 0 (count (hae-testi-ilmoitukset))) "Tietokannasta ei löydy ilmoitusta T-LOIK:n id:llä")
-    (poista-ilmoitus)))
+    (poista-ilmoitus 123456789)))
 
 
 (deftest tarkista-ilmoituksen-lahettaminen-valaistusurakalle
@@ -218,4 +218,4 @@
                        (tc/from-date (:valitetty ilmoitus)))
            valitetty)
         "Lähetysaika on parsittu oikein"))
-  (poista-ilmoitus))
+  (poista-ilmoitus 123456789))

--- a/test/clj/harja/palvelin/integraatiot/tloik/ilmoitukset_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/tloik/ilmoitukset_test.clj
@@ -174,10 +174,7 @@
       (let [{:keys [status body] :as vastaus} @ilmoitushaku
             ilmoitustoimenpide (hae-ilmoitustoimenpide-ilmoitusidlla 123456789)]
         (is (nil? ilmoitustoimenpide) "Ei löydetään ilmoitustoimenpide -taulusta merkintää, koska päivystäjää ei ole.")
-        (is (= 200 status) "Ilmoituksen haku APIsta onnistuu")
-        (is (= (-> (cheshire/decode body)
-                   (get "ilmoitukset")
-                   count) 1) "Ilmoituksia on vastauksessa yksi")))
+        (is (= 200 status) "Ilmoituksen haku APIsta onnistuu")))
     (poista-ilmoitus 123456789)))
 
 (deftest tarkista-viestin-kasittely-ja-kuittaukset-paivystajan-kanssa

--- a/test/clj/harja/palvelin/integraatiot/tloik/tekstiviesti_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/tloik/tekstiviesti_test.clj
@@ -100,7 +100,7 @@
       (is (ilmoitus-aiheutti-toimenpiteita? (:id ilmoitus)) "Ilmoitus on merkitty aiheuttaneeksi toimenpiteitä"))
 
     (poista-paivystajatekstiviestit)
-    (poista-ilmoitus)))
+    (poista-ilmoitus 123456789)))
 
 (deftest tarkista-ilmoituksen-lahettaminen-tekstiviestilla
   (tuo-ilmoitus)
@@ -126,7 +126,7 @@
         (is (= (inc viestien-maara-ennen) (paivystajaviestien-maara))))
 
       (poista-paivystajatekstiviestit)
-      (poista-ilmoitus))))
+      (poista-ilmoitus 123456789))))
 
 (deftest tekstiviestin-muodostus
   (let [ilmoitus {:tunniste "UV666"

--- a/test/clj/harja/palvelin/integraatiot/tloik/tyokalut.clj
+++ b/test/clj/harja/palvelin/integraatiot/tloik/tyokalut.clj
@@ -353,10 +353,10 @@ WHERE ilmoitus = (SELECT id FROM ilmoitus WHERE ilmoitusid = 123456789)"))
     VALUES (now() - interval '1' day, now() + interval '1' day, %s, %s, false, true)" urakka-id (first yhteyshenkilo)))
     yhteyshenkilo))
 
-(defn poista-ilmoitus []
-  (u "delete from paivystajatekstiviesti where ilmoitus = (select id from ilmoitus where ilmoitusid = 123456789);")
-  (u "delete from ilmoitustoimenpide where ilmoitus = (select id from ilmoitus where ilmoitusid = 123456789);")
-  (u "delete from ilmoitus where ilmoitusid = 123456789;"))
+(defn poista-ilmoitus [ilmoitus-id] ; 123456789
+  (u (str "delete from paivystajatekstiviesti where ilmoitus = (select id from ilmoitus where ilmoitusid = "ilmoitus-id");"))
+  (u (str "delete from ilmoitustoimenpide where ilmoitus = (select id from ilmoitus where ilmoitusid = "ilmoitus-id");"))
+  (u (str"delete from ilmoitus where ilmoitusid = "ilmoitus-id";")))
 
 (defn poista-valaistusilmoitus []
   (u "delete from paivystajatekstiviesti where ilmoitus = (select id from ilmoitus where ilmoitusid = 987654321);")

--- a/test/clj/harja/palvelin/integraatiot/tloik/tyokalut.clj
+++ b/test/clj/harja/palvelin/integraatiot/tloik/tyokalut.clj
@@ -336,6 +336,19 @@
                   (q-map "select * from ilmoitus where ilmoitusid = 123456789;"))]
     vastaus))
 
+(defn hae-ilmoitus-ilmoitusidlla-tietokannasta [ilmoitus-id]
+  (let [vastaus (first (mapv
+                         #(-> %
+                            (konv/array->set :selitteet)
+                            (set/rename-keys {:ilmoitusid :ilmoitus-id}))
+                         (q-map (str "select * from ilmoitus where ilmoitusid = " ilmoitus-id ";"))))]
+    vastaus))
+
+(defn hae-ilmoitustoimenpide-ilmoitusidlla [ilmoitus-id]
+  (let [vastaus (first (q-map (str "select id, ilmoitus, ilmoitusid, kuitattu, tila, lahetetty, lahetysid,
+                  suunta, kanava, kuittaustyyppi from ilmoitustoimenpide where ilmoitusid = " ilmoitus-id ";")))]
+    vastaus))
+
 (defn hae-valaistusilmoitus []
   (q "select * from ilmoitus where ilmoitusid = 987654321;"))
 


### PR DESCRIPTION
Tarkensin hieman ohjeita itmf jonojen käyttämiseksi lokaaliympäristössä
Lisäsin yksikkötestejä, joilla simuloidaan tilannetta, jossa t-loikilta tulee ilmoitus, josta pitää lähettää tekstiviesti/sähköposti päivystäjälle.
Lisäsin sähköpostin lähetyksen try - catchin sisään, jotta koko ilmoitusputki ei mene hajalle, jos sähköpostin lähettämisessä on jokin ongelma. (tämä oli jo tehty tekstiviestin lähettämiseen)