### PR TITLE
VHAR-7876 Korjaa turvallisuuspoikkeaman paritus liitteeseen

### DIFF
--- a/src/clj/harja/palvelin/palvelut/turvallisuuspoikkeamat.clj
+++ b/src/clj/harja/palvelin/palvelut/turvallisuuspoikkeamat.clj
@@ -203,10 +203,10 @@
                                                (:id user))]
       (q/liita-kommentti<! db tp-id (:id kommentti)))))
 
-(defn tallenna-turvallisuuspoikkeaman-liite [db turvallisuuspoikkeama]
+(defn tallenna-turvallisuuspoikkeaman-liite [db turvallisuuspoikkeama tp-id]
   (when-let [uusi-liite (:uusi-liite turvallisuuspoikkeama)]
     (log/info "UUSI LIITE: " uusi-liite)
-    (q/liita-liite<! db (:id turvallisuuspoikkeama) (:id uusi-liite))))
+    (q/liita-liite<! db tp-id (:id uusi-liite))))
 
 (defn tallenna-turvallisuuspoikkeama-kantaan [db user tp korjaavattoimenpiteet uusi-kommentti urakka]
   (jdbc/with-db-transaction [db db]
@@ -215,7 +215,7 @@
       (when tyotunnit
         (urakan-tyotunnit-q/paivita-urakan-kuluvan-vuosikolmanneksen-tyotunnit db urakka tyotunnit))
       (tallenna-turvallisuuspoikkeaman-kommentti db user uusi-kommentti (:urakka tp) tp-id)
-      (tallenna-turvallisuuspoikkeaman-liite db tp)
+      (tallenna-turvallisuuspoikkeaman-liite db tp tp-id)
       (luo-tai-paivita-korjaavat-toimenpiteet db user korjaavattoimenpiteet tp-id urakka)
       tp-id)))
 

--- a/test/clj/harja/palvelin/palvelut/turvallisuuspoikkeamat_test.clj
+++ b/test/clj/harja/palvelin/palvelut/turvallisuuspoikkeamat_test.clj
@@ -144,6 +144,11 @@
 
 (deftest tallenna-turvallisuuspoikkeama-test
   (let [urakka-id @oulun-alueurakan-2005-2010-id
+        _ (u "INSERT INTO liite (tyyppi, nimi, liite_oid, lahde) VALUES ('image/jpeg', 'IMG_0339.jpg', '123', 'harja-ui')")
+        liitteen-id (ffirst (q "SELECT id FROM liite WHERE nimi = 'IMG_0339.jpg';"))
+        liite {:kuvaus nil, :fileyard-hash nil, :urakka 567, :nimi "IMG_0339.jpg",
+               :id liitteen-id
+               :lahde "harja-ui", :tyyppi "image/jpeg", :koko 2093367}
         tp {:urakka urakka-id
             :tapahtunut (pvm/luo-pvm (+ 1900 105) 6 1)
             :tyontekijanammatti :kuorma-autonkuljettaja
@@ -161,7 +166,8 @@
             :vahinkoluokittelu #{:ymparistovahinko}
             :vaaralliset-aineet #{:vaarallisten-aineiden-kuljetus :vaarallisten-aineiden-vuoto}
             :sijainti {:type :point :coordinates [0 0]}
-            :tr {:numero 1 :alkuetaisyys 2 :loppuetaisyys 3 :alkuosa 4 :loppuosa 5}}
+            :tr {:numero 1 :alkuetaisyys 2 :loppuetaisyys 3 :alkuosa 4 :loppuosa 5}
+            :uusi-liite liite}
         korjaavat-toimenpiteet [{:kuvaus "Ei ressata liikaa"
                                 :otsikko "Ressi pois!"
                                 :tila :avoin
@@ -184,6 +190,8 @@
            :hoitokausi hoitokausi}))
 
     (is (= (hae-tp-maara) (+ 1 vanha-maara)))
+    ;; varmistetaan että liite assosioitiin turvallisuuspoikkeamaan oikein
+    (is (= 1 (ffirst (q (str "SELECT count(*) FROM turvallisuuspoikkeama_liite where liite = " liitteen-id)))))
 
     ;; Tarkistetaan, että data tallentui oikein
     (let [uusin-tp (hae-uusin-turvallisuuspoikkeama)


### PR DESCRIPTION
Välitä turvallisuuspoikkeaman ID liitteen parituksen SQL-kyselylle. Aiemmin tätä ei tapahtunut.