### PR TITLE
VHAR-5863 Palauta paikkauskohteisiin YHA-lähetys

### DIFF
--- a/asetukset.edn
+++ b/asetukset.edn
@@ -85,7 +85,7 @@
  ;:tloik {:ilmoitusviestijono "Harja.T-LOIKToHarja.Msg"
  ;        :ilmoituskuittausjono "Harja.T-LOIKToHarja.Ack"
  ;        :toimenpideviestijono "Harja.HarjaToT-LOIK.Msg"
- ;        :toimenpideAkuittausjono "Harja.HarjaToT-LOIK.Ack"
+ ;        :toimenpidekuittausjono "Harja.HarjaToT-LOIK.Ack"
  ;        :ilmoitukset {:google-static-maps-key #=(slurp "../.harja/google-static-maps-key")}
  ;        :uudelleenlahetysvali-minuuteissa 30}
 

--- a/asetukset.edn
+++ b/asetukset.edn
@@ -83,9 +83,9 @@
  ;        :kuittausjono-ulos "Harja17.SampoToHarja.Ack"
  ;        :paivittainen-lahetysaika [16 44 0]}
  ;:tloik {:ilmoitusviestijono "Harja.T-LOIKToHarja.Msg"
- ;        :ilmoituskuittausjono "Harja.T-LOIKToHarja.Ack"
+ ;        :ilmoituskuittausjono "Harja.HarjaToT-LOIK.Ack"
  ;        :toimenpideviestijono "Harja.HarjaToT-LOIK.Msg"
- ;        :toimenpidekuittausjono "Harja.HarjaToT-LOIK.Ack"
+ ;        :toimenpidekuittausjono "Harja.T-LOIKToHarja.Ack"
  ;        :ilmoitukset {:google-static-maps-key #=(slurp "../.harja/google-static-maps-key")}
  ;        :uudelleenlahetysvali-minuuteissa 30}
 

--- a/resources/json/yha/paikkausten-vienti-request.schema.json
+++ b/resources/json/yha/paikkausten-vienti-request.schema.json
@@ -177,9 +177,6 @@
           "$ref": "#/definitions/sijainti"
         },
         "tyomenetelma": {
-          "type": "integer"
-        },
-        "lahde": {
           "type": "string"
         },
         "massatyyppi": {

--- a/src/clj/harja/kyselyt/paikkaus.sql
+++ b/src/clj/harja/kyselyt/paikkaus.sql
@@ -484,3 +484,13 @@ WHERE pk.poistettu = FALSE
 -- Ehto  - jos loppuetäisyys on annettu - hyödynnetään sitä vian jos loppuosa on annettu
   AND ((:let::TEXT IS NULL AND :losa::TEXT IS NULL) OR (:let::TEXT IS NULL OR  (p.tierekisteriosoite).let <= :let))
 GROUP BY pk.id;
+
+-- name: hae-paikkauskohteen-tyomenetelma
+SELECT nimi, lyhenne
+  FROM paikkauskohde_tyomenetelma
+ WHERE id = :id;
+
+-- name: hae-paikkauskohteen-tyomenetelmien-lyhenteet
+SELECT id, lyhenne
+  FROM paikkauskohde_tyomenetelma
+ WHERE lyhenne IS NOT NULL;

--- a/src/clj/harja/kyselyt/paikkaus.sql
+++ b/src/clj/harja/kyselyt/paikkaus.sql
@@ -432,6 +432,9 @@ select pk.id                                       AS id,
        pk.yksikko                                  AS yksikko,
        pk.tarkistettu                              as tarkistettu,
        pk.lisatiedot                               AS lisatiedot,
+       pk."yhalahetyksen-tila"                     as "yhalahetyksen-tila",
+       (SELECT string_agg(pk.virhe::TEXT, ', '))   as virhe, -- YHA-lähetyksen mahdollinen virhe
+       pk."ilmoitettu-virhe"                       as "ilmoitettu-virhe", -- urakoitsijalle sähköpostiste
        (pk.tierekisteriosoite_laajennettu).tie     AS tie,
        (pk.tierekisteriosoite_laajennettu).ajorata AS ajorata,
        (pk.tierekisteriosoite_laajennettu).aosa    AS aosa,

--- a/src/clj/harja/palvelin/integraatiot/yha/sanomat/paikkauskohteen_lahetyssanoma.clj
+++ b/src/clj/harja/palvelin/integraatiot/yha/sanomat/paikkauskohteen_lahetyssanoma.clj
@@ -33,7 +33,7 @@
                                                       (rename-keys {:kuulamylly-arvo :km-arvo})
                                                       )})
         kasittele-paikkaus (fn [p] {:paikkaus (-> p
-                                                  (dissoc :sijainti :urakka-id :paikkauskohde-id :ulkoinen-id)
+                                                  (dissoc :sijainti :urakka-id :paikkauskohde-id :ulkoinen-id :lahde)
                                                   (rename-keys {:tierekisteriosoite :sijainti})
                                                   (assoc :alkuaika (pvm/aika-yha-format (:alkuaika p)))
                                                   (assoc :loppuaika (pvm/aika-yha-format (:loppuaika p)))
@@ -62,6 +62,10 @@
                       ::paikkaus/tarkistettu
                       ::paikkaus/tarkistaja-id
                       ::paikkaus/ilmoitettu-virhe)
+        tyomenetelman-lyhenne (into {}
+                                    (map (fn [{:keys [id lyhenne]}]
+                                           {id lyhenne})
+                                         (q-paikkaus/hae-paikkauskohteen-tyomenetelmien-lyhenteet db)))
         paikkaukset (q-paikkaus/hae-paikkaukset-materiaalit db {::paikkaus/paikkauskohde-id kohde-id
                                                                 ::paikkaus/urakka-id urakka-id
                                                                 :harja.domain.muokkaustiedot/poistettu? false})
@@ -71,6 +75,8 @@
                                                                                  {::paikkaus/paikkaus-id (::paikkaus/id %)}))
                              tienkohdat-parsittu (parsi-tienkohdat tienkohdat)]
                          (-> %
+                             ;; YHA:n API haluaa merkkijonon eikä integeriä
+                             (assoc ::paikkaus/tyomenetelma (tyomenetelman-lyhenne (::paikkaus/tyomenetelma %)))
                              (assoc-in [::paikkaus/tierekisteriosoite :ajorata] (::paikkaus/ajorata tienkohdat))
                              (assoc-in [::paikkaus/tierekisteriosoite :tienkohdat] tienkohdat-parsittu)))
                       paikkaukset)

