### PR TITLE
VHAR-6913 - Muuta bonuksen nimi Alihankintabonus -> Alihankintasopimusten maksuehtobonus

### DIFF
--- a/src/cljc/harja/domain/laadunseuranta/sanktio.cljc
+++ b/src/cljc/harja/domain/laadunseuranta/sanktio.cljc
@@ -196,14 +196,15 @@
   (second
     (sanktiofraasi-avaimella fraasin-avain)))
 
-(defn bonustyypin-teksti [avainsana]
+(defn bonustyypin-teksti
   "Erilliskustannustyypin teksti avainsanaa vastaan"
+  [avainsana]
   (case avainsana
     :asiakastyytyvaisyysbonus "Asiakastyytyväisyys\u00ADbonus"
     :muu-bonus "Muu bonus (vahingonkorvaus, liikennevahingot jne.)"
-    :alihankintabonus "Alihankintabonus"
+    :alihankintabonus "Alihankintasopimusten maksuehtobonus"
     :tavoitepalkkio "Tavoitepalkkio"
-    :lupausbonus "Lupausbonus"    
+    :lupausbonus "Lupausbonus"
     "- Valitse tyyppi -"))
 
 (defn luo-kustannustyypit [urakkatyyppi kayttaja toimenpideinstanssi]

--- a/src/cljs/harja/views/urakka/laadunseuranta/sanktiot.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/sanktiot.cljs
@@ -54,7 +54,7 @@
     :vesivayla_bonus "Bonus"
 
     :lupausbonus "Lupausbonus"
-    :alihankintabonus "Alihankintabonus"
+    :alihankintabonus "Alihankintasopimusten maksuehtobonus"
     :asiakastyytyvaisyysbonus "Asiakastyytyväisyysbonus"
     :muu-bonus "Muu bonus (vahingonkorvaus, liikennevahingot jne.)"
     "- valitse laji -"))


### PR DESCRIPTION
* Tilaajan palautteen pohjalta.
* Perustelu: "Alihankintabonus" teksti käyttöliittymässä voi sekoittua lupauksissa maksettavaan "alihankkijabonukseen".