### PR TITLE
korjaa kartan värit

### DIFF
--- a/src/cljc/harja/ui/kartta/esitettavat_asiat.cljc
+++ b/src/cljc/harja/ui/kartta/esitettavat_asiat.cljc
@@ -691,7 +691,7 @@
                                 ikoni))))
 
 (defmethod asia-kartalle :varusteet-ulkoiset [kohde valittu?]
-  (let [[teksti vari viivat ikoni] (ulkoasu/varustetoteuma kohde)]
+  (let [[teksti viivat vari ikoni] (ulkoasu/varustetoteuma kohde)]
     (assoc kohde
       :type :varusteet-ulkoiset
       :nimi (:ulkoinen-oid kohde)


### PR DESCRIPTION
 - varustetoteuman ulkoasun palautusarvojen järjestys oli mennyt
   sekaisin jossain välissä