### PR TITLE
Hae ilmoitukselle urakka alueurakkataulusta

### DIFF
--- a/src/clj/harja/kyselyt/urakat.sql
+++ b/src/clj/harja/kyselyt/urakat.sql
@@ -767,7 +767,7 @@ WHERE (CASE
                FROM siltapalvelusopimus sps
                WHERE sps.urakkanro = u.urakkanro
                  AND st_dwithin(sps.alue, st_makepoint(:x, :y), :threshold))))
-ORDER BY etaisyys ASC;
+ORDER BY etaisyys ASC, u.alkupvm DESC;
 
 -- name: hae-hoito-urakka-tr-pisteelle
 SELECT id

--- a/src/clj/harja/palvelin/palvelut/urakat.clj
+++ b/src/clj/harja/palvelin/palvelut/urakat.clj
@@ -43,8 +43,8 @@
   [db urakkatyyppi x y]
   (loop [radius 50
          k 1]
-    ;; Palautetaan nil, jos ei löydy urakkaa kilometrin säteeltä tai
-    ;; ollaan loopattu jo 10 kertaa eikä olla löydätty vain yhtä urakkaa
+    ;; Palautetaan nil, jos ei löydy urakkaa kilometrin säteeltä.
+    ;; Jos on useampia urakoita, palautetaan lähin tai uusin, jos urakat ovat yhtä lähellä.
     (when (and (< radius 500)
                (< k 10))
       (let [urakat (distinct (map #(dissoc % :etaisyys :urakkatyyppi )
@@ -53,7 +53,6 @@
                                                                 :urakkatyyppi urakkatyyppi})))]
         (cond
           (empty? urakat) (recur (* 2 radius) (inc k))
-          (> (count urakat) 1) (recur (* 0.75 radius) (inc k))
           :else (:id (first urakat)))))))
 
 (defn hae-lahin-urakka-id-sijainnilla


### PR DESCRIPTION
Muutoksia tulevan ilmoituksen urakan hakemiseen:

Hoidon/teiden hoidon urakoille pyritään hakemaan urakka alueurakka-taulusta. Siellä pitäisi olla aina vain voimassa oleva urakka, myös siinä tilanteessa että jotain urakkaa on venytetty sampossa. Fallbackina käytetään vanhaa systeemiä, sillä muutoksella että urakka-taulusta otetaan uusin urakka, mikäli pisteeltä löytyy useampi urakka. 

Nykyisellään tämä toimii siten, että jos pisteellä on kaksi urakkaa, niin urakkataulusta hakeminen ei onnistu, koska se odottaa löytävänsä tasan yhden urakan. Sen jälkeen se käyttää fallbackina alueurakkataulua, josta nyt löytyy oikea urakka.