### PR TITLE
Korjaa päätöksen poistaminen oikaisun muokkauksen jälkee

### DIFF
--- a/src/clj/harja/kyselyt/valikatselmus.clj
+++ b/src/clj/harja/kyselyt/valikatselmus.clj
@@ -112,9 +112,11 @@
 (defn tee-paatos [db paatos]
   (upsert! db ::valikatselmus/urakka-paatos paatos))
 
-(defn poista-paatokset [db hoitokauden-alkuvuosi]
+(defn poista-paatokset [db hoitokauden-alkuvuosi kayttaja-id]
   (update! db ::valikatselmus/urakka-paatos
-           {::muokkaustiedot/poistettu? true}
+           {::muokkaustiedot/poistettu? true
+            ::muokkaustiedot/muokattu (pvm/nyt)
+            ::muokkaustiedot/muokkaaja-id kayttaja-id}
            {::valikatselmus/hoitokauden-alkuvuosi hoitokauden-alkuvuosi}))
 
 (defn poista-paatos [db paatos-id]

--- a/src/clj/harja/palvelin/palvelut/laadunseuranta.clj
+++ b/src/clj/harja/palvelin/palvelut/laadunseuranta.clj
@@ -370,6 +370,7 @@
 (defn poista-suorasanktio
   "Merkitsee suorasanktion ja siihen liittyvän laatupoikkeaman poistetuksi. Palauttaa sanktion ID:n."
   [db user {sanktio-id :id urakka-id :urakka-id :as tiedot}]
+  (println "jere testaa:: poista-suorasanktio" sanktio-id urakka-id)
   (assert (integer? sanktio-id) "Parametria 'sanktio-id' ei ole määritelty")
   (assert (integer? urakka-id) "Parametria 'urakka-id' ei ole määritelty")
   (log/debug "Merkitse suorasanktio " sanktio-id " ja siihen liittyvä laatupoikkeama poistetuksi urakassa " urakka-id)

--- a/src/clj/harja/palvelin/palvelut/laadunseuranta.clj
+++ b/src/clj/harja/palvelin/palvelut/laadunseuranta.clj
@@ -370,7 +370,6 @@
 (defn poista-suorasanktio
   "Merkitsee suorasanktion ja siihen liittyvän laatupoikkeaman poistetuksi. Palauttaa sanktion ID:n."
   [db user {sanktio-id :id urakka-id :urakka-id :as tiedot}]
-  (println "jere testaa:: poista-suorasanktio" sanktio-id urakka-id)
   (assert (integer? sanktio-id) "Parametria 'sanktio-id' ei ole määritelty")
   (assert (integer? urakka-id) "Parametria 'urakka-id' ei ole määritelty")
   (log/debug "Merkitse suorasanktio " sanktio-id " ja siihen liittyvä laatupoikkeama poistetuksi urakassa " urakka-id)

--- a/src/cljs/harja/tiedot/urakka/kulut/mhu_kustannusten_seuranta.cljs
+++ b/src/cljs/harja/tiedot/urakka/kulut/mhu_kustannusten_seuranta.cljs
@@ -115,7 +115,8 @@
     ;; Muutetaan se {vuosi {0 {data}
     ;;                      1 {data}}}
     (assoc app :tavoitehinnan-oikaisut
-               (fmap #(zipmap (range) %) vastaus)))
+               ;; Merkitään samalla koskemattomiksi, jotta voidaan välttää turhien päivitysten tekeminen
+               (fmap #(zipmap (range) (map (fn [o] (assoc o :koskematon true)) %)) vastaus)))
 
   HaeTavoitehintojenOikaisutEpaonnistui
   (process-event [{vastaus :vastaus} app]

--- a/test/clj/harja/palvelin/palvelut/kulut/valikatselmus_test.clj
+++ b/test/clj/harja/palvelin/palvelut/kulut/valikatselmus_test.clj
@@ -149,7 +149,8 @@
                            (update :harja.domain.muokkaustiedot/luotu #(pvm/aika-iso8601-ilman-millisekunteja %)))
         muokattava-oikaisu (-> muokattava-oikaisu
                              (assoc ::valikatselmus/summa 50000M) ;; Summa muuttuu 2000 -> 50000 ja tätä nimen omaan testataan
-                             (update :harja.domain.muokkaustiedot/muokattu #(pvm/aika-iso8601-ilman-millisekunteja %))
+                             (assoc :harja.domain.muokkaustiedot/muokattu (pvm/aika-iso8601-ilman-millisekunteja
+                                                                            (pvm/hoitokauden-loppupvm (inc hoitokauden-alkuvuosi))))
                              (update :harja.domain.muokkaustiedot/luotu #(pvm/aika-iso8601-ilman-millisekunteja %)))]
     (is (= muokattava-oikaisu odotettu-vastaus) "Summan muokkaus ei onnistunut")
 


### PR DESCRIPTION
Kun oikaisua muokattiin, päätökset poistettiin, mutta ei sanktioita.

Poistetaan nyt sanktiot myös kun päätös poistetaan oikaisun muokkauksen johtosta.

Lisäksi estetään se, että tavoitehinnan oikaisua "muokattiin" vaikka oltaisiin vain klikattu riviä tekemättä muutoksia. Tämä johti siihen, että päätökset poistettiin vaikka oikaisuun ei olisi tehty muutosta. Tämä tehty lisäämällä haettaviin oikaisuihin :koskematon-avain, joka lähtee kun riviä oikeasti muokataan. Tähän olisi saattanut olla parempikin tapa, mutta en löytänyt sellaista ensihätään.