### PR TITLE
Vhar 7939 laatulupauksen tekstit

### DIFF
--- a/tietokanta/src/main/resources/db/migration/V1_1029__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1029__.sql
@@ -6,3 +6,139 @@ SET sisalto = 'Teemme urakassa muuttuvissa keliolosuhteissa laadunseurantaa myö
  viikonloppuisin. Laadimme jokaisesta pistokokeesta erillisen raportin ja luovutamme sen tilaajalle
  viimeistään seuraavassa työmaakokouksessa.'
 WHERE jarjestys = 7 AND "urakan-alkuvuosi" IN (2021, 2022);
+
+-- Lupausten pohjadata hoitokaudelle 2023-2024
+INSERT INTO lupausryhma(otsikko, jarjestys, "urakan-alkuvuosi", luotu)
+VALUES
+    ('Kannustavat alihankintasopimukset', 1, 2023, NOW()),
+    ('Toiminnan suunnitelmallisuus', 2, 2023, NOW()),
+    ('Laadunvarmistus ja reagointikyky', 3, 2023, NOW()),
+    ('Turvallisuus ja osaamisen kehittäminen', 4, 2023, NOW()),
+    ('Viestintä ja tienkäyttäjäasiakkaan palvelu', 5, 2023, NOW());
+
+INSERT INTO lupaus (jarjestys, "lupausryhma-id", "urakka-id", lupaustyyppi, "pisteet", "kirjaus-kkt", "paatos-kk", "joustovara-kkta", kuvaus, sisalto, "urakan-alkuvuosi") VALUES
+-- A. Kannustavat alihankintasopimukset
+(1, (SELECT id FROM lupausryhma WHERE otsikko = 'Kannustavat alihankintasopimukset' and "urakan-alkuvuosi" = 2023), null, 'yksittainen', 8, '{10}', 6, 0,
+ 'Talvihoidon kannustinjärjestelmä',
+ 'Kehitämme yhdessä tilaajan kanssa talvihoidon alihankkijoiden kannustinjärjestelmän, joka on
+käytössä vähintään kahdessa alihankintasopimuksessamme. Lupaus täyttyy myös
+kannustinjärjestelmän kehittämisen ja käyttöönoton jälkeisinä hoitovuosina, mikäli sama
+järjestelmä on edelleen käytössä. Tilaaja on varannut vuosittain 5 000 € ja me vähintään 15 000
+€ tämän lupauksen kannustinjärjestelmään. Tilaajan ja meidän rahavarauksemme yhdistetään
+ja tätä summaa käytetään samassa suhteessa maksettaessa mahdollisia yksittäisiä kannusteita.',
+ 2023),
+(2, (SELECT id FROM lupausryhma WHERE otsikko = 'Kannustavat alihankintasopimukset' and "urakan-alkuvuosi" = 2023), null, 'yksittainen', 8, '{10}', 9, 0,
+ 'Kesähoidon kannustinjärjestelmä',
+ 'Kehitämme yhdessä tilaajan kanssa kesähoidon alihankkijoiden kannustinjärjestelmän, joka on
+käytössä vähintään kahdessa alihankintasopimuksessamme. Lupaus täyttyy myös
+kannustinjärjestelmän kehittämisen ja käyttöönoton jälkeisinä hoitovuosina, mikäli sama
+järjestelmä on edelleen käytössä. Tilaaja on varannut vuosittain 5 000 € ja me vähintään 15 000
+€ tämän lupauksen kannustinjärjestelmään. Tilaajan ja meidän rahavarauksemme yhdistetään
+ja tätä summaa käytetään samassa suhteessa maksettaessa mahdollisia yksittäisiä kannusteita.',
+ 2023),
+(3, (SELECT id FROM lupausryhma WHERE otsikko = 'Kannustavat alihankintasopimukset' and "urakan-alkuvuosi" = 2023), null, 'kysely', 14, '{10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8}', 9, 0,
+ 'Kyselytutkimus alihankkijoille',
+ 'Kyselytutkimus alihankkijoille (6 sisäistä pistevaihtoehtoa). Tarjoaja antaa lupauksen
+tarjoamansa hoitourakan kyselytutkimuksen keskiarvosta.',
+ 2023),
+
+-- B. Toiminnan suunnitelmallisuus
+(4, (SELECT id FROM lupausryhma WHERE otsikko = 'Toiminnan suunnitelmallisuus' and "urakan-alkuvuosi" = 2023), null, 'yksittainen', 10, null, 0, 1,
+ 'Kuukausittainen töiden suunnittelu',
+ 'Suunnittelemme yhdessä tilaajan ja alihankkijoiden kanssa urakan töitä vähintään kerran
+kuukaudessa. Töitä voidaan suunnitella esimerkiksi palaverein tai sähköisin menettelyin.
+Suunnittelussa ja töiden sisältöjen (laatuvaatimukset, töiden yhteensovittaminen yms.)
+läpikäynnissä tulee olla mukana ne alihankkijatahot, jotka tulevat tekemään töitä urakassa
+seuraavan kuukauden aikana.',
+ 2023),
+-- C. Laadunvarmistus ja reagointikyky
+(5, (SELECT id FROM lupausryhma WHERE otsikko = 'Laadunvarmistus ja reagointikyky' and "urakan-alkuvuosi" = 2023), null, 'monivalinta', 10, '{10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8}', 9, 0,
+ 'Kunnossapitoilmoitukset',
+ 'Toimenpiteitä aiheuttaneiden ilmoitusten (urakoitsijaviestien) %-osuus talvihoitoon ja sorateiden
+kunnossapitoon liittyvistä ilmoituksista. (6 sisäistä pistevaihtoehtoa).',
+ 2023),
+(6, (SELECT id FROM lupausryhma WHERE otsikko = 'Laadunvarmistus ja reagointikyky' and "urakan-alkuvuosi" = 2023), null, 'yksittainen', 5, '{10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8}', 9, 0,
+ 'Luovutuksen menettely',
+ 'Meillä (pääurakoitsijalla) on käytössä itselle luovutuksen menettely määräaikaan sidotuista töistä
+/ työkokonaisuuksista, varusteiden ja laitteiden lisäämisestä ja uusimisesta, sorateiden ja siltojen
+hoidosta sekä ojituksesta. Alihankkijamme tekevät itselle luovutuksen vastaavista omista
+töistään / työkokonaisuuksista, jotka tarkastamme ennen tilaajalle luovuttamista.',
+ 2023),
+(7, (SELECT id FROM lupausryhma WHERE otsikko = 'Laadunvarmistus ja reagointikyky' and "urakan-alkuvuosi" = 2023), null, 'yksittainen', 5, '{10, 11, 12, 1, 2, 3, 4, 5}', 6, 0,
+ 'Talvihoidon pistokokeet',
+ 'Teemme urakassa muuttuvissa keliolosuhteissa laadunseurantaa myös pistokokeina ≥= 6 kertaa
+ talvessa (esim. toimenpideajassa pysyminen, työn jälki, työmenetelmä, reagointikyky ja
+ liukkaudentorjuntamateriaalien annosmäärät), joista kolme tehdään klo 20–06 välillä ja/tai
+ viikonloppuisin. Laadimme jokaisesta pistokokeesta erillisen raportin ja luovutamme sen tilaajalle
+ viimeistään seuraavassa työmaakokouksessa.',
+ 2023),
+-- D. Turvallisuus ja osaamisen kehittäminen
+(8, (SELECT id FROM lupausryhma WHERE otsikko = 'Turvallisuus ja osaamisen kehittäminen' and "urakan-alkuvuosi" = 2023), null, 'yksittainen', 5, null, 0, 0,
+ 'Työturvallisuuden raportointi',
+ 'Seuraamme urakassa systemaattisesti työturvallisuutta vaarantavia läheltä piti -tilanteita ja
+teemme korjaavia toimenpiteitä ko. tilanteiden vähentämiseksi. Raportoimme em. tilanteet sekä
+niihin liittyvät suunnitellut ja/tai tehdyt toimenpiteet tilaajalle työmaakokouksien yhteydessä.',
+ 2023),
+(9, (SELECT id FROM lupausryhma WHERE otsikko = 'Turvallisuus ja osaamisen kehittäminen' and "urakan-alkuvuosi" = 2023), null, 'yksittainen', 5,
+ '{10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8}', 9, 0,
+ 'Turvallisuuden teemakokoukset',
+ 'Pidämme vähintään 80 %:lle alihankkijoiden operatiivisesta henkilöstöstä vuosittain
+työlajikohtaiset tai synergisesti yli työlajien nivoutuvat turvallisuuden teemakokoukset.
+Kokouksien ohjelmat ja osallistujalistat todetaan viimeistään kokousta seuraavassa
+työmaakokouksessa',
+ 2023),
+(10, (SELECT id FROM lupausryhma WHERE otsikko = 'Turvallisuus ja osaamisen kehittäminen' and "urakan-alkuvuosi" = 2023), null, 'yksittainen', 5,
+ '{10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8}', 9, 0,
+ 'Koulutukset',
+ 'Järjestämme urakassa koulutuksia, joiden aiheita voivat olla esim. menetelmätieto,
+laatutietoisuus, raportointi, seurantalaitteiden käyttö ja työturvallisuus. Järjestämäämme
+koulutukseen (1 htp / hoitovuosi) osallistuu vähintään 1 alihankkijan henkilö kultakin
+sopimussuhteessa olevalta alihankkijalta. Osallistumisvelvollisuus on kirjattu
+alihankintasopimuksiimme.',
+ 2023),
+-- E. Viestintä ja tienkäyttäjäasiakkaan palvelu
+(11, (SELECT id FROM lupausryhma WHERE otsikko = 'Viestintä ja tienkäyttäjäasiakkaan palvelu' and "urakan-alkuvuosi" = 2023), null, 'yksittainen', 2, null, 0, 0,
+ 'Tilanne- ja ennakkotiedotus',
+ 'Toteutamme tilanne- ja ennakkotiedotusta vähintään 4 kertaa kuukaudessa.',
+ 2023),
+(12, (SELECT id FROM lupausryhma WHERE otsikko = 'Viestintä ja tienkäyttäjäasiakkaan palvelu' and "urakan-alkuvuosi" = 2023), null, 'yksittainen', 12, null, 9, 0,
+ 'Viestintä sidosryhmien kanssa',
+ 'Tunnistamme urakka-alueen tärkeimmät sidosryhmät (esim. Vapo, metsäyhtiöt, linja-autoyhtiöt,
+koululaiskuljetukset, yms.). Sovimme hoitovuosittain heidän kanssaan käytävästä
+vuoropuhelusta ja viestinnästä. Vuoropuhelun perusteella kehitämme toimintaamme siten, että
+sidosryhmien tarpeet sopimuksen puitteissa tulevat huomioiduiksi mahdollisimman hyvin.
+Olemme yhteydessä paikallismedioihin ja sovimme hoitovuosittain heidän kanssaan käytävästä
+vuoropuhelusta ja viestinnästä.',
+ 2023),
+(13, (SELECT id FROM lupausryhma WHERE otsikko = 'Viestintä ja tienkäyttäjäasiakkaan palvelu' and "urakan-alkuvuosi" = 2023), null, 'yksittainen', 8, null, 0, 0,
+ 'Palautteet ja kehittäminen',
+ 'Toimitamme tienkäyttäjäpalautteet ja urakoitsijaviestit henkilöstön ja alihankkijoiden
+tietoisuuteen viikoittain. Näiden palautteiden ja omien sekä alihankkijoidemme havaintojen
+perusteella kehitämme ja teemme tienkäyttäjiä palvelevia toimenpiteitä esim. reititykseen,
+työmenetelmiin ja alihankinnan ohjaukseen. Keskustelemme kehittämistoimista tilaajan kanssa
+sekä huomioimme ne viestinnässä.',
+ 2023),
+(14, (SELECT id FROM lupausryhma WHERE otsikko = 'Viestintä ja tienkäyttäjäasiakkaan palvelu' and "urakan-alkuvuosi" = 2023), null, 'yksittainen', 3, null, 9, 0,
+ 'Tyytyväisyystutkimustulokset',
+ 'Teemme Talven tienkäyttäjätyytyväisyystutkimustuloksista (ml. vapaat vastaukset) analyysin
+kerran vuodessa. Saatamme tutkimuksen ja analyysin tulokset henkilöstön ja alihankkijoiden
+tietoisuuteen. Huomioimme havaitut kehitystarpeet toiminnassa ja viestinnässä. Esitämme
+analyysit, havainnot ja kehitystoimet tilaajalle 2 kk:n kuluessa tulosten saamisesta.',
+ 2023);
+
+-- kyselytutkimus alihankkijoille lupaukset 3 osalta toimitetaan luultavasti muualla kuin Harjassa.
+-- Harjassa valitaan vain monivalintana saatu tulos
+SELECT * FROM luo_lupauksen_vaihtoehto(3, 2023, '<= 4,1 ', 0);
+SELECT * FROM luo_lupauksen_vaihtoehto(3, 2023, '> 4,1', 2);
+SELECT * FROM luo_lupauksen_vaihtoehto(3, 2023, '> 4,4', 4);
+SELECT * FROM luo_lupauksen_vaihtoehto(3, 2023, '> 4,7', 6);
+SELECT * FROM luo_lupauksen_vaihtoehto(3, 2023, '> 5,0', 10);
+SELECT * FROM luo_lupauksen_vaihtoehto(3, 2023, '> 5.3', 14);
+
+SELECT * FROM luo_lupauksen_vaihtoehto(5, 2023, '> 25 % / hoitovuosi', 0);
+SELECT * FROM luo_lupauksen_vaihtoehto(5, 2023, '10-25 % / hoitovuosi', 2);
+SELECT * FROM luo_lupauksen_vaihtoehto(5, 2023, '15-20 % / hoitovuosi', 4);
+SELECT * FROM luo_lupauksen_vaihtoehto(5, 2023, '10-15 % / hoitovuosi', 6);
+SELECT * FROM luo_lupauksen_vaihtoehto(5, 2023, '5-10 % / hoitovuosi', 8);
+SELECT * FROM luo_lupauksen_vaihtoehto(5, 2023, '0-5 % / hoitovuosi', 10);
+

