### PR TITLE
VHAR.6206 Varusteiden kartta käyttämään toteumatyyppejä kuntoluokka-tiedon sijaan

### DIFF
--- a/src/cljc/harja/ui/kartta/varit/alpha.cljc
+++ b/src/cljc/harja/ui/kartta/varit/alpha.cljc
@@ -22,11 +22,19 @@
 (def harmaa (rgba 140 140 140 0.7))
 (def tummanharmaa (rgba 77 77 77 0.7))
 
+(def fig-default   (rgba 0 176 204 0.7))
+(def lemon-default (rgba 255 195 0 0.7))
+(def eggplant-default (rgba 160 80 160 0.7))
+(def pitaya-default (rgba 229 0 131 0.7))
+(def pea-default (rgba 141 203 109 0.7))
+(def black-light (rgba 92 92 92 0.7))
+
 (def kaikki
   ^{:doc   "Vektori joka sisältää kaikki namespacen värit. Joudutaan valitettavasti rakentamaan
           käsin, koska .cljs puolelta puuttuu tarvittavat työkalut tämän luomiseen."
     :const true}
   [punainen oranssi keltainen magenta vihrea turkoosi syaani sininen
-    tummansininen violetti lime pinkki])
+    tummansininen violetti lime pinkki
+   fig-default lemon-default eggplant-default pitaya-default pea-default black-light])
 
 #?(:clj (core/varmenna-sisalto 'harja.ui.kartta.varit.alpha))

--- a/src/cljc/harja/ui/kartta/varit/puhtaat.cljc
+++ b/src/cljc/harja/ui/kartta/varit/puhtaat.cljc
@@ -21,12 +21,20 @@
 (def harmaa (rgb 140 140 140))
 (def tummanharmaa (rgb 77 77 77))
 
+(def fig-default   (rgb 0 176 204))
+(def lemon-default (rgb 255 195 0))
+(def eggplant-default (rgb 160 80 160))
+(def pitaya-default (rgb 229 0 131))
+(def pea-default (rgb 141 203 109))
+(def black-light (rgb 92 92 92))
+
 (def kaikki
   ^{:doc "Vektori joka sisältää kaikki namespacen värit. Joudutaan valitettavasti rakentamaan
           käsin, koska .cljs puolelta puuttuu tarvittavat työkalut tämän luomiseen."
     :const true}
   [punainen oranssi keltainen magenta vihrea turkoosi syaani sininen
-   tummansininen violetti lime pinkki])
+   tummansininen violetti lime pinkki
+   fig-default lemon-default eggplant-default pitaya-default pea-default black-light])
 
 #?(:clj
    (defn- poista-testit [setti]

--- a/src/cljs/harja/tiedot/urakka/toteumat/velho_varusteet_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/toteumat/velho_varusteet_tiedot.cljs
@@ -176,7 +176,7 @@
   HaeVarusteetOnnistui
   (process-event [{:keys [vastaus]} app]
     (reset! varusteet-kartalla/karttataso-varusteet
-            (map (fn [t] {:sijainti (:sijainti t)}) (:toteumat vastaus)))
+            (map (fn [t] {:sijainti (:sijainti t) :toteuma (:toteuma t)}) (:toteumat vastaus)))
     (-> app
         (assoc :haku-paalla false)
         (assoc :varusteet (:toteumat vastaus))))

--- a/src/cljs/harja/tiedot/urakka/toteumat/velho_varusteet_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/toteumat/velho_varusteet_tiedot.cljs
@@ -174,7 +174,7 @@
                                   :epaonnistui ->HaeVarusteetEpaonnistui}))))))
 
   HaeVarusteetOnnistui
