### PR TITLE
Vhar 6245 ilmoitusrajapinta muutoksia 

### DIFF
--- a/src/clj/harja/kyselyt/tieliikenneilmoitukset.sql
+++ b/src/clj/harja/kyselyt/tieliikenneilmoitukset.sql
@@ -368,7 +368,7 @@ SELECT
     i.lahettaja_puhelinnumero,
     i.lahettaja_sahkoposti,
     i."aiheutti-toimenpiteita",
-    json_agg(row_to_json(row(it.kuitattu, it.kuittaustyyppi, coalesce(it.vakiofraasi,''), coalesce(it.vapaateksti,''),
+    json_agg(row_to_json(row(it.kuitattu::timestamptz, it.kuittaustyyppi, coalesce(it.vakiofraasi,''), coalesce(it.vapaateksti,''),
         it.kuittaaja_henkilo_etunimi,it.kuittaaja_henkilo_sukunimi, it.kuittaaja_organisaatio_nimi,
         coalesce(it.kuittaaja_organisaatio_ytunnus, ''), it.kanava))) AS kuittaukset
 FROM ilmoitus i

--- a/src/clj/harja/kyselyt/tieliikenneilmoitukset.sql
+++ b/src/clj/harja/kyselyt/tieliikenneilmoitukset.sql
@@ -329,6 +329,12 @@ WHERE urakka = :urakka AND
       (muokattu > :aika OR luotu > :aika);
 
 -- name: hae-ilmoitukset-ytunnuksella
+WITH ilmoitus_urakat AS (SELECT u.id as id, u.urakkanro as urakkanro
+                           FROM urakka u
+                                JOIN organisaatio o ON o.id = u.urakoitsija AND o.ytunnus = '2163026-3'
+                                -- Haetaan vain käynnissäolevista urakoista
+                          WHERE ((u.loppupvm >= NOW() AND u.alkupvm <= NOW()) OR
+                                (u.loppupvm IS NULL AND u.alkupvm <= NOW())))
 SELECT
     i.ilmoitusid,
     i.tunniste,
@@ -363,16 +369,14 @@ SELECT
     i."aiheutti-toimenpiteita",
     json_agg(row_to_json(row(it.kuitattu, it.kuittaustyyppi, coalesce(it.vakiofraasi,''), coalesce(it.vapaateksti,''),
         it.kuittaaja_henkilo_etunimi,it.kuittaaja_henkilo_sukunimi, it.kuittaaja_organisaatio_nimi,
-        coalesce(it.kuittaaja_organisaatio_ytunnus, '')))) AS kuittaukset
+        coalesce(it.kuittaaja_organisaatio_ytunnus, ''), it.kanava))) AS kuittaukset
 FROM ilmoitus i
-    JOIN urakka u ON u.id = i.urakka
-                         -- Haetaan vain käynnissäolevista urakoista
-                         AND ((u.loppupvm >= NOW() AND u.alkupvm <= NOW()) OR (u.loppupvm IS NULL AND u.alkupvm <= NOW()))
-    JOIN organisaatio o ON o.id = u.urakoitsija AND o.ytunnus = :ytunnus
-    JOIN ilmoitustoimenpide it ON it.ilmoitus = i.id
-WHERE (i."valitetty-urakkaan" between :alkuaika::TIMESTAMP AND :loppuaika::TIMESTAMP
+     JOIN ilmoitus_urakat u ON u.id = i.urakka,
+     ilmoitustoimenpide it
+where it.ilmoitus = i.id AND
+    (i."valitetty-urakkaan" between :alkuaika::TIMESTAMP AND :loppuaika::TIMESTAMP
       OR
-       it.kuitattu between :alkuaika::TIMESTAMP AND :loppuaika::TIMESTAMP)
+      it.kuitattu between :alkuaika::TIMESTAMP AND :loppuaika::TIMESTAMP)
 GROUP BY i.id, u.urakkanro, i."valitetty-urakkaan"
 ORDER BY i."valitetty-urakkaan" ASC
 LIMIT 10000;

