### PR TITLE
VHAR-6801 Korjaa hoitokauden vaihtumisen rikkoma Harjan e2e pot2-testi

### DIFF
--- a/cypress/integration/pot_lomake.js
+++ b/cypress/integration/pot_lomake.js
@@ -302,7 +302,7 @@ describe("POT2", function() {
                 kaista: 11
             })
     })
-    it('Avaa POT2-lomake jos vuosi on 2021', function () {
+    it('Avaa POT2-lomake jos vuosi on 2021 tai sen jälkeen', function () {
         cy.viewport(1100, 2000)
         avaaPaallystysIlmoitus(2021, 'Utajärven päällystysurakka', 'Tärkeä kohde mt20', 'Kesken', 'Muokkaa')
         cy.get('div.pot2-lomake')

--- a/tietokanta/testidata/sopimukset.sql
+++ b/tietokanta/testidata/sopimukset.sql
@@ -79,7 +79,7 @@ BEGIN
     ('Ivalon MHU testiurakan sopimus',urakan_aloitus_pvm, urakan_paattymis_pvm,'MHU-TESTI-LAP-IVA', (SELECT id FROM urakka WHERE nimi='Ivalon MHU testiurakka (uusi)')),
 
     -- Päällystysurakat
-    ('Utajärven päällystyksen pääsopimus', urakan_aloitus_pvm,urakan_paattymis_pvm,'5H05339/10', (SELECT id FROM urakka WHERE nimi='Utajärven päällystysurakka'));
+    ('Utajärven päällystyksen pääsopimus', '2021-01-01','2022-12-31','5H05339/10', (SELECT id FROM urakka WHERE nimi='Utajärven päällystysurakka'));
 END $$;
 
 -- Aktiivinen oulu

--- a/tietokanta/testidata/urakat.sql
+++ b/tietokanta/testidata/urakat.sql
@@ -55,7 +55,7 @@ BEGIN
   VALUES ('1337133-TES2', 'kokonaisurakka' :: sopimustyyppi, (SELECT id
                                                               FROM organisaatio
                                                               WHERE lyhenne = 'POP'), 'Utajärven päällystysurakka',
-          urakan_aloitus_pvm, urakan_paattymis_pvm, 'paallystys', 'uta1', (SELECT id
+          '2021-01-01', '2022-12-31', 'paallystys', 'uta1', (SELECT id
                                                                            FROM organisaatio
                                                                            WHERE ytunnus = '0651792-4'));
 END $$;


### PR DESCRIPTION
Aseta testidatassa Utajärven urakan alku- ja loppuaika käsin

Ei ole tarkoituksenmukaista sitoa päällystysurakan alku- ja loppupvm:ää hoitokauden vaihtumioseen. Tämä korjaa myös rikkoutuneen testin, sekä tuo varsin hyödylliset 2021 ja 2022 kohteet pysyvästi testattavaksi käyttöliittymässä.  