### PR TITLE
VHAR-6637 Varustetapahtumien toimenpide ei tule tuonnissa oikein

### DIFF
--- a/src/clj/harja/palvelin/integraatiot/velho/sanomat/varuste_vastaanottosanoma.clj
+++ b/src/clj/harja/palvelin/integraatiot/velho/sanomat/varuste_vastaanottosanoma.clj
@@ -273,9 +273,10 @@
       (konversio-fn "v/vtykl" kuntoluokka)
       "Puuttuu")))
 
-(defn varusteen-toteuma [konversio-fn {:keys [version-voimassaolo alkaen paattyen uusin-versio toimenpiteet tekninen-tapahtuma] :as kohde}]
+(defn varusteen-toteuma [konversio-fn {:keys [version-voimassaolo alkaen paattyen uusin-versio ominaisuudet tekninen-tapahtuma] :as kohde}]
   (let [version-alku (:alku version-voimassaolo)
         version-loppu (:loppu version-voimassaolo)
+        toimenpiteet (:toimenpiteet ominaisuudet)
         toimenpidelista (->> toimenpiteet
                              (map #(konversio-fn "v/vtp" %))
                              (keep not-empty))]

--- a/test/clj/harja/palvelin/integraatiot/velho/sanomat/varuste_vastaanottosanoma_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/velho/sanomat/varuste_vastaanottosanoma_test.clj
@@ -53,12 +53,13 @@
     muunna-tiedostolista-kohteiksi))
 
 (defn poimi-tietolaji-oidista [oid]
-  "Poimitaan oid-merkkijonosta tietolaji.
-  Esimerkiksi: oid \"1.2.246.578.4.3.11.507.51457624\" tietolaji 507"
+  ; Poimitaan oid-merkkijonosta tietolaji.
+  ; Esimerkiksi: oid "1.2.246.578.4.3.11.507.51457624" tietolaji 507
+  ; Pätee vain vanhoissa Velhos oideissa!
   (as-> oid a
-        (clojure.string/split a #"\.")
-        (nth a 7)
-        (str "tl" a)))
+    (clojure.string/split a #"\.")
+    (nth a 7)
+    (str "tl" a)))
 
 (defn assertoi-kohteen-tietolaji-on-kohteen-oidissa [kohteet & tietolaji-poikkeus-map]
   (doseq [kohde kohteet]
@@ -229,14 +230,14 @@
            (vos/varusteen-lisatieto konversio-fn "tl506" kohde)))))
 
 (deftest varusteen-yleinen-kuntoluokka-konvertoituu-oikein-test
-  "Yleinen-kuntoluokka ei ole pakollinen, mutta jos on, niin sen pitää konvertoitua."
+  ; Yleinen-kuntoluokka ei ole pakollinen, mutta jos on, niin sen pitää konvertoitua.
   (let [kohde (slurp->json "test/resurssit/velho/varusteet/kuntoluokka-konvertoituu-oikein.json")
         odotettu-kuntoluokka "Hyvä"
         konversio-fn (partial koodistot/konversio (:db jarjestelma))]
     (is (= odotettu-kuntoluokka (vos/varusteen-kuntoluokka konversio-fn kohde)))))
 
 (deftest varusteen-toimenpiteet-konvertoituu-oikein-test
-  "Toimenpiteet joukko on konvertoituu niin, että pidämme vain tutut toimenpiteet."
+  ; Toimenpiteet joukko konvertoituu niin, että pidämme vain tutut toimenpiteet.
   (let [kohde (slurp->json "test/resurssit/velho/varusteet/toimenpiteet-konvertoituu-oikein.json")
         odotetut-toimenpiteet "korjaus"
         konversio-fn (partial koodistot/konversio (:db jarjestelma))]
@@ -248,9 +249,9 @@
         muokattu-kohde (assoc-in kohde [:version-voimassaolo :alku] "2019-10-15")
         uusin-kohde (assoc muokattu-kohde :uusin-versio true)
         poistettu-kohde (assoc-in uusin-kohde [:version-voimassaolo :loppu] "2021-11-01") ; Oletus: historian-viimeinen ja version-voimassaolo.loppu!=null ==> poistettu
-        tarkastettu-kohde (assoc-in muokattu-kohde [:toimenpiteet] ["varustetoimenpide/vtp01"])
-        puhdistettu-kohde (assoc-in muokattu-kohde [:toimenpiteet] ["varustetoimenpide/vtp02"])
-        korjattu-kohde (assoc-in muokattu-kohde [:toimenpiteet] ["varustetoimenpide/vtp07"])
+        tarkastettu-kohde (assoc-in muokattu-kohde [:ominaisuudet :toimenpiteet] ["varustetoimenpide/vtp01"])
+        puhdistettu-kohde (assoc-in muokattu-kohde [:ominaisuudet :toimenpiteet] ["varustetoimenpide/vtp02"])
+        korjattu-kohde (assoc-in muokattu-kohde [:ominaisuudet :toimenpiteet] ["varustetoimenpide/vtp07"])
         kohteet-ja-toteumatyypit [{:kohde uusi-kohde :odotettu-toteumatyyppi "lisatty"}
                                   {:kohde muokattu-kohde :odotettu-toteumatyyppi "paivitetty"}
                                   {:kohde poistettu-kohde :odotettu-toteumatyyppi "poistettu"}

--- a/test/clj/harja/palvelin/integraatiot/velho/sanomat/varuste_vastaanottosanoma_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/velho/sanomat/varuste_vastaanottosanoma_test.clj
@@ -239,7 +239,7 @@
 (deftest varusteen-toimenpiteet-konvertoituu-oikein-test
   ; Toimenpiteet joukko konvertoituu niin, että pidämme vain tutut toimenpiteet.
   (let [kohde (slurp->json "test/resurssit/velho/varusteet/toimenpiteet-konvertoituu-oikein.json")
-        odotetut-toimenpiteet "korjaus"
+        odotetut-toimenpiteet "tarkastus"
         konversio-fn (partial koodistot/konversio (:db jarjestelma))]
     (is (= odotetut-toimenpiteet (vos/varusteen-toteuma konversio-fn kohde)))))
 

--- a/test/resurssit/velho/varusteet/toimenpiteet-konvertoituu-oikein.json
+++ b/test/resurssit/velho/varusteet/toimenpiteet-konvertoituu-oikein.json
@@ -1,36 +1,43 @@
 {
-  "kohdeluokka": "varusteet/liikennemerkit",
   "sijainti": {
-    "osa": 12,
-    "tie": 616,
-    "etaisyys": 2139,
-    "enkoodattu": 61600042824
+    "tie": 5,
+    "enkoodattu": 500204770,
+    "osa": 154,
+    "etaisyys": 0
   },
   "version-voimassaolo": {
-    "alku": "2010-06-16",
-    "loppu": "2021-11-16"
+    "alku": "2022-01-19",
+    "loppu": null
   },
   "ominaisuudet": {
+    "korjausvastuu": [],
+    "toimenpiteet": [
+      "varustetoimenpide/vtp11",
+      "varustetoimenpide/vtp01"
+    ],
+    "omistaja": "toimija/t4",
     "toiminnalliset-ominaisuudet": {
-      "tarkenne": null,
-      "lakinumero": null,
-      "asetusnumero": "liikennemerkki-asetusnumero/liiasnro310",
-      "vaikutussuunta": null,
-      "lisatietoja": "45 Joutsa 2 Kangasniemi",
+      "asetusnumero": null,
       "voimassaolo-alkaa": null,
+      "lisatietoja": null,
+      "tehtava": null,
+      "vaikutussuunta": null,
+      "lakinumero": "liikennemerkki-lakinumero/liilnro133",
       "voimassaolo-paattyy": null
     },
+    "hoitovastuu": [],
     "infranimikkeisto": {
-      "toiminnallinen-jarjestelmakokonaisuus": [],
       "rakenteellinen-jarjestelmakokonaisuus": [
         "rakenteellinen-jarjestelmakokonaisuus/rjk03"
-      ]
+      ],
+      "toiminnallinen-jarjestelmakokonaisuus": []
     },
     "kunto-ja-vauriotiedot": {
+      "varustevauriot": [],
       "arvioitu-jaljella-oleva-kayttoika": null,
-      "yleinen-kuntoluokka": "kuntoluokka/kl04",
-      "varustevauriot": []
+      "yleinen-kuntoluokka": null
     },
+    "sijaintipoikkeus": null,
     "rakenteelliset-ominaisuudet": {
       "tekstikoko": null,
       "kilven-valaistus": null,
@@ -39,38 +46,59 @@
       "arvo": null,
       "kiinnitystapa": null,
       "tunnus": null,
-      "pinta-ala": 0,
-      "sivutie": null,
+      "pinta-ala": null,
       "lisatyyppi": [
         "liikennemerkki-lisatyyppi/liility01"
       ],
       "yhteydet-muihin-kohteisiin": [],
-      "materiaali": "materiaali/ma02",
+      "materiaali": "materiaali/ma01",
       "suunta": null,
-      "tyyppi": "liikennemerkki-tyyppi/liity06",
-      "koko": null,
+      "tyyppi": "liikennemerkki-tyyppi/liity04",
+      "koko": "liikennemerkki-koko/liikok01",
       "korkeusasema": null
     }
   },
-  "toimenpiteet": ["varustetoimenpide/vtp08", "varustetoimenpide/vtp07", "varustetoimenpide/vtp02"],
-  "luotu": "2020-05-08T12:20:15Z",
-  "lahdejarjestelman-id": "506.283640192",
-  "paattyen": null,
-  "sijainti-oid": "1.2.246.578.4.1.2.146265754",
-  "lahdejarjestelma": "lahdejarjestelma/lj01",
-  "schemaversio": 1,
-  "luoja": {
-    "kayttajanimi": "TIERb3320"
-  },
-  "sijaintitarkenne": {
-    "ajoradat": [
-      "ajorata/ajr1"
+  "geometrycollection": {
+    "type": "GeometryCollection",
+    "geometries": [
+      {
+        "coordinates": [
+          27.604706374011624,
+          62.582479244945524,
+          0.0
+        ],
+        "type": "Point"
+      }
     ]
   },
-  "muokkaaja": {
-    "kayttajanimi": "migraatio"
+  "luotu": "2022-08-22T10:19:09Z",
+  "tekninen-tapahtuma": null,
+  "keskilinjageometria": {
+    "coordinates": [
+      531066.216,
+      6939217.18900025,
+      0.0
+    ],
+    "type": "Point"
   },
-  "oid": "1.2.246.578.4.3.15.506.283640192",
-  "alkaen": "2010-06-16",
-  "muokattu": "2021-03-10T07:57:40Z"
+  "lahdejarjestelman-id": null,
+  "tiekohteen-tila": null,
+  "paattyen": null,
+  "sijainti-oid": "1.2.246.578.4.1.4.38102619",
+  "lahdejarjestelma": null,
+  "schemaversio": 1,
+  "luoja": {
+    "kayttajanimi": "api/operaattoripalvelu-stg"
+  },
+  "sijaintitarkenne": {
+    "puoli": "puoli/p01"
+  },
+  "menetelma": null,
+  "muokkaaja": {
+    "kayttajanimi": "api/operaattoripalvelu-stg"
+  },
+  "oid": "1.2.246.578.4.3.15.2349831016.1157439926",
+  "alkaen": "2022-01-19",
+  "muutoksen-lahde-oid": "1.2.246.578.8.1.2436498421.1886759677",
+  "muokattu": "2022-08-22T10:19:09Z"
 }


### PR DESCRIPTION
Tievelhoon saatiin 31 liikennemerkkiä ja 13 kaidetta testidataa, mutta niissä kirjatut toimenpide tiedot eivät tule tuonnissa Harjaan.

Tievelhossa oli muuttunut toimenpiteen paikka tietorakenteessa. Nyt se on ominaisuudet propertyn sisällä.

Toteutus muuttaa toimenpiteen jäsennyksen ja päivittää toimenpiteen testisyötteen ja testitapauksen. 

Lisäksi korjataan toisen testin synteettinen syöte vastaamaan uutta Tievelhon rakennetta