### PR TITLE
Vhar 7938 laskutusyhteenveto hoitokausi

### DIFF
--- a/src/clj/harja/palvelin/raportointi/raportit/laskutusyhteenveto.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/laskutusyhteenveto.clj
@@ -219,6 +219,13 @@
   (let [;; Aikavälit ja otsikkotekstit
         kyseessa-kk-vali? (pvm/kyseessa-kk-vali? alkupvm loppupvm)
         kyseessa-hoitokausi-vali? (pvm/kyseessa-hoitokausi-vali? alkupvm loppupvm)
+        ;; Kun koko hoitokausi on valittu ja loppupvm on myöhemmin kuin kuluva päivä, käytetään kuluvaa päivää
+        ;; Muuten laskutusyhteenveto alkaa "ennustamaan" kustannuksia tulevaisuudesta.
+        parametrit (assoc parametrit :haun-loppupvm (if (pvm/kyseessa-hoitokausi-vali? alkupvm loppupvm)
+                                                      (if (pvm/ennen? (pvm/nyt) loppupvm)
+                                                        (pvm/nyt)
+                                                        loppupvm)
+                                                      loppupvm))
         kyseessa-vuosi-vali? (pvm/kyseessa-vuosi-vali? alkupvm loppupvm)
         laskutettu-teksti (str "Laskutettu hoito\u00ADkaudella ennen " (pvm/kuukausi-ja-vuosi alkupvm))
         laskutetaan-teksti (str "Laskutetaan " (pvm/kuukausi-ja-vuosi alkupvm))

--- a/src/clj/harja/palvelin/raportointi/raportit/laskutusyhteenveto.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/laskutusyhteenveto.clj
@@ -221,10 +221,10 @@
         kyseessa-hoitokausi-vali? (pvm/kyseessa-hoitokausi-vali? alkupvm loppupvm)
         ;; Kun koko hoitokausi on valittu ja loppupvm on myöhemmin kuin kuluva päivä, käytetään kuluvaa päivää
         ;; Muuten laskutusyhteenveto alkaa "ennustamaan" kustannuksia tulevaisuudesta.
-        parametrit (assoc parametrit :haun-loppupvm (if (pvm/kyseessa-hoitokausi-vali? alkupvm loppupvm)
-                                                      (if (pvm/ennen? (pvm/nyt) loppupvm)
-                                                        (pvm/nyt)
-                                                        loppupvm)
+        parametrit (assoc parametrit :haun-loppupvm (if (and
+                                                          (pvm/kyseessa-hoitokausi-vali? alkupvm loppupvm)
+                                                          (pvm/ennen? (pvm/nyt) loppupvm))
+                                                      (pvm/nyt)
                                                       loppupvm))
         kyseessa-vuosi-vali? (pvm/kyseessa-vuosi-vali? alkupvm loppupvm)
         laskutettu-teksti (str "Laskutettu hoito\u00ADkaudella ennen " (pvm/kuukausi-ja-vuosi alkupvm))
@@ -238,8 +238,8 @@
 
         ;; Konteksti ja urakkatiedot
         konteksti (cond urakka-id :urakka
-                        hallintayksikko-id :hallintayksikko
-                        :default :urakka)
+                    hallintayksikko-id :hallintayksikko
+                    :default :urakka)
         {alueen-nimi :nimi} (first (if (= konteksti :hallintayksikko)
                                      (hallintayksikko-q/hae-organisaatio db hallintayksikko-id)
                                      (urakat-q/hae-urakka db urakka-id)))
@@ -248,17 +248,17 @@
                      :hallintayksikkoid hallintayksikko-id :urakkaid urakka-id
                      :urakkatyyppi (name (:urakkatyyppi parametrit))})
         urakoiden-parametrit (mapv #(assoc parametrit :urakka-id (:id %)
-                                                      :urakka-nimi (:nimi %)
-                                                      :indeksi (:indeksi %)
-                                                      :urakkatyyppi (:tyyppi %)) urakat)
+                                      :urakka-nimi (:nimi %)
+                                      :indeksi (:indeksi %)
+                                      :urakkatyyppi (:tyyppi %)) urakat)
         ;; Datan nostaminen tietokannasta urakoittain, hyödyntää cachea
         laskutusyhteenvedot (mapv (fn [urakan-parametrit]
                                     (mapv #(assoc % :urakka-id (:urakka-id urakan-parametrit)
-                                                    :urakka-nimi (:urakka-nimi urakan-parametrit)
-                                                    :indeksi (:indeksi urakan-parametrit)
-                                                    :urakkatyyppi (:urakkatyyppi urakan-parametrit))
-                                          (lyv-yhteiset/hae-laskutusyhteenvedon-tiedot db user urakan-parametrit)))
-                                  urakoiden-parametrit)
+                                             :urakka-nimi (:urakka-nimi urakan-parametrit)
+                                             :indeksi (:indeksi urakan-parametrit)
+                                             :urakkatyyppi (:urakkatyyppi urakan-parametrit))
+                                      (lyv-yhteiset/hae-laskutusyhteenvedon-tiedot db user urakan-parametrit)))
+                              urakoiden-parametrit)
 
         urakoiden-lahtotiedot (lyv-yhteiset/urakoiden-lahtotiedot laskutusyhteenvedot)
 

