### PR TITLE
VHAR-6357 Toteuta liikennemerkin varustetoimenpiteen lisätieto käyttäen lakinumeroa ja asetusnumeroa

### DIFF
--- a/src/clj/harja/palvelin/integraatiot/velho/sanomat/varuste_vastaanottosanoma.clj
+++ b/src/clj/harja/palvelin/integraatiot/velho/sanomat/varuste_vastaanottosanoma.clj
@@ -276,8 +276,8 @@
             ; Kuvittelemme, ettei ole kovin yleistä, että yhdessä
             ; varusteen versiossa on monta toimenpidettä
             (log/warn (str "Löytyi varusteversio, jolla on monta toimenpidettä: oid: " (:ulkoinen-oid kohde)
-                           " version-alku: " version-alku " toimenpiteet(suodatettu): " toimenpidelista
-                           " Otimme vain 1. toimenpiteen talteen."))
+                           " version-alku: " version-alku " toimenpiteet(suodatettu): (" (str/join ", " (map #(str "\"" % "\"") toimenpidelista))
+                           ") Otimme vain 1. toimenpiteen talteen."))
             (first toimenpidelista))
 
           (= 1 (count toimenpidelista))

--- a/src/clj/harja/palvelin/integraatiot/velho/sanomat/varuste_vastaanottosanoma.clj
+++ b/src/clj/harja/palvelin/integraatiot/velho/sanomat/varuste_vastaanottosanoma.clj
@@ -245,19 +245,23 @@
 (defn varusteen-lisatieto [konversio-fn tietolaji kohde]
   (when (= (name +liikennemerkki-tietolaji+) tietolaji)
     (let [asetusnumero (get-in kohde [:ominaisuudet :toiminnalliset-ominaisuudet :asetusnumero])
-          lakinumero (get-in kohde [:ominaisuudet :toiminnalliset-ominaisuudet :lakinumero])]
-      (cond
-        (and asetusnumero (nil? lakinumero))
-        (konversio-fn "v/vtlm" asetusnumero)
+          lakinumero (get-in kohde [:ominaisuudet :toiminnalliset-ominaisuudet :lakinumero])
+          lisatietoja (get-in kohde [:ominaisuudet :toiminnalliset-ominaisuudet :lisatietoja])
+          merkki (cond
+                   (and asetusnumero (nil? lakinumero))
+                   (str (konversio-fn "v/vtlm" asetusnumero))
 
-        (and (nil? asetusnumero) lakinumero)
-        (konversio-fn "v/vtlmln" lakinumero)
+                   (and (nil? asetusnumero) lakinumero)
+                   (konversio-fn "v/vtlmln" lakinumero)
 
-        (and (nil? asetusnumero) (nil? lakinumero))
-        "VIRHE: Liikennemerkin asetusnumero ja lakinumero tyhjiä Tievelhossa"
+                   (and (nil? asetusnumero) (nil? lakinumero))
+                   "VIRHE: Liikennemerkin asetusnumero ja lakinumero tyhjiä Tievelhossa"
 
-        (and asetusnumero lakinumero)
-        "VIRHE: Liikennemerkillä sekä asetusnumero että lakinumero Tievelhossa"))))
+                   (and asetusnumero lakinumero)
+                   "VIRHE: Liikennemerkillä sekä asetusnumero että lakinumero Tievelhossa")]
+      (if lisatietoja
+        (str merkki ": " lisatietoja)
+        merkki))))
 
 (defn varusteen-kuntoluokka [konversio-fn kohde]
   (let [kuntoluokka (get-in kohde [:ominaisuudet :kunto-ja-vauriotiedot :yleinen-kuntoluokka])]

--- a/src/clj/harja/palvelin/integraatiot/velho/sanomat/varuste_vastaanottosanoma.clj
+++ b/src/clj/harja/palvelin/integraatiot/velho/sanomat/varuste_vastaanottosanoma.clj
@@ -244,8 +244,20 @@
 
 (defn varusteen-lisatieto [konversio-fn tietolaji kohde]
   (when (= (name +liikennemerkki-tietolaji+) tietolaji)
-    (konversio-fn
-      "v/vtlm" (get-in kohde [:ominaisuudet :toiminnalliset-ominaisuudet :asetusnumero]))))
+    (let [asetusnumero (get-in kohde [:ominaisuudet :toiminnalliset-ominaisuudet :asetusnumero])
+          lakinumero (get-in kohde [:ominaisuudet :toiminnalliset-ominaisuudet :lakinumero])]
+      (cond
+        (and asetusnumero (nil? lakinumero))
+        (konversio-fn "v/vtlm" asetusnumero)
+
+        (and (nil? asetusnumero) lakinumero)
+        (konversio-fn "v/vtlmln" lakinumero)
+
+        (and (nil? asetusnumero) (nil? lakinumero))
+        "VIRHE: Liikennemerkin asetusnumero ja lakinumero tyhjiä Tievelhossa"
+
+        (and asetusnumero lakinumero)
+        "VIRHE: Liikennemerkillä sekä asetusnumero että lakinumero Tievelhossa"))))
 
 (defn varusteen-kuntoluokka [konversio-fn kohde]
   (let [kuntoluokka (get-in kohde [:ominaisuudet :kunto-ja-vauriotiedot :yleinen-kuntoluokka])]

--- a/test/clj/harja/palvelin/integraatiot/velho/varusteet_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/velho/varusteet_test.clj
@@ -259,7 +259,7 @@
         kohdeluokka (str (nth url-osat 7) "/" (nth url-osat 8))]
     {:palvelu palvelu :api-versio api-versio :kohdeluokka kohdeluokka}))
 