--- a/src/clj/harja/kyselyt/tieliikenneilmoitukset.sql
+++ b/src/clj/harja/kyselyt/tieliikenneilmoitukset.sql
@@ -332,8 +332,9 @@ WHERE urakka = :urakka AND
 WITH ilmoitus_urakat AS (SELECT u.id as id, u.urakkanro as urakkanro
                            FROM urakka u
                                 JOIN organisaatio o ON o.id = u.urakoitsija AND o.ytunnus = :ytunnus
-                                -- Haetaan vain käynnissäolevista urakoista
-                          WHERE ((u.loppupvm >= NOW() AND u.alkupvm <= NOW()) OR
+                                -- Haetaan vain käynnissäolevista urakoista. Urakat ovat vastuussa tieliikenneilmoituksista
+                                -- 12 h urakan päättymisvuorokauden jälkeenkin.
+                          WHERE (((u.loppupvm + interval '36 hour') >= NOW() AND (u.alkupvm + interval '36 hour') <= NOW()) OR
                                 (u.loppupvm IS NULL AND u.alkupvm <= NOW())))
 SELECT
     i.ilmoitusid,

--- a/src/clj/harja/kyselyt/tieliikenneilmoitukset.sql
+++ b/src/clj/harja/kyselyt/tieliikenneilmoitukset.sql
@@ -331,7 +331,7 @@ WHERE urakka = :urakka AND
 -- name: hae-ilmoitukset-ytunnuksella
 WITH ilmoitus_urakat AS (SELECT u.id as id, u.urakkanro as urakkanro
                            FROM urakka u
-                                JOIN organisaatio o ON o.id = u.urakoitsija AND o.ytunnus = '2163026-3'
+                                JOIN organisaatio o ON o.id = u.urakoitsija AND o.ytunnus = :ytunnus
                                 -- Haetaan vain käynnissäolevista urakoista
                           WHERE ((u.loppupvm >= NOW() AND u.alkupvm <= NOW()) OR
                                 (u.loppupvm IS NULL AND u.alkupvm <= NOW())))

--- a/src/clj/harja/palvelin/integraatiot/api/ilmoitukset.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/ilmoitukset.clj
@@ -8,7 +8,7 @@
             [taoensso.timbre :as log]
             [harja.palvelin.komponentit.http-palvelin :refer [julkaise-reitti poista-palvelut]]
             [harja.palvelin.integraatiot.api.tyokalut.kutsukasittely :refer
-             [kasittele-kutsu kasittele-get-kutsu lokita-kutsu lokita-vastaus tee-vastaus aja-virhekasittelyn-kanssa hae-kayttaja tee-kirjausvastauksen-body]]
+             [kasittele-kutsu kasittele-kevyesti-get-kutsu lokita-kutsu lokita-vastaus tee-vastaus aja-virhekasittelyn-kanssa hae-kayttaja tee-kirjausvastauksen-body]]
             [harja.palvelin.integraatiot.api.tyokalut.json-skeemat :as json-skeemat]
             [harja.palvelin.integraatiot.api.tyokalut.validointi :as validointi]
             [harja.palvelin.integraatiot.api.tyokalut.ilmoitusnotifikaatiot :as notifikaatiot]

--- a/src/clj/harja/palvelin/integraatiot/api/ilmoitukset.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/ilmoitukset.clj
@@ -183,11 +183,15 @@
   (when (not (s/valid? ::alkuaika (:alkuaika parametrit)))
     (virheet/heita-viallinen-apikutsu-poikkeus
       {:koodi virheet/+puutteelliset-parametrit+
-       :viesti (format "Alkuaika väärässä muodossa: %s Anna muodossa: yyyy-MM-dd'T'HH:mm:ssX esim: 2005-01-01T00:00:00+03" (:alkuaika parametrit))}))
+       :viesti (format "Alkuaika väärässä muodossa: %s
+       Anna muodossa: yyyy-MM-dd'T'HH:mm:ssX tai yyyy-MM-dd'T'HH:mm:ss.SSSX
+       esim: 2005-01-01T00:00:00+03 tai 2005-01-01T00:00:00.123+03" (:alkuaika parametrit))}))
   (when (and (not (nil? (:loppuaika parametrit))) (not (s/valid? ::loppuaika (:loppuaika parametrit))))
     (virheet/heita-viallinen-apikutsu-poikkeus
       {:koodi virheet/+puutteelliset-parametrit+
-       :viesti (format "Loppuaika väärässä muodossa: %s Anna muodossa: yyyy-MM-dd'T'HH:mm:ssX esim: 2005-01-02T00:00:00+03" (:loppuaika parametrit))})))
+       :viesti (format "Loppuaika väärässä muodossa: %s
+       Anna muodossa: yyyy-MM-dd'T'HH:mm:ssX tai yyyy-MM-dd'T'HH:mm:ss.SSSX
+       esim: 2005-01-02T00:00:00+03 tai 2005-01-01T00:00:00.123+03" (:loppuaika parametrit))})))
 
 (def db-kuittaus->avaimet
   {:f1 :kuitattu

--- a/src/clj/harja/palvelin/integraatiot/api/ilmoitukset.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/ilmoitukset.clj
@@ -162,8 +162,18 @@
                                          (when kuuntelun-lopetus-fn
                                            (kuuntelun-lopetus-fn)))))))))))))
 
