### PR TITLE
Vhar 5569 paikkausrajapinnan tierekisteri

### DIFF
--- a/src/clj/harja/kyselyt/paikkaus.clj
+++ b/src/clj/harja/kyselyt/paikkaus.clj
@@ -628,7 +628,6 @@
                                                                :tyomenetelmat menetelmat
                                                                :elyt elyt}))
         urakan-paikkauskohteet (kasittele-paikkauskohteiden-sijainti db urakan-paikkauskohteet)
-        ;_ (println "paikkauskohteet :: urakan-paikkauskohteet" (pr-str urakan-paikkauskohteet))
         ;; Tarkistetaan käyttäjän käyttöoikeudet suhteessa kustannuksiin.
         ;; Mikäli käyttäjälle ei ole nimenomaan annettu oikeuksia nähdä summia, niin poistetaan ne
         urakan-paikkauskohteet (map (fn [kohde]

--- a/src/clj/harja/kyselyt/paikkaus.clj
+++ b/src/clj/harja/kyselyt/paikkaus.clj
@@ -500,65 +500,85 @@
   "Pätkitään funkkari osiin, jotta se on helpommin testattavissa. Tämä laskee siis
   tien pätkälle pituudet riippuen siitä, miten osan-pituudet listassa on annettu"
   [osan-pituudet kohde]
-  ;; Pieni validointi kohteen arvoille
-  (when (and (not (nil? (:aosa kohde))) (not (nil? (:losa kohde)))
-             (<= (:aosa kohde) (:losa kohde)))
-    (reduce (fn [k rivi]
-              (cond
-                ;; Kun alkuosa ja loppuosa ovat erit
-                ;; Alkuosa täsmää, joten ei oteta koko pituutta, vaan pelkästään jäljelle jäävä pituus
-                (and (not= (:aosa k) (:losa k))
-                     (= (:aosa k) (:osa rivi)))
-                (assoc k :pituus (+
-                                   (:pituus k) ;; Nykyinen pituus
-                                   (- (:pituus rivi) (:aet k)) ;; Osamäpin osan pituudesta vähennetään alkuosan etäisyys
-                                   ))
-                ;; Kun alkuosa ja loppuosa ovat erit
-                ;; Jos loppuosa täsmää osalistan osaan, niin otetaan vain loppuosan etäisyys
-                (and (not= (:aosa k) (:losa k))
-                     (= (:losa k) (:osa rivi)))
-                (assoc k :pituus (+
-                                   (:pituus k) ;; Nykyinen pituus
-                                   (:let k) ;; Lopposan pituus, eli alusta tähän asti, ei siis koko osan pituutta
-                                   ))
-                ;; Kun alkuosa on sama kuin loppuosa
-                ;; Ja osa on olemassa. Eli jos tiepätkään ei kuulu se osa mitä mitataan, niin ei myöskään
-                ;; lasketa sitä mukaaj
-                ;; Otetaan vain osien väliin jäävä pätkä mukaan
-                (and (= (:osa rivi) (:aosa k))
-                     (= (:aosa k) (:losa k)))
-                (assoc k :pituus (+
-                                   (:pituus k) ;; Nykyinen pituus
-                                   (- (:let k) (:aet k)) ;; Osamäpin osan pituudesta vähennetään alkuosan etäisyys
-                                   ))
-
-                ;; alkuosa tai loppuosa ei täsmää, joten otetaan koko osan pituus
-                :else
-                (if
-                  ;; Varmistetaan, että tietokannasta on saatu validi osa
-                  ;; Ja että tietokannasta saatu osa pitää käsitellä vielä tälle kohteelle.
-                  ;; Jos :osa on suurimpi kuin :losa, niin mitään käsittelyitä ei tarvita enää
-                  ;; Ja jos :osa on pienempi kuin :aosa, niin käsittelyitä ei tarvita
-                  (and (:pituus rivi)
-                       (< (:osa rivi) (:losa k))
-                       (> (:osa rivi) (:aosa k)))
+  (let [varakohde kohde
+        kohde (if (and (not (nil? (:aosa kohde))) (not (nil? (:losa kohde)))
+                    (or (> (:aosa kohde) (:losa kohde))
+                      (and (= (:aosa kohde) (:losa kohde))
+                        (> (:aet kohde) (:let kohde)))))
+                (-> kohde
+                  (assoc :aosa (:losa varakohde))
+                  (assoc :losa (:aosa varakohde))
+                  (assoc :aet (:let varakohde))
+                  (assoc :let (:aet varakohde)))
+                kohde)]
+    ;; Pieni validointi kohteen arvoille
+    (when (and (not (nil? (:aosa kohde))) (not (nil? (:losa kohde)))
+            (<= (:aosa kohde) (:losa kohde)))
+      (reduce (fn [k rivi]
+                (cond
+                  ;; Kun alkuosa ja loppuosa ovat erit
+                  ;; Alkuosa täsmää, joten ei oteta koko pituutta, vaan pelkästään jäljelle jäävä pituus
+                  (and (not= (:aosa k) (:losa k))
+                    (= (:aosa k) (:osa rivi)))
                   (assoc k :pituus (+
-                                     (:pituus k) ;; Nykyinen pituus
-                                     (:pituus rivi) ;; Osamäpin osan pituus
+                                     (:pituus k)            ;; Nykyinen pituus
+                                     (- (:pituus rivi) (:aet k)) ;; Osamäpin osan pituudesta vähennetään alkuosan etäisyys
                                      ))
-                  k)))
-            ;; Annetaan reducelle mäppi, jossa :pituus avaimeen lasketaan annetun tien kohdan pituus.
-            {:pituus 0 :aosa (:aosa kohde) :aet (:aet kohde) :losa (:losa kohde) :let (:let kohde)}
-            osan-pituudet)))
+                  ;; Kun alkuosa ja loppuosa ovat erit
+                  ;; Jos loppuosa täsmää osalistan osaan, niin otetaan vain loppuosan etäisyys
+                  (and (not= (:aosa k) (:losa k))
+                    (= (:losa k) (:osa rivi)))
+                  (assoc k :pituus (+
+                                     (:pituus k)            ;; Nykyinen pituus
+                                     (:let k)               ;; Lopposan pituus, eli alusta tähän asti, ei siis koko osan pituutta
+                                     ))
+                  ;; Kun alkuosa on sama kuin loppuosa
+                  ;; Ja osa on olemassa. Eli jos tiepätkään ei kuulu se osa mitä mitataan, niin ei myöskään
+                  ;; lasketa sitä mukaaj
+                  ;; Otetaan vain osien väliin jäävä pätkä mukaan
+                  (and (= (:osa rivi) (:aosa k))
+                    (= (:aosa k) (:losa k)))
+                  (assoc k :pituus (+
+                                     (:pituus k)            ;; Nykyinen pituus
+                                     (- (:let k) (:aet k))  ;; Osamäpin osan pituudesta vähennetään alkuosan etäisyys
+                                     ))
+
+                  ;; alkuosa tai loppuosa ei täsmää, joten otetaan koko osan pituus
+                  :else
+                  (if
+                    ;; Varmistetaan, että tietokannasta on saatu validi osa
+                    ;; Ja että tietokannasta saatu osa pitää käsitellä vielä tälle kohteelle.
+                    ;; Jos :osa on suurimpi kuin :losa, niin mitään käsittelyitä ei tarvita enää
+                    ;; Ja jos :osa on pienempi kuin :aosa, niin käsittelyitä ei tarvita
+                    (and (:pituus rivi)
+                      (< (:osa rivi) (:losa k))
+                      (> (:osa rivi) (:aosa k)))
+                    (assoc k :pituus (+
+                                       (:pituus k)          ;; Nykyinen pituus
+                                       (:pituus rivi)       ;; Osamäpin osan pituus
+                                       ))
+                    k)))
+        ;; Annetaan reducelle mäppi, jossa :pituus avaimeen lasketaan annetun tien kohdan pituus.
+        {:pituus 0 :aosa (:aosa kohde) :aet (:aet kohde) :losa (:losa kohde) :let (:let kohde)}
+        osan-pituudet))))
 
 (defn laske-paikkauskohteen-pituus [db kohde]
   (let [;; Jos osan hae-osien-pituudet kyselyn tulos muuttuu, tämän funktion toiminta loppuu
         ;; Alla oleva reduce olettaa, että sille annetaan osien pituudet desc järjestyksessä ja muodossa
         ;; ({:osa 1 :pituus 3000} {:osa 2 :pituus 3000})
+        ;; Joten jos tieosoite annetaan nurinpäin, niin muokataan se sopivaan muotoon
+        varakohde kohde
+        kohde (if (and (not (nil? (:aosa kohde))) (not (nil? (:losa kohde)))
+                    (> (:aosa kohde) (:losa kohde)))
+                (-> kohde
+                  (assoc :aosa (:losa varakohde))
+                  (assoc :losa (:aosa varakohde)))
+                kohde)
         osan-pituudet (harja.kyselyt.tieverkko/hae-osien-pituudet db {:tie (:tie kohde)
                                                                       :aosa (:aosa kohde)
-                                                                      :losa (:losa kohde)})]
-    (laske-tien-osien-pituudet osan-pituudet kohde)))
+                                                                      :losa (:losa kohde)})
+        pituus (laske-tien-osien-pituudet osan-pituudet kohde)]
+    pituus))
 
 (defn- kasittele-paikkauskohteiden-sijainti
   "Poistetaan käyttämättömät avaimet ja lasketaan pituus"

--- a/src/clj/harja/kyselyt/paikkaus.clj
+++ b/src/clj/harja/kyselyt/paikkaus.clj
@@ -333,7 +333,7 @@
 (defn tallenna-paikkaus
   "APIa varten tehty paikkauksen tallennus. Olettaa saavansa ulkoisen id:n"
   [db urakka-id kayttaja-id paikkaus]
-  (let [_ (println "tallenna-paikkaus :: paikkaus:" (pr-str paikkaus))
+  (let [_ (log/debug "tallenna-paikkaus :: paikkaus:" (pr-str paikkaus))
         id (::paikkaus/id paikkaus)
         ulkoinen-id (::paikkaus/ulkoinen-id paikkaus)
         paikkauskohde-id (::paikkaus/id

--- a/src/clj/harja/palvelin/palvelut/yllapitokohteet/paikkaukset.clj
+++ b/src/clj/harja/palvelin/palvelut/yllapitokohteet/paikkaukset.clj
@@ -39,7 +39,9 @@
                 tie (if (:harja.domain.tierekisteri/tie kohde)
                       (:harja.domain.tierekisteri/tie kohde)
                       (:harja.domain.tierekisteri/tie (first (::paikkaus/paikkaukset kohde))))
-                osan-pituudet (tv/hae-osien-pituudet db {:tie tie :aosa nil :losa nil})]
+                osan-pituudet (tv/hae-osien-pituudet db {:tie tie
+                                                         :aosa (or (:aosa kohde) (::paikkaus/aosa (first (::paikkaus/paikkaukset kohde))))
+                                                         :losa (or (:losa kohde) (::paikkaus/losa (first (::paikkaus/paikkaukset kohde))))})]
             (if-not (empty? (::paikkaus/paikkaukset kohde))
               (let [paikkaukset (::paikkaus/paikkaukset kohde)
                     kohde (-> kohde

--- a/src/clj/harja/palvelin/palvelut/yllapitokohteet/paikkaukset.clj
+++ b/src/clj/harja/palvelin/palvelut/yllapitokohteet/paikkaukset.clj
@@ -24,67 +24,6 @@
            (java.sql Date)
            (java.util TimeZone)))
 
-;; Jätän vielä hetkeksi tämän tänne talteen, jos uudesta hausta löytyy vielä bugi
-#_ (defn- muodosta-tr-ehdot
-  "Muodostetaan where-osio specql:lle, jossa etsitään tierekisteriosoite määrritetyltä väliltä.
-   Tässä on aika paljon ehtoja, sillä oletuksena ei ole täydellisesti annettua tr-osiota vaan
-   mikä tahansa osa siitä tai osien kombinaatio kelpaa."
-  [tr]
-  (let [tr (into {} (filter (fn [[_ arvo]] arvo) tr))
-        ;; Täytyy luoda yhteinen pohja, koska nämä kaikki ehdot yhdistetään OR:lla. Tätä pohjaa käytetään kolmessa
-        ;; ensimmäisessä ehdossa, joissa käsitellään ne keissit, kun aosa tai aet tai molemmat ovat annettuna.
-        alun-yhteinen-pohja (cond-> {}
-                                    (:loppuosa tr) (assoc ::tierekisteri/losa (op/<= (:loppuosa tr)))
-                                    (:loppuetaisyys tr) (assoc ::tierekisteri/let (op/<= (:loppuetaisyys tr)))
-                                    (:alkuosa tr) (assoc ::tierekisteri/aosa (op/>= (:alkuosa tr)))
-                                    (:numero tr) (assoc ::tierekisteri/tie (:numero tr)))
-        ;; Jos molemmat, alkuosa ja alkuetaisyys ovat annettuna, tarvitaan ehdot 1 ja 3. Muutenhan nuo voisi yhdistää.
-
-        ;; Jos alkuosa on annettu ja kannassa oleva tr-osoitteen alkuosa on annettua arvoa isompi, pitää se palauttaa.
-        ;; Palautetaan myös ne arvot kannasta, joissa aosa on yhtäsuuri, jos aet ei ole annettu.
-        ehto-1 (when (:alkuosa tr)
-                 (assoc alun-yhteinen-pohja ::tierekisteri/aosa ((if (:alkuetaisyys tr)
-                                                                   op/>
-                                                                   op/>=)
-                                                                  (:alkuosa tr))))
-        ;; Jos alkuetaisyys on annettu, kannasas olevan arvon aet tulee olla yhtäsuuri tai suurempi, jotta sen
-        ;; voi palauttaa.
-        ehto-2 (when (:alkuetaisyys tr)
-                 (assoc alun-yhteinen-pohja ::tierekisteri/aet (op/>= (:alkuetaisyys tr))))
-        ;; Jos alkuosa ja alkuetaisyys on annettu, täytyy kannassa olevan arvon aosa olla suurempi kuin määritetyn tai
-        ;; kannassa olevan tr-arvon aosa voi olla yhtäsuuri annetun kanssa, mutta silloin myös aet:in pitää olla
-        ;; suurempi tai yhtäsuuri. Ensimmäinen näistä kahdesta vaihtoehdosta on määrritelty jo ehto-1:ssä, joten
-        ;; tässä ehto-3:ssa otetaan kantaa vain tuohon jälkimmäiseen.
-        ehto-3 (when (and (:alkuosa tr) (:alkuetaisyys tr))
-                 (assoc alun-yhteinen-pohja ::tierekisteri/aosa (:alkuosa tr)
-                                            ::tierekisteri/aet (op/>= (:alkuetaisyys tr))))
-
-        ;; ehdot 4-6 käsittelevät losa:n ja let:n samalla tavalla kuin ehdot 1-3 käsittelevät aosa:n ja aet:in
-        lopun-yhteinen-pohja (cond-> {}
-                                     (:alkuosa tr) (assoc ::tierekisteri/aosa (op/>= (:alkuosa tr)))
-                                     (:alkuetaisyys tr) (assoc ::tierekisteri/aet (op/>= (:alkuetaisyys tr)))
-                                     (:loppuosa tr) (assoc ::tierekisteri/losa (op/<= (:loppuosa tr)))
-                                     (:numero tr) (assoc ::tierekisteri/tie (:numero tr)))
-        ehto-4 (when (:loppuosa tr)
-                 (assoc lopun-yhteinen-pohja ::tierekisteri/losa ((if (:loppuetaisyys tr)
-                                                                    op/<
-                                                                    op/<=)
-                                                                   (:loppuosa tr))))
-        ehto-5 (when (:loppuetaisyys tr)
-                 (assoc lopun-yhteinen-pohja ::tierekisteri/let (op/<= (:loppuetaisyys tr))))
-        ehto-6 (when (and (:loppuosa tr) (:loppuetaisyys tr))
-                 (assoc lopun-yhteinen-pohja ::tierekisteri/losa (:loppuosa tr)
-                                             ::tierekisteri/let (op/<= (:loppuetaisyys tr))))
-
-        ;; ehto-7 on sitä varten, että jos vain tienumero on annettu eikä mitään muuta.
-        ehto-7 (when (= '(:numero) (keys tr))
-                 {::tierekisteri/tie (:numero tr)})]
-    ;; Yhdistetään kaikki ehdot, jotka eivät ole nillejä.
-    (apply op/or
-           (keep #(when-not (nil? %)
-                    {::paikkaus/tierekisteriosoite %})
-                 [ehto-1 ehto-2 ehto-3 ehto-4 ehto-5 ehto-6 ehto-7]))))
-
 (defn- kasittele-koko-ja-sijainti
   "Paikkauskohteiden sisään haetaan siis json objektina paikkaukset. Ja koska kyseessä on json objekti, niin kaikki
   data on string tyyppistä. Joten sijainnin geometriasta tulee db->clojure muunnoksessa vain PersistentVector eikä
@@ -148,7 +87,7 @@
         menetelmat (when (> (count menetelmat) 0)
                      menetelmat)
         vain-kohteet-joilla-toteumia? (= nayta :kohteet-joilla-toteumia)
-        _ (println "hae-urakan-paikkaukset :: tiedot" (pr-str tiedot) (pr-str (konversio/sql-date (first aikavali))) "tr" (pr-str tr) "vain-kohteet-joilla-toteumia?" vain-kohteet-joilla-toteumia?)
+        _ (log/debug "hae-urakan-paikkaukset :: tiedot" (pr-str tiedot) (pr-str (konversio/sql-date (first aikavali))) "tr" (pr-str tr) "vain-kohteet-joilla-toteumia?" vain-kohteet-joilla-toteumia?)
         paikkauskohteet (q/hae-urakan-paikkauskohteet-ja-paikkaukset db {:urakka-id urakka-id
                                                                          :alkuaika (when (and aikavali (first aikavali))
                                                                                      (konversio/sql-date (first aikavali)))
@@ -187,7 +126,7 @@
         ;; Sijainnin ja tien pituuden käsittely - json objekti kannasta antaa string tyyppistä sijaintidataa. Muokataan se tässä käsityönä
         ;; multiline tyyppiseksi geometriaksi
         paikkauskohteet (kasittele-koko-ja-sijainti db paikkauskohteet)
-        _ (println "hae-urakan-paikkaukset :: paikkauskohteet kpl:" (pr-str (count paikkauskohteet)))
+        _ (log/debug "hae-urakan-paikkaukset :: paikkauskohteet kpl:" (pr-str (count paikkauskohteet)))
         ]
     paikkauskohteet))
 

--- a/src/cljc/harja/domain/tierekisteri/validointi.cljc
+++ b/src/cljc/harja/domain/tierekisteri/validointi.cljc
@@ -5,20 +5,13 @@
                       [clj-time.core :as t]])
             #?@(:cljs [[cljs-time.core :as t]])))
 
-
 (defn validoi-tieosoite
   "Lisää jo saatuihin virheisiin mahdolliset tierekisteriosoitteen virheet"
   [validointivirheet tie alkuosa loppuosa alkuetaisyys loppuetaisyys]
   (let [virheet (as-> #{} virheet
                                 (if (and tie alkuosa alkuetaisyys loppuosa loppuetaisyys)
                                   virheet
-                                  (conj virheet "Osa tierekisteriosoitteesta puuttuu. "))
-                                (if (and (= alkuosa loppuosa) (>= alkuetaisyys loppuetaisyys))
-                                  (conj virheet "Tierekisteriosoitteen loppuetäisyys pienempi kuin alkuetäisyys. ")
-                                  virheet)
-                                (if (and (>= loppuosa alkuosa))
-                                  virheet
-                                  (conj virheet "Tierekisteriosoitteen loppuosa pienempi kuin alkuosa. ")))
+                                  (conj virheet "Osa tierekisteriosoitteesta puuttuu. ")))
         virheet (if-not (empty? virheet)
                   (conj validointivirheet virheet)
                   validointivirheet)]

--- a/test/clj/harja/palvelin/integraatiot/api/paikkaukset_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/paikkaukset_test.clj
@@ -73,8 +73,10 @@
                                                     ::paikkaus/ajouravalit [5 7]
                                                     ::paikkaus/reunat [1]}]}
         odotettu-paikkauskohde {::paikkaus/paikkauskohde {::paikkaus/ulkoinen-id 1231234
+                                                          ::paikkaus/paikkauskohteen-tila "tilattu"
                                                           ::paikkaus/nimi "Testipaikkauskohde"}}
         odotettu-kohde #:harja.domain.paikkaus{:nimi "Testipaikkauskohde"
+                                               :paikkauskohteen-tila "tilattu"
                                                :ulkoinen-id 1231234
                                                :urakka-id 4}
         paikkaus (first (paikkaus-q/hae-paikkaukset db {::paikkaus/ulkoinen-id paikkaustunniste}))
