### PR TITLE
Valikatselmuksen korjauksia

### DIFF
--- a/src/cljs/harja/views/urakka/kulut/valikatselmus.cljs
+++ b/src/cljs/harja/views/urakka/kulut/valikatselmus.cljs
@@ -111,7 +111,7 @@
     [:<>
      [:div.oikaisu-paatos-varoitus
       [ikonit/harja-icon-status-alert]
-      [:span "Jos tavoitehinnan oikaisun myötä myös kattohinta muuttuu, syötä uusi indeksikorjattu oikaistu kattohinta."]]
+      [:span "Jos tavoitehinnan oikaisun myötä myös kattohinta muuttuu, syötä uusi oikaistu kattohinta."]]
      [:div.caption.semibold {:style {:font-size "12px"}} "Oikaistu kattohinta"]
      [:div.flex-row.alkuun.valistys16
       (if muokkaustila?

--- a/src/cljs/harja/views/urakka/kulut/valikatselmus.cljs
+++ b/src/cljs/harja/views/urakka/kulut/valikatselmus.cljs
@@ -327,7 +327,12 @@
                           (- toteuma oikaistu-tavoitehinta))
         lomake (:tavoitehinnan-ylitys-lomake app)
         hoitokauden-alkuvuosi (:hoitokauden-alkuvuosi app)
-        muokkaustila? (or (not (::valikatselmus/paatoksen-id lomake)) (:muokataan? lomake))
+        muokkaustila? (or
+                        ;; Ei piirretä lomaketta ennen kuin se on alustettu. Muuten PaivitaPaatosLomake
+                        ;; liipaistaan, ja se ylikirjoittaa lomakkeen tilan.
+                        (and (some? lomake)
+                             (not (::valikatselmus/paatoksen-id lomake)))
+                        (:muokataan? lomake))
         maksu-prosentteina? (= :prosentti (:euro-vai-prosentti lomake))
         maksu (:maksu lomake)
         urakoitsijan-maksu (if maksu-prosentteina?
@@ -358,7 +363,7 @@
            [paatos-maksu-lomake e! app :tavoitehinnan-ylitys-lomake ylityksen-maara voi-muokata?]]
 
           [:p "Aluevastaava tekee päätöksen tavoitehinnan ylityksestä"]) ;; FIXME: Ei figma-speksiä, korjaa kunhan sellainen löytyy.
-        [:p.maksurivi "Urakoitsija maksaa hyvitystä " [:strong (fmt/desimaaliluku urakoitsijan-maksu) "€"]])
+        [:p.maksurivi "Urakoitsija maksaa hyvitystä " [:strong (fmt/desimaaliluku-opt urakoitsijan-maksu) "€"]])
       (when (and voi-muokata? urakoitsijan-maksu maksu-prosentteina)
         [:div.osuusrivit
          [:p.osuusrivi "Urakoitsijan osuus " [:strong (fmt/desimaaliluku urakoitsijan-maksu)] "€ (" (fmt/desimaaliluku maksu-prosentteina) "%)"]

--- a/src/cljs/harja/views/urakka/kulut/valikatselmus.cljs
+++ b/src/cljs/harja/views/urakka/kulut/valikatselmus.cljs
@@ -433,11 +433,12 @@
        (when muokattava?
          [:<>
           (when tavoitepalkkio-yli-maksimin?
-            [:div.tavoitepalkkio-ylitys
-             [ikonit/harja-icon-status-alert]
-             [:span "Tavoitepalkkion maksimimäärä (3% tavoitehinnasta) ylittyy. Ylimenevä osuus " [:strong (fmt/desimaaliluku maksimin-ylittava-summa) " €"]
-              " siirretään automaattisesti seuraavan vuoden alennukseksi."]]
-            [:p "Jäljelle jäävän käsiteltävän tavoitepalkkion määrä on " [:strong (fmt/desimaaliluku maksimi-tavoitepalkkio) " euroa."]])
+            [:<>
+             [:div.tavoitepalkkio-ylitys
+              [ikonit/harja-icon-status-alert]
+              [:span "Tavoitepalkkion maksimimäärä (3% tavoitehinnasta) ylittyy. Ylimenevä osuus " [:strong (fmt/desimaaliluku maksimin-ylittava-summa) " €"]
+               " siirretään automaattisesti seuraavan vuoden alennukseksi."]]
+             [:p "Jäljelle jäävän käsiteltävän tavoitepalkkion määrä on " [:strong (fmt/desimaaliluku maksimi-tavoitepalkkio) " euroa."]]])
           [kentat/tee-kentta
            {:nimi :tavoitepalkkion-tyyppi
             :tyyppi :radio-group


### PR DESCRIPTION
- Muuta teksti "indeksikorjattu oikaistu kattohinta" -> "oikaistu kattohinta"
- Laita tavoitepalkkio-infolaatikko takaisin näkyville
- Korjaa bugi, jossa tavoitehinnan ylitys näytetään tallentamattomana