### PR TITLE
Väärä-urakka toimenp. jälkeen ei lähetetä uutta viestiä

### DIFF
--- a/src/clj/harja/kyselyt/tieliikenneilmoitukset.clj
+++ b/src/clj/harja/kyselyt/tieliikenneilmoitukset.clj
@@ -9,3 +9,7 @@
 
 (defn ilmoitus-loytyy-idlla? [db ilmoitusid]
   (:exists (first (ilmoitus-loytyy-idlla db ilmoitusid))))
+
+(defn ilmoitus-on-lahetetty-urakalle? [db ilmoitusid urakkaid]
+  (:exists (first (ilmoitus-on-lahetetty-urakalle db {:ilmoitusid ilmoitusid
+                                                      :urakkaid urakkaid}))))

--- a/src/clj/harja/kyselyt/tieliikenneilmoitukset.clj
+++ b/src/clj/harja/kyselyt/tieliikenneilmoitukset.clj
@@ -13,3 +13,6 @@
 (defn ilmoitus-on-lahetetty-urakalle? [db ilmoitusid urakkaid]
   (:exists (first (ilmoitus-on-lahetetty-urakalle db {:ilmoitusid ilmoitusid
                                                       :urakkaid urakkaid}))))
+
+(defn paivita-ilmoituksen-urakka [db ilmoitusid urakkaid]
+  (paivita-ilmoituksen-urakka! db ilmoitusid urakkaid))

--- a/src/clj/harja/kyselyt/tieliikenneilmoitukset.sql
+++ b/src/clj/harja/kyselyt/tieliikenneilmoitukset.sql
@@ -398,6 +398,12 @@ SET urakka               = :urakka,
     viestiid = :viestiid
 WHERE id = :id;
 
+-- name: paivita-ilmoituksen-urakka!
+-- Päivittää ilmoitusid:n perusteella urakan. Käytetään, kun on lähetetty ilmoitus ensin väärälle urakalle
+UPDATE ilmoitus
+SET urakka = :urakkaid
+WHERE ilmoitusid = :ilmoitusid;
+
 -- name: paivita-ilmoittaja-ilmoitukselle!
 UPDATE ilmoitus
 SET

--- a/src/clj/harja/kyselyt/tieliikenneilmoitukset.sql
+++ b/src/clj/harja/kyselyt/tieliikenneilmoitukset.sql
@@ -611,6 +611,9 @@ WHERE id = :id;
 -- name: ilmoitus-loytyy-idlla
 SELECT exists(SELECT FROM ilmoitus WHERE ilmoitusid = :ilmoitusid);
 
