### PR TITLE
VHAR-6391 Korjaa varusteiden asetusten skeema

### DIFF
--- a/src/clj/harja/palvelin/asetukset.clj
+++ b/src/clj/harja/palvelin/asetukset.clj
@@ -148,7 +148,9 @@
                             :salasana s/Str
                             :varuste-api-juuri-url s/Str
                             :varuste-kayttajatunnus s/Str
-                            :varuste-salasana s/Str}
+                            :varuste-salasana s/Str
+                            :varuste-urakka-oid-url s/Str
+                            :varuste-urakka-kohteet-url s/Str}
 
    (s/optional-key :yha-velho) {}
 


### PR DESCRIPTION
`ERROR [harja.palvelin.main:833] - Validointivirhe asetuksissa: {:velho {:varuste-urakka-oid-url disallowed-key, :varuste-urakka-kohteet-url disallowed-key},`