### PR TITLE
Sammuta tarkkailija vasta kun harja on sammutettu

### DIFF
--- a/src/clj/harja/palvelin/main.clj
+++ b/src/clj/harja/palvelin/main.clj
@@ -836,11 +836,11 @@
         (System/exit 1)))))
 
 (defn sammuta-jarjestelma []
-  (sammuta-harja-tarkkailija!)
   (when harja-jarjestelma
     (alter-var-root #'harja-jarjestelma (fn [s]
                                           (component/stop s)
-                                          nil))))
+                                          nil)))
+  (sammuta-harja-tarkkailija!))
 
 (defn -main [& argumentit]
   (kaynnista-jarjestelma (or (first argumentit) asetukset-tiedosto) true)


### PR DESCRIPTION
Kun harja-järjestelmä sammuu, se yrittää kutsua tarkkailija-järjestelmässä olevaa rajapintaa kuuntelijoiden lopettamiseksi. Nykyisellään tarkkailija sammutetaan ennen harja-järjestelmää, joten rajapintakutsu aiheuttaa errorin. Tästä ei periaatteessa ole haittaa, koska molemmat järjestelmät sammuvat ja kuuntelijat poistuvat samalla.
Tämä kuitenkin heittää errorin, josta aiheutuu lokeille turhaa kohinaa.