--- a/src/clj/harja/palvelin/integraatiot/yha/yha_paikkauskomponentti.clj
+++ b/src/clj/harja/palvelin/integraatiot/yha/yha_paikkauskomponentti.clj
@@ -45,7 +45,7 @@
      (paivita-lahetyksen-tila db kohde-id tila virheet)
      (if (= tila :virhe)
        (do
-         (log/warn (str "Paikkauskohteen " kohde-id " lähettäminen YHA:an epäonnistui viheeseen " virheet))
+         (log/warn (str "Paikkauskohteen " kohde-id " lähettäminen YHA:an epäonnistui virheeseen " virheet))
          (throw+ {:type    +virhe-paikkauskohteen-lahetyksessa+
                   :virheet {:virhe virheet}}))))))
 
@@ -56,7 +56,6 @@
   [integraatioloki db {:keys [url kayttajatunnus salasana]} urakka-id kohde-id]
   (assert (integer? urakka-id) "Urakka-id:n on oltava numero")
   (assert (integer? kohde-id) "Kohde-id:n on oltava numero")
-
   (try+
     (integraatiotapahtuma/suorita-integraatio
       db integraatioloki "yha" "laheta-paikkauskohde" nil

--- a/src/cljc/harja/domain/paikkaus.cljc
+++ b/src/cljc/harja/domain/paikkaus.cljc
@@ -154,12 +154,13 @@
 (s/def ::paikkausurakan-kustannukset-vastaus (s/keys :req-un [::kustannukset]
                                                      :opt-un [::paikkauskohteet ::tyomenetelmat]))
 
-;; FIXME: keksitty lista. Hommaa YHA-jengiltä oikea lista
-(def tyomenetelmat-jotka-lahetetaan-yhaan
-  #{"massapintaus" "remix-pintaus"})
+;; VHAR-1384, huom. nämä lyhenteitä
+(def paikkaustyomenetelmat-jotka-kiinnostaa-yhaa
+  #{"UREM" "KTVA" "SIPA" "SIPU"})
 
-(defn pitaako-paikkauskohde-lahettaa-yhaan? [tyomenetelma]
-  (boolean (tyomenetelmat-jotka-lahetetaan-yhaan tyomenetelma)))
+(defn
+  pitaako-paikkauskohde-lahettaa-yhaan? [tyomenetelman-lyhenne]
+  (boolean (paikkaustyomenetelmat-jotka-kiinnostaa-yhaa tyomenetelman-lyhenne)))
 
 (defn fmt-tila [tila]
   (let [tila (if (= tila "hylatty") "hylätty" tila)]

--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_toteumat.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_toteumat.cljs
@@ -147,9 +147,7 @@
       [yleiset/vihje "Huom! Lähetetyn sähköpostiviestin sisältö tallennetaan Harjaan ja se saatetaan näyttää Harjassa paikkauskohteen tietojen yhteydessä."]]]))
 
 (def ohje-teksti-tilaajalle
-  ;; TODO: YHA-lähetys ei voi vielä toimia, koska paikkauskohteilla ei ole vielä vastinetta YHA:ssa
-  "Tarkista toteumat. Valitse Ilmoita virhe -lähettääksesi virhetiedot sähköpostitse urakoitseijalle."
-  #_"Tarkista toteumat ja valitse Merkitse tarkistetuksi, jolloin tiettyjen työmenetelmien tiedot lähtevät YHA:an. Valitse Ilmoita virhe lähettääksesi virhetiedot sähköpostitse urakoitsijalle.")
+  "Tarkista toteumat ja valitse Merkitse tarkistetuksi, jolloin tiettyjen työmenetelmien tiedot lähtevät YHA:an. Valitse Ilmoita virhe lähettääksesi virhetiedot sähköpostitse urakoitsijalle.")
 
 (def ohje-teksti-urakoitsijalle
   "Tarkista toteumatiedoista mahdolliset tilaajan raportoimat virheet. Virheet on raportoitu myös sähköpostitse urakan vastuuhenkilölle.")
@@ -482,7 +480,7 @@
                (if tarkistettu?
                  [:div.body-text.harmaa [ikonit/livicon-check] "Tarkistettu"]
                  ;; Annetaan vain tilaajan merkitä kohde tarkistetuksi
-                 (when (and tilaaja? false) ;; Merkitty falseksi niin kauan, kunnes yha-lähetys on selvitetty
+                 (when tilaaja? ;; Merkitty falseksi niin kauan, kunnes yha-lähetys on selvitetty
                    [yleiset/linkki "Merkitse tarkistetuksi"
                     #(e! (tiedot/->PaikkauskohdeTarkistettu
                            {::paikkaus/paikkauskohde paikkauskohde}))
@@ -493,10 +491,7 @@
                      :style {:margin-top "0px"}
                      :block? true
                      :stop-propagation true}]))
