### PR TITLE
VHAR-5750 Kommentoi POT2-kulutuskerroksen muun kohteen validointi

### DIFF
--- a/src/cljc/harja/domain/yllapitokohde.cljc
+++ b/src/cljc/harja/domain/yllapitokohde.cljc
@@ -1066,11 +1066,9 @@ yllapitoluokkanimi->numero
                                      (when validoitu-alikohde
                                        (with-meta validoitu-alikohde
                                                   {:alikohde (select-keys alikohde tr-domain/vali-avaimet)}))))
-        _ (println "Jarno kohde-validoitu" kohde-validoitu)
-        _ (println "Jarno alikohteet-validoitu" alikohteet-validoitu)
+        muutkohteet-validoitu nil ;; VHAR-5750 bugi tässä validoinnissa estää tallennuksen. Kommentoidaan toistaiseksi, koska tämä on ns. muun kohteen validointi, harvoin käytetty ominaisuus
+        #_(keep identity
 
-        muutkohteet-validoitu
-        (keep identity
                                     (for [muukohde muutkohteet
                                           :let [toiset-muutkohteet (remove #(= muukohde %)
                                                                            (petar-fn muukohde)
@@ -1082,13 +1080,10 @@ yllapitoluokkanimi->numero
                                                                      muiden-kohteiden-tiedot)]]
                                       (do (println "petar toiset ja kohteen tiedot " (str (vec toiset-muutkohteet) (vec kohteen-tiedot)))
                                       (validoi-muukohde tr-osoite muukohde toiset-muutkohteet kohteen-tiedot vuosi urakan-toiset-kohdeosat))))
