### PR TITLE
Korjaa back-front kommunikaation yhtenäistämällä parametrien nimet

### DIFF
--- a/src/clj/harja/kyselyt/toteumat.clj
+++ b/src/clj/harja/kyselyt/toteumat.clj
@@ -36,13 +36,13 @@
            {::rp/toteuma-id toteuma-id}))
 
 (defn hae-uusimmat-varustetoteuma-ulkoiset
-  [db {:keys [urakka-id hoitovuosi kuukausi tie aosa aeta losa leta kuntoluokat tietolajit toteuma]}]
-  (let [hoitokauden-alkupvm (pvm/luo-pvm-dec-kk hoitovuosi 10 01)
-        hoitokauden-loppupvm (pvm/luo-pvm-dec-kk (+ 1 hoitovuosi) 9 30)
+  [db {:keys [urakka-id hoitokauden-alkuvuosi hoitovuoden-kuukausi tie aosa aeta losa leta kuntoluokat tietolajit toteuma]}]
+  (let [hoitokauden-alkupvm (pvm/luo-pvm-dec-kk hoitokauden-alkuvuosi 10 01)
+        hoitokauden-loppupvm (pvm/luo-pvm-dec-kk (+ 1 hoitokauden-alkuvuosi) 9 30)
         toteumat (hae-urakan-uusimmat-varustetoteuma-ulkoiset db {:urakka urakka-id
                                                                   :hoitokauden_alkupvm (konv/sql-date hoitokauden-alkupvm)
                                                                   :hoitokauden_loppupvm (konv/sql-date hoitokauden-loppupvm)
-                                                                  :kuukausi kuukausi
+                                                                  :kuukausi hoitovuoden-kuukausi
                                                                   :tie tie
                                                                   :aosa aosa
                                                                   :aeta aeta

--- a/src/clj/harja/palvelin/palvelut/varuste_ulkoiset.clj
+++ b/src/clj/harja/palvelin/palvelut/varuste_ulkoiset.clj
@@ -28,9 +28,9 @@
     (every? nil? [tie aosa aeta losa leta])))
 
 (defn hae-urakan-uusimmat-varustetoteuma-ulkoiset
-  [db user {:keys [urakka-id hoitovuosi tie aosa aeta losa leta] :as tiedot}]
+  [db user {:keys [urakka-id hoitokauden-alkuvuosi tie aosa aeta losa leta] :as tiedot}]
   (when (nil? urakka-id) (throw (IllegalArgumentException. "urakka-id on pakollinen")))
-  (when (nil? hoitovuosi) (throw (IllegalArgumentException. "hoitovuosi on pakollinen")))
+  (when (nil? hoitokauden-alkuvuosi) (throw (IllegalArgumentException. "hoitokauden-alkuvuosi on pakollinen")))
   (when-not (kelvollinen-tr-filter tie aosa aeta losa leta)
     (throw (IllegalArgumentException. "tr-osoitteessa pakolliset, tie TAI tie aosa aeta TAI kaikki")))
   (oikeudet/vaadi-lukuoikeus oikeudet/urakat-toteumat-varusteet user urakka-id)

--- a/test/clj/harja/palvelin/palvelut/varuste_ulkoiset_test.clj
+++ b/test/clj/harja/palvelin/palvelut/varuste_ulkoiset_test.clj
@@ -35,14 +35,14 @@
                         (kutsu-palvelua (:http-palvelin jarjestelma)
                                         :hae-urakan-varustetoteuma-ulkoiset
                                         +kayttaja-jvh+
-                                        {:urakka-id nil :hoitovuosi 2019}))))
+                                        {:urakka-id nil :hoitokauden-alkuvuosi 2019}))))
 
 (deftest palvelu-on-olemassa-ja-vaatii-parametrin-hoitovuosi
-  (is (thrown-with-msg? IllegalArgumentException #"hoitovuosi on pakollinen"
+  (is (thrown-with-msg? IllegalArgumentException #"hoitokauden-alkuvuosi on pakollinen"
                         (kutsu-palvelua (:http-palvelin jarjestelma)
                                         :hae-urakan-varustetoteuma-ulkoiset
                                         +kayttaja-jvh+
-                                        {:urakka-id urakka-id-35 :hoitovuosi nil}))))
+                                        {:urakka-id urakka-id-35 :hoitokauden-alkuvuosi nil}))))
 
 (defn assertoi-saatu-lista
   [odotettu-lista parametrit hae-fn]
@@ -64,11 +64,11 @@
 (deftest palvelu-palauttaa-oikean-hoitovuoden-tuloksia
   (assertoi-saatu-oid-lista ["1.2.246.578.4.3.12.512.310173999"
                              "1.2.246.578.4.3.12.512.310174000"]
-                            {:urakka-id urakka-id-33 :hoitovuosi 2022}))
+                            {:urakka-id urakka-id-33 :hoitokauden-alkuvuosi 2022}))
 
 (deftest tyhjalle-hoitovuodelle-palautuu-tyhja-tulos
   "Ja rinnakkaisien hoitovuosien alku & loppu ovat 1.10. ja 30.9. Ne eivät tule mukaan tulokseen."
-  (assertoi-saatu-oid-lista [] {:urakka-id urakka-id-33 :hoitovuosi 2023}))
+  (assertoi-saatu-oid-lista [] {:urakka-id urakka-id-33 :hoitokauden-alkuvuosi 2023}))
 
 (deftest hae-urakan-35-uusimmat-varusteet
   (assertoi-saatu-oid-lista ["1.2.246.578.4.3.12.512.310173990"
@@ -80,35 +80,35 @@
                              "1.2.246.578.4.3.12.512.310173996"
                              "1.2.246.578.4.3.12.512.310173997"
                              "1.2.246.578.4.3.12.512.310173998"]
-                            {:urakka-id urakka-id-35 :hoitovuosi 2019}))
+                            {:urakka-id urakka-id-35 :hoitokauden-alkuvuosi 2019}))
 
 (deftest hae-vain-urakan-erittain-hyvat-varusteet
   (assertoi-saatu-oid-lista ["1.2.246.578.4.3.12.512.310173990"
                              "1.2.246.578.4.3.12.512.310173997"]
-                            {:urakka-id urakka-id-35 :hoitovuosi 2019 :kuntoluokat ["Erittäin hyvä"]}))
+                            {:urakka-id urakka-id-35 :hoitokauden-alkuvuosi 2019 :kuntoluokat ["Erittäin hyvä"]}))
 
 (deftest hae-vain-urakan-erittain-hyvat-ja-hyvat-varusteet
   (assertoi-saatu-oid-lista ["1.2.246.578.4.3.12.512.310173995"
                              "1.2.246.578.4.3.12.512.310173990"
                              "1.2.246.578.4.3.12.512.310173997"]
-                            {:urakka-id urakka-id-35 :hoitovuosi 2019 :kuntoluokat ["Erittäin hyvä" "Hyvä"] }))
+                            {:urakka-id urakka-id-35 :hoitokauden-alkuvuosi 2019 :kuntoluokat ["Erittäin hyvä" "Hyvä"] }))
 
 (deftest hae-vain-urakan-erittain-hyvat-paivitetyt-varusteet
   (assertoi-saatu-oid-lista ["1.2.246.578.4.3.12.512.310173997"]
-                            {:urakka-id urakka-id-35 :hoitovuosi 2019 :kuntoluokat ["Erittäin hyvä"] :toteuma "paivitetty"}))
+                            {:urakka-id urakka-id-35 :hoitokauden-alkuvuosi 2019 :kuntoluokat ["Erittäin hyvä"] :toteuma "paivitetty"}))
 
 (deftest hae-vain-urakan-paivitetyt-varusteet
   (assertoi-saatu-oid-lista ["1.2.246.578.4.3.12.512.310173994"
                              "1.2.246.578.4.3.12.512.310173997"]
-                            {:urakka-id urakka-id-35 :hoitovuosi 2019 :toteuma "paivitetty"}))
+                            {:urakka-id urakka-id-35 :hoitokauden-alkuvuosi 2019 :toteuma "paivitetty"}))
 
 (deftest hae-vain-urakan-tietolaji512-varusteet
   (assertoi-saatu-oid-lista ["1.2.246.578.4.3.12.512.310173997"]
-                            {:urakka-id urakka-id-35 :hoitovuosi 2019 :tietolajit ["tl506"]}))
+                            {:urakka-id urakka-id-35 :hoitokauden-alkuvuosi 2019 :tietolajit ["tl506"]}))
 
 (deftest palauta-uusin-versio-varusteesta-josta-loytyy-monta-versiota
   (assertoi-saatu-lista [{:ulkoinen-oid "1.2.246.578.4.3.12.512.310173998" :alkupvm #inst "2020-10-24T21:00:00.000-00:00"}]
-                        {:urakka-id urakka-id-35 :hoitovuosi 2020} varuste-ulkoiset/hae-urakan-uusimmat-varustetoteuma-ulkoiset))
+                        {:urakka-id urakka-id-35 :hoitokauden-alkuvuosi 2020} varuste-ulkoiset/hae-urakan-uusimmat-varustetoteuma-ulkoiset))
 
 (deftest kuukausi-rajaus
   (assertoi-saatu-lista [{:id 9} {:id 10} {:id 11}]
@@ -153,7 +153,7 @@
         saatu (->> (kutsu-palvelua (:http-palvelin jarjestelma)
                                   :hae-urakan-varustetoteuma-ulkoiset
                                   +kayttaja-jvh+
-                                  {:urakka-id urakka-id-35 :hoitovuosi 2019 :tie tie :aosa aosa :aeta aeta :losa nil :leta nil})
+                                  {:urakka-id urakka-id-35 :hoitokauden-alkuvuosi 2019 :tie tie :aosa aosa :aeta aeta :losa nil :leta nil})
                   :toteumat
                   (map #(dissoc % :sijainti :muokattu)))]
     (is (= odotettu saatu))))
@@ -334,6 +334,6 @@
         vastaus (kutsu-excel-palvelua (:http-palvelin jarjestelma)
                   :varusteet-ulkoiset-excel
                   +kayttaja-jvh+
-                  {:urakka-id @oulun-maanteiden-hoitourakan-2019-2024-id :hoitovuosi 2019})]
+                  {:urakka-id @oulun-maanteiden-hoitourakan-2019-2024-id :hoitokauden-alkuvuosi 2019})]
     (is (= vastaus odotettu) "Varusteiden excel ei vastannut odotettua")))
 


### PR DESCRIPTION
Varustetapahtumien hakupalvelun parametrien nimiä on muutettu.
Korjataan muuallekin uudet parametrien nimet.