### PR TITLE
VHAR-5376 Salli kustannusten päivittäminen, vaikka POT olisi lukittu

### DIFF
--- a/dev-resources/less/livicons.less
+++ b/dev-resources/less/livicons.less
@@ -21,7 +21,7 @@
     -moz-osx-font-smoothing: grayscale;
 }
 .navigation-ympyrassa {
-    background-color: @blue-light;
+    background-color: @blue-lighter;
     height: 20px;
     width: 20px;
     border-radius: 50%;

--- a/src/cljs/harja/views/urakka/yllapitokohteet.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet.cljs
@@ -977,7 +977,7 @@
                                            ;; Näitä ei voi muokata itse, joten turha näyttää aina tyhjiä sarakkeita.
                                            (and yha-sidottu?
                                                 (some #(or (:tr-ajorata %) (:tr-kaista %)) @kohteet-atom)))
-              paallystysilmoitus-lukittu? #(not= :lukittu (:paallystysilmoitus-tila %))
+              paallystysilmoitusta-ei-ole-lukittu? #(not= :lukittu (:paallystysilmoitus-tila %))
               validointi {:paakohde {:tr-osoite [{:fn paakohteen-validointi
                                                   :sarakkeet {:tr-numero :tr-numero
                                                               :tr-ajorata :tr-ajorata
@@ -1008,7 +1008,6 @@
              :muutos (fn [grid]
                        (hae-osien-tiedot (grid/hae-muokkaustila grid)))
              :voi-lisata? (not yha-sidottu?)
-             :voi-muokata-rivia? paallystysilmoitus-lukittu?
              :esta-poistaminen? (fn [rivi] (not (:yllapitokohteen-voi-poistaa? rivi)))
              :esta-poistaminen-tooltip (fn [_]
                                          (if yha-sidottu?
@@ -1018,23 +1017,23 @@
                   (concat
                     [{:tyyppi :vetolaatikon-tila :leveys haitari-leveys}
                      {:otsikko "Koh\u00ADde\u00ADnro" :nimi :kohdenumero
-                      :tyyppi :string :leveys id-leveys}
-                     {:otsikko "Tun\u00ADnus" :nimi :tunnus
-                      :tyyppi :string :leveys tunnus-leveys :pituus-max 1}]
+                      :tyyppi :string :leveys id-leveys :muokattava? paallystysilmoitusta-ei-ole-lukittu?}
+                      {:otsikko "Tun\u00ADnus" :nimi :tunnus
+                       :tyyppi :string :leveys tunnus-leveys :pituus-max 1 :muokattava? paallystysilmoitusta-ei-ole-lukittu?}]
                     (tierekisteriosoite-sarakkeet
                       tr-leveys
                       [{:otsikko "Nimi" :nimi :nimi
                         :tyyppi :string :leveys (if nayta-ajorata-ja-kaista? kohde-leveys (* tr-leveys 4))
-                        :pituus-max 30}
+                        :pituus-max 30 :muokattava? paallystysilmoitusta-ei-ole-lukittu?}
                        {:nimi :tr-numero :muokattava? (constantly (not yha-sidottu?))}
                        (when nayta-ajorata-ja-kaista?
                          {:nimi :tr-ajorata :muokattava? (constantly (not yha-sidottu?))})
                        (when nayta-ajorata-ja-kaista?
                          {:nimi :tr-kaista :muokattava? (constantly (not yha-sidottu?))})
-                       {:nimi :tr-alkuosa}
-                       {:nimi :tr-alkuetaisyys}
-                       {:nimi :tr-loppuosa}
-                       {:nimi :tr-loppuetaisyys}]
+                       {:nimi :tr-alkuosa :muokattava? paallystysilmoitusta-ei-ole-lukittu?}
+                       {:nimi :tr-alkuetaisyys :muokattava? paallystysilmoitusta-ei-ole-lukittu?}
+                       {:nimi :tr-loppuosa :muokattava? paallystysilmoitusta-ei-ole-lukittu?}
+                       {:nimi :tr-loppuetaisyys :muokattava? paallystysilmoitusta-ei-ole-lukittu?}]
                       true)
                     [{:otsikko "KVL"
                       :nimi :keskimaarainen-vuorokausiliikenne :tyyppi :numero :leveys kvl-leveys

--- a/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
+++ b/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
@@ -821,7 +821,7 @@
         (is (= (+ maara-ennen-lisaysta 1) maara-lisayksen-jalkeen) "Tallennuksen jälkeen päällystysilmoituksien määrä")
         (is (= (:tila paallystysilmoitus-kannassa) :valmis))
         (is (= "POT2 lisätieto" (:lisatiedot paallystysilmoitus-kannassa)) "Tallenna lisätiedot")
-        (is (= (:kokonaishinta-ilman-maaramuutoksia paallystysilmoitus-kannassa) 0))
+        (is (= (:kokonaishinta-ilman-maaramuutoksia paallystysilmoitus-kannassa) 0M))
         (poista-paallystysilmoitus-paallystyskohtella paallystyskohde-id)))))
 
 (deftest paivittaa-pot2-paallystysilmoitus-ei-muoka-kaikki-yllapitokohdeosan-kentat

--- a/test/clj/harja/palvelin/palvelut/yllapitokohteet_test.clj
+++ b/test/clj/harja/palvelin/palvelut/yllapitokohteet_test.clj
@@ -74,7 +74,7 @@
 (def yllapitokohde-testidata {:kohdenumero 999
                               :nimi "Testiramppi4564ddf"
                               :yllapitokohdetyotyyppi :paallystys
-                              :sopimuksen_mukaiset_tyot 400
+                              :sopimuksen-mukaiset-tyot 400
                               :tr-numero 20
                               :tr-ajorata 1
                               :tr-kaista 11
@@ -83,7 +83,7 @@
                               :tr-loppuosa 3
                               :tr-loppuetaisyys 2
                               :bitumi_indeksi 123
-                              :kaasuindeks 123})
+                              :kaasuindeksi 123})
 
 (def yllapitokohdeosa-testidata {:nimi "Testiosa123456"
                                  :tr-numero 20
@@ -1588,3 +1588,57 @@
         ;; Testataan että tarkastuskin palautuu arvossa true
         odotettu {:yllapitokohde-ei-olemassa true, :yllapitokohde-lahetetty true, :tiemerkinnant-yh-toteuma true, :sanktio true, :paallystysilmoitus true, :tietyomaa true, :laatupoikkeama true, :tarkastus true}]
     (is (= odotettu saako-poistaa?) "Päällystyskohteen saa poistaa")))
+
+
+(def tarkea-kohde-testidata
+  {:id 27
+   :sopimuksen-mukaiset-tyot 12,
+   :arvonvahennykset 34
+   :bitumi-indeksi 56
+   :kaasuindeksi 78
+
+   :maaramuutokset-ennustettu? false, :tila :kohde-valmis, :tr-kaista nil, :tiemerkinta-alkupvm #inst "2021-06-21T21:00:00.000-00:00", :kohdenumero "L42", :paallystys-loppupvm #inst "2021-06-20T21:00:00.000-00:00", :tr-ajorata nil, :urakka-id 7, :maaramuutokset 0, :kohde-valmispvm #inst "2021-06-23T21:00:00.000-00:00", :toteutunut-hinta nil, :tiemerkinta-loppupvm #inst "2021-06-22T21:00:00.000-00:00", :aikataulu-muokattu #inst "2022-01-25T06:15:47.000-00:00", :sakot-ja-bonukset nil, :tr-loppuosa 1, :yha-kohdenumero 116, :yllapitokohdetyyppi :paallyste, :nykyinen-paallyste nil, :tunnus nil, :lihavoi true, :tr-alkuosa 1, :urakka "Utajärven päällystysurakka"
+
+   :yllapitokohteen-voi-poistaa? false, :tr-alkuetaisyys 1062 :tr-loppuetaisyys 3827, :nimi "Tärkeä kohde mt20",  :tr-numero 20 :yllapitokohdetyotyyppi :paallystys :kohdeosat []})
+
+(deftest tallenna-yllapitokohteen-kustannukset
+  (let [urakka-id (hae-utajarven-paallystysurakan-id)
+        sopimus-id (hae-utajarven-paallystysurakan-paasopimuksen-id)
+        kohde-id (hae-yllapitokohde-tarkea-kohde-pot2)
+        _ (println "kohde-id " kohde-id)
+        alussa-ei-kustannuksia (first (q
+                                         (str "SELECT * FROM yllapitokohteen_kustannukset
+                                         WHERE yllapitokohde = " kohde-id";")))
+        vastauksen-kohteet (:yllapitokohteet (kutsu-palvelua (:http-palvelin jarjestelma)
+                                                             :tallenna-yllapitokohteet +kayttaja-jvh+ {:urakka-id urakka-id
+                                                                                                       :vuosi 2021
+                                                                                                       :sopimus-id sopimus-id
+                                                                                                       :kohteet [tarkea-kohde-testidata]}))
+        kohde (first (filter #(= kohde-id (:id %))
+                             vastauksen-kohteet))]
+
+    (let [kustannukset-tallennuksen-jalkeen (first (q
+                                                     (str "SELECT * FROM yllapitokohteen_kustannukset
+                                         WHERE yllapitokohde = " kohde-id";")))]
+
+      (is (= alussa-ei-kustannuksia [(first alussa-ei-kustannuksia) kohde-id 0M 0M 0M 0M nil nil nil]))
+
+      ;; take 8, koska emme tässä assertoi muokkausajanhetkeä
+      (is (= (take 8 kustannukset-tallennuksen-jalkeen) [(first alussa-ei-kustannuksia) kohde-id 12M 34M 56M 78M nil (:id +kayttaja-jvh+)]))
+      ;; assertoidaan kustannukset
+      (is (= 12M (:sopimuksen-mukaiset-tyot kohde)) "Sopimuksen mukaiset työt")
+      (is (= 34M (:arvonvahennykset kohde)) ":arvonvahennykset")
+      (is (= 56M (:bitumi-indeksi kohde)) ":bitumi-indeksi")
+      (is (= 78M (:kaasuindeksi kohde)) ":kaasuindeksi")
+
+      (is (= (count (filter #(= (:nimi %) "Tärkeä kohde mt20") vastauksen-kohteet)) 1))
+
+
+      #_(is (= vastauksen-kohteet
+             {:tr_numero 20
+              :tr_alkuosa 1
+              :tr_alkuetaisyys 0
+              :tr_loppuosa 1
+              :tr_loppuetaisyys 2})
+          "Pääkohdettä kutistettiin, saman tien kohdeosa kutistuu pääkohteen sisälle")
+      )))

--- a/tietokanta/testidata/yllapito/paallystys.sql
+++ b/tietokanta/testidata/yllapito/paallystys.sql
@@ -1010,6 +1010,11 @@ VALUES
      WHERE kayttajanimi = 'jvh'), NOW(),
    make_date(2021, 5, 21), make_date(2021, 6, 4));
 
+INSERT INTO yllapitokohteen_kustannukset (yllapitokohde, sopimuksen_mukaiset_tyot, arvonvahennykset, bitumi_indeksi, kaasuindeksi)
+VALUES ((SELECT id FROM yllapitokohde WHERE nimi = 'Tärkeä kohde mt20'), 0, 0, 0, 0),
+       ((SELECT id FROM yllapitokohde WHERE nimi = 'Aloittamaton kohde mt20'), 0, 0, 0, 0),
+       ((SELECT id FROM yllapitokohde WHERE nimi = '0-ajoratainen testikohde mt20'), 0, 0, 0, 0);
+
 INSERT INTO yllapitokohdeosa (yllapitokohde, nimi, tr_numero, tr_alkuosa, tr_alkuetaisyys, tr_loppuosa, tr_loppuetaisyys, tr_ajorata, tr_kaista, sijainti, yllapitoluokka, keskimaarainen_vuorokausiliikenne, poistettu, yhaid)
 VALUES ((SELECT id
               FROM yllapitokohde


### PR DESCRIPTION
Korjaa myös visuaalinen regressio: navigointi-ympyran taustavärin oltava blue-lighter