+-- name: ilmoitus-on-lahetetty-urakalle
+SELECT exists(SELECT FROM ilmoitus i WHERE i.ilmoitusid = :ilmoitusid AND i.urakka = :urakkaid);
+
 -- name: ilmoituksen-alkuperainen-kesto
 SELECT extract(EPOCH FROM (SELECT vastaanotettu - "vastaanotettu-alunperin"
                            FROM ilmoitus

--- a/src/clj/harja/palvelin/integraatiot/tloik/ilmoitukset.clj
+++ b/src/clj/harja/palvelin/integraatiot/tloik/ilmoitukset.clj
@@ -127,6 +127,11 @@
                                                             db urakka-id ilmoitus)
           uudelleen-lahetys? (ilmoitukset-q/ilmoitus-loytyy-idlla? db ilmoitus-id)
           ilmoitus-on-lahetetty-urakalle? (ilmoitukset-q/ilmoitus-on-lahetetty-urakalle? db ilmoitus-id urakka-id)
+          ;; Jos kyseessä on harvinainen tilanne, että ilmoitus on lähetetty väärälle urakalle ensin, niin korjataan
+          ;; ilmoitustauluun urakka-id oikeaksi tällä toisella kerralla
+          _ (when (and uudelleen-lahetys? (not ilmoitus-on-lahetetty-urakalle?))
+              (ilmoitukset-q/paivita-ilmoituksen-urakka db ilmoitus-id urakka-id))
+
           ilmoitus-kanta-id (ilmoitus/tallenna-ilmoitus db urakka-id ilmoitus)
           ;; Kuluneen ajan laskennassa verrataan ajankohtaa, jolloin T-LOIK on lähettänyt ilmoituksen siihen milloin se on Harjassa vastaanotettu.
           kulunut-aika (kasittele-ilmoituksessa-kulunut-aika {:valitetty (:valitetty ilmoitus) :vastaanotettu vastaanotettu

--- a/src/clj/harja/palvelin/integraatiot/tloik/ilmoitukset.clj
+++ b/src/clj/harja/palvelin/integraatiot/tloik/ilmoitukset.clj
@@ -126,6 +126,7 @@
           ilmoittaja-urakan-urakoitsijan-organisaatiossa? (kayttajat-q/onko-kayttaja-nimella-urakan-organisaatiossa?
                                                             db urakka-id ilmoitus)
           uudelleen-lahetys? (ilmoitukset-q/ilmoitus-loytyy-idlla? db ilmoitus-id)
+          ilmoitus-on-lahetetty-urakalle? (ilmoitukset-q/ilmoitus-on-lahetetty-urakalle? db ilmoitus-id urakka-id)
           ilmoitus-kanta-id (ilmoitus/tallenna-ilmoitus db urakka-id ilmoitus)
           ;; Kuluneen ajan laskennassa verrataan ajankohtaa, jolloin T-LOIK on lähettänyt ilmoituksen siihen milloin se on Harjassa vastaanotettu.
           kulunut-aika (kasittele-ilmoituksessa-kulunut-aika {:valitetty (:valitetty ilmoitus) :vastaanotettu vastaanotettu
@@ -145,10 +146,13 @@
       (notifikaatiot/ilmoita-saapuneesta-ilmoituksesta urakka-id ilmoitus-id)
       (if ilmoittaja-urakan-urakoitsijan-organisaatiossa?
         (merkitse-automaattisesti-vastaanotetuksi db ilmoitus ilmoitus-kanta-id jms-lahettaja)
-        (when (not uudelleen-lahetys?)
+        ;; Tee tähän joku logiikka, että lähetetään uusiksi, mikäli päivystäjä on eri, kuin edellisellä kerralla
+        ;; Voisko olla niin, että päivystäjille lähetetään, jos päivystäjä on eri kuin edellisellä kerralla
+        (if (or (not uudelleen-lahetys?) (and uudelleen-lahetys? (not ilmoitus-on-lahetetty-urakalle?)))
           (laheta-ilmoitus-paivystajille db
-                                         (assoc ilmoitus :sijainti (merge (:sijainti ilmoitus) tieosoite))
-                                         paivystajat urakka-id ilmoitusasetukset)))
+            (assoc ilmoitus :sijainti (merge (:sijainti ilmoitus) tieosoite))
+            paivystajat urakka-id ilmoitusasetukset)
+          (log/warn "Päivitetty ilmoitus saapui. Ei lähetetä päivystäjille, koska samat päivystäjät ovat jo saaneet viestin.")))
       (laheta-kuittaus itmf lokittaja kuittausjono kuittaus korrelaatio-id tapahtuma-id true lisatietoja))))
 
 (defn kasittele-tuntematon-urakka [itmf lokittaja kuittausjono viesti-id ilmoitus-id

--- a/test/clj/harja/palvelin/integraatiot/tloik/sahkoposti_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/tloik/sahkoposti_test.clj
@@ -8,14 +8,17 @@
             [harja.integraatio :as integraatio]
             [harja.palvelin.integraatiot.vayla-rest.sahkoposti :as sahkoposti-api]
             [harja.palvelin.integraatiot.tloik.tyokalut :refer [luo-tloik-komponentti tuo-ilmoitus] :as tloik-apurit]
+            [harja.palvelin.integraatiot.tloik.aineistot.toimenpidepyynnot :as aineisto-toimenpidepyynnot]
             [harja.palvelin.integraatiot.jms :as jms]
             [harja.palvelin.integraatiot.api.tyokalut :as api-tyokalut]
             [harja.palvelin.integraatiot.integraatiopisteet.http :as integraatiopiste-http]
             [clj-time
              [core :as t]
-             [format :as df]])
+             [format :as df]]
+            [clojure.string :as str])
   (:import (java.util UUID)))
 