-(deftest varuste-hae-varusteet-kayttaa-osajoukkoja-test
+(deftest varuste-tuonti-kayttaa-osajoukkoja-test
   (u "DELETE FROM varustetoteuma_ulkoiset")
   ; ASETA
   (let [testitunniste "osajoukkoja-test"
@@ -332,7 +332,7 @@
       (is (= expected-varustetoteuma-maara (count kaikki-varustetoteumat))
           (str "Odotettiin " expected-varustetoteuma-maara " varustetoteumaa tietokannassa testin jälkeen")))))
 
-(deftest varuste-hae-varusteet-onnistuneet-test
+(deftest varuste-tuonti-onnistuneet-test
   (u "DELETE FROM varustetoteuma_ulkoiset")
   ; ASETA
   (let [testitunniste "onnistuneet-test"

--- a/test/resurssit/velho/varusteet/liikennemerkin-lisatietoja.json
+++ b/test/resurssit/velho/varusteet/liikennemerkin-lisatietoja.json
@@ -1,0 +1,75 @@
+{
+  "kohdeluokka": "varusteet/liikennemerkit",
+  "sijainti": {
+    "osa": 12,
+    "tie": 616,
+    "etaisyys": 2139,
+    "enkoodattu": 61600042824
+  },
+  "version-voimassaolo": {
+    "alku": "2010-06-16",
+    "loppu": "2021-11-16"
+  },
+  "ominaisuudet": {
+    "toiminnalliset-ominaisuudet": {
+      "tarkenne": null,
+      "lakinumero": "liikennemerkki-lakinumero/liilnro209",
+      "asetusnumero": null,
+      "vaikutussuunta": null,
+      "lisatietoja": "Lisätietokilven teksti",
+      "voimassaolo-alkaa": null,
+      "voimassaolo-paattyy": null
+    },
+    "infranimikkeisto": {
+      "toiminnallinen-jarjestelmakokonaisuus": [],
+      "rakenteellinen-jarjestelmakokonaisuus": [
+        "rakenteellinen-jarjestelmakokonaisuus/rjk03"
+      ]
+    },
+    "kunto-ja-vauriotiedot": {
+      "arvioitu-jaljella-oleva-kayttoika": null,
+      "yleinen-kuntoluokka": "kuntoluokka/kl04",
+      "varustevauriot": []
+    },
+    "rakenteelliset-ominaisuudet": {
+      "tekstikoko": null,
+      "kilven-valaistus": null,
+      "kalvotyyppi": null,
+      "paivaloistekalvo": null,
+      "arvo": null,
+      "kiinnitystapa": null,
+      "tunnus": null,
+      "pinta-ala": 0,
+      "sivutie": null,
+      "lisatyyppi": [
+        "liikennemerkki-lisatyyppi/liility01"
+      ],
+      "yhteydet-muihin-kohteisiin": [],
+      "materiaali": "materiaali/ma02",
+      "suunta": null,
+      "tyyppi": "liikennemerkki-tyyppi/liity06",
+      "koko": null,
+      "korkeusasema": null
+    }
+  },
+  "luotu": "2020-05-08T12:20:15Z",
+  "lahdejarjestelman-id": "506.283640192",
+  "paattyen": null,
+  "sijainti-oid": "1.2.246.578.4.1.2.146265754",
+  "lahdejarjestelma": "lahdejarjestelma/lj01",
+  "schemaversio": 1,
+  "luoja": {
+    "kayttajanimi": "TIERb3320"
+  },
+  "sijaintitarkenne": {
+    "ajoradat": [
+      "ajorata/ajr1"
+    ]
+  },
+  "muokkaaja": {
+    "kayttajanimi": "migraatio"
+  },
+  "oid": "1.2.246.578.4.3.15.506.283640192",
+  "alkaen": "2010-06-16",
+  "muokattu": "2021-03-10T07:57:40Z"
+}

--- a/test/resurssit/velho/varusteet/puuttuvat-asetus-ja-lakinumerot.json
+++ b/test/resurssit/velho/varusteet/puuttuvat-asetus-ja-lakinumerot.json
@@ -1,0 +1,75 @@
+{
+  "kohdeluokka": "varusteet/liikennemerkit",
+  "sijainti": {
+    "osa": 12,
+    "tie": 616,
+    "etaisyys": 2139,
+    "enkoodattu": 61600042824
+  },
+  "version-voimassaolo": {
+    "alku": "2010-06-16",
+    "loppu": "2021-11-16"
+  },
+  "ominaisuudet": {
+    "toiminnalliset-ominaisuudet": {
+      "tarkenne": null,
+      "lakinumero": null,
+      "asetusnumero": null,
+      "vaikutussuunta": null,
+      "lisatietoja": null,
+      "voimassaolo-alkaa": null,
+      "voimassaolo-paattyy": null
+    },
+    "infranimikkeisto": {
+      "toiminnallinen-jarjestelmakokonaisuus": [],
+      "rakenteellinen-jarjestelmakokonaisuus": [
+        "rakenteellinen-jarjestelmakokonaisuus/rjk03"
+      ]
+    },
+    "kunto-ja-vauriotiedot": {
+      "arvioitu-jaljella-oleva-kayttoika": null,
+      "yleinen-kuntoluokka": "kuntoluokka/kl04",
+      "varustevauriot": []
+    },
+    "rakenteelliset-ominaisuudet": {
+      "tekstikoko": null,
+      "kilven-valaistus": null,
+      "kalvotyyppi": null,
+      "paivaloistekalvo": null,
+      "arvo": null,
+      "kiinnitystapa": null,
+      "tunnus": null,
+      "pinta-ala": 0,
+      "sivutie": null,
+      "lisatyyppi": [
+        "liikennemerkki-lisatyyppi/liility01"
+      ],
+      "yhteydet-muihin-kohteisiin": [],
+      "materiaali": "materiaali/ma02",
+      "suunta": null,
+      "tyyppi": "liikennemerkki-tyyppi/liity06",
+      "koko": null,
+      "korkeusasema": null
+    }
+  },
+  "luotu": "2020-05-08T12:20:15Z",
+  "lahdejarjestelman-id": "506.283640192",
+  "paattyen": null,
+  "sijainti-oid": "1.2.246.578.4.1.2.146265754",
+  "lahdejarjestelma": "lahdejarjestelma/lj01",
+  "schemaversio": 1,
+  "luoja": {
+    "kayttajanimi": "TIERb3320"
+  },
+  "sijaintitarkenne": {
+    "ajoradat": [
+      "ajorata/ajr1"
+    ]
+  },
+  "muokkaaja": {
+    "kayttajanimi": "migraatio"
+  },
+  "oid": "1.2.246.578.4.3.15.506.283640192",
+  "alkaen": "2010-06-16",
+  "muokattu": "2021-03-10T07:57:40Z"
+}

--- a/test/resurssit/velho/varusteet/seka-asetus-etta-lakinumero.json
+++ b/test/resurssit/velho/varusteet/seka-asetus-etta-lakinumero.json
@@ -1,0 +1,75 @@
+{
+  "kohdeluokka": "varusteet/liikennemerkit",
+  "sijainti": {
+    "osa": 12,
+    "tie": 616,
+    "etaisyys": 2139,
+    "enkoodattu": 61600042824
+  },
+  "version-voimassaolo": {
+    "alku": "2010-06-16",
+    "loppu": "2021-11-16"
+  },
+  "ominaisuudet": {
+    "toiminnalliset-ominaisuudet": {
+      "tarkenne": null,
+      "lakinumero": "liikennemerkki-lakinumero/liilnro209",
+      "asetusnumero": "liikennemerkki-asetusnumero/liiasnro310",
+      "vaikutussuunta": null,
+      "lisatietoja": null,
+      "voimassaolo-alkaa": null,
+      "voimassaolo-paattyy": null
+    },
+    "infranimikkeisto": {
+      "toiminnallinen-jarjestelmakokonaisuus": [],
+      "rakenteellinen-jarjestelmakokonaisuus": [
+        "rakenteellinen-jarjestelmakokonaisuus/rjk03"
+      ]
+    },
+    "kunto-ja-vauriotiedot": {
+      "arvioitu-jaljella-oleva-kayttoika": null,
+      "yleinen-kuntoluokka": "kuntoluokka/kl04",
+      "varustevauriot": []
+    },
+    "rakenteelliset-ominaisuudet": {
+      "tekstikoko": null,
+      "kilven-valaistus": null,
+      "kalvotyyppi": null,
+      "paivaloistekalvo": null,
+      "arvo": null,
+      "kiinnitystapa": null,
+      "tunnus": null,
+      "pinta-ala": 0,
+      "sivutie": null,
+      "lisatyyppi": [
+        "liikennemerkki-lisatyyppi/liility01"
+      ],
+      "yhteydet-muihin-kohteisiin": [],
+      "materiaali": "materiaali/ma02",
+      "suunta": null,
+      "tyyppi": "liikennemerkki-tyyppi/liity06",
+      "koko": null,
+      "korkeusasema": null
+    }
+  },
+  "luotu": "2020-05-08T12:20:15Z",
+  "lahdejarjestelman-id": "506.283640192",
+  "paattyen": null,
+  "sijainti-oid": "1.2.246.578.4.1.2.146265754",
+  "lahdejarjestelma": "lahdejarjestelma/lj01",
+  "schemaversio": 1,
+  "luoja": {
+    "kayttajanimi": "TIERb3320"
+  },
+  "sijaintitarkenne": {
+    "ajoradat": [
+      "ajorata/ajr1"
+    ]
+  },
+  "muokkaaja": {
+    "kayttajanimi": "migraatio"
+  },
+  "oid": "1.2.246.578.4.3.15.506.283640192",
+  "alkaen": "2010-06-16",
+  "muokattu": "2021-03-10T07:57:40Z"
+}


### PR DESCRIPTION
Asetusnumero on vanhan tieliikennelain mukainen liikennemerkin määrittävä tieto.
Uudessa tieliikennelaissa määritellyt liikennemerkit käyttävät lakinumero nimistä kenttää.
Jos molemmat on annettu laitetaan lisätietoon "VIRHE: Liikennemerkillä sekä asetusnumero että lakinumero Tievelhossa"
Jos molemmat ovat null laitetaan lisätiedoksi "VIRHE: Liikennemerkin asetusnumero ja lakinumero tyhjiä Tievelhossa".