### PR TITLE
VHAR-5855 Paranna Harjan integraatiolokin käyttökokemusta

### DIFF
--- a/src/cljs/harja/tiedot/hallinta/integraatioloki.cljs
+++ b/src/cljs/harja/tiedot/hallinta/integraatioloki.cljs
@@ -55,7 +55,7 @@
 
 
 (def haetut-tapahtumat (atom [])) ;; nil jos haku käynnissä, [] jos tyhjä
-(def hae-automaattisesti? (atom true))
+(def hae-automaattisesti? (atom false))
 
 (defn hae-tapahtumat! []
   (let  [valittu-jarjestelma @valittu-jarjestelma

--- a/src/cljs/harja/ui/kentat.cljs
+++ b/src/cljs/harja/ui/kentat.cljs
@@ -11,16 +11,11 @@
             [harja.ui.sijaintivalitsin :as sijaintivalitsin]
             [harja.ui.yleiset :refer [linkki ajax-loader livi-pudotusvalikko nuolivalinta valinta-ul-max-korkeus-px] :as yleiset]
             [harja.ui.napit :as napit]
-            [harja.loki :refer [log logt tarkkaile!]]
-            [harja.tiedot.navigaatio :as nav]
+            [harja.loki :refer [log logt tarkkaile!] :as loki]
             [harja.tiedot.sijaintivalitsin :as sijaintivalitsin-tiedot]
             [clojure.string :as str]
-            [goog.string :as gstr]
-            [goog.events.EventType :as EventType]
             [cljs.core.async :refer [<! >! chan] :as async]
 
-            [harja.ui.dom :as dom]
-            [harja.ui.kartta.ikonit :as kartta-ikonit]
             [harja.tiedot.kartta :as kartta]
             [harja.ui.kartta.esitettavat-asiat :refer [maarittele-feature]]
             [harja.views.kartta.tasot :as tasot]
@@ -31,15 +26,11 @@
             [harja.atom :refer [paivittaja]]
             [harja.fmt :as fmt]
             [harja.asiakas.kommunikaatio :as k]
-            [harja.ui.kartta.varit.puhtaat :as puhtaat]
             [harja.ui.kartta.asioiden-ulkoasu :as asioiden-ulkoasu]
             [harja.ui.yleiset :as y]
             [harja.domain.tierekisteri :as trd]
             [harja.views.kartta.tasot :as karttatasot]
-            [harja.tyokalut.big :as big]
-            [taoensso.timbre :as log]
-            [harja.loki :as loki]
-            [clojure.string :as string])
+            [harja.tyokalut.big :as big])
   (:require-macros [cljs.core.async.macros :refer [go go-loop]]
                    [harja.tyokalut.ui :refer [for*]]
                    [harja.makrot :refer [nappaa-virhe]]))
@@ -1732,3 +1723,18 @@
 
 (defmethod tee-kentta :valiotsikko [{:keys [teksti]} data]
   [:div [:h3 teksti]])
+
+(defn raksiboksi
+  [{:keys [teksti toiminto info-teksti nayta-infoteksti? komponentti disabled?]} checked]
+  [:span.raksiboksi
+   [:div.input-group
+    [tee-kentta
+     {:tyyppi :checkbox
+      :teksti teksti
+      :disabled? disabled?
+      :valitse! toiminto}
+     checked]
+    (when komponentti
+      komponentti)]
+   (when nayta-infoteksti?
+     info-teksti)])

--- a/src/cljs/harja/ui/yleiset.cljs
+++ b/src/cljs/harja/ui/yleiset.cljs
@@ -170,21 +170,6 @@ joita kutsutaan kun niiden näppäimiä paineetaan."
        :download ""}
    [ikonit/ikoni-ja-teksti (ikonit/livicon-download) otsikko]])
 
-(defn raksiboksi
-  [{:keys [teksti toiminto info-teksti nayta-infoteksti? komponentti disabled?]} checked]
-  [:span.raksiboksi
-   [:div.input-group
-    [harja.ui.kentat/tee-kentta
-     {:tyyppi :checkbox
-      :teksti teksti
-      :disabled? disabled?
-      :valitse! toiminto}
-     checked]
-    (when komponentti
-      komponentti)]
-   (when nayta-infoteksti?
-     info-teksti)])
-
 (defn alasveto-ei-loydoksia [teksti]
   [:div.alasveto-ei-loydoksia teksti])
 