+(def spostin-vastaanotto-url "/sahkoposti/toimenpidekuittaus")
 (def kayttaja "jvh")
 (def jarjestelma-fixture
   (laajenna-integraatiojarjestelmafixturea
@@ -124,3 +127,115 @@
            ;; Tarkista, että ilmoitukselle on kirjautunut merkintä toimenpiteistä
           (is (true? (ffirst (q (str "SELECT \"aiheutti-toimenpiteita\" FROM ilmoitus WHERE ilmoitusid = 123456789"))))
             "Sähköpostikuittauksella voi merkitä aiheutuneet toimenpiteet"))))))
+
+(def vaara-urakka-kuittaus "jes")
+
+(deftest vaara-urakka-sahkoposti-test
+  "Jos viesti on ensin mennyt väärälle urakalle ja tuo urakka on kuitannut viestin kuittauksella \"Väärä urakka\" ja sen jälkeen Liikennekeskus siirtänyt viestin toiselle urakalle niin tällöin viesti näkyy pelkästään Harjaselaimessa. Siitä ei tule sähköposteja lainkaan.
+  Simuloidaan siis tilanne näin:
+  1. Lähetetään toimenpidepyyntö
+  2. jonka perusteella Harja lähettää rest-apin kautta sähköpostia väärälle urakalle.
+  2. Väärän urakan päivystäjä vastaa kuittaus-sähköpostilla 'vaara-urakka'
+  3. Harja lähettää 'vaara-urakka' tyyppisen viesitn T-loikin jonolle."
+  (let [paivystajan-email "pekka.paivystaja@example.com"
+        toimenpiteen-vastausemail "harja@vayla.fi"
+        lokaali-sahkopostipalvelin "http://localhost:8084/api/sahkoposti"]
+
+    (with-redefs
+            [sahkoposti-api/muodosta-lahetys-uri (fn [_ _] lokaali-sahkopostipalvelin)
+             integraatiopiste-http/tee-http-kutsu (fn [_ _ _ _ _ _ _ _ _ _ _]
+                                                    {:status 200
+                                                     :header "jotain"
+                                                     :body onnistunut-kuittaus})
+             ;; Lokaalisti ei oikein ole tilanteita, joissa tulee 2 urakkaa samalle koordinaatille, joten feikataan tilanne
+             harja.palvelin.palvelut.urakat/hae-urakka-id-sijainnilla (fn [_ _ _ _]
+                                                                        (hae-rovaniemen-maanteiden-hoitourakan-id))
+             ;; Feikatulle rovaniemen urakalle ei ole lokaalikannassa päivystäjiä, joten feikataan sekin
+             harja.kyselyt.yhteyshenkilot/hae-urakan-tamanhetkiset-paivystajat
+             (fn [db urakka-id] (list {:id 1
+                                       :etunimi "Pekka"
+                                       :sukunimi "Päivystäjä"
+                                       ;; Testi olettaa, että labyrinttiä ei ole mockattu eikä käynnistetty, joten puhelinnumerot on jätetty tyhjäksi
+                                       :matkapuhelin nil
+                                       :tyopuhelin nil
+                                       :sahkoposti paivystajan-email
+                                       :alku (t/now)
+                                       :loppu (t/now)
+                                       :vastuuhenkilo true
+                                       :varahenkilo true}))
+             ;; Feikatulle rovaniemen urakalle ei ole lokaalikannassa päivystäjiä, joten feikataan sekin, uudestaan
+             harja.kyselyt.yhteyshenkilot/hae-urakan-paivystaja-sahkopostilla
+             (fn [db urakka-id lahettaja] (list {:id 1
+                                       :etunimi "Pekka"
+                                       :sukunimi "Päivystäjä"
+                                       ;; Testi olettaa, että labyrinttiä ei ole mockattu eikä käynnistetty, joten puhelinnumerot on jätetty tyhjäksi
+                                       :matkapuhelin nil
+                                       :tyopuhelin nil
+                                       :sahkoposti paivystajan-email
+                                       :alku (t/now)
+                                       :loppu (t/now)
+                                       :vastuuhenkilo true
+                                       :varahenkilo true}))]
+
+            (let [;; Alustetaan valaistusurakan viesti, mutta lähetetään se tälle väärälle rovaniemen hoitourakalle
+                  vaara-urakka-id (hae-rovaniemen-maanteiden-hoitourakan-id)
+                  viesti-id (str (UUID/randomUUID))
+                  ilmoitus-id 987654321
+                  nyt-185 (df/unparse (df/formatter "yyyy-MM-dd'T'HH:mm:ss" (t/time-zone-for-id "Europe/Helsinki"))
+                            (t/minus (t/now) (t/minutes 185)))
+                  nyt-180 (df/unparse (df/formatter "yyyy-MM-dd'T'HH:mm:ss" (t/time-zone-for-id "Europe/Helsinki"))
+                            (t/minus (t/now) (t/minutes 180)))
+                  valaistusilmoitus (tloik-apurit/testi-valaistusilmoitus-sanoma-eri-sijaintiin viesti-id ilmoitus-id nyt-185 nyt-180 815 4492320.265 3458642.657)
+
+                  ;; 1. Lähetä valaistusilmoitus ikään kuin t-loikista jonoihin - sisältää väärät tiedot. Sijainti ja urakka ei täsmää
+                  _ (jms/laheta (:itmf jarjestelma) tloik-apurit/+tloik-ilmoitusviestijono+ valaistusilmoitus)
+                  ;; Ilmoituksen käsittelyyn menee hetki
+                  ;; 2. Ei simuloida sähköpostin lähetystä urakkalle, koska se tapahtuu automaattisesti. Sen sijaan odotellaan hetki
+                  _ (Thread/sleep 1000)
+
+                  ;; Sähköposti on lähetetty ihan oikein Rest apin kautta ja kun urakoitsija sen saa, niin se vastaa, että väärä urakka
+                  sposti_xml (aseta-xml-sahkopostin-sisalto (str "#[" vaara-urakka-id "/" ilmoitus-id "] Väärä urakka")
+                               "[Väärä urakka] Ei kuulu meidän alueelle tämä homma." paivystajan-email toimenpiteen-vastausemail)
+                  ;; 3. Urakoitsija vastaa "Väärä urakka"
+                  vaara-urakka-email-vastaus (future (api-tyokalut/post-kutsu [spostin-vastaanotto-url] kayttaja portti sposti_xml nil true))
+                  _ (Thread/sleep 1000)
+                  _ (odota-ehdon-tayttymista #(realized? vaara-urakka-email-vastaus) "Saatiin väärä urakka vastaus." 5000)
+                  _ (Thread/sleep 1000)
+                  ;; 4. Harja käsittelee "Väärä urakka" viestin ja lähettää siitä T-LOIKille ilmoituksen
+                  ;; Me voidaan tarkistaa integraatioviesteistä, että näin on todella tapahtunut
+                  integraatioviestit (q-map (str "select id, integraatiotapahtuma, suunta, sisaltotyyppi, siirtotyyppi, sisalto, otsikko, parametrit, osoite, kasitteleva_palvelin
+          FROM integraatioviesti;"))]
+              ;; 1. Varmistetaan, että jonoista saatiin ilmoitus toimenpiteestä
+              (is "sisään" (:suunta (first integraatioviestit)))
+              (is "JMS" (:siirtotyyppi (first integraatioviestit)))
+              (is "tloik-ilmoituskuittausjono" (:osoite (first integraatioviestit)))
+              (is (clojure.string/includes? (:sisalto (first integraatioviestit)) viesti-id))
+
+              ;; 2. Varmistetaan, että Harja lähettää urakoitsijalle tietoa toimenpiteestä
+              (is "ulos" (:suunta (second integraatioviestit)))
+              (is "HTTP" (:siirtotyyppi (first integraatioviestit)))
+              (is lokaali-sahkopostipalvelin (:osoite (first integraatioviestit)))
+              (is (clojure.string/includes? (:sisalto (first integraatioviestit)) viesti-id))
+              ;; Sähköpostipalvelimen lähettämä kuittaus xml, että sähköposti on välitetty urakoitsijalle
+              (is "sisään" (:suunta (nth integraatioviestit 2)))
+              (is "HTTP" (:siirtotyyppi (nth integraatioviestit 2)))
+              (is lokaali-sahkopostipalvelin (:osoite (nth integraatioviestit 2)))
+              (is (clojure.string/includes? (:sisalto (nth integraatioviestit 2)) "sahkoposti:kuittaus"))
+              ;; Harjan kuittaus T-LOIKille, että ollaan välitetty viestit eteenpäin
+              (is "ulos" (:suunta (nth integraatioviestit 3)))
+              (is "JMS" (:siirtotyyppi (nth integraatioviestit 3)))
+              (is "tloik-ilmoituskuittausjono" (:osoite (nth integraatioviestit 3)))
+              (is (clojure.string/includes? (:sisalto (nth integraatioviestit 3)) viesti-id))
+
+
+              ;; 3. Varmistetaan, että urakoitsija vastaa sähköpostiin "väärä urakka"
+              (is "sisään" (:suunta (nth integraatioviestit 4)))
+              (is "HTTP" (:siirtotyyppi (nth integraatioviestit 4)))
+              (is lokaali-sahkopostipalvelin (:osoite (nth integraatioviestit 4)))
+              (is (clojure.string/includes? (:sisalto (nth integraatioviestit 4)) "Väärä urakka"))
+
+              ;; 4. Varmistetaan, että T-LOIKia informoitiin väärästä urakalasta
+              (is "ulos" (:suunta (nth integraatioviestit 5)))
+              (is "JMS" (:siirtotyyppi (nth integraatioviestit 5)))
+              (is "tloik-ilmoituskuittausjono" (:osoite (nth integraatioviestit 5)))
+              (is (clojure.string/includes? (:sisalto (nth integraatioviestit 5)) "<tyyppi>vaara-urakka</tyyppi>"))))))

--- a/test/clj/harja/palvelin/integraatiot/tloik/tyokalut.clj
+++ b/test/clj/harja/palvelin/integraatiot/tloik/tyokalut.clj
@@ -230,6 +230,45 @@
     </harja:ilmoitus>
     ")))
 
+(defn testi-valaistusilmoitus-sanoma-eri-sijaintiin [viesti-id ilmoitus-id ilmoitettu valitetty tienumero x-koordinaatti y-koordinaatti]
+  (str
+    "<harja:ilmoitus xmlns:harja=\"http://www.liikennevirasto.fi/xsd/harja\">
+     <viestiId>"viesti-id"</viestiId>
+     <lahetysaika>" valitetty "</lahetysaika>
+      <ilmoitusId>"ilmoitus-id"</ilmoitusId>
+      <tunniste>UV-1509-1a</tunniste>
+      <versionumero>1</versionumero>
+      <ilmoitustyyppi>toimenpidepyynto</ilmoitustyyppi>
+      <ilmoitettu>" ilmoitettu "</ilmoitettu>
+    <urakkatyyppi>valaistus</urakkatyyppi>
+    <otsikko>Valot pimeänä</otsikko>
+    <paikanKuvaus>Hailuodossa</paikanKuvaus>
+    <lisatieto>Valot ovat pimeänä.</lisatieto>
+    <yhteydenottopyynto>false</yhteydenottopyynto>
+    <sijainti>
+    <tienumero>"tienumero"</tienumero>
+    <x>"x-koordinaatti"</x>
+    <y>"y-koordinaatti"</y>
+    </sijainti>
+    <ilmoittaja>
+    <etunimi>Matti</etunimi>
+    <sukunimi>Meikäläinen</sukunimi>
+    <matkapuhelin>08023394852</matkapuhelin>
+    <sahkoposti>matti.meikalainen@palvelu.fi</sahkoposti>
+    <tyyppi>tienkayttaja</tyyppi>
+    </ilmoittaja>
+    <lahettaja>
+    <etunimi>Pekka</etunimi>
+    <sukunimi>Päivystäjä</sukunimi>
+    <matkapuhelin>929304449282</matkapuhelin>
+    <sahkoposti>pekka.paivystaja@livi.fi</sahkoposti>
+    </lahettaja>
+    <seliteet>
+    <selite>tievalaistusVioittunutOnnettomuudessa</selite>
+    </seliteet>
+    </harja:ilmoitus>
+    "))
+
 (def +testi-paallystysilmoitus-sanoma+
   "<harja:ilmoitus xmlns:harja=\"http://www.liikennevirasto.fi/xsd/harja\">
    <viestiId>14324234</viestiId>

--- a/test/clj/harja/testi.clj
+++ b/test/clj/harja/testi.clj
@@ -970,6 +970,11 @@
                    FROM   urakka
                    WHERE  nimi = 'Oulun tiemerkinnän palvelusopimus 2013-2022'"))))
 
+(defn hae-oulun-valaistusurakan-id []
+  (ffirst (q (str "SELECT id
+                   FROM   urakka
+                   WHERE  nimi = 'Oulun valaistuksen palvelusopimus 2013-2050'"))))
+
 (defn hae-lapin-tiemerkintaurakan-id []
   (ffirst (q (str "SELECT id
                    FROM   urakka
@@ -1683,3 +1688,8 @@
 (defn hae-ulos-lahtevat-integraatiotapahtumat []
   (q-map (str "select id, integraatiotapahtuma, suunta, sisaltotyyppi, siirtotyyppi, sisalto, otsikko, parametrit, osoite, kasitteleva_palvelin
           FROM integraatioviesti WHERE suunta = 'ulos' AND sisalto is not null and sisalto != '';")))
+
+(defn hae-kaikki-integraatioviestit []
+  (q-map (str "SELECT id, integraatiotapahtuma, suunta, sisaltotyyppi, siirtotyyppi, sisalto, otsikko, parametrit,
+                      osoite, kasitteleva_palvelin
+                 FROM integraatioviesti;")))


### PR DESCRIPTION
T-LOIKin lähettäessä toimenpideilmoituksia on mahdollista, että ilmoituksesta lähetettävä päivystysviesti (sähköposti tai/ja tekstiviesti) lähtee väärälle päivystäjälle. Eli väärälle firmalle.
Tämä on koodin perusteella teoreettisesti mahdollista. Koska urakoiden alueet menevät joskus hieman ristiin. Mutta sen simuloiminen yksikkötesteillä on hieman vaikeaa.

Niinpä testeissä tilanne on feikattu.

Ongelma oli siinä, että jos toimenpideilmoitus oli kertaalleen lähetetty (T-LOIKin toimesta), niin viestiä lähetetty sähköpostilla/tekstarilla enää uudestaan päivystäjälle.

Tämä on korjattu niin, että lisättiin tarkistus, jossa varmistetaan, että samalle urakalle ei lähetetä uudestaan samaan ilmoitusta, mutta jos urakka on eri, niin päivystäjälle lähetetään viesti.



Varmistetaan, että prosessi toimii oikein.