### PR TITLE
Harjapipelineen optionaalinen "flyway repair" -toiminto

### DIFF
--- a/Jenkins/skriptit/Tyokalut.groovy
+++ b/Jenkins/skriptit/Tyokalut.groovy
@@ -160,6 +160,15 @@ def ajaTestiserverinKanta(stagenNimi) {
         // config file plugariin lisätään feature, jossa noita kredentiaaleja voi antaa (JENKINS-43204)
         configFileProvider([configFile(fileId: 'Flyway_testiserverin_konfiguraatio', replaceTokens: true, variable: 'FLYWAY_SETTINGS')]) {
             withCredentials([usernamePassword(credentialsId: 'TESTIPANNU', passwordVariable: 'SALASANA', usernameVariable: 'KAYTTAJA')]) {
+
+                // Korjaa migraatiot, mikäli KORJAA_FLYWAY_MIGRAATIOT build parametri on true.
+                // Flyway repair komento poistaa historiasta esimerkiksi poistetut (tai uudelleenimetyt) migraatiotiedostot.
+                // Lue lisää: https://flywaydb.org/documentation/usage/commandline/repair
+                if (params.KORJAA_FLYWAY_MIGRAATIOT) {
+                    sh([script: 'mvn -f tietokanta/pom.xml clean compile flyway:repair -Dflyway.configFiles=$FLYWAY_SETTINGS' +
+                            " -Dflyway.user=$KAYTTAJA -Dflyway.password=$SALASANA"])
+                }
+
                 sh([script: 'mvn -f tietokanta/pom.xml clean compile flyway:migrate -Dflyway.configFiles=$FLYWAY_SETTINGS' +
                         " -Dflyway.user=$KAYTTAJA -Dflyway.password=$SALASANA"])
             }
@@ -212,6 +221,14 @@ def ajaStagingserverinKanta(stagenNimi) {
         // config file plugariin lisätään feature, jossa noita kredentiaaleja voi antaa (JENKINS-43204)
         configFileProvider([configFile(fileId: 'Flyway_stagingserverin_konfiguraatio', replaceTokens: true, variable: 'FLYWAY_SETTINGS')]) {
             withCredentials([usernamePassword(credentialsId: 'STAGEPANNU', passwordVariable: 'SALASANA', usernameVariable: 'KAYTTAJA')]) {
+                // Korjaa migraatiot, mikäli KORJAA_FLYWAY_MIGRAATIOT build parametri on true.
+                // Flyway repair komento poistaa historiasta esimerkiksi poistetut (tai uudelleenimetyt) migraatiotiedostot.
+                // Lue lisää: https://flywaydb.org/documentation/usage/commandline/repair
+                if (params.KORJAA_FLYWAY_MIGRAATIOT) {
+                    sh([script: 'mvn -f tietokanta/pom.xml clean compile flyway:repair -Dflyway.configFiles=$FLYWAY_SETTINGS' +
+                            " -Dflyway.user=$KAYTTAJA -Dflyway.password=$SALASANA"])
+                }
+
                 sh([script: 'mvn -f tietokanta/pom.xml clean compile flyway:migrate -Dflyway.configFiles=$FLYWAY_SETTINGS' +
                         " -Dflyway.user=$KAYTTAJA -Dflyway.password=$SALASANA"])
             }
@@ -245,6 +262,14 @@ def ajaTuotantoserverinKanta(stagenNimi) {
         // config file plugariin lisätään feature, jossa noita kredentiaaleja voi antaa (JENKINS-43204)
         configFileProvider([configFile(fileId: 'Flyway_tuotantoserverin_konfiguraatio', replaceTokens: true, variable: 'FLYWAY_SETTINGS')]) {
             withCredentials([usernamePassword(credentialsId: 'TUOTANTOPANNU', passwordVariable: 'SALASANA', usernameVariable: 'KAYTTAJA')]) {
+                // Korjaa migraatiot, mikäli KORJAA_FLYWAY_MIGRAATIOT build parametri on true.
+                // Flyway repair komento poistaa historiasta esimerkiksi poistetut (tai uudelleenimetyt) migraatiotiedostot.
+                // Lue lisää: https://flywaydb.org/documentation/usage/commandline/repair
+                if (params.KORJAA_FLYWAY_MIGRAATIOT) {
+                    sh([script: 'mvn -f tietokanta/pom.xml clean compile flyway:repair -Dflyway.configFiles=$FLYWAY_SETTINGS' +
+                            " -Dflyway.user=$KAYTTAJA -Dflyway.password=$SALASANA"])
+                }
+
                 sh([script: 'mvn -f tietokanta/pom.xml clean compile flyway:migrate -Dflyway.configFiles=$FLYWAY_SETTINGS' +
                         " -Dflyway.user=$KAYTTAJA -Dflyway.password=$SALASANA"])
             }


### PR DESCRIPTION
Lisää Harjapipelinen migraatioiden ajamiseen build-parametriin sidottu ehto, jolla voi halutessaan ajaa flyway:repair komennon ennen migraatioita.