-(s/def ::alkuaika #(and (string? %) (> (count %) 20) (inst? (.parse (SimpleDateFormat. parametrit/pvm-aika-muoto) %))))
-(s/def ::loppuaika #(and (string? %) (> (count %) 20) (inst? (.parse (SimpleDateFormat. parametrit/pvm-aika-muoto) %))))
+;; Sallitaan ajalle kaksi eri formaattia
+(def pvm-aika-muoto1 "yyyy-MM-dd'T'HH:mm:ssX")
+(def pvm-aika-muoto2 "yyyy-MM-dd'T'HH:mm:ss.SSSX")
+(defn valid-aikamuoto? [string]
+  (try
+    (if (< (count string) 25)
+      (inst? (.parse (SimpleDateFormat. pvm-aika-muoto1) string))
+      (inst? (.parse (SimpleDateFormat. pvm-aika-muoto2) string)))
+    (catch Exception e
+      false)))
+(s/def ::alkuaika #(and (string? %) (> (count %) 20) (valid-aikamuoto? %)))
+(s/def ::loppuaika #(and (string? %) (> (count %) 20) (valid-aikamuoto? %)))
 
 (defn- tarkista-ilmoitus-haun-parametrit [parametrit]
   (parametrivalidointi/tarkista-parametrit

--- a/src/clj/harja/palvelin/integraatiot/api/ilmoitukset.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/ilmoitukset.clj
@@ -205,6 +205,11 @@
    :f8 :kuittaaja_organisaatio_ytunnus
    :f9 :kanava})
 
+(defn- parsi-aika [aika]
+  (if (< (count aika) 25)
+    (.parse (SimpleDateFormat. pvm-aika-muoto1) aika)
+    (.parse (SimpleDateFormat. pvm-aika-muoto2) aika)))
+
 (defn hae-ilmoitukset-ytunnuksella
   "Haetaan ilmoitukset y-tunnuksella ja valitetty-harjaan ajan perusteella. Lisätään alueurakkanumero, jotta urakka
   on mahdollista eritellä."
@@ -213,9 +218,9 @@
   (tarkista-ilmoitus-haun-parametrit parametrit)
   (validointi/tarkista-onko-kayttaja-organisaatiossa db ytunnus kayttaja)
   (let [;; Ilmoitukset "valitettu-urakkaan" Timestamp tallennetaan UTC ajassa. Muokataan siitä syystä myös loppuaika ja alkuaika utc aikaan
-        alkuaika (c/to-sql-time (pvm/iso8601-basic->suomen-aika alkuaika))
+        alkuaika (parsi-aika alkuaika)
         loppuaika (if loppuaika
-                    loppuaika
+                    (parsi-aika loppuaika)
                     (c/to-sql-time (pvm/ajan-muokkaus (pvm/joda-timeksi (pvm/nyt)) true 1 :tunti)))
         ilmoitukset (tieliikenneilmoitukset-kyselyt/hae-ilmoitukset-ytunnuksella
                       db


### PR DESCRIPTION
Korjattu ilmoitusrajapinnan päivämääräkäsittelyyn timezone tuki. Ennen se vain ignoorasi timezonen, nyt sillä on haussa oikeasti merkitystä.
Lisäksi lisätty tuki päivämäärän sekunnin desimaaleille
Ja nopeutettu hakua
Optimoitu kutsukäsittelyä jättämällä validointi pois