### PR TITLE
VHAR-6299 Tunnista olemassaoleva päivystystieto ulkoisen id:n ja urakan perusteella

### DIFF
--- a/src/clj/harja/kyselyt/yhteyshenkilot.clj
+++ b/src/clj/harja/kyselyt/yhteyshenkilot.clj
@@ -11,8 +11,8 @@
 (defn onko-olemassa-paivystys-jossa-yhteyshenkilona-id? [db paivystaja-id]
   (:exists (first (onko-olemassa-paivystys-jossa-yhteyshenkilona-id db paivystaja-id))))
 
-(defn onko-olemassa-paivystys-ulkoisella-idlla? [db kayttaja-id ulkoinen-id]
-  (:exists (first (onko-olemassa-paivystys-ulkoisella-idlla db kayttaja-id ulkoinen-id))))
+(defn onko-olemassa-paivystys-ulkoisella-idlla? [db urakka-id ulkoinen-id]
+  (:exists (first (onko-olemassa-paivystys-ulkoisella-idlla db ulkoinen-id urakka-id))))
 
 (defn hae-urakan-tamanhetkiset-paivystajat
   "Palauttaa urakan tämän hetkiset päivystäjät"

--- a/src/clj/harja/kyselyt/yhteyshenkilot.sql
+++ b/src/clj/harja/kyselyt/yhteyshenkilot.sql
@@ -170,8 +170,8 @@ WHERE id = (SELECT yhteyshenkilo
 -- name: luo-paivystys<!
 -- Luo annetulle yhteyshenkilölle päivystyksen urakkaan
 INSERT INTO paivystys
-(alku, loppu, urakka, yhteyshenkilo, varahenkilo, vastuuhenkilo, ulkoinen_id, luoja)
-VALUES (:alku, :loppu, :urakka, :yhteyshenkilo, :varahenkilo, :vastuuhenkilo, :ulkoinen_id, :kayttaja_id);
+(alku, loppu, urakka, yhteyshenkilo, varahenkilo, vastuuhenkilo, ulkoinen_id, luoja, luotu)
+VALUES (:alku, :loppu, :urakka, :yhteyshenkilo, :varahenkilo, :vastuuhenkilo, :ulkoinen_id, :kayttaja_id, current_timestamp);
 
 -- name: hae-paivystyksen-yhteyshenkilo-id
 -- Hakee annetun urakan päivystyksen yhteyshenkilön id:n
@@ -182,7 +182,7 @@ WHERE id = :id AND urakka = :urakka;
 -- name: paivita-paivystys!
 -- Päivittää päivystyksen tiedot
 UPDATE paivystys
-SET alku = :alku, loppu = :loppu, vastuuhenkilo = :vastuuhenkilo, varahenkilo = :varahenkilo
+SET alku = :alku, loppu = :loppu, vastuuhenkilo = :vastuuhenkilo, varahenkilo = :varahenkilo, muokkaaja = :kayttaja_id, muokattu = current_timestamp
 WHERE id = :id AND urakka = :urakka;
 
 -- name: paivita-paivystys-yhteyshenkilon-idlla<!
@@ -191,7 +191,9 @@ UPDATE paivystys
 SET alku        = :alku,
   loppu         = :loppu,
   varahenkilo   = :varahenkilo,
-  vastuuhenkilo = :vastuuhenkilo
+  vastuuhenkilo = :vastuuhenkilo,
+  muokkaaja     = :kayttaja_id,
+  muokattu      = current_timestamp
 WHERE yhteyshenkilo = :yhteyshenkilo_id;
 
 -- name: paivita-paivystys-ulkoisella-idlla<!
@@ -201,9 +203,11 @@ SET alku        = :alku,
   loppu         = :loppu,
   varahenkilo   = :varahenkilo,
   vastuuhenkilo = :vastuuhenkilo,
-  yhteyshenkilo = :yhteyshenkilo_id
+  yhteyshenkilo = :yhteyshenkilo_id,
+  muokkaaja     = :kayttaja_id,
+  muokattu      = current_timestamp
 WHERE ulkoinen_id = :ulkoinen_id AND
-      luoja = :kayttaja_id;
+      urakka = :urakka;
 
 -- name: liita-sampon-yhteyshenkilo-urakkaan<!
 -- Liittää yhteyshenkilön urakkaan Sampo id:llä
@@ -252,7 +256,7 @@ SELECT exists(
     SELECT id
     FROM paivystys
     WHERE ulkoinen_id = :ulkoinen_id AND
-          luoja = :luoja_id);
+          urakka = :urakka);
 
 -- name: hae-urakan-taman-hetkiset-paivystajat
 SELECT

--- a/src/clj/harja/palvelin/integraatiot/api/paivystajatiedot.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/paivystajatiedot.clj
@@ -83,7 +83,7 @@
        :viesti (format "Tuntematon urakkatyyppi: %s" (:urakkatyyppi parametrit))})))
 
 (defn- paivita-tai-luo-uusi-paivystys [db urakka-id {:keys [alku loppu varahenkilo vastuuhenkilo id]} paivystaja-id kirjaaja]
-  (if (yhteyshenkilot-q/onko-olemassa-paivystys-ulkoisella-idlla? db id (:id kirjaaja))
+  (if (yhteyshenkilot-q/onko-olemassa-paivystys-ulkoisella-idlla? db urakka-id id)
     (do
       (log/debug "Päivitetään päivystys.")
       (yhteyshenkilot-q/paivita-paivystys-ulkoisella-idlla<!
@@ -93,8 +93,9 @@
         varahenkilo
         vastuuhenkilo
         paivystaja-id
+        (:id kirjaaja)
         id
-        (:id kirjaaja)))
+        urakka-id))
     (do
       (log/debug "Luodaan uusi päivystys.")
       (yhteyshenkilot-q/luo-paivystys<!

--- a/src/clj/harja/palvelin/palvelut/yhteyshenkilot.clj
+++ b/src/clj/harja/palvelin/palvelut/yhteyshenkilot.clj
@@ -237,7 +237,9 @@
                                            :id yht-id))
             (q/paivita-paivystys! c (assoc paivystys
                                       :id (:id p)
-                                      :yhteyshenkilo yht-id)))))
+                                      :yhteyshenkilo yht-id
+                                      :kayttaja_id (:id user))))))
+
 
       ;; Haetaan lopuksi uuden päivystäjät
       (hae-urakan-paivystajat c user urakka-id))