-        _ (println "Jarno muutkohteet-validoitu" muutkohteet-validoitu)
-        _ (println "petar muiden-kohteiden bla bla " (str (vec muiden-kohteiden-verrattavat-kohteet)))
         alustatoimet-validoitu (keep identity
                                      (for [alustatoimi alustatoimet
                                            :let [toiset-alustatoimenpiteet (remove #(= alustatoimi %) alustatoimet)]]
-                                       (validoi-alustatoimenpide alikohteet muutkohteet alustatoimi toiset-alustatoimenpiteet kohteen-tiedot muiden-kohteiden-tiedot vuosi)))
-        _ (println "Jarno alustatoimet-validoitu" alustatoimet-validoitu)]
+                                       (validoi-alustatoimenpide alikohteet muutkohteet alustatoimi toiset-alustatoimenpiteet kohteen-tiedot muiden-kohteiden-tiedot vuosi)))]
     (cond-> {}
             (not (empty? kohde-validoitu)) (assoc :paakohde [(validoitu-kohde-tekstit kohde-validoitu true)])
             (not (empty? alikohteet-validoitu)) (assoc :alikohde (map #(validoitu-kohde-tekstit % false) alikohteet-validoitu))

--- a/src/cljc/harja/domain/yllapitokohde.cljc
+++ b/src/cljc/harja/domain/yllapitokohde.cljc
@@ -591,6 +591,7 @@ yllapitoluokkanimi->numero
   ([paakohde alikohde toiset-alikohteet osien-tiedot vuosi] (validoi-alikohde paakohde alikohde toiset-alikohteet osien-tiedot vuosi nil))
   ([paakohde alikohde toiset-alikohteet osien-tiedot vuosi urakan-toiset-kohdeosat] (validoi-alikohde paakohde alikohde toiset-alikohteet osien-tiedot vuosi urakan-toiset-kohdeosat nil))
   ([paakohde alikohde toiset-alikohteet osien-tiedot vuosi urakan-toiset-kohdeosat eri-urakoiden-alikohteet]
+   #_(println "petar alikohde " (str alikohde toiset-alikohteet osien-tiedot urakan-toiset-kohdeosat eri-urakoiden-alikohteet))
    (let [tr-vali-spec (cond ;; s/and short circuittaa, jonka johdosta tässä täytyy luetella kaikki tr-valin avaimet pelkän ::tr-ajorata ja ::tr-kaista sijasta ja ::tr-paaluvali tulee tulla toisena.
                         ;; Eli jos tätä ei tekisi näin, niin ::tr-ajorata ja ::tr-kaista jäisi ilman virheviestiä, kun tarkastetaan tr-osoitteen muoto vaikka ne olisikin virheellisiä.
                         (>= vuosi 2019) (s/and (s/keys :req-un [::tr-numero
@@ -623,6 +624,7 @@ yllapitoluokkanimi->numero
   ([paakohde muukohde toiset-kohteet osien-tiedot] (validoi-muukohde paakohde muukohde toiset-kohteet osien-tiedot (pvm/vuosi (pvm/nyt))))
   ([paakohde muukohde toiset-kohteet osien-tiedot vuosi] (validoi-muukohde paakohde muukohde toiset-kohteet osien-tiedot vuosi nil))
   ([paakohde muukohde toiset-kohteet osien-tiedot vuosi urakan-toiset-kohdeosat]
+   (println "petar sad je muukohde ")
    (let [validoitu-alikohteena (-> paakohde
                                    (validoi-alikohde muukohde toiset-kohteet osien-tiedot vuosi urakan-toiset-kohdeosat)
                                    (dissoc :alikohde-paakohteen-ulkopuolella?)
@@ -1047,7 +1049,15 @@ yllapitoluokkanimi->numero
   Parametri muiden-kohteiden-tiedot sisältää muita kohteita vastaava tiedot validoinnissa käytetystä csv-tiedostosta."
   [tr-osoite kohteen-tiedot muiden-kohteiden-tiedot muiden-kohteiden-verrattavat-kohteet
    vuosi alikohteet muutkohteet alustatoimet urakan-toiset-kohdeosat eri-urakoiden-alikohteet]
-  (let [kohde-validoitu (validoi-kohde
+  (let [petar-fn (fn [muukohde]
+                   (let [mystinen-arvo (first (filter #(-> % first :tr-numero (= (:tr-numero muukohde)))
+                                                       muiden-kohteiden-verrattavat-kohteet))]
+                     (println "petar mystinen arvo " (str (vec mystinen-arvo)))
+                     (println "petar muukohde " (str muukohde))
+                     (println "petar ja ne ovat sama? " (= mystinen-arvo muukohde))
+                     mystinen-arvo))
+
+        kohde-validoitu (validoi-kohde
                           tr-osoite kohteen-tiedot {:vuosi vuosi})
         alikohteet-validoitu (keep identity
                                    (for [alikohde alikohteet
@@ -1063,14 +1073,17 @@ yllapitoluokkanimi->numero
         (keep identity
                                     (for [muukohde muutkohteet
                                           :let [toiset-muutkohteet (remove #(= muukohde %)
-                                                                           (first (filter #(-> % first :tr-numero (= (:tr-numero muukohde)))
+                                                                           (petar-fn muukohde)
+                                                                           #_(first (filter #(-> % first :tr-numero (= (:tr-numero muukohde)))
                                                                                           muiden-kohteiden-verrattavat-kohteet)))
                                                 kohteen-tiedot (some #(when (and (= (:tr-numero (first %)) (:tr-numero muukohde))
                                                                                  (= (:tr-osa (first %)) (:tr-alkuosa muukohde)))
                                                                         %)
                                                                      muiden-kohteiden-tiedot)]]
-                                      (validoi-muukohde tr-osoite muukohde toiset-muutkohteet kohteen-tiedot vuosi urakan-toiset-kohdeosat)))
+                                      (do (println "petar toiset ja kohteen tiedot " (str (vec toiset-muutkohteet) (vec kohteen-tiedot)))
+                                      (validoi-muukohde tr-osoite muukohde toiset-muutkohteet kohteen-tiedot vuosi urakan-toiset-kohdeosat))))
         _ (println "Jarno muutkohteet-validoitu" muutkohteet-validoitu)
+        _ (println "petar muiden-kohteiden bla bla " (str (vec muiden-kohteiden-verrattavat-kohteet)))
         alustatoimet-validoitu (keep identity
                                      (for [alustatoimi alustatoimet
                                            :let [toiset-alustatoimenpiteet (remove #(= alustatoimi %) alustatoimet)]]
@@ -1097,11 +1110,14 @@ yllapitoluokkanimi->numero
                                                                                                            :kohde-id kohde-id
                                                                                                            :urakka-id urakka-id})))
             verrattavat-kohteet (fn [yhden-vuoden-kohteet kohde-id urakka-id]
+                                  (println "petar tämä pitäisi olla olemassa " kohde-id)
                                   (sequence
                                     (comp (remove
                                             (fn [verrattava-kohde]
-                                              (= (:id verrattava-kohde)
-                                                 kohde-id)))
+                                              (let [tulos (= (:id verrattava-kohde)
+                                                             kohde-id)]
+                                                (println "petar tulos " tulos (:id verrattava-kohde) kohde-id)
+                                                tulos)))
                                           ;; Tässä on tarkoituksena, ettei näytetä muiden urakoiden kohteiden tietoja virheviesteissä
                                           (map #(update % :urakka (fn [nimi]
                                                                     (when (= (:urakka-id %) urakka-id)
@@ -1128,13 +1144,19 @@ yllapitoluokkanimi->numero
                                ali-ja-muut-kohteet)
             muutkohteet (filter #(not= (:tr-numero %) (:tr-numero tr-osoite))
                                 ali-ja-muut-kohteet)
-            yhden-vuoden-muut-kohteet (map #(q-yllapitokohteet/hae-yhden-vuoden-muut-kohdeosat db {:vuosi vuosi :tr-numero (:tr-numero %)})
+            yhden-vuoden-muut-kohteet (map #(do
+                                              (println "petar unutar do " vuosi (doall muutkohteet))
+                                              (q-yllapitokohteet/hae-yhden-vuoden-muut-kohdeosat db {:vuosi vuosi :tr-numero (:tr-numero %)}))
                                            muutkohteet)
             muiden-kohteiden-tiedot (for [muukohde muutkohteet]
                                       (q-tieverkko/hae-trpisteiden-valinen-tieto-yhdistaa db (select-keys muukohde #{:tr-numero :tr-alkuosa :tr-loppuosa})))
             muiden-kohteiden-verrattavat-kohteet (map (fn [muukohde toiset-kohteet]
-                                                        (verrattavat-kohteet toiset-kohteet (:id muukohde) urakka-id))
+                                                        (println "petar sisällä " muukohde toiset-kohteet)
+                                                        (verrattavat-kohteet toiset-kohteet (:kohdeosa-id muukohde) urakka-id))
                                                       muutkohteet yhden-vuoden-muut-kohteet)]
+        (println "petar muiden-kohteiden-verrattavat-kohteet: " (vec muiden-kohteiden-verrattavat-kohteet)
+                 "\n muutkohteet: " (vec muutkohteet)
+                 "\n yhden-vuoden-muut-kohteet: " (vec yhden-vuoden-muut-kohteet))
         (validoi-kaikki tr-osoite kohteen-tiedot
                         muiden-kohteiden-tiedot muiden-kohteiden-verrattavat-kohteet
                         vuosi alikohteet muutkohteet alustatoimet

--- a/src/cljc/harja/domain/yllapitokohde.cljc
+++ b/src/cljc/harja/domain/yllapitokohde.cljc
@@ -1061,7 +1061,7 @@ yllapitoluokkanimi->numero
 
                                     (for [muukohde muutkohteet
                                           :let [toiset-muutkohteet (remove #(= muukohde %)
-                                                                           #_(first (filter #(-> % first :tr-numero (= (:tr-numero muukohde)))
+                                                                           (first (filter #(-> % first :tr-numero (= (:tr-numero muukohde)))
                                                                                           muiden-kohteiden-verrattavat-kohteet)))
                                                 kohteen-tiedot (some #(when (and (= (:tr-numero (first %)) (:tr-numero muukohde))
                                                                                  (= (:tr-osa (first %)) (:tr-alkuosa muukohde)))

--- a/src/cljc/harja/domain/yllapitokohde.cljc
+++ b/src/cljc/harja/domain/yllapitokohde.cljc
@@ -1056,7 +1056,11 @@ yllapitoluokkanimi->numero
                                      (when validoitu-alikohde
                                        (with-meta validoitu-alikohde
                                                   {:alikohde (select-keys alikohde tr-domain/vali-avaimet)}))))
-        muutkohteet-validoitu (keep identity
+        _ (println "Jarno kohde-validoitu" kohde-validoitu)
+        _ (println "Jarno alikohteet-validoitu" alikohteet-validoitu)
+
+        muutkohteet-validoitu
+        (keep identity
                                     (for [muukohde muutkohteet
                                           :let [toiset-muutkohteet (remove #(= muukohde %)
                                                                            (first (filter #(-> % first :tr-numero (= (:tr-numero muukohde)))
@@ -1066,10 +1070,12 @@ yllapitoluokkanimi->numero
                                                                         %)
                                                                      muiden-kohteiden-tiedot)]]
                                       (validoi-muukohde tr-osoite muukohde toiset-muutkohteet kohteen-tiedot vuosi urakan-toiset-kohdeosat)))
+        _ (println "Jarno muutkohteet-validoitu" muutkohteet-validoitu)
         alustatoimet-validoitu (keep identity
                                      (for [alustatoimi alustatoimet
                                            :let [toiset-alustatoimenpiteet (remove #(= alustatoimi %) alustatoimet)]]
-                                       (validoi-alustatoimenpide alikohteet muutkohteet alustatoimi toiset-alustatoimenpiteet kohteen-tiedot muiden-kohteiden-tiedot vuosi)))]
+                                       (validoi-alustatoimenpide alikohteet muutkohteet alustatoimi toiset-alustatoimenpiteet kohteen-tiedot muiden-kohteiden-tiedot vuosi)))
+        _ (println "Jarno alustatoimet-validoitu" alustatoimet-validoitu)]
     (cond-> {}
             (not (empty? kohde-validoitu)) (assoc :paakohde [(validoitu-kohde-tekstit kohde-validoitu true)])
             (not (empty? alikohteet-validoitu)) (assoc :alikohde (map #(validoitu-kohde-tekstit % false) alikohteet-validoitu))

--- a/src/cljc/harja/domain/yllapitokohde.cljc
+++ b/src/cljc/harja/domain/yllapitokohde.cljc
@@ -591,7 +591,6 @@ yllapitoluokkanimi->numero
   ([paakohde alikohde toiset-alikohteet osien-tiedot vuosi] (validoi-alikohde paakohde alikohde toiset-alikohteet osien-tiedot vuosi nil))
   ([paakohde alikohde toiset-alikohteet osien-tiedot vuosi urakan-toiset-kohdeosat] (validoi-alikohde paakohde alikohde toiset-alikohteet osien-tiedot vuosi urakan-toiset-kohdeosat nil))
   ([paakohde alikohde toiset-alikohteet osien-tiedot vuosi urakan-toiset-kohdeosat eri-urakoiden-alikohteet]
-   #_(println "petar alikohde " (str alikohde toiset-alikohteet osien-tiedot urakan-toiset-kohdeosat eri-urakoiden-alikohteet))
    (let [tr-vali-spec (cond ;; s/and short circuittaa, jonka johdosta tässä täytyy luetella kaikki tr-valin avaimet pelkän ::tr-ajorata ja ::tr-kaista sijasta ja ::tr-paaluvali tulee tulla toisena.
                         ;; Eli jos tätä ei tekisi näin, niin ::tr-ajorata ja ::tr-kaista jäisi ilman virheviestiä, kun tarkastetaan tr-osoitteen muoto vaikka ne olisikin virheellisiä.
                         (>= vuosi 2019) (s/and (s/keys :req-un [::tr-numero
@@ -624,7 +623,6 @@ yllapitoluokkanimi->numero
   ([paakohde muukohde toiset-kohteet osien-tiedot] (validoi-muukohde paakohde muukohde toiset-kohteet osien-tiedot (pvm/vuosi (pvm/nyt))))
   ([paakohde muukohde toiset-kohteet osien-tiedot vuosi] (validoi-muukohde paakohde muukohde toiset-kohteet osien-tiedot vuosi nil))
   ([paakohde muukohde toiset-kohteet osien-tiedot vuosi urakan-toiset-kohdeosat]
-   (println "petar sad je muukohde ")
    (let [validoitu-alikohteena (-> paakohde
                                    (validoi-alikohde muukohde toiset-kohteet osien-tiedot vuosi urakan-toiset-kohdeosat)
                                    (dissoc :alikohde-paakohteen-ulkopuolella?)
@@ -1049,15 +1047,7 @@ yllapitoluokkanimi->numero
   Parametri muiden-kohteiden-tiedot sisältää muita kohteita vastaava tiedot validoinnissa käytetystä csv-tiedostosta."
   [tr-osoite kohteen-tiedot muiden-kohteiden-tiedot muiden-kohteiden-verrattavat-kohteet
    vuosi alikohteet muutkohteet alustatoimet urakan-toiset-kohdeosat eri-urakoiden-alikohteet]
-  (let [petar-fn (fn [muukohde]
-                   (let [mystinen-arvo (first (filter #(-> % first :tr-numero (= (:tr-numero muukohde)))
-                                                       muiden-kohteiden-verrattavat-kohteet))]
-                     (println "petar mystinen arvo " (str (vec mystinen-arvo)))
-                     (println "petar muukohde " (str muukohde))
-                     (println "petar ja ne ovat sama? " (= mystinen-arvo muukohde))
-                     mystinen-arvo))
-
-        kohde-validoitu (validoi-kohde
+  (let [kohde-validoitu (validoi-kohde
                           tr-osoite kohteen-tiedot {:vuosi vuosi})
         alikohteet-validoitu (keep identity
                                    (for [alikohde alikohteet
@@ -1071,15 +1061,13 @@ yllapitoluokkanimi->numero
 
                                     (for [muukohde muutkohteet
                                           :let [toiset-muutkohteet (remove #(= muukohde %)
-                                                                           (petar-fn muukohde)
                                                                            #_(first (filter #(-> % first :tr-numero (= (:tr-numero muukohde)))
                                                                                           muiden-kohteiden-verrattavat-kohteet)))
                                                 kohteen-tiedot (some #(when (and (= (:tr-numero (first %)) (:tr-numero muukohde))
                                                                                  (= (:tr-osa (first %)) (:tr-alkuosa muukohde)))
                                                                         %)
                                                                      muiden-kohteiden-tiedot)]]
-                                      (do (println "petar toiset ja kohteen tiedot " (str (vec toiset-muutkohteet) (vec kohteen-tiedot)))
-                                      (validoi-muukohde tr-osoite muukohde toiset-muutkohteet kohteen-tiedot vuosi urakan-toiset-kohdeosat))))
+                                      (validoi-muukohde tr-osoite muukohde toiset-muutkohteet kohteen-tiedot vuosi urakan-toiset-kohdeosat)))
         alustatoimet-validoitu (keep identity
                                      (for [alustatoimi alustatoimet
                                            :let [toiset-alustatoimenpiteet (remove #(= alustatoimi %) alustatoimet)]]
@@ -1105,14 +1093,11 @@ yllapitoluokkanimi->numero
                                                                                                            :kohde-id kohde-id
                                                                                                            :urakka-id urakka-id})))
             verrattavat-kohteet (fn [yhden-vuoden-kohteet kohde-id urakka-id]
-                                  (println "petar tämä pitäisi olla olemassa " kohde-id)
                                   (sequence
                                     (comp (remove
                                             (fn [verrattava-kohde]
-                                              (let [tulos (= (:id verrattava-kohde)
-                                                             kohde-id)]
-                                                (println "petar tulos " tulos (:id verrattava-kohde) kohde-id)
-                                                tulos)))
+                                              (= (:id verrattava-kohde)
+                                                 kohde-id)))
                                           ;; Tässä on tarkoituksena, ettei näytetä muiden urakoiden kohteiden tietoja virheviesteissä
                                           (map #(update % :urakka (fn [nimi]
                                                                     (when (= (:urakka-id %) urakka-id)
@@ -1139,19 +1124,13 @@ yllapitoluokkanimi->numero
                                ali-ja-muut-kohteet)
             muutkohteet (filter #(not= (:tr-numero %) (:tr-numero tr-osoite))
                                 ali-ja-muut-kohteet)
-            yhden-vuoden-muut-kohteet (map #(do
-                                              (println "petar unutar do " vuosi (doall muutkohteet))
-                                              (q-yllapitokohteet/hae-yhden-vuoden-muut-kohdeosat db {:vuosi vuosi :tr-numero (:tr-numero %)}))
+            yhden-vuoden-muut-kohteet (map #(q-yllapitokohteet/hae-yhden-vuoden-muut-kohdeosat db {:vuosi vuosi :tr-numero (:tr-numero %)})
                                            muutkohteet)
             muiden-kohteiden-tiedot (for [muukohde muutkohteet]
                                       (q-tieverkko/hae-trpisteiden-valinen-tieto-yhdistaa db (select-keys muukohde #{:tr-numero :tr-alkuosa :tr-loppuosa})))
             muiden-kohteiden-verrattavat-kohteet (map (fn [muukohde toiset-kohteet]
-                                                        (println "petar sisällä " muukohde toiset-kohteet)
                                                         (verrattavat-kohteet toiset-kohteet (:kohdeosa-id muukohde) urakka-id))
                                                       muutkohteet yhden-vuoden-muut-kohteet)]
-        (println "petar muiden-kohteiden-verrattavat-kohteet: " (vec muiden-kohteiden-verrattavat-kohteet)
-                 "\n muutkohteet: " (vec muutkohteet)
-                 "\n yhden-vuoden-muut-kohteet: " (vec yhden-vuoden-muut-kohteet))
         (validoi-kaikki tr-osoite kohteen-tiedot
                         muiden-kohteiden-tiedot muiden-kohteiden-verrattavat-kohteet
                         vuosi alikohteet muutkohteet alustatoimet

--- a/test/clj/harja/domain/kohteiden_validointi_test.clj
+++ b/test/clj/harja/domain/kohteiden_validointi_test.clj
@@ -644,7 +644,8 @@
       (is (empty? (yllapitokohteet/validoi-kaikki tr-osoite kohteiden-tiedot muiden-kohteiden-tiedot muiden-kohteiden-verrattavat-kohteet
                                                   vuosi kohteen-alikohteet muutkohteet alustatoimet urakan-muiden-kohteiden-alikohteet muiden-urakoiden-alikohteet))))
 
-    (testing "Muut verrattavat kohteet päällekkäin"
+    ;; VHAR-5750 takia kommentoitu
+    #_(testing "Muut verrattavat kohteet päällekkäin"
       (let [virheviestit (yllapitokohteet/validoi-kaikki tr-osoite kohteiden-tiedot muiden-kohteiden-tiedot
                                                          (assoc-in muiden-kohteiden-verrattavat-kohteet [0 0 :tr-alkuetaisyys] 100)
                                                          vuosi kohteen-alikohteet muutkohteet alustatoimet

--- a/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
+++ b/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
@@ -922,6 +922,26 @@
                                                                               :vuosi              2021
                                                                               :paallystysilmoitus paallystysilmoitus})))))
 
+(defn- muun-kohteen-paallekkaisyys-testin-paallystekerros [materiaali]
+  [{:kohdeosa-id nil, :tr-kaista 11, :leveys 2, :kokonaismassamaara 342, :tr-ajorata 0, :pinta_ala 560, :tr-loppuosa 3, :jarjestysnro 1, :tr-alkuosa 3, :massamenekki 610.7142857142857, :tr-loppuetaisyys 5000, :nimi nil, :materiaali materiaali, :tr-alkuetaisyys 1, :tr-numero 20, :toimenpide 12}
+   {:kohdeosa-id nil, :tr-kaista 11, :leveys 2, :kokonaismassamaara 342, :tr-ajorata 0, :pinta_ala 560, :tr-loppuosa 23, :jarjestysnro 1, :tr-alkuosa 23, :massamenekki 610.7142857142857, :tr-loppuetaisyys 615, :nimi nil, :materiaali materiaali, :tr-alkuetaisyys 335, :tr-numero 28401, :toimenpide 12}
+   {:kohdeosa-id nil, :tr-kaista 11, :leveys 2, :kokonaismassamaara 234, :tr-ajorata 0, :pinta_ala 760, :tr-loppuosa 23, :jarjestysnro 1, :tr-alkuosa 23, :massamenekki 307.89473684210526, :tr-loppuetaisyys 460, :nimi nil, :materiaali materiaali, :tr-alkuetaisyys 80, :tr-numero 28406, :toimenpide 12}
+   {:kohdeosa-id nil, :tr-kaista 11, :leveys 2, :kokonaismassamaara 342, :tr-ajorata 0, :pinta_ala 980, :tr-loppuosa 23, :jarjestysnro 1, :tr-alkuosa 23, :massamenekki 348.9795918367347, :tr-loppuetaisyys 525, :nimi nil, :materiaali materiaali, :tr-alkuetaisyys 35, :tr-numero 28410, :toimenpide 12}
+   {:kohdeosa-id nil, :tr-kaista 11, :leveys 2, :kokonaismassamaara 324, :tr-ajorata 0, :pinta_ala 650, :tr-loppuosa 23, :jarjestysnro 1, :tr-alkuosa 23, :massamenekki 498.46153846153845, :tr-loppuetaisyys 850, :nimi nil, :materiaali materiaali, :tr-alkuetaisyys 525, :tr-numero 28410, :toimenpide 12}])
+
+;; VHAR-5750 Liian herkästi muun kohteen päällekkäisyys vaikka ei ollut
+(deftest muun-kohteen-paallekkaisyysvalidointi-ei-liian-herkka
+  (let [paallystyskohde-id (hae-yllapitokohde-aloittamaton)
+        urakka-id (hae-utajarven-paallystysurakan-id)
+        materiaali-id (ffirst (q "SELECT id FROM pot2_mk_urakan_massa WHERE urakka_id = " urakka-id))
+        sopimus-id (hae-utajarven-paallystysurakan-paasopimuksen-id)
+        paallystysilmoitus (-> pot2-testidata
+                               (assoc :paallystyskohde-id paallystyskohde-id)
+                               (assoc :paallystekerros (muun-kohteen-paallekkaisyys-testin-paallystekerros materiaali-id)))
+
+        [paallystysilmoitus-kannassa-ennen paallystysilmoitus-kannassa-jalkeen] (tallenna-pot2-testi-paallystysilmoitus
+                                                                                  urakka-id sopimus-id paallystyskohde-id paallystysilmoitus)]))
+
 (deftest ei-saa-paivittaa-jos-on-vaara-versio
   (let [paallystyskohde-vanha-pot-id (ffirst (q "SELECT id FROM yllapitokohde WHERE nimi = 'Ouluntie'"))]
     (is (not (nil? paallystyskohde-vanha-pot-id)))

--- a/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
+++ b/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
@@ -1138,9 +1138,14 @@
                                (assoc :paallystekerros
                                       [{:kohdeosa-id 13, :tr-kaista 11, :leveys 3, :kokonaismassamaara 5000,
                                         :tr-ajorata 0, :pinta_ala 15000, :tr-loppuosa 2, :jarjestysnro 1,
-                                        :tr-alkuosa 2, :massamenekki 333, :tr-loppuetaisyys 100, :nimi "Muu tie 1",
-                                        :materiaali 2, :tr-alkuetaisyys 50, :piennar false,
-                                        :tr-numero muu-tr-numero, :toimenpide 23, :pot2p_id 3}]))
+                                        :tr-alkuosa 2, :massamenekki 333, :tr-loppuetaisyys 1100, :nimi "Muu tie 1",
+                                        :materiaali 2, :tr-alkuetaisyys 1001, :piennar false,
+                                        :tr-numero muu-tr-numero, :toimenpide 23}
+                                       {:kohdeosa-id nil, :tr-kaista 11, :leveys 3, :kokonaismassamaara 5000,
+                                        :tr-ajorata 0, :pinta_ala 15000, :tr-loppuosa 2, :jarjestysnro 1,
+                                        :tr-alkuosa 2, :massamenekki 333, :tr-loppuetaisyys 1110, :nimi "Muu tie 2",
+                                        :materiaali 2, :tr-alkuetaisyys 1100, :piennar false,
+                                        :tr-numero muu-tr-numero, :toimenpide 23}]))
         ;; Tehdään tallennus joka lisää kaksi alustariviä
         [_ paallystysilmoitus-kannassa-jalkeen] (tallenna-pot2-testi-paallystysilmoitus
                                                   urakka-id sopimus-id paallystyskohde-id paallystysilmoitus)

--- a/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
+++ b/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
@@ -1146,6 +1146,32 @@
            (clojure.set/project alustarivit-jalkeen [:pot2a_id :tr-numero])))
     (poista-paallystysilmoitus-paallystyskohtella paallystyskohde-id)))
 
+(deftest tallenna-pot2-jossa-on-alikohde-muulla-tiella-validointi-ottaa-tie-huomioon.
+  (let [urakka-id (hae-utajarven-paallystysurakan-id)
+        sopimus-id (hae-utajarven-paallystysurakan-paasopimuksen-id)
+        paallystyskohde-id (hae-yllapitokohde-tarkea-kohde-pot2)
+        muu-tr-numero 7777
+        paallystysilmoitus (-> pot2-alustatestien-ilmoitus
+                               (assoc-in [:paallystekerros 2]
+                                         {:kohdeosa-id 13, :tr-kaista 11, :leveys 3, :kokonaismassamaara 5000,
+                                          :tr-ajorata 1, :pinta_ala 15000, :tr-loppuosa 10, :jarjestysnro 1,
+                                          :tr-alkuosa 10, :massamenekki 333, :tr-loppuetaisyys 1500, :nimi "Muu tie 1",
+                                          :materiaali 2, :tr-alkuetaisyys 1066, :piennar false,
+                                          :tr-numero muu-tr-numero, :toimenpide 23, :pot2p_id 3})
+                               (assoc-in [:paallystekerros 3]
+                                         {:kohdeosa-id 13, :tr-kaista 11, :leveys 3, :kokonaismassamaara 5000,
+                                          :tr-ajorata 1, :pinta_ala 15000, :tr-loppuosa 10, :jarjestysnro 1,
+                                          :tr-alkuosa 10, :massamenekki 333, :tr-loppuetaisyys 1500, :nimi "Muu tie 2",
+                                          :materiaali 2, :tr-alkuetaisyys 1066, :piennar false,
+                                          :tr-numero muu-tr-numero, :toimenpide 23, :pot2p_id 4})
+                               (assoc :alusta pot2-alusta-esimerkki))
+        ;; Tehdään tallennus joka lisää kaksi alustariviä
+        [_ paallystysilmoitus-kannassa-jalkeen] (tallenna-pot2-testi-paallystysilmoitus
+                                                  urakka-id sopimus-id paallystyskohde-id paallystysilmoitus)
+        paallystekerrokset-jalkeen (:paallystekerros paallystysilmoitus-kannassa-jalkeen)]
+    (println "petar kerros " (str paallystysilmoitus-kannassa-jalkeen))
+    #_(poista-paallystysilmoitus-paallystyskohtella paallystyskohde-id)))
+
 (deftest ei-saa-tallenna-pot2-paallystysilmoitus-jos-alustarivi-on-tiella-joka-ei-loydy-kulutuskerroksesta
   (let [paallystyskohde-id (hae-yllapitokohde-tarkea-kohde-pot2)
         muu-tr-numero 7777

--- a/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
+++ b/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
@@ -1150,7 +1150,6 @@
         [_ paallystysilmoitus-kannassa-jalkeen] (tallenna-pot2-testi-paallystysilmoitus
                                                   urakka-id sopimus-id paallystyskohde-id paallystysilmoitus)
         paallystekerrokset-jalkeen (:paallystekerros paallystysilmoitus-kannassa-jalkeen)]
-    (println "petar kerros " (str paallystysilmoitus-kannassa-jalkeen))
     #_(poista-paallystysilmoitus-paallystyskohtella paallystyskohde-id)))
 
 (deftest ei-saa-tallenna-pot2-paallystysilmoitus-jos-alustarivi-on-tiella-joka-ei-loydy-kulutuskerroksesta

--- a/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
+++ b/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
@@ -922,26 +922,6 @@
                                                                               :vuosi              2021
                                                                               :paallystysilmoitus paallystysilmoitus})))))
 
-(defn- muun-kohteen-paallekkaisyys-testin-paallystekerros [materiaali]
-  [{:kohdeosa-id nil, :tr-kaista 11, :leveys 2, :kokonaismassamaara 342, :tr-ajorata 0, :pinta_ala 560, :tr-loppuosa 3, :jarjestysnro 1, :tr-alkuosa 3, :massamenekki 610.7142857142857, :tr-loppuetaisyys 5000, :nimi nil, :materiaali materiaali, :tr-alkuetaisyys 1, :tr-numero 20, :toimenpide 12}
-   {:kohdeosa-id nil, :tr-kaista 11, :leveys 2, :kokonaismassamaara 342, :tr-ajorata 0, :pinta_ala 560, :tr-loppuosa 23, :jarjestysnro 1, :tr-alkuosa 23, :massamenekki 610.7142857142857, :tr-loppuetaisyys 615, :nimi nil, :materiaali materiaali, :tr-alkuetaisyys 335, :tr-numero 28401, :toimenpide 12}
-   {:kohdeosa-id nil, :tr-kaista 11, :leveys 2, :kokonaismassamaara 234, :tr-ajorata 0, :pinta_ala 760, :tr-loppuosa 23, :jarjestysnro 1, :tr-alkuosa 23, :massamenekki 307.89473684210526, :tr-loppuetaisyys 460, :nimi nil, :materiaali materiaali, :tr-alkuetaisyys 80, :tr-numero 28406, :toimenpide 12}
-   {:kohdeosa-id nil, :tr-kaista 11, :leveys 2, :kokonaismassamaara 342, :tr-ajorata 0, :pinta_ala 980, :tr-loppuosa 23, :jarjestysnro 1, :tr-alkuosa 23, :massamenekki 348.9795918367347, :tr-loppuetaisyys 525, :nimi nil, :materiaali materiaali, :tr-alkuetaisyys 35, :tr-numero 28410, :toimenpide 12}
-   {:kohdeosa-id nil, :tr-kaista 11, :leveys 2, :kokonaismassamaara 324, :tr-ajorata 0, :pinta_ala 650, :tr-loppuosa 23, :jarjestysnro 1, :tr-alkuosa 23, :massamenekki 498.46153846153845, :tr-loppuetaisyys 850, :nimi nil, :materiaali materiaali, :tr-alkuetaisyys 525, :tr-numero 28410, :toimenpide 12}])
-
-;; VHAR-5750 Liian herkästi muun kohteen päällekkäisyys vaikka ei ollut
-(deftest muun-kohteen-paallekkaisyysvalidointi-ei-liian-herkka
-  (let [paallystyskohde-id (hae-yllapitokohde-aloittamaton)
-        urakka-id (hae-utajarven-paallystysurakan-id)
-        materiaali-id (ffirst (q "SELECT id FROM pot2_mk_urakan_massa WHERE urakka_id = " urakka-id))
-        sopimus-id (hae-utajarven-paallystysurakan-paasopimuksen-id)
-        paallystysilmoitus (-> pot2-testidata
-                               (assoc :paallystyskohde-id paallystyskohde-id)
-                               (assoc :paallystekerros (muun-kohteen-paallekkaisyys-testin-paallystekerros materiaali-id)))
-
-        [paallystysilmoitus-kannassa-ennen paallystysilmoitus-kannassa-jalkeen] (tallenna-pot2-testi-paallystysilmoitus
-                                                                                  urakka-id sopimus-id paallystyskohde-id paallystysilmoitus)]))
-
 (deftest ei-saa-paivittaa-jos-on-vaara-versio
   (let [paallystyskohde-vanha-pot-id (ffirst (q "SELECT id FROM yllapitokohde WHERE nimi = 'Ouluntie'"))]
     (is (not (nil? paallystyskohde-vanha-pot-id)))
@@ -1146,25 +1126,21 @@
            (clojure.set/project alustarivit-jalkeen [:pot2a_id :tr-numero])))
     (poista-paallystysilmoitus-paallystyskohtella paallystyskohde-id)))
 
+;; VHAR-5750 Liian herkästi muun kohteen päällekkäisyys vaikka ei ollut
 (deftest tallenna-pot2-jossa-on-alikohde-muulla-tiella-validointi-ottaa-tie-huomioon.
   (let [urakka-id (hae-utajarven-paallystysurakan-id)
         sopimus-id (hae-utajarven-paallystysurakan-paasopimuksen-id)
         paallystyskohde-id (hae-yllapitokohde-tarkea-kohde-pot2)
-        muu-tr-numero 7777
+        muu-tr-numero 837
         paallystysilmoitus (-> pot2-alustatestien-ilmoitus
-                               (assoc-in [:paallystekerros 2]
-                                         {:kohdeosa-id 13, :tr-kaista 11, :leveys 3, :kokonaismassamaara 5000,
-                                          :tr-ajorata 1, :pinta_ala 15000, :tr-loppuosa 10, :jarjestysnro 1,
-                                          :tr-alkuosa 10, :massamenekki 333, :tr-loppuetaisyys 1500, :nimi "Muu tie 1",
-                                          :materiaali 2, :tr-alkuetaisyys 1066, :piennar false,
-                                          :tr-numero muu-tr-numero, :toimenpide 23, :pot2p_id 3})
-                               (assoc-in [:paallystekerros 3]
-                                         {:kohdeosa-id 13, :tr-kaista 11, :leveys 3, :kokonaismassamaara 5000,
-                                          :tr-ajorata 1, :pinta_ala 15000, :tr-loppuosa 10, :jarjestysnro 1,
-                                          :tr-alkuosa 10, :massamenekki 333, :tr-loppuetaisyys 1500, :nimi "Muu tie 2",
-                                          :materiaali 2, :tr-alkuetaisyys 1066, :piennar false,
-                                          :tr-numero muu-tr-numero, :toimenpide 23, :pot2p_id 4})
-                               (assoc :alusta pot2-alusta-esimerkki))
+                               (dissoc :alusta)
+                               (dissoc :paallystekerros)
+                               (assoc :paallystekerros
+                                      [{:kohdeosa-id 13, :tr-kaista 11, :leveys 3, :kokonaismassamaara 5000,
+                                        :tr-ajorata 0, :pinta_ala 15000, :tr-loppuosa 2, :jarjestysnro 1,
+                                        :tr-alkuosa 2, :massamenekki 333, :tr-loppuetaisyys 100, :nimi "Muu tie 1",
+                                        :materiaali 2, :tr-alkuetaisyys 50, :piennar false,
+                                        :tr-numero muu-tr-numero, :toimenpide 23, :pot2p_id 3}]))
         ;; Tehdään tallennus joka lisää kaksi alustariviä
         [_ paallystysilmoitus-kannassa-jalkeen] (tallenna-pot2-testi-paallystysilmoitus
                                                   urakka-id sopimus-id paallystyskohde-id paallystysilmoitus)


### PR DESCRIPTION
VHAR-5750 Kommentoi väärin toimiva POT2-kulutuskerroksen muun kohteen validointi. Tämä estää tallennuksen tuotannossa, joten poistetaan validointi joka estää oikeellisia rivejä tallentumasta.