### PR TITLE
Korjaa poistofunktion nimeäminen ja poista samalla turha errori

### DIFF
--- a/src/clj/harja/kyselyt/status.sql
+++ b/src/clj/harja/kyselyt/status.sql
@@ -28,7 +28,7 @@ VALUES
 -- single?: true
 select 1 from toteuma limit 1;
 
--- name: poista-statusviestit
+-- name: poista-statusviestit!
 DELETE
   FROM komponenttien_status ks
  WHERE ks.luotu < NOW() - INTERVAL '2 days';

--- a/src/clj/harja/palvelin/ajastetut_tehtavat/harja_status.clj
+++ b/src/clj/harja/palvelin/ajastetut_tehtavat/harja_status.clj
@@ -67,7 +67,7 @@
     (fn [_] (tarkista-harja-status db kehitysmoodi?))))
 
 (defn- poista-statusviestit [db]
-  (status-kyselyt/poista-statusviestit db))
+  (status-kyselyt/poista-statusviestit! db))
 
 (defn- ajastus-poista-statusviestit [db]
   (log/info "Ajastetaan statusviestien siivous - ajetaan kerran vuorokaudessa - poistetaan viikon kaikki yli kaksi päivää vanhat")


### PR DESCRIPTION
Logeihin tulee:
23-02-02 22:55:00 app1-harja.solitaservices.fi ERROR [harja.palvelin.tyokalut.ajastettu-tehtava:12] - Käsittelemätön poikkeus ajastetussa tehtävässä: org.postgresql.util.PSQLException: No results were returned by the query.
Virhe, ihan turhaan. Mutta tämä korjaus poistaa errorin