### PR TITLE
VHAR-7216 - Korjaa erilliskustannusten 'muu-bonus' tyyppiset rivit

### DIFF
--- a/tietokanta/src/main/resources/db/migration/V1_978__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_978__.sql
@@ -1,0 +1,18 @@
+-- Muuta hoitourakoille 'muu-bonus'-tyyppiseksi virheellisesti muunnetut 'muu'-tyyppiset erilliskustannukset takaisin 'muu'-tyyppisiksi.
+-- Jätetään 'muu-bonus'-tyyppisiksi vain sellaiset rivit, joissa mainitaan sana 'bonus'
+
+  WITH paivitettavat AS
+           (SELECT ek.id AS ek_id
+              FROM erilliskustannus ek
+                       JOIN urakka u ON ek.urakka = u.id
+             WHERE ek.tyyppi = 'muu-bonus'
+               AND (u.tyyppi = 'hoito' AND
+                 -- lisatieto-kolumnissa voi olla NULL-arvoja, joten varmistetaan stringiin vertaaminen, jotta "NOT ILIKE" osuu.
+                    COALESCE(ek.lisatieto, '') NOT ILIKE '%bonus%'))
+
+UPDATE erilliskustannus ek2
+   SET tyyppi    = 'muu',
+       muokattu  = CURRENT_TIMESTAMP,
+       muokkaaja = (SELECT id FROM kayttaja WHERE kayttajanimi = 'Integraatio')
+  FROM paivitettavat p
+ WHERE ek2.id = p.ek_id;


### PR DESCRIPTION
Kaikki hoidon erilliskustannukset, jotka ovat tyyppiä 'muu-bonus':

```
SELECT COUNT(*)
  FROM erilliskustannus ek
           JOIN urakka u ON ek.urakka = u.id
 WHERE ek.tyyppi = 'muu-bonus'
   AND (u.tyyppi = 'hoito');

->  6186 riviä

```
Erilliskustannukset ('muu-bonus'), jotka sisältävät sanan 'bonus':
```
SELECT COUNT(*)
  FROM erilliskustannus ek
           JOIN urakka u ON ek.urakka = u.id
 WHERE ek.tyyppi = 'muu-bonus'
   AND (u.tyyppi = 'hoito' AND
        ek.lisatieto ILIKE '%bonus%');

-> 105 riviä
```
Erilliskustannukset ('muu-bonus'), jotka eivät sisällä sanaa 'bonus':

```
SELECT COUNT(*)
  FROM erilliskustannus ek
           JOIN urakka u ON ek.urakka = u.id
 WHERE ek.tyyppi = 'muu-bonus'
   AND (u.tyyppi = 'hoito' AND
        COALESCE(ek.lisatieto, '') NOT ILIKE '%bonus%');

-> 6081 riviä  (6186 - 105 = 6081)
```
-> Vaihdetaan tyyppi 'muu-bonus' -> 'muu' 6081:lle riville.
