### PR TITLE
VHAR-7713_validointi_sijainnille

### DIFF
--- a/src/clj/harja/palvelin/palvelut/turvallisuuspoikkeamat.clj
+++ b/src/clj/harja/palvelin/palvelut/turvallisuuspoikkeamat.clj
@@ -229,17 +229,19 @@
 
 (defn turvallisuuspoikkeaman-data-validi?
   [{:keys [otsikko tapahtunut tyyppi vahinkoluokittelu vakavuusaste
-           tr tila kuvaus juurisyy1]}]
-  (and (not (empty? otsikko))
-       (instance? Date tapahtunut)
-       (not (empty? tyyppi))
-       (not (empty? vahinkoluokittelu))
-       (not (nil? vakavuusaste))
-       (tr/validi-osoite? tr)
-       (not (nil? tila))
-       (not (empty? kuvaus))
-       (or (not (contains? tyyppi :tyotapaturma))
-           (not (nil? juurisyy1)))))
+           tr tila kuvaus juurisyy1 sijainti]}]
+  (and 
+    (some? sijainti)
+    (not (empty? otsikko))
+    (instance? Date tapahtunut)
+    (not (empty? tyyppi))
+    (not (empty? vahinkoluokittelu))
+    (not (nil? vakavuusaste))
+    (tr/validi-osoite? tr)
+    (not (nil? tila))
+    (not (empty? kuvaus))
+    (or (not (contains? tyyppi :tyotapaturma))
+      (not (nil? juurisyy1)))))
 
 (defn tallenna-turvallisuuspoikkeama [turi db user {:keys [tp korjaavattoimenpiteet uusi-kommentti hoitokausi]}]
   (let [{:keys [id urakka]} tp]

--- a/src/cljs/harja/ui/validointi.cljs
+++ b/src/cljs/harja/ui/validointi.cljs
@@ -198,6 +198,10 @@
           (some? (avain rivi)))
     (or viesti "Syötä molemmat arvot")))
 
+(defmethod validoi-saanto :ei-tyhja-avain [_ _ data rivi _ & [avain viesti]]
+  (when (nil? (avain rivi))
+    (or viesti "Syötä arvo avaimelle " avain)))
+
 (defmethod validoi-saanto :ainakin-toinen-annettu [_ _ _ rivi _ & [[avain1 avain2] viesti]]
   (when-not (or (avain1 rivi)
                 (avain2 rivi))

--- a/src/cljs/harja/ui/validointi.cljs
+++ b/src/cljs/harja/ui/validointi.cljs
@@ -200,7 +200,7 @@
 
 (defmethod validoi-saanto :ei-tyhja-avain [_ _ data rivi _ & [avain viesti]]
   (when (nil? (avain rivi))
-    (or viesti "Syötä arvo avaimelle " avain)))
+    (or viesti (str "Syötä arvo avaimelle " avain))))
 
 (defmethod validoi-saanto :ainakin-toinen-annettu [_ _ _ rivi _ & [[avain1 avain2] viesti]]
   (when-not (or (avain1 rivi)

--- a/src/cljs/harja/views/urakka/turvallisuuspoikkeamat.cljs
+++ b/src/cljs/harja/views/urakka/turvallisuuspoikkeamat.cljs
@@ -314,11 +314,12 @@
                 :karttavalinta-tehty-fn #(swap! turvallisuuspoikkeama assoc :sijainti %)}
                {:otsikko "Tierekisteriosoite"
                 :nimi :tr
+                :ala-nayta-virhetta-komponentissa? false
                 :pakollinen? true
                 :tyyppi :tierekisteriosoite
-                :validoi [[:validi-tr "Reittiä ei saada tehtyä" [:sijainti]]]
-                :sijainti (r/wrap (:sijainti @turvallisuuspoikkeama)
-                            #(swap! turvallisuuspoikkeama assoc :sijainti %))})
+                :validoi [[:ei-tyhja-avain :sijainti "Sijaintia ei löytynyt, valitse reitti uudelleen"]
+                          [:validi-tr "Reittiä ei saada tehtyä" [:sijainti]]]
+                :sijainti nil})
              {:otsikko "Paikan kuvaus"
               :nimi :paikan-kuvaus
               :tyyppi :string

--- a/src/cljs/harja/views/urakka/turvallisuuspoikkeamat.cljs
+++ b/src/cljs/harja/views/urakka/turvallisuuspoikkeamat.cljs
@@ -319,7 +319,8 @@
                 :tyyppi :tierekisteriosoite
                 :validoi [[:ei-tyhja-avain :sijainti "Sijaintia ei löytynyt, valitse reitti uudelleen"]
                           [:validi-tr "Reittiä ei saada tehtyä" [:sijainti]]]
-                :sijainti nil})
+                :sijainti (r/wrap (:sijainti @turvallisuuspoikkeama)
+                            #(swap! turvallisuuspoikkeama assoc :sijainti %))})
              {:otsikko "Paikan kuvaus"
               :nimi :paikan-kuvaus
               :tyyppi :string

--- a/src/cljs/harja/views/urakka/turvallisuuspoikkeamat.cljs
+++ b/src/cljs/harja/views/urakka/turvallisuuspoikkeamat.cljs
@@ -316,7 +316,6 @@
                 :nimi :tr
                 :pakollinen? true
                 :tyyppi :tierekisteriosoite
-                :ala-nayta-virhetta-komponentissa? true
                 :validoi [[:validi-tr "Reittiä ei saada tehtyä" [:sijainti]]]
                 :sijainti (r/wrap (:sijainti @turvallisuuspoikkeama)
                             #(swap! turvallisuuspoikkeama assoc :sijainti %))})


### PR DESCRIPTION
Meille on päässyt tietokantaan turvallisuuspoikkeamia NULL geometrioilla, pitkällä pähkäilyllä löytyi että itse sijainnille ei ollut mitään validointia kun se tallennetaan tietokantaan. Validointi on lisätty. Tuotannosta pitää käydä vielä korjaamassa tilanne.