### PR TITLE
VHAR-6381 Korjataan VarustetapahtumaUI:n ulkoasua

### DIFF
--- a/dev-resources/less/yleiset.less
+++ b/dev-resources/less/yleiset.less
@@ -503,6 +503,9 @@ button > .ajax-loader {
       margin-top: 5px
     }
   }
+  &.alasveto-erotin {
+    border-top: 1px solid @harmaa-tumma;
+  }
 }
 
 .tila-ympyra(@vari: @green-dark) {

--- a/dev-resources/less/yleiset.less
+++ b/dev-resources/less/yleiset.less
@@ -473,7 +473,7 @@ button > .ajax-loader {
       }
     }
     .otsikko {
-      color: @harmaa-tumma;
+      color: @black-light;
       font-weight: normal;
       margin-bottom: 5px
     }
@@ -498,13 +498,13 @@ button > .ajax-loader {
     .ala-otsikko {
       padding-left: 7px;
       padding-right: 7px;
-      color: @harmaa-tumma;
+      color: @black-light;
       font-weight: normal;
       margin-top: 5px
     }
   }
   &.alasveto-erotin {
-    border-top: 1px solid @harmaa-tumma;
+    border-top: 1px solid @black-light;
   }
 }
 

--- a/src/cljs/harja/views/urakka/toteumat/velho_varusteet.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/velho_varusteet.cljs
@@ -84,7 +84,7 @@
      [debug app {:otsikko "TUCK STATE"}]
      [:div.row.filtterit-container {:style {:height "100px"}}
       [yleiset/pudotusvalikko "Hoitovuosi"
-       {:wrap-luokka "col-md-2 filtteri label-ja-alasveto-grid"
+       {:wrap-luokka "col-md-1 filtteri label-ja-alasveto-grid"
         :valinta hoitokauden-alkuvuosi
         :vayla-tyyli? true
         :data-cy "hoitokausi-valinta"

--- a/src/cljs/harja/views/urakka/toteumat/velho_varusteet.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/velho_varusteet.cljs
@@ -84,7 +84,7 @@
      [debug app {:otsikko "TUCK STATE"}]
      [:div.row.filtterit-container {:style {:height "100px"}}
       [yleiset/pudotusvalikko "Hoitovuosi"
-       {:wrap-luokka "col-md-1 filtteri label-ja-alasveto-grid"
+       {:wrap-luokka "col-md-2 filtteri label-ja-alasveto-grid"
         :valinta hoitokauden-alkuvuosi
         :vayla-tyyli? true
         :data-cy "hoitokausi-valinta"

--- a/src/cljs/harja/views/urakka/toteumat/velho_varusteet.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/velho_varusteet.cljs
@@ -131,7 +131,9 @@
        {:wrap-luokka "col-md-2 filtteri label-ja-alasveto-grid"
         :vayla-tyyli? true
         :fmt itse-tai-kaikki
-        :valintojen-maara (count (:varustetyypit valinnat))}]
+        :valintojen-maara (count (:varustetyypit valinnat))
+        :li-luokka-fn (fn [valinta]
+                        (when (= "Aidat" (:teksti (second valinta))) "varusteet alasveto-erotin"))}]
       [valinnat/monivalinta-pudotusvalikko
        "Kuntoluokitus"
        kuntoluokat

--- a/src/cljs/harja/views/urakka/toteumat/velho_varusteet.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/velho_varusteet.cljs
@@ -214,7 +214,7 @@
       (fn [e! varuste toteumat]
         [:div.varustelomake {:on-click #(.stopPropagation %)}
          [lomake/lomake
-          {:luokka " overlay-oikealla"
+          {:luokka " overlay-oikealla overlay-leveampi"
            :otsikko-komp (fn [_]
                            [:span
                             [:div.lomake-otsikko-pieni (:ulkoinen-oid varuste)]])


### PR DESCRIPTION
- ~Kavenna Hoitovuosi filteri~ - Valittiin sittenkin leveämpi kenttä tälle.
- Varustetoimenpiteiden "suosituiden" ja aakkosjärjestyksen väliin paksumpi viiva
- Varustetoimenpiteiden haussa varusteiden modaali: leveydeksi 600px