--- a/src/cljs/harja/views/hallinta/integraatioloki.cljs
+++ b/src/cljs/harja/views/hallinta/integraatioloki.cljs
@@ -135,7 +135,7 @@
                             (js/Math.round (* .5 lkm-max))
                             (js/Math.round (* .75 lkm-max))
                             lkm-max])
-           nayta-labelit? (< (count pvm-kohtaiset-maarat-summattu) 10)]
+           nayta-labelit? (< (count pvm-kohtaiset-maarat-summattu) 100)]
        [vis/bars {:width w
                   :height (min 200 h)
                   :label-fn #(if nayta-labelit?

--- a/src/cljs/harja/views/ilmoitukset/tieliikenneilmoitukset.cljs
+++ b/src/cljs/harja/views/ilmoitukset/tieliikenneilmoitukset.cljs
@@ -14,8 +14,8 @@
             [harja.ui.bootstrap :as bs]
             [harja.ui.komponentti :as komp]
             [harja.ui.grid :refer [grid]]
-            [harja.ui.yleiset :refer [ajax-loader raksiboksi] :as yleiset]
-            [harja.ui.kentat :refer [tee-kentta]]
+            [harja.ui.yleiset :refer [ajax-loader] :as yleiset]
+            [harja.ui.kentat :refer [tee-kentta] :as kentat]
             [harja.loki :refer [log tarkkaile!]]
             [harja.tiedot.istunto :as istunto]
             [harja.ui.napit :refer [palvelinkutsu-nappi] :as napit]
@@ -33,7 +33,6 @@
             [harja.ui.notifikaatiot :as notifikaatiot]
             [tuck.core :refer [tuck send-value! send-async!]]
             [harja.tiedot.ilmoitukset.viestit :as v]
-            [harja.ui.kentat :as kentat]
             [harja.domain.oikeudet :as oikeudet]
             [harja.tiedot.kartta :as kartta-tiedot]
             [harja.ui.debug :as debug]
@@ -258,11 +257,11 @@
                                                                            (:urakka rivi))]
                             [:span (when liidosta-tullut?
                                      {:title tiedot/vihje-liito})
-                             [raksiboksi {:disabled (or liidosta-tullut?
-                                                        (not kirjoitusoikeus?))
-                                          :toiminto (when (and (not ilmoituksen-haku-kaynnissa?)
-                                                               (nil? pikakuittaus))
-                                                      #(valitse-ilmoitus! rivi))}
+                             [kentat/raksiboksi {:disabled (or liidosta-tullut?
+                                                               (not kirjoitusoikeus?))
+                                                 :toiminto (when (and (not ilmoituksen-haku-kaynnissa?)
+                                                                      (nil? pikakuittaus))
+                                                             #(valitse-ilmoitus! rivi))}
                               (boolean (valitut-ilmoitukset rivi))]]))
            :leveys 2})
         {:otsikko "Urakka" :nimi :urakkanimi :leveys 7

--- a/src/cljs/harja/views/raportit.cljs
+++ b/src/cljs/harja/views/raportit.cljs
@@ -287,7 +287,7 @@
 
      (when-not (or vain-hoitokausivalinta? vain-kuukausivalinta?)
        [:div.raportin-valittu-aikavali
-        [yleiset/raksiboksi {:teksti "Valittu aikaväli"
+        [kentat/raksiboksi {:teksti "Valittu aikaväli"
                              :komponentti (when @vapaa-aikavali?
                                             [:div
                                              [ui-valinnat/aikavali vapaa-aikavali {:aikavalin-rajoitus [+raportin-aikavalin-max-pituus-vuotta+ :vuosi]
@@ -350,7 +350,7 @@
   (if @nav/valittu-urakka
     [:span]
     [:div.urakoittain
-     [yleiset/raksiboksi {:teksti (:nimi p)
+     [kentat/raksiboksi {:teksti (:nimi p)
                           :toiminto #(do (swap! urakoittain? not)
                                          (reset! arvo
                                                  {:urakoittain? @urakoittain?}))}
@@ -462,7 +462,7 @@
                               {(or (tyomaakokousraportit (:nimi p))
                                    (:nimi p)) (get-in @muistetut-parametrit [(:nimi @valittu-raporttityyppi) (:nimi p)])}))]
     [:div
-     [yleiset/raksiboksi {:teksti (:nimi p)
+     [kentat/raksiboksi {:teksti (:nimi p)
                           :toiminto paivita!}
       (get-in @muistetut-parametrit avaimet)]]))
 
@@ -484,7 +484,7 @@
                     (for [{:keys [nimi numero]} sarake
                           :let [valittu? (boolean (valitut numero))]]
                       ^{:key numero}
-                      [yleiset/raksiboksi {:teksti nimi
+                      [kentat/raksiboksi {:teksti nimi
                                            :toiminto #(let [uusi-arvo {:hoitoluokat
                                                                        ((if valittu? disj conj) valitut numero)}]
                                                        (reset! arvo uusi-arvo)

--- a/src/cljs/harja/views/urakka/suunnittelu/kokonaishintaiset_tyot.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/kokonaishintaiset_tyot.cljs
@@ -3,7 +3,7 @@
   (:require [reagent.core :refer [atom] :as r]
             [harja.ui.grid :as grid]
             [harja.ui.ikonit :as ikonit]
-            [harja.ui.yleiset :refer [ajax-loader linkki raksiboksi
+            [harja.ui.yleiset :refer [ajax-loader linkki
                                       alasveto-ei-loydoksia livi-pudotusvalikko]
              :as yleiset]
             [harja.visualisointi :as vis]
@@ -441,10 +441,10 @@
                :muokkaa-footer (fn [g]
                                  (when-not @prosenttijako?
                                    [:div.kok-hint-muokkaa-footer
-                                    [raksiboksi {:teksti (s/monista-tuleville-teksti (:tyyppi @urakka))
-                                                 :toiminto #(swap! tuleville? not)
-                                                 :info-teksti [:div.raksiboksin-info (ikonit/livicon-warning-sign) "Tulevilla hoitokausilla eri tietoa, jonka tallennus ylikirjoittaa."]
-                                                 :nayta-infoteksti? (and @tuleville? @varoita-ylikirjoituksesta?)}
+                                    [kentat/raksiboksi {:teksti (s/monista-tuleville-teksti (:tyyppi @urakka))
+                                                        :toiminto #(swap! tuleville? not)
+                                                        :info-teksti [:div.raksiboksin-info (ikonit/livicon-warning-sign) "Tulevilla hoitokausilla eri tietoa, jonka tallennus ylikirjoittaa."]
+                                                        :nayta-infoteksti? (and @tuleville? @varoita-ylikirjoituksesta?)}
                                      @tuleville?]]))
                :rivi-jalkeen-fn (when @prosenttijako?
                                   (fn [rivit]

--- a/src/cljs/harja/views/urakka/suunnittelu/materiaalit.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/materiaalit.cljs
@@ -1,6 +1,5 @@
 (ns harja.views.urakka.suunnittelu.materiaalit
   (:require [reagent.core :refer [atom] :as r]
-            [harja.ui.yleiset :refer [raksiboksi]]
             [harja.tiedot.urakka.suunnittelu.materiaalit :as t]
             [harja.loki :refer [log logt]]
             [harja.tiedot.urakka :as u]
@@ -13,7 +12,8 @@
             [cljs.core.async :refer [<!]]
             [harja.views.urakka.valinnat :as valinnat]
             [harja.domain.oikeudet :as oikeudet]
-            [harja.ui.yleiset :as yleiset])
+            [harja.ui.yleiset :as yleiset]
+            [harja.ui.kentat :as kentat])
   (:require-macros [cljs.core.async.macros :refer [go]]
                    [reagent.ratom :refer [run! reaction]]
                    [harja.atom :refer [reaction-writable]]))
@@ -153,7 +153,7 @@
 
 
           (when voi-muokata?
-            [raksiboksi {:teksti (s/monista-tuleville-teksti (:tyyppi ur))
+            [kentat/raksiboksi {:teksti (s/monista-tuleville-teksti (:tyyppi ur))
                          :info-teksti [:div.raksiboksin-info (ikonit/livicon-warning-sign) "Tulevilla hoitokausilla eri tietoa, jonka tallennus ylikirjoittaa."]
                          :nayta-infoteksti? (and @tuleville? @varoita-ylikirjoituksesta?)}
              tuleville?])

--- a/src/cljs/harja/views/urakka/suunnittelu/yksikkohintaiset_tyot.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/yksikkohintaiset_tyot.cljs
@@ -3,8 +3,7 @@
   (:require [reagent.core :refer [atom] :as reagent]
             [harja.ui.grid :as grid]
             [harja.ui.ikonit :as ikonit]
-            [harja.ui.yleiset :as yleiset :refer [ajax-loader linkki raksiboksi
-                                                  alasveto-ei-loydoksia livi-pudotusvalikko vihje]]
+            [harja.ui.yleiset :as yleiset :refer [ajax-loader linkki alasveto-ei-loydoksia livi-pudotusvalikko vihje]]
             [harja.visualisointi :as vis]
             [harja.ui.komponentti :as komp]
             [harja.tiedot.urakka :as u]
@@ -21,7 +20,7 @@
             [harja.domain.urakka :as urakka-domain]
             [clojure.string :as str]
             [harja.ui.valinnat :as valinnat]
-            [harja.domain.urakka :as u-domain])
+            [harja.ui.kentat :as kentat])
   (:require-macros [cljs.core.async.macros :refer [go]]
                    [reagent.ratom :refer [reaction run!]]))
 
@@ -236,8 +235,8 @@
                        :ei-mahdollinen)
            :tallenna-vain-muokatut false
            :tallennus-ei-mahdollinen-tooltip (oikeudet/oikeuden-puute-kuvaus
-                                              :kirjoitus
-                                              oikeudet/urakat-suunnittelu-yksikkohintaisettyot)
+                                               :kirjoitus
+                                               oikeudet/urakat-suunnittelu-yksikkohintaisettyot)
            :peruuta #(reset! tuleville? false)
            :tunniste :tehtava
            :voi-lisata? false
@@ -248,9 +247,9 @@
                                    (ryhmittele-hinnoitellut @tyorivit)))
            :piilota-toiminnot? true
            :muokkaa-footer (fn [g]
-                             [raksiboksi {:teksti (s/monista-tuleville-teksti (:tyyppi ur))
-                                          :info-teksti [:div.raksiboksin-info (ikonit/livicon-warning-sign) "Tulevilla hoitokausilla eri tietoa, jonka tallennus ylikirjoittaa."]
-                                          :nayta-infoteksti? @varoita-ylikirjoituksesta?}
+                             [kentat/raksiboksi {:teksti (s/monista-tuleville-teksti (:tyyppi ur))
+                                                 :info-teksti [:div.raksiboksin-info (ikonit/livicon-warning-sign) "Tulevilla hoitokausilla eri tietoa, jonka tallennus ylikirjoittaa."]
+                                                 :nayta-infoteksti? @varoita-ylikirjoituksesta?}
                               tuleville?])
            :prosessoi-muutos (if (= :hoito (:tyyppi ur))
                                (fn [rivit]

--- a/src/cljs/harja/views/urakka/tiemerkinnan_yksikkohintaiset_tyot.cljs
+++ b/src/cljs/harja/views/urakka/tiemerkinnan_yksikkohintaiset_tyot.cljs
@@ -1,7 +1,7 @@
 (ns harja.views.urakka.tiemerkinnan-yksikkohintaiset-tyot
   (:require [reagent.core :refer [atom] :as reagent]
             [harja.ui.grid :as grid]
-            [harja.ui.yleiset :as yleiset :refer [ajax-loader linkki raksiboksi
+            [harja.ui.yleiset :as yleiset :refer [ajax-loader linkki
                                                   alasveto-ei-loydoksia livi-pudotusvalikko vihje]]
             [harja.ui.komponentti :as komp]
             [harja.tiedot.urakka :as u]


### PR DESCRIPTION
-defaulttina ei päivitetä enää automaattisesti
-näytä pvm labelit myös default 3kk ajanjaksolta, parantaa luettavuutta
-siirrä raksiboksi --> kentat namespaceen, jotta syklinen riippuvuus (ja käännösvaroitus) poistuu