### PR TITLE
VHAR-6398 Tuhaterottimet ympäristöraporttiin

### DIFF
--- a/src/clj/harja/palvelin/raportointi/excel.clj
+++ b/src/clj/harja/palvelin/raportointi/excel.clj
@@ -76,15 +76,9 @@
                         nil
                         [:kustomi desimaalien-maara]))])
 
-(defmethod muodosta-solu :erotus-ja-prosentti [[_ {:keys [arvo prosentti desimaalien-maara lihavoi? korosta? 
+(defmethod muodosta-solu :erotus [[_ {:keys [arvo prosentti desimaalien-maara lihavoi? korosta?
                                                           korosta-hennosti? ala-korosta? varoitus?]}] solun-tyyli]
-  (let [etuliite (cond
-                   (neg? arvo) "- "
-                   (zero? arvo) ""
-                   :else "+ ")
-        arvo (Math/abs (float arvo))
-        prosentti (Math/abs (float prosentti))
-        oletustyyli (raportti-domain/solun-oletustyyli-excel lihavoi? korosta? korosta-hennosti?)
+  (let [oletustyyli (raportti-domain/solun-oletustyyli-excel lihavoi? korosta? korosta-hennosti?)
         solun-tyyli (if-not (empty? solun-tyyli)
                       solun-tyyli
                       oletustyyli)
@@ -96,10 +90,7 @@
                         {:background :red
                          :font {:color :white}})
                       solun-tyyli)]
-    [(str etuliite
-       (cond desimaalien-maara (fmt/desimaaliluku-opt arvo desimaalien-maara)
-             :else arvo)
-       (when prosentti (str " (" etuliite (fmt/prosentti-opt prosentti) ")"))) solun-tyyli]))
+    [arvo solun-tyyli]))
 
 ;; Säädä yksittäisestä solusta haluttu. Solun tyyli saadaan raporttielementilla esim. näin:
 ;; [:arvo-ja-yksikko-korostettu {:arvo yht :korosta-hennosti? true :yksikko "%" :desimaalien-maara 2}]

--- a/src/clj/harja/palvelin/raportointi/excel.clj
+++ b/src/clj/harja/palvelin/raportointi/excel.clj
@@ -76,9 +76,15 @@
                         nil
                         [:kustomi desimaalien-maara]))])
 
