### PR TITLE
Tee kokonaisluku-opt funktiosta resilientimpi

### DIFF
--- a/src/cljc/harja/fmt.cljc
+++ b/src/cljc/harja/fmt.cljc
@@ -551,9 +551,11 @@
 
 (defn kokonaisluku-opt
   [luku]
-  (assert (number? luku) "Luvun on oltava numerotyyppinen.")
   (if luku
-    (int luku)
+    (if (number? luku)
+      (int luku)
+      #?(:cljs (js/parseInt luku)
+         :clj  (Integer/parseInt luku)))
     ""))
 
 (defn pyorista-ehka-kolmeen [arvo]


### PR DESCRIPTION
Ennen vaati, että kaikki pdf:ään asetettavat luvut oli int tyyppisiä. Nyt konvertoi stringin intiksi.