--- a/test/clj/harja/palvelin/integraatiot/api/paivystajat_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/paivystajat_test.clj
@@ -7,8 +7,9 @@
             [cheshire.core :as cheshire]
             [harja.fmt :as fmt]))
 
-(def kayttaja-yit "yit-rakennus")
-(def kayttaja-jvh "jvh")
+(def kayttaja-yit   "yit-rakennus")
+(def kayttaja-yit-2 "yit-pk")
+(def kayttaja-jvh   "jvh")
 
 (def jarjestelma-fixture
   (laajenna-integraatiojarjestelmafixturea kayttaja-yit
@@ -174,7 +175,8 @@
     (tee-testiyhteyshenkilo 9876543456)
     (tee-urakalle-paivystys 4 paivystys-id-1 9876543456 kayttaja-yit)
     (tee-urakalle-paivystys 1 paivystys-id-2 9876543456 kayttaja-yit)
-    (is (= 2 (count (q "SELECT * FROM paivystys WHERE yhteyshenkilo = (SELECT id FROM yhteyshenkilo WHERE ulkoinen_id = '9876543456')"))) "toisen urakan paivystaja samalla ulkoisella id:lla edelleen olemassa")
+    (tee-urakalle-paivystys 1 paivystys-id-2 9876543456 kayttaja-yit-2) ;; Ei luo uutta, päivittää edellisen rivin tallentaman päivystyksen
+    (is (= 2 (count (q "SELECT * FROM paivystys WHERE yhteyshenkilo = (SELECT id FROM yhteyshenkilo WHERE ulkoinen_id = '9876543456')"))) "toisen urakan paivystaja samalla ulkoisella id:lla edelleen olemassa, omassa urakassa ei kahta päivystystä samalla ulkoisella-id:llä")
     (let [msg (cheshire/encode
                 {:otsikko {:lahettaja {:jarjestelma "jarjestelma"
                                        :organisaatio {:nimi "Urakoitsija"

--- a/test/clj/harja/palvelin/integraatiot/api/paivystajat_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/paivystajat_test.clj
@@ -7,9 +7,8 @@
             [cheshire.core :as cheshire]
             [harja.fmt :as fmt]))
 
-(def kayttaja-yit   "yit-rakennus")
-(def kayttaja-yit-2 "yit-pk")
-(def kayttaja-jvh   "jvh")
+(def kayttaja-yit "yit-rakennus")
+(def kayttaja-jvh "jvh")
 
 (def jarjestelma-fixture
   (laajenna-integraatiojarjestelmafixturea kayttaja-yit
@@ -175,8 +174,7 @@
     (tee-testiyhteyshenkilo 9876543456)
     (tee-urakalle-paivystys 4 paivystys-id-1 9876543456 kayttaja-yit)
     (tee-urakalle-paivystys 1 paivystys-id-2 9876543456 kayttaja-yit)
-    (tee-urakalle-paivystys 1 paivystys-id-2 9876543456 kayttaja-yit-2) ;; Ei luo uutta, päivittää edellisen rivin tallentaman päivystyksen
-    (is (= 2 (count (q "SELECT * FROM paivystys WHERE yhteyshenkilo = (SELECT id FROM yhteyshenkilo WHERE ulkoinen_id = '9876543456')"))) "toisen urakan paivystaja samalla ulkoisella id:lla edelleen olemassa, omassa urakassa ei kahta päivystystä samalla ulkoisella-id:llä")
+    (is (= 2 (count (q "SELECT * FROM paivystys WHERE yhteyshenkilo = (SELECT id FROM yhteyshenkilo WHERE ulkoinen_id = '9876543456')"))) "toisen urakan paivystaja samalla ulkoisella id:lla edelleen olemassa")
     (let [msg (cheshire/encode
                 {:otsikko {:lahettaja {:jarjestelma "jarjestelma"
                                        :organisaatio {:nimi "Urakoitsija"

--- a/tietokanta/src/main/resources/db/migration/V1_942__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_942__.sql
@@ -1,0 +1,4 @@
+ALTER TABLE paivystys
+    ADD COLUMN luotu  timestamp,
+    ADD COLUMN muokattu  timestamp,
+    ADD COLUMN muokkaaja integer REFERENCES kayttaja (id);


### PR DESCRIPTION
Tämä mahdollistaa sen, että eri käyttäjätunnuksella voidaan päivittää päivystystietoja omassa urakassa.