### PR TITLE
Toteumat / Pohjavesialueiden suola ym. asiaan liittyvät muutokset

### DIFF
--- a/dev-resources/less/pages/toteumat.less
+++ b/dev-resources/less/pages/toteumat.less
@@ -35,5 +35,9 @@
         padding: 1rem 0 0.5rem 1rem !important;
       }
     }
+
+    .sarake-pohjavesialueet {
+      white-space: nowrap;
+    }
   }
 }

--- a/dev-resources/less/pages/toteumat.less
+++ b/dev-resources/less/pages/toteumat.less
@@ -19,7 +19,18 @@
 
 .pohjavesialueiden-suola {
   .taulukon-kontrollit {
+    display: flex;
+    flex-flow: row;
+    gap: 1rem;
+    width: fit-content;
     margin-bottom: 2rem;
+    justify-content: center;
+    align-items: end;
+
+    .nappi-hae-toteumat {
+      height: min-content;
+      margin-bottom: 5px;
+    }
   }
 
   div.livi-grid-reunaviiva {

--- a/dev-resources/less/pages/toteumat.less
+++ b/dev-resources/less/pages/toteumat.less
@@ -1,3 +1,5 @@
+@import "../vayla/colors";
+
 .kustannuserotus-positiivinen {
   color: @onnistuminen;
 }
@@ -38,6 +40,22 @@
 
     .sarake-pohjavesialueet {
       white-space: nowrap;
+    }
+
+    // Solujen sisäiset korostukset
+    // Asetetaan käyttöliittymäkoodissa solun luokaksi
+    td, th {
+      &.rajoitus-ylitetty {
+        > div {
+          display: inline-block;
+          width: fit-content;
+          padding: 0.1rem 0.75rem;
+          border-radius: 4px;
+          background-color: @red-light;
+          color: @red-darker;
+          font-weight: 600;
+        }
+      }
     }
   }
 }

--- a/dev-resources/less/pages/toteumat.less
+++ b/dev-resources/less/pages/toteumat.less
@@ -24,6 +24,16 @@
     border-left: 3px solid #0066CC;
     padding-left: 1rem;
     // Säädetään left-marginia siten, että viiva asettuu sopivasti aiemman rivin vatolaatikon avausikonin keskikohtaan.
-    margin-left: 5px;
+    margin-left: 8px;
+  }
+
+  .livi-grid {
+    tr.vetolaatikko-auki {
+      padding: 1rem 0 0.5rem 1rem;
+
+      > td {
+        padding: 1rem 0 0.5rem 1rem !important;
+      }
+    }
   }
 }

--- a/dev-resources/less/pages/toteumat.less
+++ b/dev-resources/less/pages/toteumat.less
@@ -18,7 +18,8 @@
 .pohjavesialueiden-suola {
   div.livi-grid-reunaviiva {
     border-left: 3px solid #0066CC;
-    padding-left: 16px;
+    padding-left: 1rem;
+    // Säädetään left-marginia siten, että viiva asettuu sopivasti aiemman rivin vatolaatikon avausikonin keskikohtaan.
     margin-left: 5px;
   }
 }

--- a/dev-resources/less/pages/toteumat.less
+++ b/dev-resources/less/pages/toteumat.less
@@ -16,6 +16,10 @@
 
 
 .pohjavesialueiden-suola {
+  .taulukon-kontrollit {
+    margin-bottom: 2rem;
+  }
+
   div.livi-grid-reunaviiva {
     border-left: 3px solid #0066CC;
     padding-left: 1rem;

--- a/dev-resources/less/pages/toteumat.less
+++ b/dev-resources/less/pages/toteumat.less
@@ -13,3 +13,12 @@
 .materiaalierotus-negatiivinen {
   color: @vaara;
 }
+
+
+.pohjavesialueiden-suola {
+  div.livi-grid-reunaviiva {
+    border-left: 3px solid #0066CC;
+    padding-left: 16px;
+    margin-left: 5px;
+  }
+}

--- a/src/cljs/harja/tiedot/urakka/toteumat/suola.cljs
+++ b/src/cljs/harja/tiedot/urakka/toteumat/suola.cljs
@@ -127,11 +127,11 @@
                     :let 2837}
         :pituus 4854
         :pituus_ajoradat 4857
-        :pohjavesialueet [{:nimi "Hanko" :tunnus "107801"}]
+        :pohjavesialueet [{:nimi "Hanko" :tunnus "107801"} {:nimi "Sandö-Grönvik" :tunnus "107803"}]
         :suolankayttoraja 6.6
         :kaytettava-formaattia? false
         :formiaatit_t_per_ajoratakm nil
-        :talvisuola_t_per_ajoratakm 0.002}
+        :talvisuola_t_per_ajoratakm 1.077}
        {:id 1
         :tr-osoite {:tie 104
                     :aosa 2
@@ -144,7 +144,20 @@
         :suolankayttoraja 1.0
         :kaytettava-formaattia? true
         :formiaatit_t_per_ajoratakm 0.002
-        :talvisuola_t_per_ajoratakm 0.457}]))
+        :talvisuola_t_per_ajoratakm 0.457}
+       {:id 2
+        :tr-osoite {:tie 116
+                    :aosa 1
+                    :aet 590
+                    :losa 1
+                    :let 3508}
+        :pituus 1548
+        :pituus_ajoradat 1548
+        :pohjavesialueet [{:nimi "Lohjanharju" :tunnus "142851 B"}]
+        :suolankayttoraja 0.0
+        :kaytettava-formaattia? true
+        :formiaatit_t_per_ajoratakm nil
+        :talvisuola_t_per_ajoratakm 0.221}]))
 
 ;; TODO: Tarvitaan palvelu rajoitusalueen toteumien summatietojen hakemiseen. Feikataan data nyt tässä.
 (defn hae-rajoitusalueen-toteumien-summatiedot [rajoitusalue-id]
@@ -152,25 +165,54 @@
   ;; TODO: Ks. esimerkiksi kyselyt/materiaalit.sql "hae-suolatoteumien-summatiedot"
   #_(k/post! :hae-rajoitusalueen-toteumien-summatiedot {:urakka-id urakka-id})
 
-
-  (go [{:id 0 ;; tai uniikki "rivinumero"
-        :pvm (pvm/nyt)
-        :maara-t 4.234
-        :materiaali-nimi "Talvisuola, rakeinen NaCl"
-        :materiaali-id 7
-        :toteuma-lkm 2
-        ;; Toteuma-idt tarvitaan, jotta voidaan hakea tarkemmat toteumatiedot, jos käyttöliittymässä klikataan auki
-        ;; summatietorivin vetolaatikko (joka sisältää siihen liittyvät toteumat)
-        :toteuma-idt [0 1]
-        :koneellinen? true}
-       {:id 1 ;; tai uniikki "rivinumero"
-        :pvm (pvm/nyt)
-        :maara-t 1.001
-        :materiaali-nimi "Talvisuolaliuos NaCl"
-        :materiaali-id 1
-        :toteuma-lkm 2
-        :toteuma-idt [2 3]
-        :koneellinen? true}]))
+  ;; Feikkaa rajoitusalueen id:llä haku.
+  (go (vec (remove nil? [(when (#{0} rajoitusalue-id)
+                           {:id 0 ;; tai uniikki "rivinumero"
+                            :pvm (pvm/nyt)
+                            :maara-t 4.234
+                            :materiaali-nimi "Talvisuola, rakeinen NaCl"
+                            :materiaali-id 7
+                            :toteuma-lkm 2
+                            ;; Toteuma-idt tarvitaan, jotta voidaan hakea tarkemmat toteumatiedot, jos käyttöliittymässä klikataan auki
+                            ;; summatietorivin vetolaatikko (joka sisältää siihen liittyvät toteumat)
+                            :toteuma-idt [0 1]
+                            :koneellinen? true})
+                         (when (#{0} rajoitusalue-id)
+                           {:id 1 ;; tai uniikki "rivinumero"
+                            :pvm (pvm/nyt)
+                            :maara-t 1.001
+                            :materiaali-nimi "Talvisuolaliuos NaCl"
+                            :materiaali-id 1
+                            :toteuma-lkm 2
+                            :toteuma-idt [2 3]
+                            :koneellinen? true})
+                         (when (#{1} rajoitusalue-id)
+                           {:id 2 ;; tai uniikki "rivinumero"
+                            :pvm (pvm/nyt)
+                            :maara-t 0.707
+                            :materiaali-nimi "Talvisuola, rakeinen NaCl"
+                            :materiaali-id 7
+                            :toteuma-lkm 1
+                            :toteuma-idt [4]
+                            :koneellinen? true})
+                         (when (#{1} rajoitusalue-id)
+                           {:id 3 ;; tai uniikki "rivinumero"
+                            :pvm (pvm/nyt)
+                            :maara-t 0.00309
+                            :materiaali-nimi "Natriumformiaatti"
+                            :materiaali-id 16
+                            :toteuma-lkm 1
+                            :toteuma-idt [5]
+                            :koneellinen? true})
+                         (when (#{2} rajoitusalue-id)
+                           {:id 4 ;; tai uniikki "rivinumero"
+                            :pvm (pvm/nyt)
+                            :maara-t 0.342108
+                            :materiaali-nimi "Talvisuolaliuos NaCl"
+                            :materiaali-id 1
+                            :toteuma-lkm 1
+                            :toteuma-idt [6]
+                            :koneellinen? true})]))))
 
 
 ;; TODO: Tarvitaan palvelu hae-rajoitusalueen-suolatoteumat. Feikataan data nyt tässä.
@@ -206,6 +248,27 @@
           :alkanut (pvm/nyt)
           :paattynyt (pvm/nyt)
           :maara-t 0.599
+          :materiaali-nimi "Talvisuolaliuos NaCl"
+          :materiaali-id 1
+          :lisatieto "rdm40"}
+         {:id 4
+          :alkanut (pvm/nyt)
+          :paattynyt (pvm/nyt)
+          :maara-t 0.707
+          :materiaali-nimi "Talvisuolaliuos NaCl"
+          :materiaali-id 1
+          :lisatieto "rdm40"}
+         {:id 5
+          :alkanut (pvm/nyt)
+          :paattynyt (pvm/nyt)
+          :maara-t 0.00309
+          :materiaali-nimi "Natriumformiaatti"
+          :materiaali-id 16
+          :lisatieto "rdm40"}
+         {:id 6
+          :alkanut (pvm/nyt)
+          :paattynyt (pvm/nyt)
+          :maara-t 0.221
           :materiaali-nimi "Talvisuolaliuos NaCl"
           :materiaali-id 1
           :lisatieto "rdm40"}])))