-(defmethod muodosta-solu :erotus [[_ {:keys [arvo prosentti desimaalien-maara lihavoi? korosta?
+(defmethod muodosta-solu :erotus-ja-prosentti [[_ {:keys [arvo prosentti desimaalien-maara lihavoi? korosta?
                                                           korosta-hennosti? ala-korosta? varoitus?]}] solun-tyyli]
-  (let [oletustyyli (raportti-domain/solun-oletustyyli-excel lihavoi? korosta? korosta-hennosti?)
+  (let [etuliite (cond
+                   (neg? arvo) "- "
+                   (zero? arvo) ""
+                   :else "+ ")
+        arvo (Math/abs (float arvo))
+        prosentti (Math/abs (float prosentti))
+        oletustyyli (raportti-domain/solun-oletustyyli-excel lihavoi? korosta? korosta-hennosti?)
         solun-tyyli (if-not (empty? solun-tyyli)
                       solun-tyyli
                       oletustyyli)
@@ -90,7 +96,10 @@
                         {:background :red
                          :font {:color :white}})
                       solun-tyyli)]
-    [arvo solun-tyyli]))
+    [(str etuliite
+       (cond desimaalien-maara (fmt/desimaaliluku-opt arvo desimaalien-maara)
+             :else arvo)
+       (when prosentti (str " (" etuliite (fmt/prosentti-opt prosentti) ")"))) solun-tyyli]))
 
 ;; Säädä yksittäisestä solusta haluttu. Solun tyyli saadaan raporttielementilla esim. näin:
 ;; [:arvo-ja-yksikko-korostettu {:arvo yht :korosta-hennosti? true :yksikko "%" :desimaalien-maara 2}]

--- a/src/clj/harja/palvelin/raportointi/pdf.clj
+++ b/src/clj/harja/palvelin/raportointi/pdf.clj
@@ -69,18 +69,18 @@
 
 ;; Toimii tismalleen samoin, kuin :arvo-ja-yksikko, mutta tämän avulla
 ;; PDF:lle saadaan yksittäisille soluille korostuksia
-(defmethod muodosta-pdf :arvo-ja-yksikko-korostettu [[_ {:keys [arvo yksikko fmt desimaalien-maara]}]]
+(defmethod muodosta-pdf :arvo-ja-yksikko-korostettu [[_ {:keys [arvo yksikko fmt desimaalien-maara ryhmitelty?]}]]
   [:fo:inline
    [:fo:inline (cond
-                 desimaalien-maara (fmt/desimaaliluku-opt arvo desimaalien-maara)
+                 desimaalien-maara (fmt/desimaaliluku-opt arvo desimaalien-maara ryhmitelty?)
                  fmt (fmt arvo)
                  :else arvo)]
    [:fo:inline (str "\u00A0" yksikko)]])
 
-(defmethod muodosta-pdf :arvo-ja-yksikko [[_ {:keys [arvo yksikko fmt desimaalien-maara]}]]
+(defmethod muodosta-pdf :arvo-ja-yksikko [[_ {:keys [arvo yksikko fmt desimaalien-maara ryhmitelty?]}]]
   [:fo:inline
    [:fo:inline (cond
-                 desimaalien-maara (fmt/desimaaliluku-opt arvo desimaalien-maara)
+                 desimaalien-maara (fmt/desimaaliluku-opt arvo desimaalien-maara ryhmitelty?)
                  fmt (fmt arvo)
                  :else arvo)]
    [:fo:inline (str "\u00A0" yksikko)]])
@@ -101,19 +101,17 @@
 (defmethod muodosta-pdf :infopallura [_]
   nil)
 
-(defmethod muodosta-pdf :erotus-ja-prosentti [[_ {:keys [arvo prosentti desimaalien-maara]}]]
+(defmethod muodosta-pdf :erotus [[_ {:keys [arvo prosentti desimaalien-maara ryhmitelty?]}]]
   (let [etuliite (cond
                    (neg? arvo) "-\u00A0"  
                    (zero? arvo) ""
                    :else "+\u00A0")
-        arvo (Math/abs (float arvo))
-        prosentti (Math/abs (float prosentti))]
+        arvo (Math/abs (float arvo))]
     [:fo:inline
      [:fo:inline (str etuliite
                    (cond
-                     desimaalien-maara (fmt/desimaaliluku-opt arvo desimaalien-maara)
-                     :else arvo))]
-     [:fo:inline (str "\n" "(" etuliite (fmt/prosentti-opt prosentti) ")")]]))
+                     desimaalien-maara (fmt/desimaaliluku-opt arvo desimaalien-maara ryhmitelty?)
+                     :else arvo))]]))
 
 (def alareuna
   {:border-bottom reunan-tyyli})

--- a/src/clj/harja/palvelin/raportointi/pdf.clj
+++ b/src/clj/harja/palvelin/raportointi/pdf.clj
@@ -101,17 +101,19 @@
 (defmethod muodosta-pdf :infopallura [_]
   nil)
 
-(defmethod muodosta-pdf :erotus [[_ {:keys [arvo prosentti desimaalien-maara ryhmitelty?]}]]
+(defmethod muodosta-pdf :erotus-ja-prosentti [[_ {:keys [arvo prosentti desimaalien-maara  ryhmitelty?]}]]
   (let [etuliite (cond
                    (neg? arvo) "-\u00A0"  
                    (zero? arvo) ""
                    :else "+\u00A0")
-        arvo (Math/abs (float arvo))]
+        arvo (Math/abs (float arvo))
+        prosentti (Math/abs (float prosentti))]
     [:fo:inline
      [:fo:inline (str etuliite
                    (cond
-                     desimaalien-maara (fmt/desimaaliluku-opt arvo desimaalien-maara ryhmitelty?)
-                     :else arvo))]]))
+                     desimaalien-maara (fmt/desimaaliluku-opt arvo desimaalien-maara  ryhmitelty?)
+                     :else arvo))]
+     [:fo:inline (str "\n" "(" etuliite (fmt/prosentti-opt prosentti) ")")]]))
 
 (def alareuna
   {:border-bottom reunan-tyyli})

--- a/src/clj/harja/palvelin/raportointi/raportit/ymparisto.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/ymparisto.clj
@@ -132,7 +132,8 @@
                                     (if yksikot-soluissa?
                                       [:arvo-ja-yksikko {:arvo (reduce + (keep :maara rivit))
                                                          :yksikko (:yksikko materiaali)
-                                                         :desimaalien-maara 2}]
+                                                         :desimaalien-maara 2
+                                                         :ryhmitelty? true}]
                                       (reduce + (keep :maara rivit)))))
                   {} kk-rivit))
 