--- a/src/clj/harja/palvelin/raportointi/raportit/laskutusyhteenveto_tuotekohtainen.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/laskutusyhteenveto_tuotekohtainen.clj
@@ -187,10 +187,10 @@
 
         ;; Kun koko hoitokausi on valittu ja loppupvm on myöhemmin kuin kuluva päivä, käytetään kuluvaa päivää
         ;; Muuten laskutusyhteenveto alkaa "ennustamaan" kustannuksia tulevaisuudesta.
-        parametrit (assoc parametrit :haun-loppupvm (if (pvm/kyseessa-hoitokausi-vali? alkupvm loppupvm)
-                                                      (if (pvm/ennen? (pvm/nyt) loppupvm)
-                                                        (pvm/nyt)
-                                                        loppupvm)
+        parametrit (assoc parametrit :haun-loppupvm (if (and
+                                                          (pvm/kyseessa-hoitokausi-vali? alkupvm loppupvm)
+                                                          (pvm/ennen? (pvm/nyt) loppupvm))
+                                                      (pvm/nyt)
                                                       loppupvm))
         ;; Konteksti ja urakkatiedot
         konteksti (cond urakka-id :urakka

--- a/src/clj/harja/palvelin/raportointi/raportit/laskutusyhteenveto_tuotekohtainen.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/laskutusyhteenveto_tuotekohtainen.clj
@@ -185,6 +185,13 @@
         ;; Hoitokausi valittuna?
         hoitokausi? (= aikarajaus :hoitokausi)
 
+        ;; Kun koko hoitokausi on valittu ja loppupvm on myöhemmin kuin kuluva päivä, käytetään kuluvaa päivää
+        ;; Muuten laskutusyhteenveto alkaa "ennustamaan" kustannuksia tulevaisuudesta.
+        parametrit (assoc parametrit :haun-loppupvm (if (pvm/kyseessa-hoitokausi-vali? alkupvm loppupvm)
+                                                      (if (pvm/ennen? (pvm/nyt) loppupvm)
+                                                        (pvm/nyt)
+                                                        loppupvm)
+                                                      loppupvm))
         ;; Konteksti ja urakkatiedot
         konteksti (cond urakka-id :urakka
                     hallintayksikko-id :hallintayksikko

--- a/src/clj/harja/palvelin/raportointi/raportit/laskutusyhteenveto_tyomaa.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/laskutusyhteenveto_tyomaa.clj
@@ -188,10 +188,10 @@
 
         ;; Kun koko hoitokausi on valittu ja loppupvm on myöhemmin kuin kuluva päivä, käytetään kuluvaa päivää
         ;; Muuten laskutusyhteenveto alkaa "ennustamaan" kustannuksia tulevaisuudesta.
-        parametrit (assoc parametrit :haun-loppupvm (if (pvm/kyseessa-hoitokausi-vali? alkupvm loppupvm)
-                                                      (if (pvm/ennen? (pvm/nyt) loppupvm)
-                                                        (pvm/nyt)
-                                                        loppupvm)
+        parametrit (assoc parametrit :haun-loppupvm (if (and
+                                                          (pvm/kyseessa-hoitokausi-vali? alkupvm loppupvm)
+                                                          (pvm/ennen? (pvm/nyt) loppupvm))
+                                                      (pvm/nyt)
                                                       loppupvm))
 
         ;; Jos käytetään valittua aikaväliä, näytetään vain "Määrä" -otsikko
@@ -241,10 +241,8 @@
     [:raportti {:nimi (str "Laskutusyhteenveto (" (pvm/pvm alkupvm) " - " (pvm/pvm loppupvm) ")")
                 :otsikon-koko :iso}
      [:otsikko-heading-small (str alueen-nimi)]
-     (if (pvm/kyseessa-hoitokausi-vali? alkupvm loppupvm)
-       (if (pvm/ennen? (pvm/nyt) loppupvm)
-         [:otsikko-heading (str "Tavoitehintaan vaikuttavat toteutuneet kustannukset aikajaksolta (" (pvm/pvm alkupvm) " - " (pvm/pvm (pvm/nyt)) ")")]
-         [:otsikko-heading "Tavoitehintaan vaikuttavat toteutuneet kustannukset"])
+     (if (and (pvm/kyseessa-hoitokausi-vali? alkupvm loppupvm) (pvm/ennen? (pvm/nyt) loppupvm))
+       [:otsikko-heading (str "Tavoitehintaan vaikuttavat toteutuneet kustannukset aikajaksolta (" (pvm/pvm alkupvm) " - " (pvm/pvm (pvm/nyt)) ")")]
        [:otsikko-heading "Tavoitehintaan vaikuttavat toteutuneet kustannukset"])
 
      (concat (for [x otsikot]
@@ -271,10 +269,8 @@
                                      :laskutetaan-teksti laskutetaan-teksti
                                      :kyseessa-kk-vali? kyseessa-kk-vali?})
 
-     (if (pvm/kyseessa-hoitokausi-vali? alkupvm loppupvm)
-       (if (pvm/ennen? (pvm/nyt) loppupvm)
-         [:otsikko-heading (str "Muut toteutuneet kustannukset (ei lasketa tavoitehintaan) aikajaksolta (" (pvm/pvm alkupvm) " - " (pvm/pvm (pvm/nyt)) ")")]
-         [:otsikko-heading "Muut toteutuneet kustannukset (ei lasketa tavoitehintaan)"])
+     (if (and (pvm/kyseessa-hoitokausi-vali? alkupvm loppupvm) (pvm/ennen? (pvm/nyt) loppupvm))
+       [:otsikko-heading (str "Muut toteutuneet kustannukset (ei lasketa tavoitehintaan) aikajaksolta (" (pvm/pvm alkupvm) " - " (pvm/pvm (pvm/nyt)) ")")]
        [:otsikko-heading "Muut toteutuneet kustannukset (ei lasketa tavoitehintaan)"])
      
      (let [otsikot ["Lisätyöt" "Muut"]]


### PR DESCRIPTION
Päätellään, että ollaanko näyttämässä koko hoitokautta laskutusyhteevedossa. Jos ollaan ja jos nyt on aiemmin, kuin annettu loppupäivämäärä, niin ei käytetä tulevaisuuden loppupäivämäärää, koska laskutusyhteenvetoon tehty sproci ei osaa silloin toimia oikein. Se alkaa "ennustamaan" kustannuksia. 
Näin saadaan rajoitettua kustannukset oikeasti toteutuneisiin ja vältetään "ennustelu".