--- a/src/cljs/harja/tiedot/urakka/toteumat/suola.cljs
+++ b/src/cljs/harja/tiedot/urakka/toteumat/suola.cljs
@@ -268,7 +268,7 @@
          {:id 6
           :alkanut (pvm/nyt)
           :paattynyt (pvm/nyt)
-          :maara-t 0.221
+          :maara-t 0.342108
           :materiaali-nimi "Talvisuolaliuos NaCl"
           :materiaali-id 1
           :lisatieto "rdm40"}])))

--- a/src/cljs/harja/tiedot/urakka/toteumat/suola.cljs
+++ b/src/cljs/harja/tiedot/urakka/toteumat/suola.cljs
@@ -115,7 +115,8 @@
   #_(k/post! :hae-urakan-rajoitusalueet {:urakka-id urakka-id})
 
 
-  (go [{:tr-osoite {:tie 25
+  (go [{:id 0
+        :tr-osoite {:tie 25
                     :aosa 2
                     :aet 200
                     :losa 3
@@ -127,7 +128,8 @@
         :kaytettava-formaattia? false
         :formiaatit_t_per_ajoratakm nil
         :talvisuola_t_per_ajoratakm 0.002}
-       {:tr-osoite {:tie 104
+       {:id 1
+        :tr-osoite {:tie 104
                     :aosa 2
                     :aet 1882
                     :losa 2

--- a/src/cljs/harja/tiedot/urakka/toteumat/suola.cljs
+++ b/src/cljs/harja/tiedot/urakka/toteumat/suola.cljs
@@ -16,6 +16,8 @@
 
 (defonce urakan-pohjavesialueet (atom nil))
 
+(defonce urakan-rajoitusalueet (atom nil))
+
 (defonce suolatoteumissa? (atom false))
 
 (defonce suodatin-valinnat (atom {:suola "Kaikki"}))
@@ -105,6 +107,39 @@
   (k/post! :hae-pohjavesialueen-suolatoteuma {:pohjavesialue pohjavesialue
                                               :alkupvm alkupvm
                                               :loppupvm loppupvm}))
+
+
+;; TODO: Tarvitaan palvelu rajoitusalueille. Feikataan data nyt tässä.
+(defn hae-urakan-rajoitusalueet [urakka-id]
+  {:pre [(int? urakka-id)]}
+  #_(k/post! :hae-urakan-rajoitusalueet {:urakka-id urakka-id})
+
+
+  (go [{:tr-osoite {:tie 25
+                    :aosa 2
+                    :aet 200
+                    :losa 3
+                    :let 2837}
+        :pituus 4854
+        :pituus_ajoradat 4857
+        :pohjavesialueet [{:nimi "Hanko" :tunnus "107801"}]
+        :suolankayttoraja 6.6
+        :kaytettava-formaattia? false
+        :formiaatit_t_per_ajoratakm nil
+        :talvisuola_t_per_ajoratakm 0.002}
+       {:tr-osoite {:tie 104
+                    :aosa 2
+                    :aet 1882
+                    :losa 2
+                    :let 3430}
+        :pituus 1548
+        :pituus_ajoradat 1548
+        :pohjavesialueet [{:nimi "Manibacka" :tunnus "160607"}]
+        :suolankayttoraja 1.0
+        :kaytettava-formaattia? true
+        :formiaatit_t_per_ajoratakm 0.002
+        :talvisuola_t_per_ajoratakm 0.457}]))
+
 
 (defn poista-valituista-suolatoteumista [toteumat]
   (reset! valitut-toteumat

--- a/src/cljs/harja/tiedot/urakka/toteumat/suola.cljs
+++ b/src/cljs/harja/tiedot/urakka/toteumat/suola.cljs
@@ -2,7 +2,7 @@
   "Tämän nimiavaruuden avulla voidaan hakea urakan suola- ja lämpötilatietoja."
   (:require [reagent.core :refer [atom] :as r]
             [harja.asiakas.kommunikaatio :as k]
-            [cljs.core.async :refer [<! >! chan]]
+            [cljs.core.async :refer [<! >! chan close!]]
             [harja.loki :refer [log logt tarkkaile!]]
             [harja.pvm :as pvm]
             [harja.atom :refer-macros [reaction<!]]
@@ -119,7 +119,12 @@
   #_(k/post! :hae-urakan-rajoitusalueet {:urakka-id urakka-id})
 
 
-  (go [{:id 0
+  (go
+    ;; Simuloi latausaikaa
+    (<! (let [c (chan)]
+          (js/setTimeout (fn [] (close! c)) 1000)
+          c))
+    [{:id 0
         :tr-osoite {:tie 25
                     :aosa 2
                     :aet 200
@@ -166,7 +171,12 @@
   #_(k/post! :hae-rajoitusalueen-toteumien-summatiedot {:urakka-id urakka-id})
 
   ;; Feikkaa rajoitusalueen id:llä haku.
-  (go (vec (remove nil? [(when (#{0} rajoitusalue-id)
+  (go
+    ;; Simuloi latausaikaa
+    (<! (let [c (chan)]
+          (js/setTimeout (fn [] (close! c)) 1000)
+          c))
+    (vec (remove nil? [(when (#{0} rajoitusalue-id)
                            {:id 0 ;; tai uniikki "rivinumero"
                             :pvm (pvm/nyt)
                             :maara-t 4.234
@@ -222,7 +232,12 @@
 
 
   ;; Feikataan toteuma-id:llä haku
-  (go (filterv #((set toteuma-idt) (:id %))
+  (go
+    ;; Simuloi latausaikaa
+    (<! (let [c (chan)]
+          (js/setTimeout (fn [] (close! c)) 2000)
+          c))
+    (filterv #((set toteuma-idt) (:id %))
         [{:id 0
           :alkanut (pvm/nyt)
           :paattynyt (pvm/nyt)

--- a/src/cljs/harja/tiedot/urakka/toteumat/suola.cljs
+++ b/src/cljs/harja/tiedot/urakka/toteumat/suola.cljs
@@ -18,6 +18,9 @@
 
 (defonce urakan-rajoitusalueet (atom nil))
 
+(defonce urakan-rajoitusalueiden-summatiedot (atom {}))
+(defonce urakan-rajoitusalueiden-toteumat (atom {}))
+
 (defonce suolatoteumissa? (atom false))
 
 (defonce suodatin-valinnat (atom {:suola "Kaikki"}))
@@ -84,8 +87,6 @@
                yksittaiset-toteumat))
         #(constantly false)))))
 
-(defonce pohjavesialueen-toteuma (atom nil))
-
 (defn eriteltavat-toteumat [toteumat]
   (map #(hash-map :tid (:tid %)) toteumat))
 
@@ -99,10 +100,13 @@
                 (concat @valitut-toteumat
                         (eriteltavat-toteumat toteumat)))))
 
+
+;; FIXME: Vanha implementaatio (poista)
 (defn hae-urakan-pohjavesialueet [urakka-id]
   {:pre [(int? urakka-id)]}
   (k/post! :hae-urakan-pohjavesialueet {:urakka-id urakka-id}))
 
+;; FIXME: Vanha implementaatio (poista)
 (defn hae-pohjavesialueen-suolatoteuma [pohjavesialue [alkupvm loppupvm]]
   (k/post! :hae-pohjavesialueen-suolatoteuma {:pohjavesialue pohjavesialue
                                               :alkupvm alkupvm
@@ -141,6 +145,72 @@
         :kaytettava-formaattia? true
         :formiaatit_t_per_ajoratakm 0.002
         :talvisuola_t_per_ajoratakm 0.457}]))
+
+;; TODO: Tarvitaan palvelu rajoitusalueen toteumien summatietojen hakemiseen. Feikataan data nyt tässä.
+(defn hae-rajoitusalueen-toteumien-summatiedot [rajoitusalue-id]
+  {:pre [(int? rajoitusalue-id)]}
+  ;; TODO: Ks. esimerkiksi kyselyt/materiaalit.sql "hae-suolatoteumien-summatiedot"
+  #_(k/post! :hae-rajoitusalueen-toteumien-summatiedot {:urakka-id urakka-id})
+
+
+  (go [{:id 0 ;; tai uniikki "rivinumero"
+        :pvm (pvm/nyt)
+        :maara-t 4.234
+        :materiaali-nimi "Talvisuola, rakeinen NaCl"
+        :materiaali-id 7
+        :toteuma-lkm 2
+        ;; Toteuma-idt tarvitaan, jotta voidaan hakea tarkemmat toteumatiedot, jos käyttöliittymässä klikataan auki
+        ;; summatietorivin vetolaatikko (joka sisältää siihen liittyvät toteumat)
+        :toteuma-idt [0 1]
+        :koneellinen? true}
+       {:id 1 ;; tai uniikki "rivinumero"
+        :pvm (pvm/nyt)
+        :maara-t 1.001
+        :materiaali-nimi "Talvisuolaliuos NaCl"
+        :materiaali-id 1
+        :toteuma-lkm 2
+        :toteuma-idt [2 3]
+        :koneellinen? true}]))
+
+
+;; TODO: Tarvitaan palvelu hae-rajoitusalueen-suolatoteumat. Feikataan data nyt tässä.
+(defn hae-rajoitusalueen-suolatoteumat [toteuma-idt]
+  {:pre [(seq toteuma-idt)]}
+  #_(k/post! :hae-rajoitusalueen-suolatoteumat {:toteuma-idt toteuma-idt})
+
+
+  ;; Feikataan toteuma-id:llä haku
+  (go (filterv #((set toteuma-idt) (:id %))
+        [{:id 0
+          :alkanut (pvm/nyt)
+          :paattynyt (pvm/nyt)
+          :maara-t 2.232
+          :materiaali-nimi "Talvisuola, rakeinen NaCl"
+          :materiaali-id 7
+          :lisatieto "rdm40"}
+         {:id 1
+          :alkanut (pvm/nyt)
+          :paattynyt (pvm/nyt)
+          :maara-t 2.000
+          :materiaali-nimi "Talvisuola, rakeinen NaCl"
+          :materiaali-id 7
+          :lisatieto "rdm40"}
+         {:id 2
+          :alkanut (pvm/nyt)
+          :paattynyt (pvm/nyt)
+          :maara-t 0.402
+          :materiaali-nimi "Talvisuolaliuos NaCl"
+          :materiaali-id 1
+          :lisatieto "rdm40"}
+         {:id 3
+          :alkanut (pvm/nyt)
+          :paattynyt (pvm/nyt)
+          :maara-t 0.599
+          :materiaali-nimi "Talvisuolaliuos NaCl"
+          :materiaali-id 1
+          :lisatieto "rdm40"}])))
+
+;; ------
 
 
 (defn poista-valituista-suolatoteumista [toteumat]

--- a/src/cljs/harja/views/urakka/toteumat.cljs
+++ b/src/cljs/harja/views/urakka/toteumat.cljs
@@ -67,7 +67,7 @@
                     (#{:hoito :teiden-hoito} (:tyyppi ur)))
            [suolatoteumat])
 
-         "Pohjavesialueet" :pohjavesialueet
+         "Pohjavesialueiden suola" :pohjavesialueiden-suola
          (when (and (oikeudet/urakat-toteumat-suola id)
                     (#{:hoito :teiden-hoito} (:tyyppi ur)))
            [pohjavesialueen-suola])

--- a/src/cljs/harja/views/urakka/toteumat.cljs
+++ b/src/cljs/harja/views/urakka/toteumat.cljs
@@ -10,9 +10,10 @@
             [harja.views.urakka.toteumat.maarien-toteuma-lomake :as akilliset-htyot]
             [harja.views.urakka.toteumat.erilliskustannukset :as erilliskustannukset]
             [harja.views.urakka.toteumat.maarien-toteumat :as maarien-toteumat-nakyma]
-            [harja.views.urakka.toteumat.materiaalit :refer [materiaalit-nakyma]]
+            [harja.views.urakka.toteumat.muut-materiaalit :refer [muut-materiaalit-nakyma]]
             [harja.views.urakka.toteumat.varusteet :as varusteet]
-            [harja.views.urakka.toteumat.suola :refer [suolatoteumat pohjavesialueen-suola]]
+            [harja.views.urakka.toteumat.talvisuola :refer [talvisuolatoteumat]]
+            [harja.views.urakka.toteumat.pohjavesialueiden-suola :as pohjavesialueiden-suola]
             [harja.views.urakka.toteumat.velho-varusteet :as velho-varusteet]
             [harja.ui.lomake :refer [lomake]]
             [harja.loki :refer [log logt]]
@@ -62,19 +63,19 @@
                     (not mhu-urakka?))
            [muut-tyot/muut-tyot-toteumat ur])
 
-         "Suola" :suola
+         "Talvisuola" :talvisuola
          (when (and (oikeudet/urakat-toteumat-suola id)
                     (#{:hoito :teiden-hoito} (:tyyppi ur)))
-           [suolatoteumat])
+           [talvisuolatoteumat])
 
          "Pohjavesialueiden suola" :pohjavesialueiden-suola
          (when (and (oikeudet/urakat-toteumat-suola id)
                     (#{:hoito :teiden-hoito} (:tyyppi ur)))
-           [pohjavesialueen-suola])
+           [pohjavesialueiden-suola/pohjavesialueiden-suola])
 
-         "Materiaalit" :materiaalit
+         "Muut materiaalit" :muut-materiaalit
          (when (oikeudet/urakat-toteumat-materiaalit id)
-           [materiaalit-nakyma ur])
+           [muut-materiaalit-nakyma ur])
 
          "Erilliskustannukset" :erilliskustannukset
          (when (oikeudet/urakat-toteumat-erilliskustannukset id)

--- a/src/cljs/harja/views/urakka/toteumat/muut_materiaalit.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/muut_materiaalit.cljs
@@ -1,4 +1,4 @@
-(ns harja.views.urakka.toteumat.materiaalit
+(ns harja.views.urakka.toteumat.muut-materiaalit
   (:require [harja.views.urakka.valinnat :as valinnat]
             [reagent.core :refer [atom wrap]]
             [harja.loki :refer [log]]
@@ -360,7 +360,7 @@ rivi on poistettu, poistetaan vastaava rivi toteumariveistä."
 
     (sort-by (comp :nimi :materiaali) @urakan-materiaalin-kaytot)]])
 
-(defn materiaalit-nakyma [ur]
+(defn muut-materiaalit-nakyma [ur]
   (komp/luo
     (komp/lippu materiaali-tiedot/materiaalinakymassa?)
     (fn [ur]

--- a/src/cljs/harja/views/urakka/toteumat/pohjavesialueiden_suola.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/pohjavesialueiden_suola.cljs
@@ -75,7 +75,7 @@
          [{:tyyppi :vetolaatikon-tila :leveys 0.18}
           {:otsikko "Päivämäärä" :hae :pvm :tyyppi :pvm :fmt pvm/pvm-opt :leveys 0.8}
           {:otsikko "Materiaali" :nimi :materiaali-nimi :leveys 1}
-          {:otsikko "Käytetty määrä (t)" :nimi :maara-t :fmt #(if % (fmt/pyorista-ehka-kolmeen %) "-")
+          {:otsikko "Käytetty määrä (t)" :nimi :maara-t :fmt #(if % (fmt/pyorista-ehka-kolmeen %) "–")
            :tasaa :oikea :leveys 1}
           {:otsikko "Toteumia" :nimi :toteuma-lkm :tasaa :oikea :leveys 1}
           {:otsikko "Lisätieto" :nimi :koneellinen? :fmt #(when % "Koneellisesti raportoitu") :leveys 1}]
@@ -121,11 +121,15 @@
     {:otsikko "Pituus ajoradat (m)" :nimi :pituus_ajoradat :fmt fmt/pyorista-ehka-kolmeen
      :tasaa :oikea :leveys 1}
     {:otsikko "Formiaatit (t/ajoratakm)" :nimi :formiaatit_t_per_ajoratakm
-     :fmt #(if % (fmt/pyorista-ehka-kolmeen %) "-") :tasaa :oikea :leveys 1}
+     :fmt #(if % (fmt/pyorista-ehka-kolmeen %) "–") :tasaa :oikea :leveys 1}
     {:otsikko "Talvisuola (t/ajoratakm)" :nimi :talvisuola_t_per_ajoratakm
-     :fmt #(if % (fmt/pyorista-ehka-kolmeen %) "-") :tasaa :oikea :leveys 1}
+     :fmt #(if % (fmt/pyorista-ehka-kolmeen %) "–")
+     :solun-luokka (fn [arvo rivi]
+                     (when (> arvo (:suolankayttoraja rivi))
+                       "rajoitus-ylitetty"))
+     :tasaa :oikea :leveys 1}
     {:otsikko "Suolankäyttöraja (t/ajoratakm)" :nimi :suolankayttoraja :tasaa :oikea
-     :fmt #(if % (fmt/desimaaliluku % 1) "-") :leveys 1}
+     :fmt #(if % (fmt/desimaaliluku % 1) "–") :leveys 1}
     {:otsikko "" :nimi :kaytettava-formaattia? :fmt #(when % "Käytettävä formaattia") :leveys 1}]
    rajoitusalueet])
 

--- a/src/cljs/harja/views/urakka/toteumat/pohjavesialueiden_suola.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/pohjavesialueiden_suola.cljs
@@ -103,7 +103,7 @@
      :fmt (fn [tr-osoite]
             (str
               (str (:aosa tr-osoite) " / " (:aet tr-osoite))
-              " – 3 "
+              " – "
               (str (:losa tr-osoite) " / " (:let tr-osoite))))
      :leveys 1}
     {:otsikko "Pohjavesialue (tunnus)" :nimi :pohjavesialueet

--- a/src/cljs/harja/views/urakka/toteumat/pohjavesialueiden_suola.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/pohjavesialueiden_suola.cljs
@@ -1,0 +1,259 @@
+(ns harja.views.urakka.toteumat.pohjavesialueiden-suola
+  "Suolankäytön toteumat hoidon alueurakoissa"
+  (:require [reagent.core :refer [atom wrap]]
+            [harja.tiedot.urakka :as tiedot-urakka]
+            [harja.tiedot.urakka.toteumat.suola :as tiedot]
+            [harja.tiedot.navigaatio :as nav]
+            [harja.ui.komponentti :as komp]
+            [harja.ui.grid :as grid]
+            [harja.ui.yleiset :as yleiset]
+            [harja.ui.valinnat :as ui-valinnat]
+            [harja.pvm :as pvm]
+            [harja.views.kartta.pohjavesialueet :as pohjavesialueet]
+            [harja.views.urakka.valinnat :as urakka-valinnat]
+            [harja.loki :refer [log logt]]
+            [harja.atom :refer [paivita!]]
+            [cljs.core.async :refer [<! >!]]
+            [harja.views.kartta :as kartta]
+            [harja.domain.oikeudet :as oikeudet]
+            [harja.fmt :as fmt]
+            [harja.ui.ikonit :as ikonit]
+            [harja.ui.napit :as napit]
+            [harja.ui.lomake :as lomake]
+            [harja.asiakas.kommunikaatio :as k])
+  (:require-macros [reagent.ratom :refer [reaction]]
+                   [harja.atom :refer [reaction<!]]
+                   [cljs.core.async.macros :refer [go]]))
+
+(defn nayta-toteumat-kartalla [toteumat]
+  (nav/vaihda-kartan-koko! :L)
+  (tiedot/valitse-suolatoteumat toteumat))
+
+(defn piilota-toteumat-kartalla [toteumat]
+  (tiedot/poista-valituista-suolatoteumista toteumat))
+
+(defn suolankayton-paivan-erittely [suolan-kaytto]
+  [grid/grid
+   {:otsikko "Päivän toteumat"
+    :tyhja "Ei päivän toteumia"
+    :tunniste :tid}
+   [{:otsikko "Alkanut" :nimi :alkanut :tyyppi :pvm-aika :fmt pvm/pvm-aika :leveys 10}
+    {:otsikko "Päättynyt" :nimi :paattynyt :tyyppi :pvm-aika :fmt pvm/pvm-aika :leveys 10}
+    {:otsikko "Määrä" :nimi :maara :tyyppi :positiivinen-numero
+     :fmt #(fmt/desimaaliluku-opt % 3) :desimaalien-maara 3 :leveys 10}
+    {:otsikko ""
+     :nimi :nayta-kartalla
+     :tyyppi :komponentti
+     :leveys 7
+     :komponentti (fn [toteuma]
+                    [:div
+                     [(if (tiedot/valittu-suolatoteuma? toteuma)
+                        :button.nappi-toissijainen.nappi-grid
+                        :button.nappi-ensisijainen.nappi-grid)
+                      {:on-click #(if (tiedot/valittu-suolatoteuma? toteuma)
+                                    (piilota-toteumat-kartalla [toteuma])
+                                    (nayta-toteumat-kartalla [toteuma]))}
+                      (ikonit/ikoni-ja-teksti
+                        (ikonit/map-marker)
+                        (if (tiedot/valittu-suolatoteuma? toteuma)
+                          "Piilota kartalta"
+                          "Näytä kartalla"))]])}]
+   suolan-kaytto])
+
+(defn vetolaatikon-suolarivit [rivi urakka]
+  (let [vetolaatikon-rivit (atom nil)]
+    (go
+      (reset! vetolaatikon-rivit
+              (<! (k/post! :hae-suolatoteumien-tarkat-tiedot {:toteumaidt (:toteumaidt rivi)
+                                                              :materiaali-id (get-in rivi [:materiaali :id])
+                                                              :urakka-id (:id urakka)}))))
+    (fn [rivi urakka]
+      [suolankayton-paivan-erittely @vetolaatikon-rivit])))
+
+(defonce tallennetaan (atom false))
+
+(defn suolatoteumat-taulukko [muokattava? urakka sopimus-id listaus materiaali-nimet kaytetty-yhteensa]
+  [:div.suolatoteumat
+   [kartta/kartan-paikka]
+   [:span.valinnat
+    [urakka-valinnat/aikavali-nykypvm-taakse urakka
+     tiedot/valittu-aikavali
+     {:aikavalin-rajoitus [12 :kuukausi]}]
+    [ui-valinnat/materiaali-valikko {:valittu-materiaali (:suola @tiedot/suodatin-valinnat)
+                                     :otsikko "Suola"
+                                     :valitse-fn #(swap! tiedot/suodatin-valinnat assoc :suola %)
+                                     :lisaa-kaikki? true
+                                     :materiaalit materiaali-nimet}]]
+
+   [lomake/lomake
+    {:otsikko "Hae suolatoteumia tieosoiteväliltä"
+     :muokkaa! #(reset! tiedot/ui-lomakkeen-tila %)
+     :footer-fn (fn [rivi]
+                  [:div
+                   [napit/yleinen-toissijainen "Hae"
+                    (fn []
+                                        ; aiheuta tiedot/toteumat -reaktio
+                      (reset! tiedot/lomakkeen-tila {:tierekisteriosoite (:tierekisteriosoite @tiedot/ui-lomakkeen-tila)
+                                                     :refresh (inc (:refresh @tiedot/lomakkeen-tila))}))
+                    {:ikoni (ikonit/livicon-search)}]
+                   [napit/yleinen-toissijainen "Tyhjennä tieosoiteväli"
+                    (fn []
+                      (reset! tiedot/lomakkeen-tila nil)
+                      (reset! tiedot/ui-lomakkeen-tila nil))]])
+     :ei-borderia? true}
+    [{:nimi :tierekisteriosoite
+      :otsikko "Tierekisteriosoite"
+      :tyyppi :tierekisteriosoite
+      :tyyli :rivitetty
+      :sijainti (atom nil)
+      :vaadi-vali? true}]
+    @tiedot/ui-lomakkeen-tila]
+
+   [grid/grid {:otsikko "Talvisuolan käyttö"
+               :tunniste :rivinumero
+               :tallenna (if (oikeudet/voi-kirjoittaa?
+                               oikeudet/urakat-toteumat-suola
+                               (:id @nav/valittu-urakka))
+                           #(go (if-let [tulos (<! (tiedot/tallenna-toteumat (:id urakka) sopimus-id %))]
+                                  (paivita! tiedot/toteumat)))
+                           :ei-mahdollinen)
+               :tallennus-ei-mahdollinen-tooltip (oikeudet/oikeuden-puute-kuvaus :kirjoitus oikeudet/urakat-toteumat-suola)
+               :tyhja (if (nil? @tiedot/toteumat)
+                        [yleiset/ajax-loader "Suolatoteumia haetaan..."]
+                        "Ei suolatoteumia valitulle aikavälille")
+               :uusi-rivi #(assoc % :pvm (pvm/nyt))
+               :voi-poistaa? muokattava?
+               :max-rivimaara 500
+               :max-rivimaaran-ylitys-viesti "Yli 500 suolatoteumaa. Rajoita hakuehtoja."
+               :vetolaatikot (into {}
+                                   (map (juxt :rivinumero (fn [rivi]
+                                                            [vetolaatikon-suolarivit rivi urakka])))
+                                   @tiedot/toteumat)
+               :piilota-toiminnot? true}
+    [{:tyyppi :vetolaatikon-tila :leveys 3}
+     {:otsikko "Suola\u00ADtyyppi" :nimi :materiaali :fmt :nimi :leveys 30 :muokattava? muokattava?
+      :tyyppi :valinta
+      :validoi [[:ei-tyhja "Valitse materiaali"]]
+      :valinta-nayta #(or (:nimi %) "- valitse -")
+      :valinnat @tiedot/materiaalit}
+     {:otsikko "Pvm" :nimi :pvm :fmt pvm/pvm-opt :tyyppi :pvm :leveys 30 :muokattava? muokattava?
+      :validoi [[:ei-tyhja "Anna päivämäärä"]]
+      :huomauta [[:valitun-kkn-aikana-urakan-hoitokaudella]]}
+     {:otsikko "Käytetty määrä (t)" :nimi :maara :fmt #(fmt/desimaaliluku-opt % 3)
+      :tyyppi :positiivinen-numero :desimaalien-maara 3 :leveys 30 :muokattava? muokattava?
+      :validoi [[:ei-tyhja "Anna määrä"]] :tasaa :oikea}
+     {:otsikko "Lisätieto" :nimi :lisatieto :tyyppi :string :leveys 60 :muokattava? muokattava?
+      :hae #(if (muokattava? %)
+              (:lisatieto %)
+              (str (:lisatieto %) " (Koneellisesti raportoitu, toteumia: "
+                   (:lukumaara %) ")"))}
+     {:otsikko ""
+      :nimi :nayta-kartalla
+      :tyyppi :komponentti
+      :leveys 40
+      :komponentti (fn [rivi]
+                     (let [toteumat (map (fn [tid]
+                                           {:tid tid})
+                                         (:toteumaidt rivi))
+                           valittu? #(some (fn [toteuma] (tiedot/valittu-suolatoteuma? toteuma)) toteumat)]
+                       (when (and (not (empty? toteumat))
+                                  (:koneellinen rivi))
+                         [:div
+                          [(if (valittu?)
+                             :button.nappi-toissijainen.nappi-grid
+                             :button.nappi-ensisijainen.nappi-grid)
+                           {:on-click #(if (valittu?)
+                                         (piilota-toteumat-kartalla toteumat)
+                                         (nayta-toteumat-kartalla toteumat))}
+                           (ikonit/ikoni-ja-teksti
+                            (ikonit/map-marker)
+                            (if (valittu?)
+                              "Piilota kartalta"
+                              "Näytä kartalla"))]])))}]
+    listaus]
+   (when-not (empty? @tiedot/toteumat)
+     [:div.bold kaytetty-yhteensa])
+   [yleiset/vihje yleiset/rajapinnan-kautta-lisattyja-ei-voi-muokata]])
+
+(defn pohjavesialueiden-suola []
+  (komp/luo
+   (komp/sisaan
+    (fn []
+      (let [urakkaid @nav/valittu-urakka-id]
+        (go
+          (reset! tiedot/pohjavesialueen-toteuma nil)
+          (reset! tiedot/urakan-pohjavesialueet (<! (tiedot/hae-urakan-pohjavesialueet urakkaid)))))))
+   (fn []
+     (let [alueet @tiedot/urakan-pohjavesialueet
+           urakka @nav/valittu-urakka]
+       [:div
+        [urakka-valinnat/aikavali-nykypvm-taakse urakka
+         tiedot/valittu-aikavali
+         {:aikavalin-rajoitus [12 :kuukausi]}]
+        [grid/grid {:otsikko "Urakan pohjavesialueet"
+                    :tunniste :tunnus
+                    :mahdollista-rivin-valinta? true
+                    :rivi-valinta-peruttu (fn [rivi]
+                                            (reset! tiedot/pohjavesialueen-toteuma nil))
+                    :rivi-klikattu
+                    (fn [rivi]
+                      (go
+                        (reset! tiedot/pohjavesialueen-toteuma
+                                (<! (tiedot/hae-pohjavesialueen-suolatoteuma (:tunnus rivi) @tiedot/valittu-aikavali)))))
+                         
+                    :tyhjä (if (nil? @tiedot/urakan-pohjavesialueet)
+                             [yleiset/ajax-loader "Pohjavesialueita haetaan..."]
+                             "Ei pohjavesialueita")}
+         [{:otsikko "Tunnus" :nimi :tunnus :leveys 1}
+          {:otsikko "Nimi" :nimi :nimi :leveys 3}]
+         alueet]
+        (let [toteuma @tiedot/pohjavesialueen-toteuma]
+          (when toteuma
+            [grid/grid
+             {:otsikko "Pohjavesialueen suolatoteuma"
+              :tunniste :maara_t_per_km
+              :piilota-toiminnot? true
+              :tyhja (if (empty? toteuma)
+                       "Ei tietoja")
+              }
+             [{:otsikko "Pohjavesialueen pituus (km)"
+               :nimi :pituus
+               :fmt #(fmt/desimaaliluku-opt % 1)
+               :leveys 10}
+              {:otsikko "Määrä t/km"
+               :nimi :maara_t_per_km
+               :fmt #(fmt/desimaaliluku-opt % 1)
+               :leveys 10}
+              {:otsikko "Määrä yhteensä"
+               :leveys 10
+               :fmt #(fmt/desimaaliluku-opt % 1)
+               :nimi :yhteensa}
+              {:otsikko "Käyttöraja"
+               :leveys 10
+               :nimi :kayttoraja}]
+             toteuma]))]))))
+
+(defn suolatoteumat []
+  (komp/luo
+    (komp/lippu tiedot/suolatoteumissa?
+                pohjavesialueet/karttataso-pohjavesialueet
+                tiedot-urakka/aseta-kuluva-kk-jos-hoitokaudella?
+                tiedot/karttataso-suolatoteumat)
+    (fn []
+      (let [urakka @nav/valittu-urakka
+            [sopimus-id _] @tiedot-urakka/valittu-sopimusnumero
+            muokattava? (comp not true? :koneellinen)
+            listaus (filter (fn [{{nimi :nimi} :materiaali}]
+                              (or (= (:suola @tiedot/suodatin-valinnat) "Kaikki")
+                                  (= (:suola @tiedot/suodatin-valinnat) nimi)))
+                            @tiedot/toteumat)
+            materiaali-nimet (distinct (map #(let [{{nimi :nimi} :materiaali} %]
+                                               nimi)
+                                            @tiedot/toteumat))
+            kaytetty-yhteensa (str "Käytetty yhteensä: " (fmt/desimaaliluku-opt (reduce + (keep :maara listaus))) "t")]
+        (suolatoteumat-taulukko muokattava?
+                                urakka
+                                sopimus-id
+                                listaus
+                                materiaali-nimet
+                                kaytetty-yhteensa)))))

--- a/src/cljs/harja/views/urakka/toteumat/pohjavesialueiden_suola.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/pohjavesialueiden_suola.cljs
@@ -16,39 +16,36 @@
 
 
 (defn vetolaatikko-taso-2 [rajoitusalueet]
-  [:div {:style {:display "flex"}}
-   [:div {:style {:width "3px"
-                  :height "auto"
-                  :margin-left "5px" ;; Manuaalinen säätö, jotta sininen viiva menee vatolaatikon avausnapin kanssa samaa linjaa
-                  :border-left "3px solid blue"}}]
-   [:div {:style {:margin-left "1rem"}}
-    [grid/grid {:tunniste (fn [rivi]
-                            (str "rajoitusalue_vetolaatikko_taso_2_rivi_" (hash rivi)))
-                :tyhjä (if (nil? @tiedot/urakan-rajoitusalueet)
-                         [yleiset/ajax-loader "Rajoitusalueita haetaan..."]
-                         "Ei Rajoitusalueita")}
-     [{:tyyppi :avattava-rivi :leveys "2%"}
-      {:otsikko "Tie" :tunniste :tie :hae (comp :tie :tr-osoite) :leveys 1}
-      {:otsikko "Osoiteväli" :tunniste :tie :hae :tr-osoite
-       :fmt (fn [tr-osoite]
-              (str
-                (str (:aosa tr-osoite) " / " (:aet tr-osoite))
-                " - "
-                (str (:losa tr-osoite) " / " (:let tr-osoite))))
-       :leveys 1}
-      {:otsikko "Pohjavesialue (tunnus)" :tunniste :pohjavesialueet :hae :pohjavesialueet :leveys 1}
-      {:otsikko "Pituus (m)" :tunniste :pituus :hae :pituus :leveys 1}
-      {:otsikko "Pituus ajoradat (m)" :tunniste :pituus_ajoradat :hae :pituus_ajoradat :leveys 1}
-      {:otsikko "Formiaatit (t/ajoratakm)" :tunniste :formiaatit_t_per_ajoratakm
-       :hae :formiaatit_t_per_ajoratakm :leveys 1}
-      {:otsikko "Talvisuola (t/ajoratakm)" :tunniste :formiaatit_t_per_ajoratakm
-       :hae :formiaatit_t_per_ajoratakm :leveys 1}
-      {:otsikko "Suolankäyttöraja (t/ajoratakm)" :tunniste :suolankayttoraja :hae :suolankayttoraja :leveys 1}
-      {:otsikko "" :tunniste :pituus :hae :kaytettava-formaattia? :fmt #(when % "Käytettävä formaattia") :leveys 1}]
-     rajoitusalueet]]])
+  [grid/grid {:tunniste (fn [rivi]
+                          (str "rajoitusalue_vetolaatikko_taso_2_rivi_" (hash rivi)))
+              :piilota-muokkaus? true
+              :reunaviiva? true
+              :tyhjä (if (nil? @tiedot/urakan-rajoitusalueet)
+                       [yleiset/ajax-loader "Rajoitusalueita haetaan..."]
+                       "Ei Rajoitusalueita")}
+   [{:tyyppi :avattava-rivi :leveys "2%"}
+    {:otsikko "Tie" :tunniste :tie :hae (comp :tie :tr-osoite) :leveys 1}
+    {:otsikko "Osoiteväli" :tunniste :tie :hae :tr-osoite
+     :fmt (fn [tr-osoite]
+            (str
+              (str (:aosa tr-osoite) " / " (:aet tr-osoite))
+              " - "
+              (str (:losa tr-osoite) " / " (:let tr-osoite))))
+     :leveys 1}
+    {:otsikko "Pohjavesialue (tunnus)" :tunniste :pohjavesialueet :hae :pohjavesialueet :leveys 1}
+    {:otsikko "Pituus (m)" :tunniste :pituus :hae :pituus :leveys 1}
+    {:otsikko "Pituus ajoradat (m)" :tunniste :pituus_ajoradat :hae :pituus_ajoradat :leveys 1}
+    {:otsikko "Formiaatit (t/ajoratakm)" :tunniste :formiaatit_t_per_ajoratakm
+     :hae :formiaatit_t_per_ajoratakm :leveys 1}
+    {:otsikko "Talvisuola (t/ajoratakm)" :tunniste :formiaatit_t_per_ajoratakm
+     :hae :formiaatit_t_per_ajoratakm :leveys 1}
+    {:otsikko "Suolankäyttöraja (t/ajoratakm)" :tunniste :suolankayttoraja :hae :suolankayttoraja :leveys 1}
+    {:otsikko "" :tunniste :pituus :hae :kaytettava-formaattia? :fmt #(when % "Käytettävä formaattia") :leveys 1}]
+   rajoitusalueet])
 
 (defn vetolaatikko-taso-1 [rajoitusalueet]
   [grid/grid {:tunniste :id
+              :piilota-muokkaus? true
               :reunaviiva? true
               :vetolaatikot (into {}
                               (map (juxt :id (fn [rivi] [vetolaatikko-taso-2 rajoitusalueet])))
@@ -85,6 +82,7 @@
   vielä tiettyyn suolariviin liittyviin toteutumiin."
   [rajoitusalueet]
   [grid/grid {:tunniste :id
+              :piilota-muokkaus? true
               :ensimmainen-sarake-sticky? true
               #_#_:esta-tiivis-grid? true
               #_#_:samalle-sheetille? true
@@ -128,10 +126,17 @@
         [:div.pohjavesialueiden-suola
          ;; TODO: Yleiskäyttöinen komponentti. Speksissä halutaan erilainen komponentti, jossa on nappula, jolla
          ;;       käynnistetään tietojen hakeminen aikavälin valinnan jälkeen
-         ;; Aikavälivalinta
-         [urakka-valinnat/aikavali-nykypvm-taakse urakka
-          tiedot/valittu-aikavali
-          {:aikavalin-rajoitus [12 :kuukausi]}]
 
-         ;; Rajoitiusalueiden taulukko
+         [:h2 "Pohjavesialueiden suolatoteumat"]
+
+         ;; Aikavälivalinta ja muut kontrollit
+         [:div.taulukon-kontrollit
+          [urakka-valinnat/aikavali-nykypvm-taakse urakka
+           tiedot/valittu-aikavali
+           {:aikavalin-rajoitus [12 :kuukausi]}]]
+
+         ;; TODO: Kartta
+         #_[kartta]
+
+         ;; Rajoitusalueiden taulukko
          [taulukko rajoitusalueet]]))))

--- a/src/cljs/harja/views/urakka/toteumat/pohjavesialueiden_suola.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/pohjavesialueiden_suola.cljs
@@ -9,83 +9,129 @@
             [harja.ui.yleiset :as yleiset]
             [harja.views.urakka.valinnat :as urakka-valinnat]
             [cljs.core.async :refer [<! >!]]
-            [harja.fmt :as fmt]
-            [harja.domain.tierekisteri :as tierekisteri])
+            [harja.fmt :as fmt])
   (:require-macros [reagent.ratom :refer [reaction]]
                    [harja.atom :refer [reaction<!]]
                    [cljs.core.async.macros :refer [go]]))
 
+
+(defn vetolaatikko-taso-2 [rajoitusalueet]
+  [:div {:style {:display "flex"}}
+   [:div {:style {:width "3px"
+                  :height "auto"
+                  :margin-left "5px" ;; Manuaalinen säätö, jotta sininen viiva menee vatolaatikon avausnapin kanssa samaa linjaa
+                  :border-left "3px solid blue"}}]
+   [:div {:style {:margin-left "1rem"}}
+    [grid/grid {:tunniste (fn [rivi]
+                            (str "rajoitusalue_vetolaatikko_taso_2_rivi_" (hash rivi)))
+                :tyhjä (if (nil? @tiedot/urakan-rajoitusalueet)
+                         [yleiset/ajax-loader "Rajoitusalueita haetaan..."]
+                         "Ei Rajoitusalueita")}
+     [{:tyyppi :avattava-rivi :leveys "2%"}
+      {:otsikko "Tie" :tunniste :tie :hae (comp :tie :tr-osoite) :leveys 1}
+      {:otsikko "Osoiteväli" :tunniste :tie :hae :tr-osoite
+       :fmt (fn [tr-osoite]
+              (str
+                (str (:aosa tr-osoite) " / " (:aet tr-osoite))
+                " - "
+                (str (:losa tr-osoite) " / " (:let tr-osoite))))
+       :leveys 1}
+      {:otsikko "Pohjavesialue (tunnus)" :tunniste :pohjavesialueet :hae :pohjavesialueet :leveys 1}
+      {:otsikko "Pituus (m)" :tunniste :pituus :hae :pituus :leveys 1}
+      {:otsikko "Pituus ajoradat (m)" :tunniste :pituus_ajoradat :hae :pituus_ajoradat :leveys 1}
+      {:otsikko "Formiaatit (t/ajoratakm)" :tunniste :formiaatit_t_per_ajoratakm
+       :hae :formiaatit_t_per_ajoratakm :leveys 1}
+      {:otsikko "Talvisuola (t/ajoratakm)" :tunniste :formiaatit_t_per_ajoratakm
+       :hae :formiaatit_t_per_ajoratakm :leveys 1}
+      {:otsikko "Suolankäyttöraja (t/ajoratakm)" :tunniste :suolankayttoraja :hae :suolankayttoraja :leveys 1}
+      {:otsikko "" :tunniste :pituus :hae :kaytettava-formaattia? :fmt #(when % "Käytettävä formaattia") :leveys 1}]
+     rajoitusalueet]]])
+
+(defn vetolaatikko-taso-1 [rajoitusalueet]
+  [grid/grid {:tunniste :id
+              :reunaviiva? true
+              :vetolaatikot (into {}
+                              (map (juxt :id (fn [rivi] [vetolaatikko-taso-2 rajoitusalueet])))
+                              rajoitusalueet)
+              :tyhjä (if (nil? @tiedot/urakan-rajoitusalueet)
+                       [yleiset/ajax-loader "Rajoitusalueita haetaan..."]
+                       "Ei Rajoitusalueita")}
+   [{:tyyppi :vetolaatikon-tila :leveys 0.5}
+    {:otsikko "Tie" :tunniste :tie :hae (comp :tie :tr-osoite) :leveys 0.5}
+    {:otsikko "Osoiteväli" :tunniste :tie :hae :tr-osoite
+     :fmt (fn [tr-osoite]
+            (str
+              (str (:aosa tr-osoite) " / " (:aet tr-osoite))
+              " - "
+              (str (:losa tr-osoite) " / " (:let tr-osoite))))
+     :leveys 1}
+    {:otsikko "Pohjavesialue (tunnus)" :tunniste :pohjavesialueet :hae :pohjavesialueet :leveys 1}
+    {:otsikko "Pituus (m)" :tunniste :pituus :hae :pituus :leveys 1}
+    {:otsikko "Pituus ajoradat (m)" :tunniste :pituus_ajoradat :hae :pituus_ajoradat :leveys 1}
+    {:otsikko "Formiaatit (t/ajoratakm)" :tunniste :formiaatit_t_per_ajoratakm
+     :hae :formiaatit_t_per_ajoratakm :leveys 1}
+    {:otsikko "Talvisuola (t/ajoratakm)" :tunniste :formiaatit_t_per_ajoratakm
+     :hae :formiaatit_t_per_ajoratakm :leveys 1}
+    {:otsikko "Suolankäyttöraja (t/ajoratakm)" :tunniste :suolankayttoraja :hae :suolankayttoraja :leveys 1}
+    {:otsikko "" :tunniste :pituus :hae :kaytettava-formaattia? :fmt #(when % "Käytettävä formaattia") :leveys 1}]
+   rajoitusalueet])
+
+
+
+
+(defn taulukko
+  "Rajoitusalueiden taulukko. Näyttää pääriveillä rajoitusalueiden tietojen yhteenvedot.
+  Määrittelee tason 1 ja 2 vetolaatikot, joista pääsee sukeltamaan rajoitusalueen suolojen käytön yhteenvetoon ja sieltä
+  vielä tiettyyn suolariviin liittyviin toteutumiin."
+  [rajoitusalueet]
+  [grid/grid {:tunniste :id
+              :ensimmainen-sarake-sticky? true
+              #_#_:esta-tiivis-grid? true
+              #_#_:samalle-sheetille? true
+              :vetolaatikot (into {}
+                              (map (juxt :id (fn [rivi] [vetolaatikko-taso-1 rajoitusalueet])))
+                              rajoitusalueet)
+              :tyhjä (if (nil? @tiedot/urakan-rajoitusalueet)
+                       [yleiset/ajax-loader "Rajoitusalueita haetaan..."]
+                       "Ei Rajoitusalueita")}
+   [{:tyyppi :vetolaatikon-tila :leveys 0.5}
+    {:otsikko "Tie" :tunniste :tie :hae (comp :tie :tr-osoite) :leveys 0.5}
+    {:otsikko "Osoiteväli" :tunniste :tie :hae :tr-osoite
+     :fmt (fn [tr-osoite]
+            (str
+              (str (:aosa tr-osoite) " / " (:aet tr-osoite))
+              " - "
+              (str (:losa tr-osoite) " / " (:let tr-osoite))))
+     :leveys 1}
+    {:otsikko "Pohjavesialue (tunnus)" :tunniste :pohjavesialueet :hae :pohjavesialueet :leveys 1}
+    {:otsikko "Pituus (m)" :tunniste :pituus :hae :pituus :leveys 1}
+    {:otsikko "Pituus ajoradat (m)" :tunniste :pituus_ajoradat :hae :pituus_ajoradat :leveys 1}
+    {:otsikko "Formiaatit (t/ajoratakm)" :tunniste :formiaatit_t_per_ajoratakm
+     :hae :formiaatit_t_per_ajoratakm :leveys 1}
+    {:otsikko "Talvisuola (t/ajoratakm)" :tunniste :formiaatit_t_per_ajoratakm
+     :hae :formiaatit_t_per_ajoratakm :leveys 1}
+    {:otsikko "Suolankäyttöraja (t/ajoratakm)" :tunniste :suolankayttoraja :hae :suolankayttoraja :leveys 1}
+    {:otsikko "" :tunniste :pituus :hae :kaytettava-formaattia? :fmt #(when % "Käytettävä formaattia") :leveys 1}]
+   rajoitusalueet])
+
 (defn pohjavesialueiden-suola []
   (komp/luo
-   (komp/sisaan
+    (komp/sisaan
+      (fn []
+        (let [urakkaid @nav/valittu-urakka-id]
+          (go
+            (reset! tiedot/pohjavesialueen-toteuma nil)
+            (reset! tiedot/urakan-rajoitusalueet (<! (tiedot/hae-urakan-rajoitusalueet urakkaid)))))))
     (fn []
-      (let [urakkaid @nav/valittu-urakka-id]
-        (go
-          (reset! tiedot/pohjavesialueen-toteuma nil)
-          (reset! tiedot/urakan-rajoitusalueet (<! (tiedot/hae-urakan-rajoitusalueet urakkaid)))))))
-   (fn []
-     (let [rajoitusalueet @tiedot/urakan-rajoitusalueet
-           urakka @nav/valittu-urakka]
-       [:div
-        [urakka-valinnat/aikavali-nykypvm-taakse urakka
-         tiedot/valittu-aikavali
-         {:aikavalin-rajoitus [12 :kuukausi]}]
-        [grid/grid {:tunniste :tunnus
-                    :mahdollista-rivin-valinta? true
-                    :rivi-valinta-peruttu (fn [rivi]
-                                            (reset! tiedot/pohjavesialueen-toteuma nil))
-                    :rivi-klikattu
-                    (fn [rivi]
-                      (go
-                        (reset! tiedot/pohjavesialueen-toteuma
-                                (<! (tiedot/hae-pohjavesialueen-suolatoteuma (:tunnus rivi) @tiedot/valittu-aikavali)))))
-                         
-                    :tyhjä (if (nil? @tiedot/urakan-pohjavesialueet)
-                             [yleiset/ajax-loader "Rajoitusalueita haetaan..."]
-                             "Ei Rajoitusalueita")}
-         [{:otsikko "Tie" :tunniste :tie :hae (comp :tie :tr-osoite) :leveys 1}
-          {:otsikko "Osoiteväli" :tunniste :tie :hae :tr-osoite
-           :fmt (fn [tr-osoite]
-                  (tierekisteri/tierekisteriosoite-tekstina
-                    {:tr-numero (:tie tr-osoite)
-                     :tr-alkuosa (:aosa tr-osoite)
-                     :tr-alkuetaisyys (:aet tr-osoite)
-                     :tr-loppuosa (:losa tr-osoite)
-                     :tr-loppuetaisyys (:let tr-osoite)}
-                    {:teksti-tie? false}))
-           :leveys 1}
-          {:otsikko "Pohjavesialue (tunnus)" :tunniste :pohjavesialueet :hae :pohjavesialueet :leveys 1}
-          {:otsikko "Pituus (m)" :tunniste :pituus :hae :pituus :leveys 1}
-          {:otsikko "Pituus ajoradat (m)" :tunniste :pituus_ajoradat :hae :pituus_ajoradat :leveys 1}
-          {:otsikko "Formiaatit (t/ajoratakm)" :tunniste :formiaatit_t_per_ajoratakm
-           :hae :formiaatit_t_per_ajoratakm :leveys 1}
-          {:otsikko "Talvisuola (t/ajoratakm)" :tunniste :formiaatit_t_per_ajoratakm
-           :hae :formiaatit_t_per_ajoratakm :leveys 1}
-          {:otsikko "Suolankäyttöraja (t/ajoratakm)" :tunniste :suolankayttoraja :hae :suolankayttoraja :leveys 1}
-          {:otsikko "" :tunniste :pituus :hae :kaytettava-formaattia? :fmt #(when % "Käytettävä formaattia") :leveys 1}]
-         rajoitusalueet]
-        (let [toteuma @tiedot/pohjavesialueen-toteuma]
-          (when toteuma
-            [grid/grid
-             {:otsikko "Pohjavesialueen suolatoteuma"
-              :tunniste :maara_t_per_km
-              :piilota-toiminnot? true
-              :tyhja (if (empty? toteuma)
-                       "Ei tietoja")
-              }
-             [{:otsikko "Pohjavesialueen pituus (km)"
-               :nimi :pituus
-               :fmt #(fmt/desimaaliluku-opt % 1)
-               :leveys 10}
-              {:otsikko "Määrä t/km"
-               :nimi :maara_t_per_km
-               :fmt #(fmt/desimaaliluku-opt % 1)
-               :leveys 10}
-              {:otsikko "Määrä yhteensä"
-               :leveys 10
-               :fmt #(fmt/desimaaliluku-opt % 1)
-               :nimi :yhteensa}
-              {:otsikko "Käyttöraja"
-               :leveys 10
-               :nimi :kayttoraja}]
-             toteuma]))]))))
+      (let [rajoitusalueet @tiedot/urakan-rajoitusalueet
+            urakka @nav/valittu-urakka]
+        [:div.pohjavesialueiden-suola
+         ;; TODO: Yleiskäyttöinen komponentti. Speksissä halutaan erilainen komponentti, jossa on nappula, jolla
+         ;;       käynnistetään tietojen hakeminen aikavälin valinnan jälkeen
+         ;; Aikavälivalinta
+         [urakka-valinnat/aikavali-nykypvm-taakse urakka
+          tiedot/valittu-aikavali
+          {:aikavalin-rajoitus [12 :kuukausi]}]
+
+         ;; Rajoitiusalueiden taulukko
+         [taulukko rajoitusalueet]]))))

--- a/src/cljs/harja/views/urakka/valinnat.cljs
+++ b/src/cljs/harja/views/urakka/valinnat.cljs
@@ -75,18 +75,19 @@
 (defn aikavali-hoitokauden-sisalla []
   [valinnat/aikavali u/valittu-aikavali-hoitokauden-sisalla])
 
-(def aikavali-valinnat [["Edellinen viikko" #(pvm/aikavali-nyt-miinus 7)]
-                        ["Edelliset 2 viikkoa" #(pvm/aikavali-nyt-miinus 14)]
-                        ["Edelliset 3 viikkoa" #(pvm/aikavali-nyt-miinus 21)]
-                        ["Valittu aikaväli" nil]])
+(def aikavali-valinnat-oletus [["Edellinen viikko" #(pvm/aikavali-nyt-miinus 7)]
+                               ["Edelliset 2 viikkoa" #(pvm/aikavali-nyt-miinus 14)]
+                               ["Edelliset 3 viikkoa" #(pvm/aikavali-nyt-miinus 21)]
+                               ["Valittu aikaväli" nil]])
 
 (defn aikavali-nykypvm-taakse
   "Näyttää aikavalinnan tästä hetkestä taaksepäin, jos urakka on käynnissä.
   Jos urakka ei ole käynnissä, näyttää hoitokausi ja kuukausi valinnat."
   ([urakka valittu-aikavali] (aikavali-nykypvm-taakse urakka valittu-aikavali nil))
   ([urakka valittu-aikavali {:keys [otsikko vaihda-filtteri-urakan-paattyessa?
-                                    aikavalin-rajoitus vayla-tyyli?] :as optiot}]
-   (let [[valittu-aikavali-alku valittu-aikavali-loppu
+                                    aikavali-valinnat aikavalin-rajoitus vayla-tyyli?] :as optiot}]
+   (let [aikavali-valinnat (if (seq aikavali-valinnat) aikavali-valinnat aikavali-valinnat-oletus)
+         [valittu-aikavali-alku valittu-aikavali-loppu
           :as valittu-aikavali-nyt] @valittu-aikavali
          vaihda-filtteri-urakan-paattyessa? (if (some? vaihda-filtteri-urakan-paattyessa?)
                                               vaihda-filtteri-urakan-paattyessa?


### PR DESCRIPTION
 ### :heavy_check_mark: Tehty
 #### Toteumien välilehtien nimet muutettu
- Suola -->  Talvisuola
- Pohjavesialueet -->  Pohjavesialueiden suola
- Materiaalit --> Muut materiaalit

 #### Pohjavesialueiden suola-välilehti
* Uuden taulukon hierarkinen rakenne, korostukset ja datan käsittely näyttämistä varten.
* Tarkempaa dataa haetaan taulukon hierarkiaan porautuessa kutsumalla hakufunktioita (funktiot palauttava mockup-dataa, eivätkä ole kytköksissä palveluihin), jotta käyttöliittymä ja haut toimivat nopeasti. 
* Taulukkoon haetaan mockup-dataa.
* Aikavälifiltteri-komponentin parannukset speksin mukaisesti
   * :question:  ```Edellinen kuukausi```: Tarkoitetaanko tällä aikaväliä, joka alkaa edellisen kuukauden ensimmäisestä päivästä ja päättyy edellisen kuukauden viimeiseen päivään **VAI** edelliset 4*7 päivää kuluvasta päivästä alkaen.
    * :question: ```Edellinen viikko```: Tarkoitetaanko aikaväliä, joka alkaa edellisen viikon ensimmäisestä päivästä ja päättyy edellisen viikon viimeiseen päivään **VAI** halutaanko edelliset 7 päivää  kuluvasta päivästä alkaen.

### :warning: Puuttuu
* Toteumiin liittyvä tietomalli (vaatii rajoitusalueiden tietomallin ensin, joka tulee rajoitusalueiden suunnittelua toteuttaessa)
   * Katsotaan tehdäänkö suunnitteluun liittyvät asiat eri branchissä, vai tehdäänkö suoraan tähän toteumien kylkeen samaan branchiin (ovat riippuvaisia toisistaan)
* Sopivat muutokset palveluihin 'materiaalit' tai 'pohjavesialueensuola' (tai ihan uusi palvelu rajoitusalueille), joilla data oikeasti haetaan näkymään.
* Taulukon järjestelyominaisuudet speksin mukaisesti
* Suolatoteumat pitäisi kytkeä tuck-tilanhallintaan palanen kerrallaan.

### :no_entry_sign:  Ei kuulu tähän 
* Karttakomponentti (Speksissä **määritelty tehtäväksi myöhemmin**, voidaan tehdä myöhemmin kunhan kartan tarkka speksi on selvillä)