@@ -171,7 +172,7 @@
 
 (def poikkeama-info
   [:p [:b "Poikkeamalla "] "tarkoitetaan hoitoluokille kohdistettujen materiaalimäärien ja urakoitsijan 
-ilmoittaman kokonaismateriaalimäärän erotusta.\n\nPoikkeamaa on yleensä aina jonkin verran (+/- x %), sillä
+ilmoittaman kokonaismateriaalimäärän erotusta.\n\nPoikkeamaa on yleensä aina jonkin verran (+/- x), sillä
 reittitiedot ja kokonaismateriaalimäärät raportoidaan eri tavalla."])
 
 (def hoitoluokka-puuttuu-info
@@ -268,10 +269,10 @@ reittitiedot ja kokonaismateriaalimäärät raportoidaan eri tavalla."])
                                                prosentti (if (zero? kk-arvo)
                                                            0
                                                            (with-precision 2 (* 100 (/ erotus kk-arvo))))]
-                                           {kk [:erotus-ja-prosentti
+                                           {kk [:erotus
                                                 {:arvo erotus
-                                                 :prosentti prosentti
                                                  :desimaalien-maara 2
+                                                 :ryhmitelty? true
                                                  :varoitus? (< poikkeama-varoitus-raja (Math/abs (float prosentti)))}]}))
                                     (group-by :kk luokitellut)))
               yhteenvetorivi? (:yht-rivi materiaali)
@@ -282,10 +283,12 @@ reittitiedot ja kokonaismateriaalimäärät raportoidaan eri tavalla."])
                                       [:arvo-ja-yksikko-korostettu {:arvo yht
                                                                     :korosta-hennosti? true
                                                                     :yksikko (:yksikko materiaali)
-                                                                    :desimaalien-maara 2}]
+                                                                    :desimaalien-maara 2
+                                                                    :ryhmitelty? true}]
                                       [:arvo-ja-yksikko-korostettu {:arvo yht
                                                                     :korosta-hennosti? true
-                                                                    :desimaalien-maara 2}]))))
+                                                                    :desimaalien-maara 2
+                                                                    :ryhmitelty? true}]))))
               toteuma-prosentti (when (and kk-arvot (not (zero? (or suunniteltu 0))))
                                   (/ (* 100.0 kk-arvot-yht) suunniteltu))]
           (concat
@@ -319,23 +322,27 @@ reittitiedot ja kokonaismateriaalimäärät raportoidaan eri tavalla."])
                                                              :yksikko nil
                                                              :desimaalien-maara 2
                                                              :lihavoi? false
-                                                             :ala-korosta? true}]
+                                                             :ala-korosta? true
+                                                             :ryhmitelty? true}]
                                [:arvo-ja-yksikko-korostettu {:arvo suunniteltu
                                                              :yksikko (when suunniteltu (:yksikko materiaali))
                                                              :desimaalien-maara 2
                                                              :lihavoi? false
-                                                             :ala-korosta? true}])
+                                                             :ala-korosta? true
+                                                             :ryhmitelty? true}])
                              (if (nil? toteuma-prosentti)
                                [:arvo-ja-yksikko-korostettu {:arvo nil
                                                              :yksikko nil
                                                              :desimaalien-maara 2
                                                              :varoitus? (< 100 (or toteuma-prosentti 0))
-                                                             :ala-korosta? true}]
+                                                             :ala-korosta? true
+                                                             :ryhmitelty? true}]
                                [:arvo-ja-yksikko-korostettu {:arvo toteuma-prosentti
                                                              :yksikko (when suunniteltu "%")
                                                              :desimaalien-maara 2
                                                              :varoitus? (< 100 (or toteuma-prosentti 0))
-                                                             :ala-korosta? true}])]
+                                                             :ala-korosta? true
+                                                             :ryhmitelty? true}])]
                             [(yhteensa-kentta (vals kk-arvot) true)])))})]
 
             ;; Mahdolliset hoitoluokkakohtaiset rivit - Hoitoluokat ovat valmiina vain talvisuolalle ja formiaateille
