### PR TITLE
VHAR-7952-piilota-excel-nappi

### DIFF
--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_toteumat.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_toteumat.cljs
@@ -9,8 +9,6 @@
             [harja.pvm :as pvm]
             [harja.loki :refer [log]]
 
-            [harja.tyokalut.tuck :as tuck-apurit]
-
             [harja.domain.paikkaus :as paikkaus]
             [harja.domain.tierekisteri :as tierekisteri]
             [harja.domain.roolit :as roolit]
@@ -610,8 +608,10 @@
    [excel-tuonti-virhe-modal e! app]
    [:div.row
     [kartta/kartan-paikka]]
-   [:div.row
-    [lataa-urem-excel]]
+   ;; Näytetään Urapaikkaustoteumien tuonti-Excel vain ylläpito/päällystys tyyppisille urakoille.
+   (when (= :paallystys (:arvo @nav/urakkatyyppi))
+     [:div.row
+      [lataa-urem-excel]])
    [:div.row
     [paikkaukset e! app]]])
 


### PR DESCRIPTION
Piilotetaan urapaikkaustoteumien lataamiseen suuniteltu nappi
muilta kuin paikkausurakoilta, koska muilla se ei ole käytössä.