### PR TITLE
Vhar 7241 valikatselmus tavoitehinnanoikaisu

### DIFF
--- a/src/clj/harja/kyselyt/valikatselmus.clj
+++ b/src/clj/harja/kyselyt/valikatselmus.clj
@@ -33,9 +33,17 @@
   (insert! db ::valikatselmus/tavoitehinnan-oikaisu oikaisu))
 
 (defn paivita-oikaisu [db oikaisu]
-  (update! db ::valikatselmus/tavoitehinnan-oikaisu
-           oikaisu
-           {::valikatselmus/oikaisun-id (::valikatselmus/oikaisun-id oikaisu)}))
+  (let [;; Päivitä oikaisu palauttaa vain päivitettyjen rivien määrän
+        _ (update! db ::valikatselmus/tavoitehinnan-oikaisu
+             oikaisu
+             {::valikatselmus/oikaisun-id (::valikatselmus/oikaisun-id oikaisu)})
+
+        ;; Haetaan id:n perusteella juuri päivitetty oikaisu
+        paivitetty (first
+                     (fetch db ::valikatselmus/tavoitehinnan-oikaisu
+                       (columns ::valikatselmus/tavoitehinnan-oikaisu)
+                       {::valikatselmus/oikaisun-id (::valikatselmus/oikaisun-id oikaisu)}))]
+    paivitetty))
 
 (defn poista-oikaisu [db oikaisu]
   (update! db ::valikatselmus/tavoitehinnan-oikaisu

--- a/src/cljs/harja/tiedot/urakka/kulut/valikatselmus.cljs
+++ b/src/cljs/harja/tiedot/urakka/kulut/valikatselmus.cljs
@@ -110,12 +110,17 @@
     (let [oikaisu (merge {::urakka/id (-> @tila/yleiset :urakka :id)
                           :harja.domain.kulut.valikatselmus/hoitokauden-alkuvuosi (:hoitokauden-alkuvuosi app)}
                          oikaisu)]
-      (tuck-apurit/post! :tallenna-tavoitehinnan-oikaisu
-                         oikaisu
-                         {:onnistui ->TallennaOikaisuOnnistui
-                          :onnistui-parametrit [id]
-                          :epaonnistui ->TallennaOikaisuEpaonnistui
-                          :paasta-virhe-lapi? true}))
+      ;; Lähetetään oikaisun tallennus serverille vain, jos kaikki tiedot on syötetty
+      (when (and (:harja.domain.kulut.valikatselmus/otsikko oikaisu)
+              (:harja.domain.kulut.valikatselmus/summa oikaisu)
+              (:harja.domain.kulut.valikatselmus/hoitokauden-alkuvuosi oikaisu)
+              (::urakka/id oikaisu))
+        (tuck-apurit/post! :tallenna-tavoitehinnan-oikaisu
+          oikaisu
+          {:onnistui ->TallennaOikaisuOnnistui
+           :onnistui-parametrit [id]
+           :epaonnistui ->TallennaOikaisuEpaonnistui
+           :paasta-virhe-lapi? true})))
     app)
 
   TallennaOikaisuOnnistui

