### PR TITLE
VHAR-6313 Muuta varusteintegraatio toimimaan ilman kohdeluokka arvoa

### DIFF
--- a/src/clj/harja/palvelin/integraatiot/velho/varusteet.clj
+++ b/src/clj/harja/palvelin/integraatiot/velho/varusteet.clj
@@ -450,28 +450,23 @@
                       viimeksi-haettu (hae-viimeisin-hakuaika-lahteelle db tietolahteen-kohdeluokka)
                       tallenna-hakuaika-fn (partial tallenna-viimeisin-hakuaika-kohdeluokalle db tietolahteen-kohdeluokka)
                       tallenna-virhe-fn (partial lokita-ja-tallenna-hakuvirhe db)
-                      tallenna-toteuma-fn (fn [{:keys [kohdeluokka] :as kohde}]
-                                            (if (= tietolahteen-kohdeluokka kohdeluokka)
-                                              (do
-                                                (log/debug "Tallennetaan kohdeluokka: " tietolahteen-kohdeluokka "oid: " (:oid kohde)
-                                                           " version-voimassaolo.alku: " (get-in kohde [:version-voimassaolo :alku]))
-                                                (let [{varustetoteuma :tulos
-                                                       virheviesti :virheviesti} (jasenna-ja-tarkasta-varustetoteuma db kohde)]
-                                                  (cond varustetoteuma
-                                                        (lisaa-tai-paivita-kantaan db varustetoteuma kohde)
+                      tallenna-toteuma-fn (fn [{:keys [oid muokattu] :as kohde}]
+                                            (log/debug "Tallennetaan kohdeluokka: " tietolahteen-kohdeluokka "oid: " oid
+                                                       " version-voimassaolo.alku: " (-> kohde :version-voimassaolo :alku))
+                                            (let [{varustetoteuma :tulos
+                                                   virheviesti :virheviesti} (jasenna-ja-tarkasta-varustetoteuma db kohde)]
+                                              (cond varustetoteuma
+                                                    (lisaa-tai-paivita-kantaan db varustetoteuma kohde)
 
-                                                        virheviesti
-                                                        (lokita-ja-tallenna-hakuvirhe
-                                                          db kohde
-                                                          (str "hae-varustetoteumat-velhosta: tallenna-toteuma-fn: Kohde ei onnistu muuttaa Harjan muotoon. ulkoinen_oid: "
-                                                               (:oid kohde) " muokattu: " (:muokattu kohde) " validointivirhe: " virheviesti))
+                                                    virheviesti
+                                                    (lokita-ja-tallenna-hakuvirhe
+                                                      db kohde
+                                                      (str "hae-varustetoteumat-velhosta: tallenna-toteuma-fn: Kohde ei onnistu muuttaa Harjan muotoon. ulkoinen_oid: "
+                                                           (format "%s muokattu: %s validointivirhe: %s"
+                                                                   oid muokattu virheviesti)))
 
-                                                        :else
-                                                        :ohita)))
-                                              (lokita-ja-tallenna-hakuvirhe
-                                                db kohde
-                                                (str "hae-varustetoteumat-velhosta: tallenna-toteuma-fn: Kohde ei ole oikeasta kohdeluokasta "
-                                                     (:oid kohde) " muokattu: " (:muokattu kohde) " odotettu kohdeluokka: " tietolahteen-kohdeluokka " saatu kohdeluokka: " kohdeluokka))))]
+                                                    :else
+                                                    :ohita)))]
                   (hae-ja-tallenna
                     tietolahde viimeksi-haettu konteksti varuste-api-juuri-url
                     token-fn tallenna-toteuma-fn tallenna-hakuaika-fn tallenna-virhe-fn)))

--- a/test/clj/harja/palvelin/integraatiot/velho/varusteet_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/velho/varusteet_test.clj
@@ -685,16 +685,6 @@
        {:url +varuste-kohteet-regex+ :method :post} ei-sallittu]
       (velho-integraatio/tuo-uudet-varustetoteumat-velhosta (:velho-integraatio jarjestelma)))))
 
-(deftest varuste-velho-palauttaa-vaaran-kohdeluokan-varusteen
-  (u "DELETE FROM varustetoteuma_ulkoiset")
-  (let [odotettu-oidit-vastaus "[\"1.2.246.578.4.3.1.501.125998655\", \"1.2.246.578.4.3.15.506.283640192\"]"
-        odotettu-kohteet-vastaus (slurp "test/resurssit/velho/varusteet/varusterekisteri_api_v1_historia_kohteet-vaara-kohdeluokka.jsonl")
-        odotettu-oid-lista #{"1.2.246.578.4.3.1.501.125998655"}
-        lokiteksti (kutsu-ja-palauta-varusteiden-loki #(feikkaa-ja-kutsu-varusteintegraatiota odotettu-oidit-vastaus odotettu-kohteet-vastaus))]
-    (is (not (str/includes? lokiteksti "ERROR")))
-    (is (str/includes? lokiteksti "odotettu kohdeluokka: varusteet/kaiteet saatu kohdeluokka: varusteet/liikennemerkit"))
-    (is (= odotettu-oid-lista (kaikki-varustetoteuma-oidt)))))
-
 (deftest velho-palauttaa-teknisen-tapahtuman
   (u "DELETE FROM varustetoteuma_ulkoiset")
   (let [odotettu-oidit-vastaus "[\"1.2.246.578.4.3.1.501.158276054\"]"


### PR DESCRIPTION
Velhon vastauksissa aiemmin ollut `kohdeluokka` tieto poistui ja sen käyttö assertiona ei enää ole sopivaa.
Poistetaan kohdeluokka varmistus toteutuksesta ja testeistä.

> [Kimmo Rantala]ext-urpo [20 minutes ago]
> Jaa kappas siellä on tullut tuollainen ylimääräinen tieto mukana jota ei ole json-schemassa. Tein tällä viikolla muutoksen jossa kohteet-rajapinnassa siivotaan ylimääräiset tiedot pois.
> Jos ei ole tiedossa mitä kohdeluokkaa kohde on, niin oikea tapa on päätellä se oid-prefixista. Ne oid-prefixit kerrotaan metatietopalvelusta saatavassa json-schemassa