### PR TITLE
Vhar 7439 ilmoitusapi kuittaus tz

### DIFF
--- a/src/clj/harja/palvelin/integraatiot/api/ilmoitukset.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/ilmoitukset.clj
@@ -12,7 +12,7 @@
             [harja.palvelin.integraatiot.api.tyokalut.json-skeemat :as json-skeemat]
             [harja.palvelin.integraatiot.api.tyokalut.validointi :as validointi]
             [harja.palvelin.integraatiot.api.tyokalut.ilmoitusnotifikaatiot :as notifikaatiot]
-            [harja.palvelin.integraatiot.api.tyokalut.json :refer [aika-string->java-sql-date]]
+            [harja.palvelin.integraatiot.api.tyokalut.json :refer [aika-string->java-sql-date sql-timestamp-str->utc-timestr]]
             [harja.kyselyt.tieliikenneilmoitukset :as tieliikenneilmoitukset-kyselyt]
             [harja.kyselyt.konversio :as konversio]
             [harja.palvelin.integraatiot.api.sanomat.ilmoitus-sanomat :as sanomat]
@@ -239,8 +239,8 @@
                                    (fn [r]
                                      ;; Haussa käytetään left joinia, joten on mahdollista, että löytyy nil id
                                      (when (not (nil? (:f1 r)))
-                                       (let [r (-> r
-                                                 (clojure.set/rename-keys db-kuittaus->avaimet))]
+                                       (let [r (-> r (clojure.set/rename-keys db-kuittaus->avaimet))
+                                             r (assoc r :kuitattu (sql-timestamp-str->utc-timestr (:kuitattu r)))]
                                          r)))
                                    rivit)]
                        tulos)))))

--- a/src/clj/harja/palvelin/integraatiot/api/tyokalut/json.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/tyokalut/json.clj
@@ -3,10 +3,12 @@
   (:require [harja.kyselyt.konversio :as konv]
             [harja.geo :as geo]
             [clj-time.format :as format]
+            [clj-time.core :as t]
             [taoensso.timbre :as log]
-            [clj-time.coerce :as coerce]
+            [harja.pvm :as pvm]
             [clj-time.coerce :as c])
-  (:import (java.text SimpleDateFormat)))
+  (:import (java.text SimpleDateFormat)
+           (java.util TimeZone)))
 
 (defn aika-string->java-sql-date [paivamaara]
   (when paivamaara
@@ -23,6 +25,11 @@
 (defn aika-string->joda-time [paivamaara]
   (when paivamaara
     (c/from-date (aika-string->java-util-date paivamaara))))
+
+(defn sql-timestamp-str->utc-timestr
+  "Anna timestamp str muodossa: 'yyyy-MM-dd'T'HH:mm:ss' palauttaa tuloksen UTC ajassa: 'yyyy-MM-dd'T'HH:mm:ssZ'"
+  [aika-str]
+  (format/unparse (format/formatter "yyyy-MM-dd'T'HH:mm:ss'Z'") (pvm/iso8601-basic->suomen-aika aika-str)))
 
 (defn pvm-string->java-sql-date [paivamaara]
   (when paivamaara


### PR DESCRIPTION
Ilmoitus apin lähetyksessä kuittausten timezone jäi pois. Tässä muokattu aika utc ajaksi ja lisätty Z merkki kuittausten ajankohdan perään kertomaan, että kyseessä on UTC ajassa annettuja timestamppejä.