### PR TITLE
VHAR-7372-ilmoitukset-tyokalu-vihjeet

### DIFF
--- a/src/cljs/harja/ui/grid/perus.cljs
+++ b/src/cljs/harja/ui/grid/perus.cljs
@@ -733,6 +733,12 @@
                                         Saa sarakkeen skeema.
   :komponentti                          Jos sarakkeen tyyppi on :komponentti, tämän avaimen takana tulee olla
                                         komponentin määrittävä funktio.
+  :solun-tooltip                        Koko solulle näytettävä tooltip. Arvona funktio joka palauttaa mapin jossa sallittuja 
+                                        arvoja ovat :teksti, :tooltip-tyyppi ja :tooltip-komponentti. Voit antaa siis teksti arvon tai 
+                                        määritellä tyypiksi komponentin.
+  :huomio                               Solun sisällön jälkeen renderöidään ikoni jossa tooltip. Arvona funktio joka palauttaa mapin 
+                                        jossa sallittuja arvoja ovat :teksti ja :tyyppi. Tyyppi arvo määrittää ikonin ja teksti arvo 
+                                        tooltipin tekstin. 
 
   Tyypin mukaan voi olla lisäavaimia, jotka määrittelevät tarkemmin kentän validoinnin.
 

--- a/src/cljs/harja/ui/grid/perus.cljs
+++ b/src/cljs/harja/ui/grid/perus.cljs
@@ -246,20 +246,20 @@
                                     leveys
                                     1)
                         :class (y/luokat
-                                (y/tasaus-luokka tasaa)
-                                (when pakota-rivitys? "grid-pakota-rivitys")
-                                (when solu-klikattu "klikattava")
-                                (grid-yleiset/tiivis-tyyli skeema esta-tiivis-grid?)
-                                (case reunus
-                                  :ei "grid-reunus-ei"
-                                  :vasen "grid-reunus-vasen"
-                                  :oikea "grid-reunus-oikea"
-                                  nil)
-                                (when solun-luokka
-                                  (solun-luokka haettu-arvo rivi))
-                                (if (fn? luokka)
-                                  (luokka rivi)
-                                  luokka))}
+                                 (y/tasaus-luokka tasaa)
+                                 (when pakota-rivitys? "grid-pakota-rivitys")
+                                 (when solu-klikattu "klikattava")
+                                 (grid-yleiset/tiivis-tyyli skeema esta-tiivis-grid?)
+                                 (case reunus
+                                   :ei "grid-reunus-ei"
+                                   :vasen "grid-reunus-vasen"
+                                   :oikea "grid-reunus-oikea"
+                                   nil)
+                                 (when solun-luokka
+                                   (solun-luokka haettu-arvo rivi))
+                                 (if (fn? luokka)
+                                   (luokka rivi)
+                                   luokka))}
                    ;; Solun sisältö
                    [yleiset/tooltip {:tooltip-disabloitu? (when-not solun-tooltip true)}
                     [:div (when (and (:oikealle? rivi) ((:oikealle? rivi) nimi)) {:style {:float "right"}})
@@ -267,18 +267,18 @@
                     ;; Semanttisesti sen kuuluisi olla suhteessa riviin (koska laatikko kuvaa rivin lisätietoa).
                     ;; mutta HTML:n säännöt kieltävät div-elementit suoraan tr:n lapsena
                      (when (and
-                            (= id @valittu-rivi)
-                            (= (inc i) (count skeema))
-                            rivin-infolaatikko
-                            @infolaatikko-nakyvissa?)
+                             (= id @valittu-rivi)
+                             (= (inc i) (count skeema))
+                             rivin-infolaatikko
+                             @infolaatikko-nakyvissa?)
                        [rivin-infolaatikko* rivin-infolaatikko rivi data])
                      (cond
                        (= tyyppi :komponentti) (apply komponentti rivi {:index index
                                                                         :muokataan? false}
-                                                      komponentti-args)
+                                                 komponentti-args)
                        (= tyyppi :reagent-komponentti) (vec (concat [komponentti rivi {:index index
                                                                                        :muokataan? false}]
-                                                                    komponentti-args))
+                                                              komponentti-args))
                        :else
                        (if fmt
                          (fmt haettu-arvo)
@@ -293,7 +293,7 @@
                            (when teksti
                              [yleiset/tooltip {} [:span {:style {:margin-left "3px"}
                                                          :class (str "grid-huomio-"
-                                                                     (name (:tyyppi huomion-tiedot)))}
+                                                                  (name (:tyyppi huomion-tiedot)))}
                                                   ikoni]
                               teksti]))))]
                     (when solun-tooltip
@@ -301,7 +301,7 @@
                         (let [teksti (:teksti solun-tooltip-tiedot)
                               tooltip-tyyppi (:tooltip-tyyppi solun-tooltip-tiedot)
                               tooltip-komponentti (:tooltip-komponentti solun-tooltip-tiedot)]
-                          (cond 
+                          (cond
                             (= tooltip-tyyppi :komponentti) tooltip-komponentti
                             :else
                             (or teksti "-")))))]])))

--- a/src/cljs/harja/ui/yleiset.cljs
+++ b/src/cljs/harja/ui/yleiset.cljs
@@ -857,7 +857,7 @@ jatkon."
                                   :on-mouse-leave #(reset! tooltip-visible?-atom false)}
                                  komponentti
                                  [tooltip-sisalto opts @tooltip-visible?-atom sisalto]])