-               [:div.small-text.harmaa (if tarkistettu? "Lähetetty YHAan" "Lähetys YHAan ei käytössä"
-                                                        ;;TODO: YHA-lähetys ei ole vielä käytössä
-                                                        ;; #_ "Lähetys YHAan ei käytössä"
-                                                        )]])]])))))
+               [:div.small-text.harmaa (if tarkistettu? "Lähetetty YHAan" "Lähetys YHAan")]])]])))))
 
 (defn paikkaukset [e! {:keys [paikkaukset-grid
                               paikkauksien-haku-kaynnissa?

--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_toteumat.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_toteumat.cljs
@@ -395,7 +395,7 @@
           tarkistettu ::paikkaus/tarkistettu
           tyomenetelma ::paikkaus/tyomenetelma
           ilmoitettu-virhe ::paikkaus/ilmoitettu-virhe
-          lahetyksen-tila ::paikkaus/yhalahetyksen-tila
+          yha-lahetyksen-tila ::paikkaus/yhalahetyksen-tila
           paikkauskohteen-tila ::paikkaus/paikkauskohteen-tila
           yksikko ::paikkaus/yksikko :as paikkauskohde}]
       (let [urapaikkaus? (urem? tyomenetelma tyomenetelmat)
@@ -473,7 +473,11 @@
                  :block? true
                  :ikoni (ikonit/harja-icon-action-send-email)
                  :disabloitu? urakoitsija-kayttajana?
-                 :stop-propagation true}])]
+                 :stop-propagation true}])
+             (when ilmoitettu-virhe
+               [:span.pieni-teksti
+                [:div "Ilmoitettu virhe:"]
+                [:p ilmoitettu-virhe]])]
             (let [tarkistettu? (boolean tarkistettu)]
               [:div.basis192.nogrow.shrink1.body-text
                {:class (str (when tarkistettu? "tarkistettu"))}
@@ -491,7 +495,18 @@
                      :style {:margin-top "0px"}
                      :block? true
                      :stop-propagation true}]))