--- a/tietokanta/src/main/resources/db/migration/V1_1029__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1029__.sql
@@ -1,0 +1,8 @@
+-- Lupaus -taulussa on ollut vuosina 21-23 virhe järjestyksessään 7:ssä lupauksessa. Laadunseuranta oli virheellisesti yli 6 kertaa. Tässä korjataan kuuten tai enemmän
+UPDATE lupaus
+SET sisalto = 'Teemme urakassa muuttuvissa keliolosuhteissa laadunseurantaa myös pistokokeina ≥ 6 kertaa
+ talvessa (esim. toimenpideajassa pysyminen, työn jälki, työmenetelmä, reagointikyky ja
+ liukkaudentorjuntamateriaalien annosmäärät), joista kolme tehdään klo 20–06 välillä ja/tai
+ viikonloppuisin. Laadimme jokaisesta pistokokeesta erillisen raportin ja luovutamme sen tilaajalle
+ viimeistään seuraavassa työmaakokouksessa.'
+WHERE jarjestys = 7 AND "urakan-alkuvuosi" IN (2021, 2022);

--- a/tietokanta/testidata/lupaus_testidata.sql
+++ b/tietokanta/testidata/lupaus_testidata.sql
@@ -95,7 +95,7 @@ töistään / työkokonaisuuksista, jotka tarkastamme ennen tilaajalle luovuttam
  2019),
 (7, (SELECT id FROM lupausryhma WHERE otsikko = 'Laadunvarmistus ja reagointikyky'  AND "urakan-alkuvuosi" = 2019), null, 'yksittainen', 5, '{10, 11, 12, 1, 2, 3, 4, 5}', 6, 0,
  'Talvihoidon pistokokeet',
- 'Teemme urakassa muuttuvissa keliolosuhteissa laadunseurantaa myös pistokokeina > 6 kertaa
+ 'Teemme urakassa muuttuvissa keliolosuhteissa laadunseurantaa myös pistokokeina ≥ 6 kertaa
  talvessa (esim. toimenpideajassa pysyminen, työn jälki, työmenetelmä, reagointikyky ja
  liukkaudentorjuntamateriaalien annosmäärät), joista kolme tehdään klo 20–06 välillä ja/tai
  viikonloppuisin. Laadimme jokaisesta pistokokeesta erillisen raportin ja luovutamme sen tilaajalle


### PR DESCRIPTION
Tässä on kaksi asiaa laitettu kuntoon.
Vuoden 2023 lokakuussa alkavilta urakoilta puuttui lupaustekstit. Ne on samat kuin edellisenä vuonna, joten copypaste.

Alkuperäinen bugi liittyi > merkkiin. Se vaihdettu teksteihin >= merkiksi.