-  (process-event [{:keys [vastaus] :as jotain} app]
+  (process-event [{:keys [vastaus]} app]
     (reset! varusteet-kartalla/karttataso-varusteet
             (map (fn [t] {:sijainti (:sijainti t)}) (:toteumat vastaus)))
     (-> app
@@ -182,7 +182,7 @@
         (assoc :varusteet (:toteumat vastaus))))
 
   HaeVarusteetEpaonnistui
-  (process-event [{:keys [vastaus] :as jotain-muuta} app]
+  (process-event [_ app]
     (reset! varusteet-kartalla/karttataso-varusteet nil)
     (viesti/nayta! "Varusteiden haku epäonnistui!" :danger)
     (-> app

--- a/src/cljs/harja/tiedot/urakka/varusteet_kartalla.cljs
+++ b/src/cljs/harja/tiedot/urakka/varusteet_kartalla.cljs
@@ -22,7 +22,7 @@
              (when (and (not-empty kohteet) @karttataso-nakyvissa?)
                (with-meta (mapv (fn [{:keys [toteuma] :as kohde}]
                                   (when (:sijainti kohde)
-                                    (let [vari (or (get toteuma-vari toteuma) "white")]
+                                    (let [vari (get toteuma-vari toteuma "white")]
                                       {:alue (merge {:stroke {:width 8
                                                               :color vari}}
                                                     (:sijainti kohde))

--- a/src/cljs/harja/tiedot/urakka/varusteet_kartalla.cljs
+++ b/src/cljs/harja/tiedot/urakka/varusteet_kartalla.cljs
@@ -12,6 +12,7 @@
                    "korjaus" "black"
                    "puhdistus" "white"})
 (def karttataso-varusteet (atom []))
+
 (defonce karttataso-nakyvissa? (atom true))
 
 (defonce varusteet-kartalla

--- a/src/cljs/harja/tiedot/urakka/varusteet_kartalla.cljs
+++ b/src/cljs/harja/tiedot/urakka/varusteet_kartalla.cljs
@@ -5,6 +5,12 @@
   (:require-macros [reagent.ratom :refer [reaction]]))
 
 
+(def toteuma-vari {"lisatty" "green"
+                   "paivitetty" "yellow"
+                   "poistettu" "red"
+                   "tarkastus" "purple"
+                   "korjaus" "black"
+                   "puhdistus" "white"})
 (def karttataso-varusteet (atom []))
 (defonce karttataso-nakyvissa? (atom true))
 
@@ -12,10 +18,10 @@
          (reaction
            (let [kohteet @karttataso-varusteet]
              (when (and (not-empty kohteet) @karttataso-nakyvissa?)
-               (with-meta (mapv (fn [kohde]
+               (with-meta (mapv (fn [{:keys [toteuma] :as kohde}]
                                   (when (:sijainti kohde)
                                     {:alue (merge {:stroke {:width 8
-                                                            :color "red"}}
+                                                            :color (or (get toteuma-vari toteuma) "pink")}}
                                                   (:sijainti kohde))
                                      :selite {:teksti "Varuste"
                                               :img (kartta-ikonit/pinni-ikoni "sininen")}

--- a/src/cljs/harja/tiedot/urakka/varusteet_kartalla.cljs
+++ b/src/cljs/harja/tiedot/urakka/varusteet_kartalla.cljs
@@ -1,16 +1,17 @@
 (ns harja.tiedot.urakka.varusteet-kartalla
   (:require [reagent.core :refer [atom] :as r]
             [harja.ui.kartta.ikonit :as kartta-ikonit]
-            [harja.ui.kartta.varit.puhtaat :as puhtaat])
+            [harja.ui.kartta.varit.puhtaat :as puhtaat]
+            [harja.ui.kartta.varit.alpha :as alpha])
   (:require-macros [reagent.ratom :refer [reaction]]))
 
+(def toteuma-vari {"lisatty" alpha/fig-default
+                   "paivitetty" alpha/lemon-default
+                   "poistettu" alpha/eggplant-default
+                   "tarkastus" alpha/pitaya-default
+                   "korjaus" alpha/pea-default
+                   "puhdistus" alpha/black-light})
 
-(def toteuma-vari {"lisatty" "green"
-                   "paivitetty" "yellow"
-                   "poistettu" "red"
-                   "tarkastus" "purple"
-                   "korjaus" "black"
-                   "puhdistus" "white"})
 (def karttataso-varusteet (atom []))
 
 (defonce karttataso-nakyvissa? (atom true))
@@ -21,19 +22,21 @@
              (when (and (not-empty kohteet) @karttataso-nakyvissa?)
                (with-meta (mapv (fn [{:keys [toteuma] :as kohde}]
                                   (when (:sijainti kohde)
-                                    {:alue (merge {:stroke {:width 8
-                                                            :color (or (get toteuma-vari toteuma) "pink")}}
-                                                  (:sijainti kohde))
-                                     :selite {:teksti "Varuste"
-                                              :img (kartta-ikonit/pinni-ikoni "sininen")}
-                                     :ikonit [{:tyyppi :merkki
-                                               :paikka [:loppu]
-                                               :zindex 21
-                                               :img (kartta-ikonit/pinni-ikoni "sininen")}]}))
+                                    (let [vari (or (get toteuma-vari toteuma) "white")]
+                                      {:alue (merge {:stroke {:width 8
+                                                              :color vari}}
+                                                    (:sijainti kohde))
+                                       :selite {:teksti toteuma
+                                                :img (kartta-ikonit/pinni-ikoni "sininen")}
+                                       :ikonit [{:tyyppi :merkki
+                                                 :paikka [:loppu]
+                                                 :zindex 21
+                                                 :img (kartta-ikonit/pinni-ikoni "sininen")}]})))
                                 kohteet)
-                          {:selitteet [{:vari (map :color [{:color puhtaat/musta-raja
-                                                            :width 8}
-                                                           {:color puhtaat/vihrea
-                                                            :width 6}])
-                                        :teksti "Varusteet"}]})))))
+                          {:selitteet [{:teksti "Lisätty" :vari puhtaat/fig-default}
+                                       {:teksti "Poistettu" :vari puhtaat/eggplant-default}
+                                       {:teksti "Tarkistettu" :vari puhtaat/pitaya-default}
+                                       {:teksti "Puhdistettu" :vari puhtaat/black-light}
+                                       {:teksti "Korjattu" :vari puhtaat/pea-default}
+                                       {:teksti "Päivitetty" :vari puhtaat/lemon-default}]})))))
 

--- a/src/cljs/harja/ui/yleiset.cljs
+++ b/src/cljs/harja/ui/yleiset.cljs
@@ -906,7 +906,7 @@ jatkon."
   (let [osio (fn [komponentti otsikko] komponentti)]
     (fn [{:keys [wrap-luokka]} {:keys [tie aosa aeta losa leta]}]
       [:div {:class (or wrap-luokka "col-md-3 filtteri tr-osoite")}
-       [:label.otsikko "Tierekisteriosoite"]
+       [:label.alasvedon-otsikko-vayla "Tierekisteriosoite"]
       [:div
        [:div.varusteet.tr-osoite-flex
         [osio tie "Tie"]

--- a/src/cljs/harja/views/urakka/toteumat/velho_varusteet.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/velho_varusteet.cljs
@@ -81,8 +81,8 @@
         losa (:losa valinnat)
         leta (:leta valinnat)]
     [:div
-     [:div.row.filtterit-container
-      [debug app {:otsikko "TUCK STATE"}]
+     [debug app {:otsikko "TUCK STATE"}]
+     [:div.row.filtterit-container {:style {:height "100px"}}
       [yleiset/pudotusvalikko "Hoitovuosi"
        {:wrap-luokka "col-md-2 filtteri label-ja-alasveto-grid"
         :valinta hoitokauden-alkuvuosi


### PR DESCRIPTION
Muutettiin varustelistaus -> varustetoimenpidelistaukseksi. Niinpä kartalle tuli toimenpide tärkeämmäksi kuin kuntoluokka. 
Vaihdetaan kartalle toimenpide (=toteuma) legendaksi ja värikoodaukseksi.