@@ -128,6 +130,7 @@
                                     :harja.domain.paikkaus/tyyppi "kokonaishintainen"}]
         odotettu-kohde #:harja.domain.paikkaus{:nimi "Testipaikkauskohde"
                                                :ulkoinen-id 466645
+                                               :paikkauskohteen-tila "tilattu"
                                                :urakka-id 4}]
 
     (is (false? poistettu-ennen) "Ei ole alussa poistettu")
@@ -225,29 +228,31 @@
 (deftest kirjaa-paikkaus-ja-muokkaa-onnistuneesti
   (let [urakka (hae-oulun-alueurakan-2014-2019-id)
         paikkaustunniste 200
+        paikkaustunniste2 201
         kohdetunniste 1231234
         json1 (->
                 (slurp "test/resurssit/api/paikkausten-kirjaus-tieosoite-toisin-pain.json")
                 (.replace "<PAIKKAUSTUNNISTE>" (str paikkaustunniste))
                 (.replace "<KOHDETUNNISTE>" (str kohdetunniste))
-                (.replace "2764" (str "5000")) ;; Korjataan liian pieni lopetuskohta
-                )
+                (.replace "<AOSA>" (str 3))
+                (.replace "<LOSA>" (str 4)))
         json2 (->
                 (slurp "test/resurssit/api/paikkausten-kirjaus-tieosoite-toisin-pain.json")
-                (.replace "<PAIKKAUSTUNNISTE>" (str paikkaustunniste))
+                (.replace "<PAIKKAUSTUNNISTE>" (str paikkaustunniste2))
                 (.replace "<KOHDETUNNISTE>" (str kohdetunniste))
-                (.replace "2764" (str "6000")) ;; Korjataan liian pieni lopetuskohta
+                (.replace "<AOSA>" (str 3))
+                (.replace "<LOSA>" (str 22))
                 )
         json1-vastaus (api-tyokalut/post-kutsu ["/api/urakat/" urakka "/paikkaus"] kayttaja portti json1)
-        let-5000 (trosoite-obj->map (first (q-map "SELECT * FROM paikkaus WHERE \"ulkoinen-id\" = " paikkaustunniste ";")))
+        let-3000 (trosoite-obj->map (first (q-map "SELECT * FROM paikkaus WHERE \"ulkoinen-id\" = " paikkaustunniste ";")))
         json2-vastaus (api-tyokalut/post-kutsu ["/api/urakat/" urakka "/paikkaus"] kayttaja portti json2)
-        let-6000 (trosoite-obj->map (first (q-map "SELECT * FROM paikkaus WHERE \"ulkoinen-id\" = " paikkaustunniste ";")))]
+        losa-22 (trosoite-obj->map (first (q-map "SELECT * FROM paikkaus WHERE \"ulkoinen-id\" = " paikkaustunniste2 ";")))]
     (is (= 200 (:status json1-vastaus)))
     (is (= 200 (:status json2-vastaus)))
     ;; Ensimmäisessä toteumassa loppuosa on 5000m
