### PR TITLE
VHAR-6731 Ota YHA:n api.testivaylapilvi ympäristö käyttöön Harjan muualla kuin tuotannossa

### DIFF
--- a/.circleci/aja-cypress-kontissa.bash
+++ b/.circleci/aja-cypress-kontissa.bash
@@ -11,7 +11,7 @@ sed -i -e 's/:kehitysmoodi true/:kehitysmoodi false/g' asetukset.edn
 sed -i -e "s/:palvelin \"localhost\"/:palvelin \"postgres\"/g" asetukset.edn
 mkdir -p ../.harja
 echo aaaa > ../.harja/anti-csrf-token
-touch ../.harja/{mml,google-static-maps-key,turi-salasana,ava-salasana,yha-salasana,labyrintti-salasana,velho-salasana,velho-varuste-salasana,api-sahkoposti,salasana}
+touch ../.harja/{mml,google-static-maps-key,turi-salasana,ava-salasana,yha-salasana,yha-api-key,labyrintti-salasana,velho-salasana,velho-varuste-salasana,api-sahkoposti,salasana}
 java -jar /jar/harja.jar > harja.out 2>&1 &
 javapid=$!
 for i in $(seq 4); do

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,7 +241,7 @@ jobs:
             cp /tmp/harja/.harja_env .
             mkdir -p ../.harja
             echo aaaa > ../.harja/anti-csrf-token
-            touch ../.harja/{mml,google-static-maps-key,turi-salasana,ava-salasana,yha-salasana,labyrintti-salasana,velho-salasana,velho-varuste-salasana,api-sahkoposti-salasana}
+            touch ../.harja/{mml,google-static-maps-key,turi-salasana,ava-salasana,yha-salasana,yha-api-key,labyrintti-salasana,velho-salasana,velho-varuste-salasana,api-sahkoposti-salasana}
             java -jar /tmp/harja/target/harja-0.0.1-SNAPSHOT-standalone.jar > harja.out 2>&1 &
             for i in $(seq 10); do
               curl localhost:3000 > /dev/null 2>&1 && break

--- a/.circleci/docker-harja-testit/Dockerfile
+++ b/.circleci/docker-harja-testit/Dockerfile
@@ -23,7 +23,7 @@ RUN rm ~/phantomjs-2.1.1-linux-x86_64.tar.bz2
 RUN cd /tmp; git clone https://github.com/finnishtransportagency/harja.git;
 RUN mkdir .harja; \
     echo aaaa > .harja/anti-csrf-token; \
-    touch .harja/{mml,google-static-maps-key,turi-salasana,ava-salasana,yha-salasana,labyrintti-salasana,velho-salasana,velho-varuste-salasana,api-sahkoposti-salasana};
+    touch .harja/{mml,google-static-maps-key,turi-salasana,ava-salasana,yha-salasana,yha-api-key,labyrintti-salasana,velho-salasana,velho-varuste-salasana,api-sahkoposti-salasana};
 # Tässä cachetetaan dependensyt imageen. Muuttuneet dependencyt joudutaan kumminkin hakemaan toisessa lein ajossa.
 RUN cd /tmp/harja/; lein deps;
 RUN cd /tmp/harja/; lein with-profile test deps;

--- a/asetukset.edn
+++ b/asetukset.edn
@@ -185,9 +185,10 @@
                         :kanavien-osoite "https://ava.vayla.fi/harja/Kanavat.shz"
                         :kanavien-tuontikohde "./shp/Vesivaylien_kanavat/Kanavat.shz"}
 
- :yha {:url "https://harja-test.solitaservices.fi/harja/integraatiotesti/yha/"
-       :kayttajatunnus "restusr"
-       :salasana #=(slurp "../.harja/yha-salasana")}
+ :yha {:url "https://api.testivaylapilvi.fi/yha/rest/"
+       :kayttajatunnus "restusr" ;; Poistetaan kun pilviversio käytössä
+       :salasana #=(slurp "../.harja/yha-salasana") ;; Poistetaan kun pilviversio käytössä
+       :api-key #=(slurp "../.harja/yha-api-key")}
 
  :velho {:paallystetoteuma-url "https://api-v2.stg.velho.vayla.fi/toimenpiderekisteri/api/v1/kohde/toimenpiteet/tienrakennetoimenpiteet"
          :token-url "https://auth.stg.velho.vayla.fi/oauth2/token"

--- a/asetukset.edn
+++ b/asetukset.edn
@@ -188,7 +188,7 @@
  :yha {:url "https://api.testivaylapilvi.fi/yha/rest/"
        :kayttajatunnus "restusr" ;; Poistetaan kun pilviversio käytössä
        :salasana #=(slurp "../.harja/yha-salasana") ;; Poistetaan kun pilviversio käytössä
-       :api-key #=(slurp "../.harja/yha-api-key")}
+       :api-key #=(slurp "../.harja/yha-api-key")} ;; Testipalvelimen avain projektin jakamassa LastPass-kansiossa.
 
  :velho {:paallystetoteuma-url "https://api-v2.stg.velho.vayla.fi/toimenpiderekisteri/api/v1/kohde/toimenpiteet/tienrakennetoimenpiteet"
          :token-url "https://auth.stg.velho.vayla.fi/oauth2/token"

--- a/src/clj/harja/palvelin/asetukset.clj
+++ b/src/clj/harja/palvelin/asetukset.clj
@@ -151,7 +151,8 @@
 
    (s/optional-key :yha) {:url s/Str
                           :kayttajatunnus s/Str
-                          :salasana s/Str}
+                          :salasana s/Str
+                          :api-key s/Str}
 
    (s/optional-key :velho) {:paallystetoteuma-url s/Str
                             :token-url s/Str

--- a/src/clj/harja/palvelin/integraatiot/yha/yha_komponentti.clj
+++ b/src/clj/harja/palvelin/integraatiot/yha/yha_komponentti.clj
@@ -145,8 +145,8 @@
     parametrit))
 
 (defn- yha-otsikot [api-key]
-  {"Content-Type" "text/xml; charset=utf-8"
-   "x-api-key" api-key} )
+  (merge {"Content-Type" "text/xml; charset=utf-8"}
+         (when api-key {"x-api-key" api-key})) )
 
 (defn hae-kohteen-paallystysilmoitus [db kohde-id]
   (let [ilmoitus (first (q-paallystys/hae-paallystysilmoitus-kohdetietoineen-paallystyskohteella db {:paallystyskohde kohde-id}))


### PR DESCRIPTION
Mahdollista YHA:n käyttäminen testiväyläpilvestä

Tämän hetkinen koodi tukee molempia tapoja käyttää YHA:aa:
-tuotannossa voidaan käyttää yliheittoon asti api.vayla.fi
-staging ja alemmissa ympäristöissä otetaan käyttöön testivaylapilvi.fi