### PR TITLE
VHAR-5614 Korjaa feilaava materiaalien haun yksikkötesti

### DIFF
--- a/test/clj/harja/palvelin/palvelut/materiaalit_test.clj
+++ b/test/clj/harja/palvelin/palvelut/materiaalit_test.clj
@@ -74,7 +74,7 @@
               vastaus))))
 
 ;; VHAR-5571 aiheutti unique constraint poikkeuksen ennen korjausta
-#_(deftest tallenna-suunniteltu-materiaali-tulevillekin-hoitokausille
+(deftest tallenna-suunniteltu-materiaali-tulevillekin-hoitokausille
   (let [urakka-id @oulun-alueurakan-2014-2019-id
         sopimus-id @oulun-alueurakan-2014-2019-paasopimuksen-id
         tallennus (kutsu-palvelua (:http-palvelin jarjestelma)
@@ -122,9 +122,8 @@
         vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
                                 :hae-urakan-materiaalit
                                 +kayttaja-jvh+ urakka-id)]
-    (is (= vastaus
-           [{:id 1, :alkupvm #inst "2014-09-30T21:00:00.000-00:00", :loppupvm #inst "2015-09-29T21:00:00.000-00:00", :maara 666.0, :sopimus 2, :materiaali {:id 5, :nimi "Hiekoitushiekka", :yksikko "t"}} {:id 2, :alkupvm #inst "2015-09-30T21:00:00.000-00:00", :loppupvm #inst "2016-09-29T21:00:00.000-00:00", :maara 666.0, :sopimus 2, :materiaali {:id 5, :nimi "Hiekoitushiekka", :yksikko "t"}} {:id 3, :alkupvm #inst "2016-09-30T21:00:00.000-00:00", :loppupvm #inst "2017-09-29T21:00:00.000-00:00", :maara 666.0, :sopimus 2, :materiaali {:id 5, :nimi "Hiekoitushiekka", :yksikko "t"}} {:id 4, :alkupvm #inst "2017-09-30T21:00:00.000-00:00", :loppupvm #inst "2018-09-29T21:00:00.000-00:00", :maara 666.0, :sopimus 2, :materiaali {:id 5, :nimi "Hiekoitushiekka", :yksikko "t"}} {:id 6, :alkupvm #inst "2018-09-30T21:00:00.000-00:00", :loppupvm #inst "2019-09-29T21:00:00.000-00:00", :maara 666.0, :sopimus 2, :materiaali {:id 5, :nimi "Hiekoitushiekka", :yksikko "t"}}]
-           ))))
+    (is (= (sort-by :id vastaus)
+           (sort-by :id [{:id 1, :alkupvm #inst "2014-09-30T21:00:00.000-00:00", :loppupvm #inst "2015-09-29T21:00:00.000-00:00", :maara 666.0, :sopimus 2, :materiaali {:id 5, :nimi "Hiekoitushiekka", :yksikko "t"}} {:id 2, :alkupvm #inst "2015-09-30T21:00:00.000-00:00", :loppupvm #inst "2016-09-29T21:00:00.000-00:00", :maara 666.0, :sopimus 2, :materiaali {:id 5, :nimi "Hiekoitushiekka", :yksikko "t"}} {:id 3, :alkupvm #inst "2016-09-30T21:00:00.000-00:00", :loppupvm #inst "2017-09-29T21:00:00.000-00:00", :maara 666.0, :sopimus 2, :materiaali {:id 5, :nimi "Hiekoitushiekka", :yksikko "t"}} {:id 4, :alkupvm #inst "2017-09-30T21:00:00.000-00:00", :loppupvm #inst "2018-09-29T21:00:00.000-00:00", :maara 666.0, :sopimus 2, :materiaali {:id 5, :nimi "Hiekoitushiekka", :yksikko "t"}} {:id 6, :alkupvm #inst "2018-09-30T21:00:00.000-00:00", :loppupvm #inst "2019-09-29T21:00:00.000-00:00", :maara 666.0, :sopimus 2, :materiaali {:id 5, :nimi "Hiekoitushiekka", :yksikko "t"}}])))))
 
 (deftest hae-urakan-toteumat-materiaalille-sarakkeet
   (let [tunnisteet


### PR DESCRIPTION
 Järjestä odotettu tulos materiaalitestissä

Näytti satunnaisesti tulevan eri järjestyksessä rivejä testissä, vähän riippuen kenen koneella ajoi. Järjestetään rivit id:n mukaan assertoidessa niin ei tule random feilejä.