-    (is (= "5000" (:let let-5000)))
+    (is (= "3000" (:let let-3000)))
     ;; Muokatussa toteumassa loppuosa on 6000m
-    (is (= "6000" (:let let-6000)))))
+    (is (= "22" (:losa losa-22)))))
 
 ;; TODO: Rakenna testiaineisto yit-käyttäjälle. Ja testaa poistoja.
 

--- a/test/clj/harja/palvelin/palvelut/yllapitokohteet/paikkauskohteet_test.clj
+++ b/test/clj/harja/palvelin/palvelut/yllapitokohteet/paikkauskohteet_test.clj
@@ -344,6 +344,8 @@
                         {:osa 4 :pituus 100})
         keksitty-kohde1 {:tie 1 :aosa 1 :aet 0 :losa 2 :let 10}
         laskettu1 (q-paikkaus/laske-tien-osien-pituudet keksityt-osat keksitty-kohde1)
+        keksitty-kohde11 {:tie 1 :aosa 1 :aet 0 :losa 5 :let 100}
+        laskettu11 (q-paikkaus/laske-tien-osien-pituudet keksityt-osat keksitty-kohde11)
 
         keksitty-kohde2 {:tie 1 :aosa 1 :aet 0 :losa 3 :let 50}
         laskettu2 (q-paikkaus/laske-tien-osien-pituudet keksityt-osat keksitty-kohde2)
