### PR TITLE
Kustannusten seuranta & paikkauskohteet excelin nimi

### DIFF
--- a/src/clj/harja/palvelin/palvelut/kulut/kustannusten_seuranta_excel.clj
+++ b/src/clj/harja/palvelin/palvelut/kulut/kustannusten_seuranta_excel.clj
@@ -236,6 +236,10 @@
                      (luo-excel-rivit kustannusdata "bonukset" "Bonukset yms."))]]
         taulukko (concat
                    [:raportti {:nimi (str urakka-nimi "_" alkupvm "-" loppupvm)
+                               :raportin-yleiset-tiedot {:raportin-nimi "Kustannusten seuranta"
+                                                         :urakka urakka-nimi
+                                                         :alkupvm alkupvm
+                                                         :loppupvm loppupvm}
                                :orientaatio :landscape}]
                    (if (empty? taulukot)
                      [[:taulukko optiot nil [["Ei kustannuksia valitulla aikavälillä"]]]]

--- a/src/clj/harja/palvelin/palvelut/yllapitokohteet/paikkauskohteet_excel.clj
+++ b/src/clj/harja/palvelin/palvelut/yllapitokohteet/paikkauskohteet_excel.clj
@@ -192,6 +192,10 @@
         ;; Nimi: <urakkan_nimi>-Paikkauskohteet-<vuosi>
         taulukko (concat
                    [:raportti {:nimi tiedostonimi
+                               :raportin-yleiset-tiedot {:raportin-nimi "Paikkauskohteet"
+                                                         :urakka (:nimi urakka)
+                                                         :alkupvm (pvm/kokovuosi-ja-kuukausi (:alkupvm tiedot))
+                                                         :loppupvm (pvm/kokovuosi-ja-kuukausi (:loppupvm tiedot))}
                                :orientaatio :landscape}]
                    (if (empty? taulukot)
                      [[:taulukko optiot nil [["Ei paikkauskohteita"]]]]


### PR DESCRIPTION
Raporttiexcelien otsikon lisäys -muutoksen yhteydessä excelin tiedostonimen luonti muutettiin ja nämä export-ominaisuudet jäivät silloin huomiotta, jolloin syntyneen tiedoston nimi oli vain pari pilkkua. Nyt tiedostonimi muodostuu taas oikein täälläkin.