### PR TITLE
Lisää urakoiden velho-oid-haku ajastettuun funktioon

### DIFF
--- a/src/clj/harja/palvelin/integraatiot/velho/varusteet.clj
+++ b/src/clj/harja/palvelin/integraatiot/velho/varusteet.clj
@@ -106,8 +106,6 @@
     (assert (some? alkupvm) "`alkupvm` on pakollinen")
     urakka-id))
 
-(def +urakka-memoize-ttl+ (* 10 60 1000))
-
 (defn hae-id->urakka-pvm-map
   "Hakee urakan päivämäärätietoja sellaisille urakoille, joille on olemassa velho_oid (ovat siis velhosta löytyviä MHU urakoita).
   Palauttaa:

--- a/src/clj/harja/palvelin/integraatiot/velho/velho_komponentti.clj
+++ b/src/clj/harja/palvelin/integraatiot/velho/velho_komponentti.clj
@@ -47,7 +47,7 @@
       (assoc this :varustetoteuma-tuonti-tehtava (tee-varustetoteuma-haku-tehtava-fn this suoritusaika))))
   (stop [this]
     (log/info "Sammutetaan tuo-uudet-varustetoteumat-velhosta -komponentti.")
-    (let [varustetoteuma-tuonti-tehtava-cancel (:varustetoteuma-tuonti-tehtava this)]
+    (when-let [varustetoteuma-tuonti-tehtava-cancel (:varustetoteuma-tuonti-tehtava this)]
       (varustetoteuma-tuonti-tehtava-cancel))
     (dissoc this :varustetoteuma-tuonti-tehtava))
 


### PR DESCRIPTION
Testattu paikallisessa asennuksessa ja singletonilla, asettaen :varuste-tuonti-suoritusaika n. minuutin päähän ja käynnistämällä repl. Singletonilla oli muita muutoksia, joiden takia en voinut varmistaa käliltä toimivuutta, mutta lokitusten mukaan kaikki näytti toimivan.