@@ -351,11 +353,14 @@
         keksitty-kohde3 {:tie 1 :aosa 2 :aet 20 :losa 2 :let 80}
         laskettu3 (q-paikkaus/laske-tien-osien-pituudet keksityt-osat keksitty-kohde3)
 
-        keksitty-kohde4 {:tie 1 :aosa 20 :aet 20 :losa 2 :let 80}
+        keksitty-kohde4 {:tie 1 :aosa 2 :aet 10 :losa 1 :let 0}
         laskettu4 (q-paikkaus/laske-tien-osien-pituudet keksityt-osat keksitty-kohde4)
+        keksitty-kohde41 {:tie 1 :aosa 4 :aet 100 :losa 1 :let 0}
+        laskettu41 (q-paikkaus/laske-tien-osien-pituudet keksityt-osat keksitty-kohde41)
         ]
     ;; Perus case, otetaan osasta 1 loput ja osan 2 alku
     (is (= 110 (:pituus laskettu1)))
+    (is (= 400 (:pituus laskettu11)))
 
     ;; Perus case 2, otetaan osasta 1 loput ja osan 2 alku
     (is (= 250 (:pituus laskettu2)))
@@ -364,9 +369,10 @@
     ;; Esim jos osa 2 on 100m pitkä ja otetaan kohdasta 20 kohtaan 80 tulee 60m
     (is (= 60 (:pituus laskettu3)))
 
