### PR TITLE
VHAR-5721 Vaadi POT2-lomakkeella Kohteen valmistusmispäivämäärä

### DIFF
--- a/dev-resources/less/pages/paallystys_ja_paikkaus.less
+++ b/dev-resources/less/pages/paallystys_ja_paikkaus.less
@@ -90,6 +90,9 @@
             .form-group {
                 padding-left: 0;
             }
+            .pvm-kentta > .form-control {
+                max-width: 243px;
+            }
         }
     }
 }

--- a/src/clj/harja/kyselyt/yllapitokohteet.sql
+++ b/src/clj/harja/kyselyt/yllapitokohteet.sql
@@ -769,6 +769,18 @@ WHERE yllapitokohde = :id
            FROM yllapitokohde
            WHERE id = :id) = :urakka;
 
+-- name: tallenna-paallystyskohteen-aloitus-ja-lopetus!
+UPDATE yllapitokohteen_aikataulu
+   SET
+       kohde_alku       = :aikataulu_kohde_alku,
+       kohde_valmis     = :aikataulu_kohde_valmis,
+       muokattu         = NOW(),
+       muokkaaja        = :aikataulu_muokkaaja
+ WHERE yllapitokohde = :id
+   AND (SELECT urakka
+          FROM yllapitokohde
+         WHERE id = :id) = :urakka;
+
 -- name: tallenna-yllapitokohteen-kustannukset!
 -- Tallentaa ylläpitokohteen kustannukset
 UPDATE yllapitokohteen_kustannukset

--- a/src/cljs/harja/views/urakka/pot_yhteinen.cljs
+++ b/src/cljs/harja/views/urakka/pot_yhteinen.cljs
@@ -345,12 +345,12 @@
                ::lomake/col-luokka "col-xs-12 col-sm-6 col-md-6 col-lg-6" :muokattava? false-fn})
             (when-not paikkauskohteet?
               {:otsikko "Työ aloitettu" :nimi :aloituspvm :tyyppi :pvm
-               ::lomake/col-luokka "col-xs-12 col-sm-6 col-md-6 col-lg-6" :muokattava? false-fn})
+               ::lomake/col-luokka "col-xs-12 col-sm-6 col-md-6 col-lg-6" :muokattava? (constantly muokattava?)})
             (when-not paikkauskohteet?
-             (when valmispvm-kohde
-               {:otsikko "Päällystyskohde valmistunut" :nimi :valmispvm-kohde
-                ::lomake/col-luokka "col-xs-12 col-sm-6 col-md-6 col-lg-6"
-                :tyyppi :pvm :muokattava? false-fn}))
+              {:otsikko "Päällystyskohde valmistunut" :nimi :valmispvm-kohde
+               ::lomake/col-luokka "col-xs-12 col-sm-6 col-md-6 col-lg-6"
+               :tyyppi :pvm :muokattava? (constantly muokattava?)
+               :pakollinen? true})
             (when-not paikkauskohteet?
               {:otsikko "Takuupvm" :nimi :takuupvm :tyyppi :valinta
               :valinnat (paallystys/takuupvm-valinnat takuupvm) :kaariva-luokka "takuupvm-valinta"


### PR DESCRIPTION
Todettiin palaverissa asiakkaan kanssa, että POT-lomakkeen on vaadittava pakollisena tietona kohteen valmistusmispvm koska se tieto halutaan YHA:an.