### PR TITLE
Vhar 6762

### DIFF
--- a/src/cljs/harja/views/urakka/suunnittelu/suola.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/suola.cljs
@@ -403,16 +403,18 @@
         :varoita [tarkasta-sakko-ja-bonus]
         :vihje "Jos urakassa käytössä vain suolasakko eikä bonusta, täytä vain tämä"
         :vayla-tyyli? false}
-       (when (urakka/indeksi-kaytossa-sakoissa?)
-         {:otsikko "Indeksi"
-          :nimi :indeksi
-          :tyyppi :komponentti
-          :komponentti (fn [_]
-                         [:div.kentta-indeksi
-                          ;; Näytetään käyttäjälle aina urakan indeksin nimi rajoitusalueiden suolasanktioissa.
-                          ;; Indeksin nimi asetetaan aina automaattisesti back-endissä. Käyttäjä ei saa valita sitä itse.
-                          [:div (-> @tila/yleiset :urakka :indeksi)]])
-          :palstoja 1})]
+
+       {:otsikko "Indeksi"
+        :nimi :indeksi
+        :tyyppi :komponentti
+        :komponentti (fn [_]
+                       [:div.kentta-indeksi
+                        ;; Näytetään käyttäjälle aina urakan indeksin nimi rajoitusalueiden suolasanktioissa.
+                        ;; Indeksin nimi asetetaan aina automaattisesti back-endissä urakan indeksiksi. Käyttäjä ei saa valita sitä itse
+                        (if (urakka/indeksi-kaytossa-sakoissa?)
+                          [:div (-> @tila/yleiset :urakka :indeksi)]
+                          [:div "Ei indeksiä"])])
+        :palstoja 1}]
       lomake]]))
 
 
@@ -458,7 +460,9 @@
                          [:div.kentta-indeksi
                           ;; Näytetään käyttäjälle aina urakan indeksin nimi rajoitusalueiden suolasanktioissa.
                           ;; Indeksin nimi asetetaan aina automaattisesti back-endissä urakan indeksiksi. Käyttäjä ei saa valita sitä itse.
-                          [:div (-> @tila/yleiset :urakka :indeksi)]])
+                          (if (urakka/indeksi-kaytossa-sakoissa?)
+                            [:div (-> @tila/yleiset :urakka :indeksi)]
+                            [:div "Ei indeksiä"])])
           :palstoja 1})]
       (get-in app [:kayttorajat :rajoitusalueiden-suolasanktio])]]))
 

--- a/src/cljs/harja/views/urakka/suunnittelu/suola.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/suola.cljs
@@ -451,17 +451,15 @@
           :yksikko "€"
           :piilota-yksikko-otsikossa? true
           :vayla-tyyli? true}
-
-         (when (urakka/indeksi-kaytossa-sakoissa?)
-           {:otsikko "Indeksi"
-            :nimi :indeksi
-            :tyyppi :komponentti
-            :komponentti (fn [_]
-                           [:div.kentta-indeksi
-                            ;; Näytetään käyttäjälle aina urakan indeksin nimi rajoitusalueiden suolasanktioissa.
-                            ;; Indeksin nimi asetetaan aina automaattisesti back-endissä. Käyttäjä ei saa valita sitä itse.
-                            [:div (-> @tila/yleiset :urakka :indeksi)]])
-            :palstoja 1}))]
+         {:otsikko "Indeksi"
+          :nimi :indeksi
+          :tyyppi :komponentti
+          :komponentti (fn [_]
+                         [:div.kentta-indeksi
+                          ;; Näytetään käyttäjälle aina urakan indeksin nimi rajoitusalueiden suolasanktioissa.
+                          ;; Indeksin nimi asetetaan aina automaattisesti back-endissä urakan indeksiksi. Käyttäjä ei saa valita sitä itse.
+                          [:div (-> @tila/yleiset :urakka :indeksi)]])
+          :palstoja 1})]
       (get-in app [:kayttorajat :rajoitusalueiden-suolasanktio])]]))
 
 (defn taulukko-rajoitusalueet


### PR DESCRIPTION
Korjaus: Näytetään aina tieto tallennettavasta urakan indeksistä käyttöliittymässä suolasuunnittelun puolella, jotta indeksi-kenttä ei jää tyhjäksi. (Indeksin nimeä ei näy ollenkaan kuitenkaan siinä tapauksessa, jos urakalle ei ole muistettu määritellä MAKU-indeksiä, jonka pitäisi olla melko harvinaista.)

Tässä korjauksessa ei ole mitenkään otettu huomioon sitä, että lasketaanko indeksikorjausta oikeasti sakolle/sanktiolle urakan tyypin/alkuvuoden. Näytetään vain urakan indeksin nimi, joka tallennetaan suolasakko-tauluun sakon/sanktion määrän kanssa.
Päätös indeksikorjauksen tekemisestä tehdään muualla back-endissä.

Ajateltavaa erillseen tikettiin:
Täytyisi miettiä yleisesti paremmin, miten käyttäjää informoidaan indeksikorjauksen laskennasta.
Päätökset indeksikorjauksen laskennasta tehdään back-endissä ja sql-koodissa, mutta kaikki tähän päätökseen johtavat säännöt eivät ole suoraan saatavilla käyttöliittymäkoodissa, jotta käyttäjää voisi informoida tarvittaessa.