-    ;; Vielä härömpi tapaus, missä alkuosa alkaa myöhemmin kuin loppuosa.
+    ;; Erikoistapaus, jossa tierekisterin osat merkataan eri järjestyksessä. Eli loppuosa on pienempi, kuin alkuosa
     ;; Nyt tuloksena pitäisi olla nil
-    (is (= nil (:pituus laskettu4)))))
+    (is (= 110 (:pituus laskettu4)))
+    (is (= 400 (:pituus laskettu41)))))
 
 ;; Testataan käsin lisätyn paikkauksen toimintaa
 (defn testipaikkaus [paikkauskohde-id urakka-id kayttaja-id]
@@ -461,6 +467,7 @@
     (is (= (:id paikkauskohde) (::paikkaus/paikkauskohde-id tallennettu-paikkaus)))))
 
 (deftest tallenna-levittimella-tehty-paikkaussoiro-kasin-epaonnistuu-test
+
   (let [urakka-id @kemin-alueurakan-2019-2023-id
         kohde (merge {:urakka-id urakka-id}
                      default-paikkauskohde)

--- a/test/clj/harja/palvelin/palvelut/yllapitokohteet/paikkauskohteet_test.clj
+++ b/test/clj/harja/palvelin/palvelut/yllapitokohteet/paikkauskohteet_test.clj
@@ -476,8 +476,8 @@
                                       +kayttaja-jvh+
                                       (assoc kohde :paikkauskohteen-tila "tilattu"))
         paikkaus (testipaikkauslevittimella (:id paikkauskohde) urakka-id (:id +kayttaja-jvh+))
-        ;; Muutetaan alkuetäisyys suuremmaksi kuin loppuetäisyys
-        paikkaus (assoc paikkaus :aosa 1
+        ;; Muutetaan alkuosa liian suureksi.
+        paikkaus (assoc paikkaus :aosa 99999999999999
                                  :aet 100
                                  :losa 1
                                  :let 99)]

--- a/test/resurssit/api/paikkausten-kirjaus-tieosoite-toisin-pain.json
+++ b/test/resurssit/api/paikkausten-kirjaus-tieosoite-toisin-pain.json
@@ -10,7 +10,7 @@
     "viestintunniste": {
       "id": 123
     },
-    "lahetysaika": "2018-01-30T12:00:00Z"
+    "lahetysaika": "2022-01-01T12:00:00Z"
   },
   "paikkaukset": [
     {
@@ -19,19 +19,19 @@
           "id": <PAIKKAUSTUNNISTE>
         },
         "paikkauskohde": {
-          "nimi": "Testipaikkauskohde",
+          "nimi": "Pituuspaikkauskohde",
           "tunniste": {
             "id": <KOHDETUNNISTE>
           }
         },
-        "alkuaika": "2018-01-30T12:00:00Z",
-        "loppuaika": "2018-01-30T18:00:00Z",
+        "alkuaika": "2022-01-05T12:00:00Z",
+        "loppuaika": "2022-01-05T18:00:00Z",
         "sijainti": {
-          "tie": 924,
-          "aosa": 13,
-          "aet": 2972,
-          "losa": 13,
-          "let": 2764
+          "tie": 20,
+          "aosa": <AOSA>,
+          "aet": 3500,
+          "losa": <LOSA>,
+          "let": 3000
         },
         "tyomenetelma": "UREM",
         "massatyyppi": "AB, Asfalttibetoni",


### PR DESCRIPTION
Annetun tienkohdan pituuden laskemisen vapauttaminen.
Ennen oli pakko olla alkutolppa (alkuosa) pienempi kuin lopputolppa (loppuosa), mutta se on nyt vapautettu sekä ui:hin, että rajapintaan.
Samalla lisäsin jonkilaiset tilauspäivämäärän paikkauskohteelle, jos lisätään ensimmäistä paikkaustoteumaa rajapinnan kautta. Ilman tilauspäivämäärää paikkauskohdetta ei voi löytää toteumat välilehdeltä.

Siivosin myös hieman koodeja ja tein uusia yksikkötestejä, joilla varmistetaan, että tehdyt muutokset toimivat oikein.