@@ -351,7 +358,8 @@ reittitiedot ja kokonaismateriaalimäärät raportoidaan eri tavalla."])
                                              (map (juxt :kk #(if yksikot-soluissa?
                                                                [:arvo-ja-yksikko {:arvo (:maara %)
                                                                                   :yksikko (:yksikko materiaali)
-                                                                                  :desimaalien-maara 2}]
+                                                                                  :desimaalien-maara 2
+                                                                                  :ryhmitelty? true}]
                                                                (:maara %))))
                                              rivit)]
                               {:lihavoi? false
@@ -395,13 +403,11 @@ reittitiedot ja kokonaismateriaalimäärät raportoidaan eri tavalla."])
 
                             (let [arvo (yhteensa-arvo (vals poikkeamat))]
                               (concat
-                                [[:erotus-ja-prosentti
+                                [[:erotus
                                   {:arvo arvo
-                                   :prosentti (if (zero? kk-arvot-yht)
-                                                0
-                                                (with-precision 2 (* 100 (/ arvo kk-arvot-yht))))
                                    :desimaalien-maara 2
-                                   :korosta-hennosti? true}]]
+                                   :korosta-hennosti? true
+                                   :ryhmitelty? true}]]
                                 (when nayta-suunnittelu? [nil nil])))))}])))))
      osamateriaalit)]))
 

--- a/src/clj/harja/palvelin/raportointi/raportit/ymparisto.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/ymparisto.clj
@@ -172,7 +172,7 @@
 
 (def poikkeama-info
   [:p [:b "Poikkeamalla "] "tarkoitetaan hoitoluokille kohdistettujen materiaalimäärien ja urakoitsijan 
-ilmoittaman kokonaismateriaalimäärän erotusta.\n\nPoikkeamaa on yleensä aina jonkin verran (+/- x), sillä
+ilmoittaman kokonaismateriaalimäärän erotusta.\n\nPoikkeamaa on yleensä aina jonkin verran, sillä
 reittitiedot ja kokonaismateriaalimäärät raportoidaan eri tavalla."])
 
 (def hoitoluokka-puuttuu-info
@@ -269,8 +269,9 @@ reittitiedot ja kokonaismateriaalimäärät raportoidaan eri tavalla."])
                                                prosentti (if (zero? kk-arvo)
                                                            0
                                                            (with-precision 2 (* 100 (/ erotus kk-arvo))))]
-                                           {kk [:erotus
+                                           {kk [:erotus-ja-prosentti
                                                 {:arvo erotus
+                                                 :prosentti prosentti
                                                  :desimaalien-maara 2
                                                  :ryhmitelty? true
                                                  :varoitus? (< poikkeama-varoitus-raja (Math/abs (float prosentti)))}]}))
@@ -403,8 +404,11 @@ reittitiedot ja kokonaismateriaalimäärät raportoidaan eri tavalla."])
 
                             (let [arvo (yhteensa-arvo (vals poikkeamat))]
                               (concat
-                                [[:erotus
+                                [[:erotus-ja-prosentti
                                   {:arvo arvo
+                                   :prosentti (if (zero? kk-arvot-yht)
+                                                0
+                                                (with-precision 2 (* 100 (/ arvo kk-arvot-yht))))
                                    :desimaalien-maara 2
                                    :korosta-hennosti? true
                                    :ryhmitelty? true}]]

--- a/src/cljc/harja/domain/hoitoluokat.cljc
+++ b/src/cljc/harja/domain/hoitoluokat.cljc
@@ -19,7 +19,7 @@ talvihoitoluokat
    {:nimi "L"  :numero 8 :numero-str "8"} ; 1.10.2019 alkaen käyttöön kentällä. On jo tierekisterissä 14.6.2018 alkaen ja talvihoitoluokat-geom.aineistossa.
    {:nimi "K1"  :numero 9 :numero-str "9"}
    {:nimi "K2"  :numero 10 :numero-str "10"}
-   {:nimi "Ei talvihoitoa" :numero 11 :numero-str "11"}
+   {:nimi "K (ei talvihoitoa)" :numero 11 :numero-str "11"}
    {:nimi "Käsin kirjattu" :numero 99 :numero-str "99"}
    {:nimi ei-talvihoitoluokkaa-nimi :numero 100 :numero-str "100"}])
 

--- a/src/cljs/harja/ui/raportti.cljs
+++ b/src/cljs/harja/ui/raportti.cljs
@@ -47,18 +47,18 @@
 ;; Tavallisesti raportin solujen tyylit tulevat rivitasolta ja HTML raporteissa yksittäisen solun tyyli annetaan luokka
 ;; määritteessä (:sarakkeen-luokka). Niinpä tämän elementin ainoa olemassaolon syy on se, että tätä vaaditaan PDF ja Excelraportoissa.
 ;; Tämä on siis identtinen :arvo-ja-yksikkö elementin kanssa, mutta sallii raportin toiminnan.
-(defmethod muodosta-html :arvo-ja-yksikko-korostettu [[_ {:keys [arvo yksikko fmt desimaalien-maara]}]]
+(defmethod muodosta-html :arvo-ja-yksikko-korostettu [[_ {:keys [arvo yksikko fmt desimaalien-maara ryhmitelty?]}]]
   [:span.arvo-ja-yksikko
    [:span.arvo (cond
-                 desimaalien-maara (fmt/desimaaliluku-opt arvo desimaalien-maara)
+                 desimaalien-maara (fmt/desimaaliluku-opt arvo desimaalien-maara ryhmitelty?)
                  fmt (fmt arvo)
                  :else arvo)]
    [:span.yksikko (str "\u00A0" yksikko)]])
 
-(defmethod muodosta-html :arvo-ja-yksikko [[_ {:keys [arvo yksikko fmt desimaalien-maara]}]]
+(defmethod muodosta-html :arvo-ja-yksikko [[_ {:keys [arvo yksikko fmt desimaalien-maara ryhmitelty?]}]]
   [:span.arvo-ja-yksikko
    [:span.arvo (cond
-                 desimaalien-maara (fmt/desimaaliluku-opt arvo desimaalien-maara)
+                 desimaalien-maara (fmt/desimaaliluku-opt arvo desimaalien-maara ryhmitelty?)
                  fmt (fmt arvo)
                  :else arvo)]
    [:span.yksikko (str "\u00A0" yksikko)]])
@@ -68,20 +68,16 @@
    [:span.arvo arvo]
    [:div.selite.small-caption selite]])
 
-(defmethod muodosta-html :erotus-ja-prosentti [[_ {:keys [arvo prosentti desimaalien-maara]}]]
+(defmethod muodosta-html :erotus [[_ {:keys [arvo prosentti desimaalien-maara ryhmitelty?]}]]
   (let [etuliite (cond
                    (neg? arvo) "- "
                    (zero? arvo) ""
                    :else "+ ")
-        arvo (Math/abs arvo)
-        prosentti (Math/abs prosentti)]
+        arvo (Math/abs arvo)]
     [:span.erotus-ja-prosentti
      [:span.arvo (str etuliite (cond
-                                 desimaalien-maara (fmt/desimaaliluku-opt arvo desimaalien-maara)
-                                 :else arvo))]
-     [:div.selite.small-caption
-      {:style {:text-align :inherit}}
-      (str "(" etuliite (fmt/prosentti-opt prosentti) ")")]]))
+                                 desimaalien-maara (fmt/desimaaliluku-opt arvo desimaalien-maara ryhmitelty?)
+                                 :else arvo))]]))
 
 (defmethod muodosta-html :teksti-ja-info [[_ {:keys [arvo info]}]]
   [:span.teksti-ja-info [:span.arvo (str arvo "\u00A0")]

--- a/src/cljs/harja/ui/raportti.cljs
+++ b/src/cljs/harja/ui/raportti.cljs
@@ -68,16 +68,20 @@
    [:span.arvo arvo]
    [:div.selite.small-caption selite]])
 
