### PR TITLE
VHAR-5525 Hoidon alueurakassa ei pysty lisäämään indeksiä suoraan sanktioon

### DIFF
--- a/src/cljs/harja/tiedot/urakka.cljs
+++ b/src/cljs/harja/tiedot/urakka.cljs
@@ -465,10 +465,11 @@
   (some? (:indeksi @nav/valittu-urakka)))
 
 (defn indeksi-kaytossa-sakoissa?
-  "Riippuen urakan alkuvuodesta, indeksejä ei välttämättä käytetä sakoissa/sanktioissa. 2021-> etteenpäin niitä ei sidota indeksiin"
+  "Riippuen urakan alkuvuodesta, indeksejä ei välttämättä käytetä sakoissa/sanktioissa. MHU urakoissa joiden alkuvuosi 2021 tai eteenpäin niitä ei sidota indeksiin"
   []
-  (and (some? (:indeksi @nav/valittu-urakka))
-       (< (-> @nav/valittu-urakka :alkupvm pvm/vuosi) 2021)))
+  (not (and
+         (= :teiden-hoito (:tyyppi @nav/valittu-urakka))
+         (> (-> @nav/valittu-urakka :alkupvm pvm/vuosi) 2020))))
 
 (def urakan-tiedot-ladattu?
   ;; Kertoo, onko ladattu urakasta kaikki sellaiset tiedot, joihin

--- a/src/cljs/harja/views/urakka/laadunseuranta/sanktiot.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/sanktiot.cljs
@@ -69,7 +69,7 @@
                       [:span.nappiwrappi
                        [napit/palvelinkutsu-nappi
                         "Tallenna sanktio"
-                        #(tiedot/tallenna-sanktio @muokattu urakka-id)
+                        #(tiedot/tallenna-sanktio (lomake/ilman-lomaketietoja @muokattu) urakka-id)
                         {:luokka "nappi-ensisijainen"
                          :ikoni (ikonit/tallenna)
                          :kun-onnistuu #(reset! tiedot/valittu-sanktio nil)
@@ -90,7 +90,7 @@
                                 :hyvaksy "Poista"
                                 :toiminto-fn #(do
                                                 (let [res (tiedot/tallenna-sanktio
-                                                            (assoc @muokattu
+                                                            (assoc (lomake/ilman-lomaketietoja @muokattu)
                                                               :poistettu true)
                                                             urakka-id)]
                                                   (do (viesti/nayta! "Sanktio poistettu")


### PR DESCRIPTION
VHAR-5525 Hoidon alueurakassa ei pysty lisäämään indeksiä suoraan sanktioon

Korjaa indeksin väkisin asettaminen nil:ksi siten että se tapahtuu vain MHU-urakoissa joiden alkuvuosi 2021 tai myöhemmin. Nyt se tapahtui kaikille urakoille, koska when-ehdon käyttämä urakan-tiedot oli yhden urakan sisältävä lista urakoita, eikä yksi urakka. 

Frontilla pudota lomake-tiedot pois ennen lähettämistä backendille

Lisää testit että indeksi tallentuu oikein sekä aseteteaan oikein nil:ksi kun pitää