### PR TITLE
Korjaa pudotusvalikkojen listaelementtien klikkausalue

### DIFF
--- a/dev-resources/less/livi_tyylit.less
+++ b/dev-resources/less/livi_tyylit.less
@@ -103,6 +103,7 @@ table.table-striped {
     width: @leveys;
 
     .disabled {
+        align-items: center;
         background-color: @harmaa10;
         color: @harmaa6;
     }
@@ -172,13 +173,28 @@ table.table-striped {
     &:focus {
         background-color: @gray245;
     }
-    > span, div.boolean {
-        align-items: center;
+    > span {
+        align-items: stretch;
         display: flex;
         flex: 1;
         padding-left: @valistys-8;
         padding-right: @valistys-8;
     }
+
+  // Hack, että saadaan monimutkainen checkbox-elementin sisältö asettumaan keskelle list-itemissä
+  // TODO: List itemien sisällölle pudotusvalikossa pitäisi tehdä kokonaisvaltainen remontti,
+  //       eikä niiden tyylejä pitäisi joutua muokkaamaan ulkoa päin tällä tavalla.
+    & div.boolean {
+      display: flex;
+      align-items: center;
+      flex: 1;
+      padding-left: @valistys-8;
+      padding-right: @valistys-8;
+    }
+
+  // TODO: Sama tässä kuin yllä. Yleiskäyttöisen linkki-komponentin tyyliä ei tarvitsi joutua muokkaamaan tässä.
+  //       Tämä on fragiili muutoksille linkki-komponentissa. Kokonaisvaltainen remontti komponenttien käytölle ja
+  //       tyylittelylle tarvitaan.
     & > span > a {
         display: flex;
         align-items: center;

--- a/dev-resources/less/vayla/inputs-and-selects.less
+++ b/dev-resources/less/vayla/inputs-and-selects.less
@@ -188,13 +188,21 @@ label {
             border-radius:4px;
         }
         > * {
-          align-self: center;
+          align-items: stretch;
           padding-left: 8px;
           padding-right: 8px;
           flex: 1;
           display: flex;
           min-height: 30px;
           justify-content: space-between;
+
+          // Hack, että saadaan monimutkainen checkbox-elementin sisältö asettumaan keskelle list-itemissä
+          // TODO: List itemien sisällölle pudotusvalikossa pitäisi tehdä kokonaisvaltainen remontti,
+          //       eikä niiden tyylejä pitäisi joutua muokkaamaan ulkoa päin tällä tavalla.
+          & div.boolean * {
+              display: flex;
+              align-items: center;
+          }
         }
         a {
           color: inherit;


### PR DESCRIPTION
* Aiemmin ongelmana oli, että listaelementin (li) klikkausalue ei ollut riittävän iso pudotusvalikossa
   * Nyt klikkausalue täyttää koko listaelementin
   * Samalla ilmeni sisällön vertikaaliseen keskitykseen liittyviä ongelmia, joita on korjattu eri listaelementtien sisältötyypeille (a, checkbox) väylä ja ei-väylä tyyleille.