### PR TITLE
Insertoi 'Muut, MHU ylläpito (F)'-tehtäväryhmä testi-db:tä varten

### DIFF
--- a/tietokanta/src/main/resources/db/migration/R__Toimenpidekoodit_tehtavaryhmat.sql
+++ b/tietokanta/src/main/resources/db/migration/R__Toimenpidekoodit_tehtavaryhmat.sql
@@ -126,6 +126,12 @@ ON CONFLICT (nimi) DO UPDATE set emo = (select id from tehtavaryhma where nimi =
 
 -- Nimetään vanha Muut (F) tehtäväryhmä "Muut, MHU ylläpito (F)":ksi ja käytetään sitä nimeä jatkossa.
 UPDATE tehtavaryhma SET nimi = 'Muut, MHU ylläpito (F)' WHERE nimi = 'Muut (F)';
+-- Mikäli 'Muut, MHU ylläpito (F)'-tehtäväryhmää ei ole olemassa ollenkaan tässä kohtaa (esim. testidb:ssä sitä ei ole), niin insertoidaan se.
+INSERT INTO tehtavaryhma (otsikko, nimi, emo, tyyppi, jarjestys, luotu, luoja, nakyva)
+VALUES ('5 KORJAAMINEN', 'Muut, MHU ylläpito (F)',
+        (SELECT id FROM tehtavaryhma WHERE nimi = 'Välitaso Pohjavesisuojaukset'), 'alataso', 152, CURRENT_TIMESTAMP,
+        (SELECT id FROM kayttaja WHERE kayttajanimi = 'Integraatio'), FALSE)
+    ON CONFLICT (nimi) DO UPDATE SET emo = (SELECT id FROM tehtavaryhma WHERE nimi = 'Välitaso Pohjavesisuojaukset');
 
 -- FIXME: Mitä tehdään näiden kahden uuden tehtäväryhmän järjestysnumeroille? Yhteys: Maarit.
 INSERT INTO tehtavaryhma (otsikko, nimi, emo, tyyppi, jarjestys, luotu, luoja, nakyva)


### PR DESCRIPTION
* Testitietokannassa ei ole 'Muut (F)' tai 'Muut, MHU ylläpito (F)'
tehtäväryhmiä ennestään, joten 'Muut, MHU ylläpito (F)' pitää varmuuden
vuoksi insertoida R-migraatiossa, jotta testit eivät mene rikki.

RelNotes:
Related: