### PR TITLE
VHAR-7385-ilmoituksen-tiedot-back-toiminnallisuus

### DIFF
--- a/src/cljs-dev/harja/df_data.cljs
+++ b/src/cljs-dev/harja/df_data.cljs
@@ -4,7 +4,8 @@
   (:require-macros [reagent.ratom :refer [reaction]]))
 
 (defonce data
-         (reaction {:harja.tiedot.navigaatio    {:valittu-urakka @nav/valittu-urakka}
+         (reaction {:harja.tiedot.navigaatio    {:valittu-urakka @nav/valittu-urakka
+                                                 :valittu-ilmoitus-id @nav/valittu-ilmoitus-id}
                     :harja.tiedot.urakka.urakka {:yleiset                          @urakka/yleiset
                                                  :suunnittelu-tehtavat             @urakka/suunnittelu-tehtavat
                                                  :suunnittelu-kustannussuunnitelma @urakka/suunnittelu-kustannussuunnitelma

--- a/src/cljs/harja/tiedot/ilmoitukset/tieliikenneilmoitukset.cljs
+++ b/src/cljs/harja/tiedot/ilmoitukset/tieliikenneilmoitukset.cljs
@@ -190,7 +190,7 @@ tila-filtterit [:kuittaamaton :vastaanotettu :aloitettu :lopetettu])
              :taustahaku? taustahaku?}))))
     (if taustahaku?
       app
-      (assoc app :ilmoitukset nil)))
+      (assoc app :ilmoitukset nil))) 
 
   v/IlmoitusHaku
   (process-event [{tulokset :tulokset} {valittu :valittu-ilmoitus :as app}]
@@ -206,22 +206,17 @@ tila-filtterit [:kuittaamaton :vastaanotettu :aloitettu :lopetettu])
                                   (:taustahaku? tulokset)
                                   (merkitse-uudet-ilmoitukset uudet-ilmoitusidt)
                                   true
-                                  (jarjesta-ilmoitukset))
-
-             ;; Jos on valittuna ilmoitus joka ei ole haetuissa, perutaan valinta
-             :valittu-ilmoitus (if (some #(= (:ilmoitusid valittu) %)
-                                         (map :ilmoitusid (:ilmoitukset tulokset)))
-                                 valittu
-                                 nil))
+                                  (jarjesta-ilmoitukset)))
            taustahaun-viive-ms
            true)))
 
   v/ValitseIlmoitus
-  (process-event [{ilmoitus :ilmoitus} app]
-    (let [tulos (t/send-async! v/->IlmoituksenTiedot)]
+  (process-event [{id :ilmoitus} app]
+    (let [tulos (t/send-async! v/->IlmoituksenTiedot)
+          _ (nav/valitse-ilmoitus! id)]
       (go
-        (tulos (<! (k/post! :hae-ilmoitus (:id ilmoitus))))))
-    (assoc app :ilmoituksen-haku-kaynnissa? true))
+        (tulos (<! (k/post! :hae-ilmoitus id)))))
+    (assoc app :ilmoituksen-haku-kaynnissa? true)) 
 
   v/IlmoituksenTiedot
   (process-event [{ilmoitus :ilmoitus} app]
@@ -231,6 +226,7 @@ tila-filtterit [:kuittaamaton :vastaanotettu :aloitettu :lopetettu])
 
   v/PoistaIlmoitusValinta
   (process-event [_ app]
+    (nav/valitse-ilmoitus! nil)
     (assoc app :valittu-ilmoitus nil))
 
   ;; Valitun ilmoituksen uuden kuittauksen teko

--- a/src/cljs/harja/tiedot/navigaatio.cljs
+++ b/src/cljs/harja/tiedot/navigaatio.cljs
@@ -318,12 +318,10 @@
   (valitse-urakka-id! (:id ur))
   (log "VALITTIIN URAKKA: " (pr-str (dissoc ur :alue))))
 
-(defn valitse-ilmoitus-id! [id]
-  (reset! valittu-ilmoitus-id id)
-  (paivita-url))
 
 (defn valitse-ilmoitus! [id]
-  (valitse-ilmoitus-id! id)
+  (reset! valittu-ilmoitus-id id)
+  (paivita-url)
   (log "VALITTIIN ILMOITUS: " (pr-str id)))
 
 (defonce urakka-klikkaus-kuuntelija

--- a/src/cljs/harja/tiedot/navigaatio.cljs
+++ b/src/cljs/harja/tiedot/navigaatio.cljs
@@ -201,6 +201,9 @@
                                  nil)))
                            oletus-urakkatyyppi))))
 
+;; Jos ilmoitus valitaan id:n perusteella (url parametrilla), asetetaan se tänne
+(defonce valittu-ilmoitus-id (atom nil))
+
 (defn vaihda-urakkatyyppi!
   "Vaihtaa urakkatyypin ja resetoi valitun urakoitsijan, jos kyseinen urakoitsija ei
    löydy valitun tyyppisten urakoitsijain listasta."
@@ -315,6 +318,14 @@
   (valitse-urakka-id! (:id ur))
   (log "VALITTIIN URAKKA: " (pr-str (dissoc ur :alue))))
 
+(defn valitse-ilmoitus-id! [id]
+  (reset! valittu-ilmoitus-id id)
+  (paivita-url))
+
+(defn valitse-ilmoitus! [id]
+  (valitse-ilmoitus-id! id)
+  (log "VALITTIIN ILMOITUS: " (pr-str id)))
+
 (defonce urakka-klikkaus-kuuntelija
          (t/kuuntele! :urakka-klikattu
                       (fn [urakka]
@@ -327,10 +338,11 @@
                     h))
 
 (defn nykyinen-url []
-  (str (reitit/muodosta-polku @reitit/url-navigaatio)
-       "?"
-       (when-let [hy @valittu-hallintayksikko-id] (str "&hy=" hy))
-       (when-let [u @valittu-urakka-id] (str "&u=" u))))
+   (str (reitit/muodosta-polku @reitit/url-navigaatio)
+    "?"
+    (when-let [hy @valittu-hallintayksikko-id] (str "&hy=" hy))
+    (when-let [u @valittu-urakka-id] (str "&u=" u))
+    (when-let [i @valittu-ilmoitus-id] (str "&i=" i))))
 
 (defonce ^{:doc "Tämä lippu voi estää URL tokenin päivittämisen, käytetään siirtymissä, joissa
  halutaan tehdä useita muutoksia ilman että välissä pävitetään URLia keskeneräisenä."}
@@ -417,6 +429,7 @@
           parametrit (.getQueryData uri)]
       (reset! valittu-hallintayksikko-id (some-> parametrit (.get "hy") js/parseInt))
       (reset! valittu-urakka-id (some-> parametrit (.get "u") js/parseInt))
+      (reset! valittu-ilmoitus-id (some-> parametrit (.get "i") js/parseInt))
       ;; Kun ollaan aloitusikkunassa, katsotaan mikä on käyttäjän perusurakkatyyppi, jotta voidaan näyttää oikean
       ;; väylämuodon hallintayksiköt
       (when (= polku "urakat/yleiset")

--- a/src/cljs/harja/views/ilmoitukset/tieliikenneilmoitukset.cljs
+++ b/src/cljs/harja/views/ilmoitukset/tieliikenneilmoitukset.cljs
@@ -237,7 +237,7 @@
         :rivi-klikattu (when (and (not ilmoituksen-haku-kaynnissa?)
                                   (nil? pikakuittaus))
                          (or valitse-ilmoitus!
-                             #(e! (v/->ValitseIlmoitus %))))
+                             #(e! (v/->ValitseIlmoitus (:id %)))))
         :piilota-toiminnot true
         :max-rivimaara 500
         :max-rivimaaran-ylitys-viesti "Yli 500 ilmoitusta. Tarkenna hakuehtoja."
@@ -315,7 +315,7 @@
 
   (komp/luo
     (komp/lippu tiedot/karttataso-ilmoitukset)
-    (komp/kuuntelija :ilmoitus-klikattu (fn [_ i] (e! (v/->ValitseIlmoitus i))))
+    (komp/kuuntelija :ilmoitus-klikattu (fn [_ i] (e! (v/->ValitseIlmoitus (:id i)))))
     (komp/watcher tiedot/valinnat (fn [_ _ uusi]
                                     (e! (v/->YhdistaValinnat uusi))))
     (komp/sisaan-ulos #(do
@@ -323,9 +323,11 @@
                          (reset! nav/kartan-edellinen-koko @nav/kartan-koko)
                          (nav/vaihda-kartan-koko! :M)
                          (nav/vaihda-urakkatyyppi! {:nimi "Kaikki" :arvo :kaikki})
+                         (when @nav/valittu-ilmoitus-id
+                           (e! (v/->ValitseIlmoitus @nav/valittu-ilmoitus-id)))
                          (kartta-tiedot/kasittele-infopaneelin-linkit!
                            {:ilmoitus {:toiminto (fn [ilmoitus-infopaneelista]
-                                                   (e! (v/->ValitseIlmoitus ilmoitus-infopaneelista)))
+                                                   (e! (v/->ValitseIlmoitus (:id ilmoitus-infopaneelista))))
                                        :teksti "Valitse ilmoitus"}}))
                       #(do
                          (kartta-tiedot/kasittele-infopaneelin-linkit! nil)
@@ -333,7 +335,7 @@
     (fn [e! {valittu-ilmoitus :valittu-ilmoitus :as ilmoitukset}]
       [:span
        [kartta/kartan-paikka]
-       (if valittu-ilmoitus
+       (if (and @nav/valittu-ilmoitus-id valittu-ilmoitus)
          [ilmoituksen-tiedot e! valittu-ilmoitus]
          [ilmoitusten-paanakyma e! ilmoitukset])])))
 


### PR DESCRIPTION
- Toteutettu back napin toimivuuden korjaus passaamalla ilmoitus-id urliin.

- Testattu että ilmoitukset kuuluvat yhä myös tiedot sivulla.

- Testattu että ilmoituksen tiedot latautuvat urlista navigoitaessa.

- Tässä ehkä itsellä jäi mietityttämään että statea on vähän nyt tässä tapauksessa kahdessa paikassa mutta ilmeisesti kuitenkin yleistä Harjassa.