### PR TITLE
Vhar 7769 paivystajat tyomaapaivakirja

### DIFF
--- a/src/clj/harja/kyselyt/tyomaapaivakirja.sql
+++ b/src/clj/harja/kyselyt/tyomaapaivakirja.sql
@@ -63,7 +63,7 @@ SELECT t.id as tyomaapaivakirja_id, t.urakka_id, u.nimi as "urakka-nimi", t.vers
        t.luotu, t.luoja, t.muokattu, t.muokkaaja
   FROM tyomaapaivakirja t
        JOIN urakka u ON t.urakka_id = u.id
- WHERE t.id = t.id
+ WHERE t.id = :tyomaapaivakirja_id
    AND t.versio = :versio
  GROUP BY t.id, u.nimi;
 

--- a/src/clj/harja/kyselyt/yhteyshenkilot.sql
+++ b/src/clj/harja/kyselyt/yhteyshenkilot.sql
@@ -341,7 +341,7 @@ FROM paivystys p
 WHERE u.loppupvm >= :pvm;
 
 -- name: hae-urakat-paivystystarkistukseen
--- Hakee urakat, jotka ovat voimassa annettuna päivänä
+-- Hakee urakat, jotka ovat voimassa annettuna päivänä ja joiden tyyppi passaa annettuun tyyppi-listaan.
 SELECT
   id,
   nimi,
@@ -351,7 +351,7 @@ WHERE u.alkupvm <= :pvm
       AND u.loppupvm >= :pvm
       -- PENDING Lisätään urakkatyyppejä sitä mukaan kun
       -- päätyvät tuotantoon
-      AND (:tyyppi::urakkatyyppi IS NULL OR tyyppi = :tyyppi::urakkatyyppi);
+        AND (TRUE IN (SELECT unnest(ARRAY[:tyypit]::urakkatyyppi[]) IS NULL) OR tyyppi = ANY(ARRAY[:tyypit]::urakkatyyppi[]));
 
 -- name: hae-urakan-vastuuhenkilot
 SELECT * FROM urakanvastuuhenkilo WHERE urakka = :urakka;

--- a/src/clj/harja/kyselyt/yhteyshenkilot.sql
+++ b/src/clj/harja/kyselyt/yhteyshenkilot.sql
@@ -348,10 +348,9 @@ SELECT
   sampoid
 FROM urakka u
 WHERE u.alkupvm <= :pvm
-      AND u.loppupvm >= :pvm
-      -- PENDING Lisätään urakkatyyppejä sitä mukaan kun
-      -- päätyvät tuotantoon
-        AND (TRUE IN (SELECT unnest(ARRAY[:tyypit]::urakkatyyppi[]) IS NULL) OR tyyppi = ANY(ARRAY[:tyypit]::urakkatyyppi[]));
+  AND u.loppupvm >= :pvm
+  AND u.urakkanro IS NOT NULL
+  AND (TRUE IN (SELECT unnest(ARRAY[:tyypit]::urakkatyyppi[]) IS NULL) OR tyyppi = ANY(ARRAY[:tyypit]::urakkatyyppi[]));
 
 -- name: hae-urakan-vastuuhenkilot
 SELECT * FROM urakanvastuuhenkilo WHERE urakka = :urakka;

--- a/src/clj/harja/palvelin/ajastetut_tehtavat/paivystystarkistukset.clj
+++ b/src/clj/harja/palvelin/ajastetut_tehtavat/paivystystarkistukset.clj
@@ -107,8 +107,7 @@
                                                                     (mapv name urakkatyypit))})))
 
 (defn- paivystyksien-tarkistustehtava [db fim email nykyhetki]
-  (let [voimassa-olevat-urakat (hae-urakat-paivystystarkistukseen db nykyhetki #{:paallystys :valaistus
-                                                                                 :hoito :teiden-hoito})
+  (let [voimassa-olevat-urakat (hae-urakat-paivystystarkistukseen db nykyhetki #{:valaistus :hoito :teiden-hoito})
         paivystykset (hae-voimassa-olevien-urakoiden-paivystykset db nykyhetki)
         urakat-ilman-paivystysta (urakat-ilman-paivystysta paivystykset voimassa-olevat-urakat nykyhetki)]
     (ilmoita-paivystyksettomista-urakoista urakat-ilman-paivystysta fim email nykyhetki)))

--- a/src/clj/harja/palvelin/ajastetut_tehtavat/paivystystarkistukset.clj
+++ b/src/clj/harja/palvelin/ajastetut_tehtavat/paivystystarkistukset.clj
@@ -101,13 +101,14 @@
 (defn hae-urakat-paivystystarkistukseen
   ;; TODO Poista urakkatyyppi-filtteri kun kaikki urakat tuotannossa (joku kaunis päivä)
   ([db pvm] (hae-urakat-paivystystarkistukseen db pvm nil))
-  ([db pvm urakkatyyppi]
+  ([db pvm urakkatyypit]
   (yhteyshenkilot-q/hae-urakat-paivystystarkistukseen db {:pvm (c/to-sql-time pvm)
-                                                          :tyyppi (when urakkatyyppi
-                                                                    (name urakkatyyppi))})))
+                                                          :tyypit (when urakkatyypit
+                                                                    (mapv name urakkatyypit))})))
 
 (defn- paivystyksien-tarkistustehtava [db fim email nykyhetki]
-  (let [voimassa-olevat-urakat (hae-urakat-paivystystarkistukseen db nykyhetki :hoito)
+  (let [voimassa-olevat-urakat (hae-urakat-paivystystarkistukseen db nykyhetki #{:paallystys :valaistus
+                                                                                 :hoito :teiden-hoito})
         paivystykset (hae-voimassa-olevien-urakoiden-paivystykset db nykyhetki)
         urakat-ilman-paivystysta (urakat-ilman-paivystysta paivystykset voimassa-olevat-urakat nykyhetki)]
     (ilmoita-paivystyksettomista-urakoista urakat-ilman-paivystysta fim email nykyhetki)))

--- a/src/cljs/harja/tiedot/tyomaapaivakirja_tiedot.cljs
+++ b/src/cljs/harja/tiedot/tyomaapaivakirja_tiedot.cljs
@@ -10,6 +10,7 @@
   (:require-macros [harja.atom :refer [reaction<!]]
                    [reagent.ratom :refer [reaction]]))
 