--- a/src/cljs/harja/views/urakka/kulut/valikatselmus.cljs
+++ b/src/cljs/harja/views/urakka/kulut/valikatselmus.cljs
@@ -150,6 +150,7 @@
 (defn tavoitehinnan-oikaisut [e! {:keys [urakan-paatokset valittu-hoitokausi tavoitehinnan-oikaisut hoitokauden-alkuvuosi] :as app}]
   (let [paatoksia? (seq urakan-paatokset)
         hoitokauden-oikaisut (get tavoitehinnan-oikaisut hoitokauden-alkuvuosi)
+        hoitokauden-oikaisut-atom (atom hoitokauden-oikaisut)
         nykyhetki (pvm/nyt)
         ;; Joskus valittua hoitokautta ei ole asetettu
         valittu-hoitokausi (or
@@ -171,7 +172,7 @@
                                            voi-muokata?
                                            (lupaus-domain/vuosi-19-20? urakan-alkuvuosi))]
     [:div
-     [yhteiset/tavoitehinnan-oikaisut-taulukko hoitokauden-oikaisut
+     [yhteiset/tavoitehinnan-oikaisut-taulukko hoitokauden-oikaisut-atom
       {:voi-muokata? voi-muokata? :hoitokauden-alkuvuosi hoitokauden-alkuvuosi
        :poista-oikaisu-fn #(e! (valikatselmus-tiedot/->PoistaOikaisu %1 %2))
        :tallenna-oikaisu-fn #(e! (valikatselmus-tiedot/->TallennaOikaisu %1 %2))

--- a/src/cljs/harja/views/urakka/kulut/yhteiset.cljs
+++ b/src/cljs/harja/views/urakka/kulut/yhteiset.cljs
@@ -189,77 +189,78 @@
   :tallenna-oikaisu-fn    Funktio, jolla tallennetaan oikaisu, esimerkiksi tuck-funktio joka tekee kutsun bäkkäriin.
   :tallenna-oikaisut-fn   Funktio, jolla päivitetään oikaisut, esimerkiksi tuck-funktio joka tekee kutsun bäkkäriin.
                           Kutsutaan jokaisesta muutoksesta."
-  [hoitokauden-oikaisut {:keys [_voi-muokata? _poista-oikaisu-fn _tallenna-oikaisu-fn
-                                _paivita-oikaisu-fn _hoitokauden-alkuvuosi]}]
-  (let [tallennettu-tila (atom hoitokauden-oikaisut)
-        virheet (atom {})]
-    (fn [hoitokauden-oikaisut {:keys [voi-muokata? poista-oikaisu-fn tallenna-oikaisu-fn
-                                      paivita-oikaisu-fn hoitokauden-alkuvuosi]}]
-      [grid/muokkaus-grid
-       {:otsikko "Tavoitehinnan oikaisut"
-        :tyhja "Ei oikaisuja"
-        :voi-kumota? false
-        :voi-muokata? voi-muokata?
-        :toimintonappi-fn (when voi-muokata?
-                            (fn [rivi _muokkaa! id]
-                              [napit/poista ""
-                               #(do
-                                  (poista-oikaisu-fn rivi id)
-                                  (reset! tallennettu-tila hoitokauden-oikaisut))
-                               {:luokka "napiton-nappi"}]))
-        :uusi-rivi-nappi-luokka "nappi-reunaton"
-        :lisaa-rivi "Lisää oikaisu"
-        :validoi-uusi-rivi? false
-        :on-rivi-blur (fn [oikaisu i]
-                        (when-not (or (= @tallennettu-tila hoitokauden-oikaisut)
-                                    (seq (get @virheet i))
-                                    (:koskematon (get hoitokauden-oikaisut i)))
-                          (tallenna-oikaisu-fn oikaisu i)
-                          (reset! tallennettu-tila hoitokauden-oikaisut)))
-        :uusi-id (if (empty? (keys hoitokauden-oikaisut))
-                   0
-                   (inc (apply max (keys hoitokauden-oikaisut))))
-        :virheet virheet
-        :nayta-virheikoni? false}
-       [{:otsikko "Luokka"
-         :nimi ::valikatselmus/otsikko
-         :tyyppi :valinta
-         :valinnat valikatselmus/luokat ;; TODO: Älä näytä "Alleviivatun fontin vaikutus tavoitehintaan" muissa kuin 19-20 alkaneissa.
-         :validoi [[:ei-tyhja "Valitse arvo"]]
-         :leveys 2}
-        {:otsikko "Selite"
-         :nimi ::valikatselmus/selite
-         :tyyppi :string
-         :validoi [[:ei-tyhja "Täytä arvo"]]
-         :leveys 3}
-        {:otsikko "Lisäys / Vähennys"
-         :nimi :lisays-tai-vahennys
-         :hae #(if (neg? (::valikatselmus/summa %)) :vahennys :lisays)
-         :aseta (fn [rivi arvo]
-                  ;; Käännetään summa, jos valittu arvo ei täsmää arvon merkkisyyteen.
-                  (let [maksu (js/parseFloat (::valikatselmus/summa rivi))
-                        rivi (assoc rivi :lisays-tai-vahennys arvo)]
-                    (if (or (and (neg? maksu) (= :lisays arvo)) (and (pos? maksu) (= :vahennys arvo)))
-                      (update rivi ::valikatselmus/summa -)
-                      rivi)))
-         :tyyppi :valinta
-         :valinnat [:lisays :vahennys]
-         :valinta-arvo identity
-         :valinta-nayta {:lisays "Lisäys" ;; TODO: Korjaa lukumoodissa
-                         :vahennys "Vähennys"}
-         :leveys 2}
-        {:otsikko "Summa"
-         :nimi ::valikatselmus/summa
-         :tyyppi :numero
-         :tasaa :oikea
-         :aseta (fn [rivi arvo]
-                  (let [vahennys? (= :vahennys (:lisays-tai-vahennys rivi))]
-                    (if (and vahennys? (pos? arvo))
-                      (assoc rivi ::valikatselmus/summa (- arvo))
-                      (assoc rivi ::valikatselmus/summa arvo))))
-         :fmt #(str (Math/abs %))
-         :validoi [[:ei-tyhja "Täytä arvo"]]
-         :leveys 2}]
-       (r/wrap hoitokauden-oikaisut
-         (fn [uusi]
-           (paivita-oikaisu-fn hoitokauden-alkuvuosi uusi)))])))
+  [hoitokauden-oikaisut-atom {:keys [voi-muokata? poista-oikaisu-fn tallenna-oikaisu-fn
+                                                                 paivita-oikaisu-fn hoitokauden-alkuvuosi]}]
+  (let [virheet (atom {})
+        uusi-id (if (empty? (keys @hoitokauden-oikaisut-atom))
+                  0
+                  (inc (apply max (keys @hoitokauden-oikaisut-atom))))]
+    [grid/muokkaus-grid
+     {:otsikko "Tavoitehinnan oikaisut"
+      :tyhja "Ei oikaisuja"
+      :voi-kumota? false
+      :voi-muokata? voi-muokata?
+      ;; Lisää oikaisunappula taulukon yläpuolella oikealla
+      :custom-toiminto {:teksti "Lisää oikaisu"
+                        :toiminto #(do
+                                     (swap! hoitokauden-oikaisut-atom assoc uusi-id
+                                       {:id uusi-id :koskematon true :lisays-tai-vahennys :lisays}))
+                        :opts {:ikoni (ikonit/livicon-plus)
+                               :luokka "nappi-toissijainen"}}
+      ;; Roskakorinappula rivin päässä
+      :toimintonappi-fn (when voi-muokata?
+                              (fn [rivi _muokkaa! id]
+                                [napit/poista ""
+                                 #(do
+                                    (poista-oikaisu-fn rivi id)
+                                    #_ (reset! tallennettu-tila hoitokauden-oikaisut))
+                                 {:luokka "napiton-nappi"}]))
+      :voi-lisata? false ;; Piilotetaan default lisää rivi -nappi. Se on korvattu custom-toiminnolla
+      :validoi-uusi-rivi? false
+      :on-rivi-blur (fn [oikaisu i]
+                      (when-not (or (seq (get @virheet i))
+                                  (:koskematon (get @hoitokauden-oikaisut-atom i)))
+                        (tallenna-oikaisu-fn oikaisu i)))
+      :uusi-id uusi-id
+      :virheet virheet
+      :nayta-virheikoni? false}
+     [{:otsikko "Luokka"
+       :nimi ::valikatselmus/otsikko
+       :tyyppi :valinta
+       :valinnat valikatselmus/luokat ;; TODO: Älä näytä "Alleviivatun fontin vaikutus tavoitehintaan" muissa kuin 19-20 alkaneissa.
+       :validoi [[:ei-tyhja "Valitse arvo"]]
+       :leveys 2}
+      {:otsikko "Selite"
+       :nimi ::valikatselmus/selite
+       :tyyppi :string
+       :validoi [[:ei-tyhja "Täytä arvo"]]
+       :leveys 3}
+      {:otsikko "Lisäys / Vähennys"
+       :nimi :lisays-tai-vahennys
+       :hae #(if (neg? (::valikatselmus/summa %)) :vahennys :lisays)
+       :aseta (fn [rivi arvo]
+                ;; Käännetään summa, jos valittu arvo ei täsmää arvon merkkisyyteen.
+                (let [maksu (js/parseFloat (::valikatselmus/summa rivi))
+                      rivi (assoc rivi :lisays-tai-vahennys arvo)]
+                  (if (or (and (neg? maksu) (= :lisays arvo)) (and (pos? maksu) (= :vahennys arvo)))
+                    (update rivi ::valikatselmus/summa -)
+                    rivi)))
+       :tyyppi :valinta
+       :valinnat [:lisays :vahennys]
+       :valinta-arvo identity
+       :valinta-nayta {:lisays "Lisäys" ;; TODO: Korjaa lukumoodissa
+                       :vahennys "Vähennys"}
+       :leveys 2}
+      {:otsikko "Summa"
+       :nimi ::valikatselmus/summa
+       :tyyppi :numero
+       :tasaa :oikea
+       :aseta (fn [rivi arvo]
+                (let [vahennys? (= :vahennys (:lisays-tai-vahennys rivi))]
+                  (if (and vahennys? (pos? arvo))
+                    (assoc rivi ::valikatselmus/summa (- arvo))
+                    (assoc rivi ::valikatselmus/summa arvo))))
+       :fmt #(str (Math/abs %))
+       :validoi [[:ei-tyhja "Täytä arvo"]]
+       :leveys 2}]
+     hoitokauden-oikaisut-atom]))

--- a/test/clj/harja/palvelin/palvelut/kulut/valikatselmus_test.clj
+++ b/test/clj/harja/palvelin/palvelut/kulut/valikatselmus_test.clj
@@ -141,8 +141,16 @@
                   (kutsu-palvelua (:http-palvelin jarjestelma)
                                   :tallenna-tavoitehinnan-oikaisu
                                   +kayttaja-jvh+
-                                  (assoc muokattava-oikaisu ::valikatselmus/summa 50000)))]
-    (is (= 1 vastaus) "Summan muokkaus ei onnistunut")
+                                  (assoc muokattava-oikaisu ::valikatselmus/summa 50000)))
+        ;; Ajankohtien millisekunnit hieman heittävät tallennuksen yhteydessä, niin trimmataan niitä hieman
+        odotettu-vastaus (-> vastaus
+                           (update :harja.domain.muokkaustiedot/muokattu #(pvm/aika-iso8601-ilman-millisekunteja %))
+                           (update :harja.domain.muokkaustiedot/luotu #(pvm/aika-iso8601-ilman-millisekunteja %)))
+        muokattava-oikaisu (-> muokattava-oikaisu
+                             (assoc ::valikatselmus/summa 50000M) ;; Summa muuttuu 2000 -> 50000 ja tätä nimen omaan testataan
+                             (update :harja.domain.muokkaustiedot/muokattu #(pvm/aika-iso8601-ilman-millisekunteja %))
+                             (update :harja.domain.muokkaustiedot/luotu #(pvm/aika-iso8601-ilman-millisekunteja %)))]
+    (is (= muokattava-oikaisu odotettu-vastaus) "Summan muokkaus ei onnistunut")
 
     (let [oikaisut-jalkeen (get (kutsu-palvelua (:http-palvelin jarjestelma)
                                                 :hae-tavoitehintojen-oikaisut


### PR DESCRIPTION
Toisen tavoitehinnan oikaisun lisääminen hajottaa molemmat. App-state/atomit menivät sekaisin.
Nyt tässä korjattu.