### PR TITLE
Korjaa laskutusyhteenveto, jolla väärin kirjattuja muutoshintaisia töitä

### DIFF
--- a/tietokanta/src/main/resources/db/migration/R__Laskutusyhteenveto.sql
+++ b/tietokanta/src/main/resources/db/migration/R__Laskutusyhteenveto.sql
@@ -393,7 +393,7 @@ BEGIN
     vahinkojen_korjaukset_laskutetaan_ind_korotettuna := 0.0;
     vahinkojen_korjaukset_laskutetaan_ind_korotus := 0.0;
 
-    FOR mhti IN SELECT COALESCE(tt.paivan_hinta, tt.maara * mht.yksikkohinta) AS mht_summa,
+    FOR mhti IN SELECT COALESCE(tt.paivan_hinta, tt.maara * mht.yksikkohinta, 0) AS mht_summa,
                        tot.alkanut AS tot_alkanut,
 		       tt.indeksi,
 		       tot.tyyppi


### PR DESCRIPTION
On mahdollista kirjata muutoshintainen- tai lisätyö siten, että sille ei voida laskea kustannusta. Jos niin tapahtuu, laskutusyhteenvedolla näytetään virheellisesti, että indeksiä ei olisi saataville kyseiselle toimenpiteelle, koska kustannukseksi lasketaan NULL -> PSQL ei tykkää. Coalescetoidaan se nollaksi jolloin laskenta toimii.