-          komponentti))
+    komponentti))
 
 (defn wrap-if
   "If condition is truthy, return container-component with

--- a/src/cljs/harja/ui/yleiset.cljs
+++ b/src/cljs/harja/ui/yleiset.cljs
@@ -843,6 +843,7 @@ jatkon."
     wrapper-luokka: Custom luokan nimi tai vektori luokan nimiä, joilla voidaan tyylitellä tooltip wrapperia ja sen lapsia.
     wrapperin-koko: Käyttäjän määrittelemä koko tooltip-wrapprille. Vaikuttaa siihen, miten tooltip asetellaan annetun komponentin viereen.
                     Käytä ainoastaan silloin, kun tooltipin wrapperin kokoa ei voida laskea automaattisesti (esim. display: none;)
+   tooltip-disabloitu?: Mikäli arvo on true ei renderöidä tooltippiä vaan palautetaan vain annettu komponentti.
 
   komponentti: Komponentti, jolle tooltip asetetaan.
   sisalto: Tooltipin teksti tai hiccup-html.

--- a/src/cljs/harja/ui/yleiset.cljs
+++ b/src/cljs/harja/ui/yleiset.cljs
@@ -848,16 +848,16 @@ jatkon."
   sisalto: Tooltipin teksti tai hiccup-html.
   "
 
-  [{:keys [suunta leveys wrapper-luokka wrapperin-koko] :as opts} komponentti sisalto]
-  (r/with-let [tooltip-visible?-atom (atom false)]
-    [:div.inline-block
-     {:style {:position "relative"}
-      :class wrapper-luokka
-      :on-mouse-enter #(reset! tooltip-visible?-atom true)
-      :on-mouse-leave #(reset! tooltip-visible?-atom false)}
-     komponentti
-
-     [tooltip-sisalto opts @tooltip-visible?-atom sisalto]]))
+  [{:keys [suunta leveys wrapper-luokka wrapperin-koko tooltip-disabloitu?] :as opts} komponentti sisalto]
+  (if-not tooltip-disabloitu? (r/with-let [tooltip-visible?-atom (atom false)]
+                                [:div.inline-block
+                                 {:style {:position "relative"}
+                                  :class wrapper-luokka
+                                  :on-mouse-enter #(reset! tooltip-visible?-atom true)
+                                  :on-mouse-leave #(reset! tooltip-visible?-atom false)}
+                                 komponentti
+                                 [tooltip-sisalto opts @tooltip-visible?-atom sisalto]])
+          komponentti))
 
 (defn wrap-if
   "If condition is truthy, return container-component with

--- a/src/cljs/harja/views/ilmoitukset/tieliikenneilmoitukset.cljs
+++ b/src/cljs/harja/views/ilmoitukset/tieliikenneilmoitukset.cljs
@@ -203,6 +203,11 @@
   (let [tyyppi (domain/ilmoitustyypin-lyhenne ilmoitustyyppi)]
     [:div {:class tyyppi} tyyppi]))
 
+(defn tunniste-tooltip [tunniste] 
+    [:div 
+     [:div.harmaa-teksti "Tunniste"]
+     [:span (or tunniste "-")]])
+
 (defn ilmoitusten-paanakyma
   [e! {valinnat-nyt :valinnat
        kuittaa-monta :kuittaa-monta
@@ -266,11 +271,16 @@
            :leveys 2})
         {:otsikko "Urakka" :nimi :urakkanimi :leveys 7
          :hae (comp fmt/lyhennetty-urakan-nimi :urakkanimi)}
-        {:otsikko "Tunniste" :nimi :tunniste :leveys 3}
         {:otsikko "Lisätietoja" :nimi :lisatieto :leveys 6
-         :hae #(leikkaa-sisalto-pituuteen 30 (:lisatieto %))}
+         :hae #(leikkaa-sisalto-pituuteen 30 (:lisatieto %)) 
+         :solun-tooltip (fn [rivi]
+                          {:teksti (:lisatieto rivi)})}
         {:otsikko "Tiedotettu urakkaan" :nimi :valitetty-urakkaan
-         :hae (comp pvm/pvm-aika :valitetty-urakkaan) :leveys 6}
+         :hae (comp pvm/pvm-aika :valitetty-urakkaan) 
+         :leveys 6
+         :solun-tooltip (fn [rivi]
+                          {:tooltip-tyyppi :komponentti
+                           :tooltip-komponentti (tunniste-tooltip (:tunniste rivi))})}
         {:otsikko "Tyyppi" :nimi :ilmoitustyyppi
          :tyyppi :komponentti
          :komponentti #(ilmoitustyypin-selite (:ilmoitustyyppi %))

--- a/src/cljs/harja/views/ilmoitukset/tieliikenneilmoitukset.cljs
+++ b/src/cljs/harja/views/ilmoitukset/tieliikenneilmoitukset.cljs
@@ -203,10 +203,10 @@
   (let [tyyppi (domain/ilmoitustyypin-lyhenne ilmoitustyyppi)]
     [:div {:class tyyppi} tyyppi]))
 
-(defn tunniste-tooltip [tunniste] 
-    [:div 
-     [:div.harmaa-teksti "Tunniste"]
-     [:span (or tunniste "-")]])
+(defn tunniste-tooltip [tunniste]
+  [:div
+   [:div.harmaa-teksti "Tunniste"]
+   [:span (or tunniste "-")]])
 
 (defn ilmoitusten-paanakyma
   [e! {valinnat-nyt :valinnat


### PR DESCRIPTION
https://issues.solita.fi/browse/VHAR-7372
- Lisätty solun-tooltip valinta perus-gridiin
- Muokkaus gridiin ei ole tässä vielä lisätty
- Muokattu tooltip komponentti niin että parametrilla se ei tee mitään