+(defonce raportti-avain :tyomaapaivakirja-nakyma)
 (def nakymassa? (atom false))
 
 (defonce tila (atom {:tiedot []
@@ -24,15 +25,17 @@
                   :puuttuvat "puuttuu"})
 
 (def aikavali-atom (atom (pvm/kuukauden-aikavali (pvm/nyt))))
-(defonce raportti-avain :tyomaapaivakirja-nakyma)
 
 (defonce raportin-parametrit
-  (reaction (let [ur @nav/valittu-urakka]
-              (raportit/urakkaraportin-parametrit
-                (:id ur)
-                raportti-avain
-                {:urakkatyyppi (:tyyppi ur)
-                 :valittu-rivi (:valittu-rivi @tila)}))))
+  (reaction (let [ur @nav/valittu-urakka
+                  valittu-tila @tila
+                  valittu-rivi (:valittu-rivi valittu-tila)
+                  parametrit (raportit/urakkaraportin-parametrit
+                               (:id ur)
+                               raportti-avain
+                               {:urakkatyyppi (:tyyppi ur)
+                                :valittu-rivi valittu-rivi})]
+              parametrit)))
 
 (defonce raportin-tiedot
   (reaction<! [p @raportin-parametrit]
@@ -78,7 +81,8 @@
 
   HaeTiedot
   (process-event [_ app]
-    (hae-paivakirjat app))
+    (hae-paivakirjat app)
+    app)
 
   HaeTiedotOnnistui
   (process-event [{vastaus :vastaus} app]

--- a/test/clj/harja/palvelin/ajastetut_tehtavat/paivystystarkistukset_test.clj
+++ b/test/clj/harja/palvelin/ajastetut_tehtavat/paivystystarkistukset_test.clj
@@ -154,6 +154,27 @@
     ;; Ei urakoita käynnissä tänä aikana, mitään ei palaudu
     (is (= (count urakat-ilman-paivystysta) (count urakat)))))
 
+(deftest hoidon-urakat-paivystys-loytyy
+  (let [pvm (t/local-date 2015 12 5)
+        testitietokanta (:db jarjestelma)
+        hoitourakat (paivystajatarkistukset/hae-urakat-paivystystarkistukseen testitietokanta pvm #{:hoito :teiden-hoito})]
+    ;; Löytyy 4 urakkaa annettuna ajankohtana
+    (is (= (count hoitourakat) 4))))
+
+(deftest valaistus-urakat-paivystys-loytyy
+  (let [pvm (t/local-date 2015 12 5)
+        testitietokanta (:db jarjestelma)
+        valaistusurakat (paivystajatarkistukset/hae-urakat-paivystystarkistukseen testitietokanta pvm #{:valaistus})]
+    ;; Löytyy 2 urakkaa annettuna ajankohtana
+    (is (= (count valaistusurakat) 2))))
+
+(deftest paallystys-urakat-paivystys-loytyy
+  (let [pvm (t/local-date 2015 12 5)
+        testitietokanta (:db jarjestelma)
+        paallystysurakat (paivystajatarkistukset/hae-urakat-paivystystarkistukseen testitietokanta pvm #{:paallystys})]
+    ;; Löytyy 4 urakkaa annettuna ajankohtana
+    (is (= (count paallystysurakat) 4))))
+
 (deftest ilmoituksien-saajien-haku-toimii
   (let [vastaus-xml (slurp (io/resource "xsd/fim/esimerkit/hae-oulun-hoidon-urakan-kayttajat.xml"))]
     (with-fake-http


### PR DESCRIPTION
Lisätty yölliseen päivystystarkistukseen mhu ja valaistusurakat. Muutamalta urakalta puuttui päivystäjä ja heitä ei informoitu siitä.
Samalla korjattu työmaapäiväkirjan aukeaminen.