### PR TITLE
korjattu kulujen syötössä laskun päivämäärässä bugi, jossa koontilask…

### DIFF
--- a/src/cljs/harja/views/urakka/kulut.cljs
+++ b/src/cljs/harja/views/urakka/kulut.cljs
@@ -140,10 +140,12 @@
                                                       :optiot {:validoitava? true}})
     :luokat        #{(str "input" (if (validi-ei-tarkistettu-tai-ei-koskettu? erapaiva-meta) "" "-error") "-default")
                      "komponentin-input"}
-    :paivamaara    (kulut/koontilaskun-kuukausi->pvm 
-                     koontilaskun-kuukausi                     
-                     (-> @tila/yleiset :urakka :alkupvm)
-                     (-> @tila/yleiset :urakka :loppupvm))
+    :paivamaara    (or
+                     erapaiva 
+                     (kulut/koontilaskun-kuukausi->pvm 
+                       koontilaskun-kuukausi                     
+                       (-> @tila/yleiset :urakka :alkupvm)
+                       (-> @tila/yleiset :urakka :loppupvm)))
     :pakota-suunta false
     :disabled      disabled
     :valittava?-fn (kulut/koontilaskun-kuukauden-sisalla?-fn


### PR DESCRIPTION
…un kuukauden valinta päivittää kalenterin osoittamaan kys kuukauteen, mutta eräpäivä oli aina kuukauden eka. nyt eräpäivä otetaan oikein huomioon.