-(defmethod muodosta-html :erotus [[_ {:keys [arvo prosentti desimaalien-maara ryhmitelty?]}]]
+(defmethod muodosta-html :erotus-ja-prosentti [[_ {:keys [arvo prosentti desimaalien-maara ryhmitelty?]}]]
   (let [etuliite (cond
                    (neg? arvo) "- "
                    (zero? arvo) ""
                    :else "+ ")
-        arvo (Math/abs arvo)]
+        arvo (Math/abs arvo)
+        prosentti (Math/abs prosentti)]
     [:span.erotus-ja-prosentti
      [:span.arvo (str etuliite (cond
                                  desimaalien-maara (fmt/desimaaliluku-opt arvo desimaalien-maara ryhmitelty?)
-                                 :else arvo))]]))
+                                 :else arvo))]
+     [:div.selite.small-caption
+      {:style {:text-align :inherit}}
+      (str "(" etuliite (fmt/prosentti-opt prosentti) ")")]]))
 
 (defmethod muodosta-html :teksti-ja-info [[_ {:keys [arvo info]}]]
   [:span.teksti-ja-info [:span.arvo (str arvo "\u00A0")]


### PR DESCRIPTION
Pakota tuhat erottimet yhteensä ja suunnittelu riveille ympäristöraportissa

Muuta erotusrivi stringistä numeroksi

Poista sulkeissa oleva prosenttirivi poikkeamariviltä.

Muuta "Ei talvihoitoa" Talvihoitoryhmän nimi K (ei talvihoitoa)