-               [:div.small-text.harmaa (if tarkistettu? "Lähetetty YHAan" "Lähetys YHAan")]])]])))))
+               [:div.small-text.harmaa (cond
+                                         (= yha-lahetyksen-tila "lahetetty") "Lähetetty YHAan"
+
+                                         (true? tarkistettu?) "Tarkistettu"
+
+                                         (and
+                                           (false? tarkistettu?)
+                                           (paikkaus/pitaako-paikkauskohde-lahettaa-yhaan? (paikkaus/tyomenetelma-id->lyhenne tyomenetelma tyomenetelmat))) "Lähetys YHAan"
+
+                                         :else
+                                         "Ko. toimenpidettä ei lähetetä YHA:an")]])]])))))
+
 
 (defn paikkaukset [e! {:keys [paikkaukset-grid
                               paikkauksien-haku-kaynnissa?

--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_toteumat.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_toteumat.cljs
@@ -484,7 +484,7 @@
                (if tarkistettu?
                  [:div.body-text.harmaa [ikonit/livicon-check] "Tarkistettu"]
                  ;; Annetaan vain tilaajan merkitä kohde tarkistetuksi
-                 (when tilaaja? ;; Merkitty falseksi niin kauan, kunnes yha-lähetys on selvitetty
+                 (when tilaaja?
                    [yleiset/linkki "Merkitse tarkistetuksi"
                     #(e! (tiedot/->PaikkauskohdeTarkistettu
                            {::paikkaus/paikkauskohde paikkauskohde}))

--- a/test/clj/harja/palvelin/integraatiot/yha/paikkauskohteen_lahetyssanoma_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/yha/paikkauskohteen_lahetyssanoma_test.clj
@@ -21,6 +21,8 @@
                          first
                          :paikkaus)]
     (is (= "Oulun alueurakka 2014-2019" (get-in sanoma [:urakka :nimi])) "Urakan tiedot palautuvat.")
+    (is (= "UREM" (get eka-paikkaus :tyomenetelma)) "Työmenetelmä string")
+    (is (nil? (get eka-paikkaus :lahde)) "Lähde ei ole YHA-skeemassa")
     (is (= 1
            (get-in eka-paikkaus [:sijainti :ajorata])) "Ajorata läsnä")
     (is (= {:ajourat [{:ajoura 1}]


### PR DESCRIPTION
Palauta paikkauskohteisiin YHA-lähetys
-tunnista backissä ja frontilla paikkauksen työmenetelmät, jotka lähetetään YHA:an
-palauta urakoitsijalle ilmoitetun virheen näyttäminen käyttöliittymässä