### PR TITLE
Siivotaan pois TR url myös localhostilta

### DIFF
--- a/asetukset.edn
+++ b/asetukset.edn
@@ -118,7 +118,7 @@
                   :kayttajatunnus "harja"
                   :salasana #=(slurp "../.harja/api-sahkoposti-salasana")}
 
- :tierekisteri {:url "https://harja-test.solitaservices.fi/harja/integraatiotesti/tierekisteri"
+ :tierekisteri {:url ""
                 :uudelleenlahetys-aikavali-minuutteina 60}
 
  :integraatiot {:paivittainen-lokin-puhdistusaika nil}

--- a/src/clj/harja/palvelin/palvelut/toteumat.clj
+++ b/src/clj/harja/palvelin/palvelut/toteumat.clj
@@ -792,7 +792,6 @@
   Tierekisteri tarvitaan parametrina muuntamaan varusteiden arvot. "
   ([] (varustetoteuma-xf nil))
   ([tierekisteri]
-   (println "petrisi1023: " tierekisteri)
    (comp
      (map #(assoc % :tyyppi-kartalla :varustetoteuma))
      (map #(konv/string->keyword % :toimenpide))

--- a/src/clj/harja/palvelin/palvelut/toteumat.clj
+++ b/src/clj/harja/palvelin/palvelut/toteumat.clj
@@ -792,6 +792,7 @@
   Tierekisteri tarvitaan parametrina muuntamaan varusteiden arvot. "
   ([] (varustetoteuma-xf nil))
   ([tierekisteri]
+   (println "petrisi1023: " tierekisteri)
    (comp
      (map #(assoc % :tyyppi-kartalla :varustetoteuma))
      (map #(konv/string->keyword % :toimenpide))


### PR DESCRIPTION
TR osoitteen konffi oli erilainen tuotannossa, localhostilla, testingissä ja stagingissa. Nyt laitetaan kaikkiin "", niin saadaan TR pois käytöstä. 