### PR TITLE
VHAR-6393 Korjaa varusteiden integraatiossa partition haussa liian aikaisin katkeava haku

### DIFF
--- a/src/clj/harja/palvelin/integraatiot/velho/varusteet.clj
+++ b/src/clj/harja/palvelin/integraatiot/velho/varusteet.clj
@@ -362,10 +362,10 @@
                                     +kohde-haku-maksimi-koko+
                                     nil
                                     oidit)
-                  kaikki-onnistunut (every? #(hae-kohdetiedot-ja-tallenna-kohde lahde varuste-api-juuri konteksti token-fn
-                                                                               % tallenna-fn tallenna-virhe-fn)
-                                            oidit-alijoukot)]
-              (if kaikki-onnistunut
+                  tulokset (map #(hae-kohdetiedot-ja-tallenna-kohde lahde varuste-api-juuri konteksti token-fn
+                                                                       % tallenna-fn tallenna-virhe-fn)
+                                   oidit-alijoukot)]
+              (if (every? true? tulokset)
                 (do
                   (tallenna-hakuaika-fn haku-alkanut)
                   true)


### PR DESCRIPTION
Partitioiden toteutuksessa haettaessa kohteita on väärin käytetty every? predikaattia ja haku keskeytyy ensimmäiseen virheeseen.

`kaikki-onnistunut (every? 
                                    #(hae-kohdetiedot-ja-tallenna-kohde lahde varuste-api-juuri konteksti token-fn
                                                                                                          % tallenna-fn tallenna-virhe-fn) 
                                    oidit-alijoukot)]`

Kaikkien kohteiden käsittelemiseksi ei saa käyttää short-circuit every? predikaattia, vaan pitää ensin mapilla tehdä kaikki haut ja sitten every?:lla katsoa tuliko yksikin virhe.