### PR TITLE
Lisää varmuuskopio-sarake reittipisteisiin suoloja varten

### DIFF
--- a/test/clj/harja/kyselyt/kevyen_liikenteen_talvisuola_test.clj
+++ b/test/clj/harja/kyselyt/kevyen_liikenteen_talvisuola_test.clj
@@ -7,8 +7,16 @@
 (defn suolaa-kelvilla-kysely [urakka alku loppu]
   (q-map (str "SELECT rp.talvihoitoluokka, SUM(mat.maara) AS maara FROM toteuman_reittipisteet trp join toteuma t ON t.id = trp.toteuma join lateral unnest(trp.reittipisteet) rp ON TRUE join lateral unnest(rp.materiaalit) mat ON TRUE WHERE t.urakka = " urakka " AND t.alkanut BETWEEN '" alku "'::DATE AND '" loppu "'::DATE GROUP BY rp.talvihoitoluokka")))
 
+(defn palauta-varmuuskopio-kysely []
+  (u "UPDATE toteuman_reittipisteet trp SET reittipisteet = reittipisteiden_kopio, reittipisteiden_kopio = NULL WHERE reittipisteiden_kopio IS NOT NULL"))
+
+(defn paivita-materiaalicache [urakka alku loppu]
+  (q (format "SELECT paivita_urakan_materiaalin_kaytto_hoitoluokittain(%s, '%s'::DATE, '%s'::DATE)" urakka alku loppu)))
+
 (deftest siirra-suola-pois-kelveilta
-  (let [oulun-au-id (hae-oulun-alueurakan-2014-2019-id)
+  (let [oulun-au-id (hae-oulun-alueurakan-2014-2019-id) 
+        alku "2018-10-01"
+        loppu "2019-09-30"
         suolaa-kelveilla-ennen (suolaa-kelvilla-kysely oulun-au-id
                            "2018-10-01"
                            "2019-09-30")
@@ -19,7 +27,18 @@
                            "2018-10-01"
                            "2019-09-30")
         mat-yht-jalkeen (apply + (map :maara suolaa-kelveilla-jalkeen))
-        mat-kelvi-jalkeen (apply + (map :maara (filter #(#{9, 10, 11} (:talvihoitoluokka %)) suolaa-kelveilla-jalkeen)))]
+        mat-kelvi-jalkeen (apply + (map :maara (filter #(#{9, 10, 11} (:talvihoitoluokka %)) suolaa-kelveilla-jalkeen)))
+        
+        ;; Testataan, toimiiko varmuuskopio.
+        _palauta-suola (do (palauta-varmuuskopio-kysely)
+                           (paivita-materiaalicache urakka alku loppu))
+        suolaa-kelveilla-varmuuskopio (suolaa-kelvilla-kysely oulun-au-id
+                                        "2018-10-01"
+                                        "2019-09-30")
+        mat-yht-varmuuskopio (apply + (map :maara suolaa-kelveilla-varmuuskopio))
+        mat-kelvi-varmuuskopio (apply + (map :maara (filter #(#{9, 10, 11} (:talvihoitoluokka %)) suolaa-kelveilla-varmuuskopio)))]
       (is (< 0 mat-kelvi-ennen))
       (is (zero? mat-kelvi-jalkeen))
-      (is (= mat-yht-ennen mat-yht-jalkeen))))
+      (is (= mat-yht-ennen mat-yht-jalkeen))
+      (is (= mat-yht-ennen mat-yht-varmuuskopio))
+      (is (= mat-kelvi-ennen mat-kelvi-varmuuskopio))))

--- a/tietokanta/src/main/resources/db/migration/R__Kevyen_liikenteen_talvisuola.sql
+++ b/tietokanta/src/main/resources/db/migration/R__Kevyen_liikenteen_talvisuola.sql
@@ -1,4 +1,6 @@
--- hieno
+ALTER TABLE toteuman_reittipisteet ADD COLUMN IF NOT EXISTS reittipisteiden_kopio reittipistedata[];
+COMMENT ON COLUMN toteuman_reittipisteet.reittipisteiden_kopio IS 'Reittipisteiden varmuuskopio, kun ollaan siirretty talvisuolia pois kevyen liikenteen väyliltä.'
+
 CREATE OR REPLACE FUNCTION siirra_talvisuola_kelvilta(urakka_ INTEGER, alku TIMESTAMP, loppu TIMESTAMP)
     RETURNS INTEGER AS
 $$
@@ -38,7 +40,8 @@ BEGIN
                                   WHERE trp.talvihoitoluokka = ANY(kelvien_talvihoitoluokat)))
         LOOP
             UPDATE toteuman_reittipisteet trp
-            SET reittipisteet = (SELECT ARRAY_AGG((rp.aika, rp.sijainti,
+            SET reittipisteiden_kopio = trp.reittipisteet,
+                reittipisteet = (SELECT ARRAY_AGG((rp.aika, rp.sijainti,
                                                    (CASE
                                                         WHEN rp.talvihoitoluokka = ANY (kelvien_talvihoitoluokat)
                                                             THEN hoitoluokka_pisteelle(rp.sijainti::GEOMETRY,
@@ -53,7 +56,6 @@ BEGIN
             WHERE trp.toteuma = uusi_trp.toteuma;
             maara := maara + count(uusi_trp.reittipisteet);
         END LOOP;
-
 
     PERFORM paivita_urakan_materiaalin_kaytto_hoitoluokittain(
             urakka_::INTEGER,

--- a/tietokanta/src/main/resources/db/migration/R__Kevyen_liikenteen_talvisuola.sql
+++ b/tietokanta/src/main/resources/db/migration/R__Kevyen_liikenteen_talvisuola.sql
@@ -1,5 +1,5 @@
 ALTER TABLE toteuman_reittipisteet ADD COLUMN IF NOT EXISTS reittipisteiden_kopio reittipistedata[];
-COMMENT ON COLUMN toteuman_reittipisteet.reittipisteiden_kopio IS 'Reittipisteiden varmuuskopio, kun ollaan siirretty talvisuolia pois kevyen liikenteen väyliltä.'
+COMMENT ON COLUMN toteuman_reittipisteet.reittipisteiden_kopio IS 'Reittipisteiden varmuuskopio, kun ollaan siirretty talvisuolia pois kevyen liikenteen väyliltä.';
 
 CREATE OR REPLACE FUNCTION siirra_talvisuola_kelvilta(urakka_ INTEGER, alku TIMESTAMP, loppu TIMESTAMP)
     RETURNS INTEGER AS


### PR DESCRIPTION
Lokakuun 2021 suolojen siirto toi 1336kb lisää dataa, eli 0.002% lisäys datan määrässä, eli ei merkittävä lisäys. Lisäksi tämä varmuuskopio poistetaan, kun todetaan että se on turvallista.
Tammikuu 2022, joka on yksi kiireisimmistä kuukausista, lisäsi taulun kokoa 23MB, mikä ei vieläkään tunnu pahalta 50gb+ taulussa.