### PR TITLE
VHAR-5516 Jos liite poistetaan, poista myös tarkastus_liite viittaukset

### DIFF
--- a/tietokanta/src/main/resources/db/migration/V1_915__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_915__.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tarkastus_liite DROP CONSTRAINT tarkastus_liite_liite_fkey;
+ALTER TABLE tarkastus_liite ADD FOREIGN KEY (liite) REFERENCES liite(id) ON DELETE CASCADE;


### PR DESCRIPTION
Harjaan saapui urakoitsijan järjestelmän virheellisen käyttäytymisen myötä noin 200 000 duplikaattiriviä jotka liittyivät kahteen tarkastukseen. Turhia rivejä on siis valtava määrä tauluissa tarkastus, tarkastus_liite ja liite. 

Jotta voidaan tehdä siivous tietokannassa, lisätään tarkastus_liite taulusta alunperin unohtunut ON DELETE CASCADE. 