### PR TITLE
Vhar 7880 rajoita api-käyttäjien käyttöoikeuksia

### DIFF
--- a/src/clj/harja/kyselyt/kayttajat.sql
+++ b/src/clj/harja/kyselyt/kayttajat.sql
@@ -414,7 +414,7 @@ WHERE kayttajanimi = :kayttajanimi;
 -- single?: true
 SELECT jarjestelma
 FROM kayttaja
-WHERE api_oikeus = :api-oikeus::api_oikeudet
+WHERE api_oikeus = :api-oikeus::apioikeus
   AND kayttajanimi = :kayttajanimi;
 
 -- name: liikenneviraston-jarjestelma?

--- a/src/clj/harja/kyselyt/kayttajat.sql
+++ b/src/clj/harja/kyselyt/kayttajat.sql
@@ -410,11 +410,12 @@ SELECT jarjestelma
 FROM kayttaja
 WHERE kayttajanimi = :kayttajanimi;
 
--- name: onko-jarjestelma-ja-analytiikka?
+-- name: onko-jarjestelma-ja-api-oikeus?
 -- single?: true
 SELECT jarjestelma
 FROM kayttaja
-WHERE "analytiikka-oikeus" = true AND kayttajanimi = :kayttajanimi;
+WHERE api_oikeus = :api-oikeus::api_oikeudet
+  AND kayttajanimi = :kayttajanimi;
 
 -- name: liikenneviraston-jarjestelma?
 -- single?: true

--- a/src/clj/harja/palvelin/integraatiot/api/analytiikka.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/analytiikka.clj
@@ -564,8 +564,8 @@
           :analytiikka-hae-toteumat request
           (fn [parametrit kayttaja db]
             (palauta-toteumat db parametrit kayttaja))
-          ;; Tarkista sallitaanko admin käyttälle API:en käyttöoikeus
-          (not kehitysmoodi?))))
+          ;; Vaaditaan analytiikka-oikeudet
+          "analytiikka")))
 
     (julkaise-reitti
       http :analytiikka-toteumat
@@ -589,8 +589,8 @@
           :analytiikka-hae-suunnitellut-materiaalimaarat request
           (fn [parametrit kayttaja db]
             (palauta-suunnitellut-materiaalimaarat db parametrit kayttaja))
-          ;; Tarkista sallitaanko admin käyttälle API:en käyttöoikeus
-          (not kehitysmoodi?))))
+          ;; Vaaditaan analytiikka-oikeudet
+          "analytiikka")))
 
     (julkaise-reitti
       http :analytiikka-suunnitellut-materiaalit-urakka
@@ -599,8 +599,8 @@
           :analytiikka-hae-suunnitellut-materiaalimaarat request
           (fn [parametrit kayttaja db]
             (palauta-urakan-suunnitellut-materiaalimaarat db parametrit kayttaja))
-          ;; Tarkista sallitaanko admin käyttälle API:en käyttöoikeus
-          (not kehitysmoodi?))))
+          ;; Vaaditaan analytiikka-oikeudet
+          "analytiikka")))
 
     (julkaise-reitti
       http :analytiikka-suunnitellut-tehtavamaarat-hoitovuosi
@@ -609,8 +609,8 @@
           :analytiikka-hae-suunnitellut-tehtavamaarat request
           (fn [parametrit kayttaja db]
             (palauta-suunnitellut-tehtavamaarat db parametrit kayttaja))
-          ;; Tarkista sallitaanko admin käyttälle API:en käyttöoikeus
-          (not kehitysmoodi?))))
+          ;; Vaaditaan analytiikka-oikeudet
+          "analytiikka")))
 
     (julkaise-reitti
       http :analytiikka-suunnitellut-tehtavamaarat-urakka
@@ -619,8 +619,8 @@
           :analytiikka-hae-suunnitellut-tehtavamaarat request
           (fn [parametrit kayttaja db]
             (palauta-urakan-suunnitellut-tehtavamaarat db parametrit kayttaja))
-          ;; Tarkista sallitaanko admin käyttälle API:en käyttöoikeus
-          (not kehitysmoodi?))))
+          ;; Vaaditaan analytiikka-oikeudet
+          "analytiikka")))
 
     (julkaise-reitti
       http :analytiikka-materiaalit
@@ -629,8 +629,8 @@
           :analytiikka-hae-materiaalikoodit request
           (fn [parametrit kayttaja db]
             (palauta-materiaalit db parametrit kayttaja))
-          ;; Tarkista sallitaanko admin käyttälle API:en käyttöoikeus
-          (not kehitysmoodi?))))
+          ;; Vaaditaan analytiikka-oikeudet
+          "analytiikka")))
 
     (julkaise-reitti
       http :analytiikka-tehtavat
@@ -639,8 +639,8 @@
           :analytiikka-hae-tehtavat request
           (fn [parametrit kayttaja db]
             (palauta-tehtavat db parametrit kayttaja))
-          ;; Tarkista sallitaanko admin käyttälle API:en käyttöoikeus
-          (not kehitysmoodi?))))
+          ;; Vaaditaan analytiikka-oikeudet
+          "analytiikka")))
 
     (julkaise-reitti
       http :analytiikka-urakat
@@ -649,8 +649,8 @@
           :analytiikka-hae-urakat request
           (fn [parametrit kayttaja db]
             (palauta-urakat db parametrit kayttaja))
-          ;; Tarkista sallitaanko admin käyttälle API:en käyttöoikeus
-          (not kehitysmoodi?))))
+          ;; Vaaditaan analytiikka-oikeudet
+          "analytiikka")))
 
     (julkaise-reitti
       http :analytiikka-organisaatiot
@@ -659,8 +659,8 @@
           :analytiikka-hae-organisaatiot request
           (fn [parametrit kayttaja db]
             (palauta-organisaatiot db parametrit kayttaja))
-          ;; Tarkista sallitaanko admin käyttälle API:en käyttöoikeus
-          (not kehitysmoodi?))))
+          ;; Vaaditaan analytiikka-oikeudet
+          "analytiikka")))
     (julkaise-reitti
       http :analytiikka-turvallisuuspoikkeamat
       (GET "/api/analytiikka/turvallisuuspoikkeamat/:alkuaika/:loppuaika" request
@@ -668,8 +668,8 @@
           json-skeemat/+turvallisuuspoikkeamien-vastaus+
           (fn [parametrit kayttaja db]
             (hae-turvallisuuspoikkeamat db parametrit kayttaja))
-          ;; Tarkista sallitaanko admin käyttälle API:en käyttöoikeus
-          (not kehitysmoodi?))))
+          ;; Vaaditaan analytiikka-oikeudet
+          "analytiikka")))
     this)
 
   (stop [{http :http-palvelin :as this}]

--- a/src/clj/harja/palvelin/integraatiot/api/ilmoitukset.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/ilmoitukset.clj
@@ -260,14 +260,14 @@
         (kasittele-kevyesti-get-kutsu db integraatioloki :hae-ilmoitukset-ytunnuksella request
           (fn [parametrit kayttaja db]
             (hae-ilmoitukset-ytunnuksella db parametrit kayttaja))
-          false)))
+          nil)))
     (julkaise-reitti
       http :hae-ilmoitukset-ytunnuksella
       (GET "/api/ilmoitukset/:ytunnus/:alkuaika" request
         (kasittele-kevyesti-get-kutsu db integraatioloki :hae-ilmoitukset-ytunnuksella request
           (fn [parametrit kayttaja db]
             (hae-ilmoitukset-ytunnuksella db parametrit kayttaja))
-          false)))
+          nil)))
 
 
     ;; Tässä rajapinnassa on virheellisesti kauttaviiva. Rajapinta duplikoitu ilman kauttaviivaa,

--- a/src/clj/harja/palvelin/integraatiot/api/tieluvat.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/tieluvat.clj
@@ -105,14 +105,16 @@
     (julkaise-reitti
       http :kirjaa-tielupa
       (POST "/api/tieluvat" request
-        (kasittele-kutsu db
-                         integraatioloki
-                         :kirjaa-tielupa
-                         request
-                         json-skeemat/tieluvan-kirjaus-request
-                         json-skeemat/kirjausvastaus
-                         (fn [_ data kayttaja db]
-                           (kirjaa-tielupa liitteiden-hallinta db data kayttaja)))))
+        (kasittele-kutsu
+          db
+          integraatioloki
+          :kirjaa-tielupa
+          request
+          json-skeemat/tieluvan-kirjaus-request
+          json-skeemat/kirjausvastaus
+          (fn [_ data kayttaja db]
+            (kirjaa-tielupa liitteiden-hallinta db data kayttaja))
+          "tielupa")))
     this)
 
   (stop [{http :http-palvelin :as this}]

--- a/src/clj/harja/palvelin/integraatiot/api/tyokalut/kutsukasittely.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/tyokalut/kutsukasittely.clj
@@ -307,7 +307,8 @@
   "Käyttäjä on oltava validoitu ennen tämän funktion kutsumista. Tässä varmennetaan,
   että käyttäjällä on oikeaan apiin lisätty oikeus tietokannassa."
   [db kayttaja vaadittu-api-oikeus]
-  (let [on-oikeus (if vaadittu-api-oikeus
+  (let [_ (println "vaadi-api-oikeudet :: tulee tänne: kayttaja:" (pr-str kayttaja))
+        on-oikeus (if vaadittu-api-oikeus
                     ;; vaadittu-api-oikeus voi olla nil esim testitapauksissa, joten riittää, että on järjestelmä käyttäjä
                     (kayttajat/onko-jarjestelma-ja-api-oikeus? db {:kayttajanimi (:kayttajanimi kayttaja)
                                                                    :api-oikeus vaadittu-api-oikeus})

--- a/src/clj/harja/palvelin/integraatiot/api/tyokalut/kutsukasittely.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/tyokalut/kutsukasittely.clj
@@ -311,7 +311,8 @@
                     ;; vaadittu-api-oikeus voi olla nil esim testitapauksissa, joten riittää, että on järjestelmä käyttäjä
                     (kayttajat/onko-jarjestelma-ja-api-oikeus? db {:kayttajanimi (:kayttajanimi kayttaja)
                                                                    :api-oikeus vaadittu-api-oikeus})
-                    (kayttajat/onko-jarjestelma? db {:kayttajanimi (:kayttajanimi kayttaja)}))]
+                    (kayttajat/onko-jarjestelma? db {:kayttajanimi (:kayttajanimi kayttaja)}))
+        _ (println "vaadi-api-oikeudet :: on-oikeus:" (pr-str on-oikeus))]
     (if (nil? on-oikeus)
       (do
         (log/error "Käyttäjällä ei ole järjestelmäoikeuksia: " (:kayttajanimi kayttaja))
@@ -525,6 +526,7 @@
           kayttaja (hae-kayttaja db (get
                                       (todennus/prosessoi-kayttaja-headerit (:headers request))
                                       "oam_remote_user"))
+          _ (println "kasittele-kevyesti-get-kutsu :: kayttaja:" (pr-str kayttaja))
           tapahtuma-id (when integraatioloki
                          (lokita-kutsu integraatioloki resurssi request nil))
           parametrit (:params request)

--- a/src/clj/harja/palvelin/integraatiot/api/tyokalut/kutsukasittely.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/tyokalut/kutsukasittely.clj
@@ -307,13 +307,11 @@
   "Käyttäjä on oltava validoitu ennen tämän funktion kutsumista. Tässä varmennetaan,
   että käyttäjällä on oikeaan apiin lisätty oikeus tietokannassa."
   [db kayttaja vaadittu-api-oikeus]
-  (let [_ (println "vaadi-api-oikeudet :: tulee tänne: kayttaja:" (pr-str kayttaja))
-        on-oikeus (if vaadittu-api-oikeus
+  (let [on-oikeus (if vaadittu-api-oikeus
                     ;; vaadittu-api-oikeus voi olla nil esim testitapauksissa, joten riittää, että on järjestelmä käyttäjä
                     (kayttajat/onko-jarjestelma-ja-api-oikeus? db {:kayttajanimi (:kayttajanimi kayttaja)
                                                                    :api-oikeus vaadittu-api-oikeus})
-                    (kayttajat/onko-jarjestelma? db {:kayttajanimi (:kayttajanimi kayttaja)}))
-        _ (println "vaadi-api-oikeudet :: on-oikeus:" (pr-str on-oikeus))]
+                    (kayttajat/onko-jarjestelma? db {:kayttajanimi (:kayttajanimi kayttaja)}))]
     (if (nil? on-oikeus)
       (do
         (log/error "Käyttäjällä ei ole järjestelmäoikeuksia: " (:kayttajanimi kayttaja))
@@ -527,7 +525,6 @@
           kayttaja (hae-kayttaja db (get
                                       (todennus/prosessoi-kayttaja-headerit (:headers request))
                                       "oam_remote_user"))
-          _ (println "kasittele-kevyesti-get-kutsu :: kayttaja:" (pr-str kayttaja))
           tapahtuma-id (when integraatioloki
                          (lokita-kutsu integraatioloki resurssi request nil))
           parametrit (:params request)

--- a/test/clj/harja/palvelin/integraatiot/api/analytiikka_materiaalit_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/analytiikka_materiaalit_test.clj
@@ -62,7 +62,8 @@
         kayttajadb (q-map (format "SELECT * from kayttaja where kayttajanimi = '%s'" "analytiikka-testeri"))
         _ (println "***************** kayttajadb: " kayttajadb)
         vastaus (api-tyokalut/get-kutsu [(str "/api/analytiikka/urakat")] kayttaja-analytiikka portti)
-        encoodattu-body (cheshire/decode (:body vastaus) true)]
+        encoodattu-body (cheshire/decode (:body vastaus) true)
+        (println "***************** encoodattu-body: " encoodattu-body)]
     (is (= 200 (:status vastaus)))
     (is (= (count urakat-kannasta) (count (:urakat encoodattu-body))))))
 
@@ -358,6 +359,7 @@
         ;; Haetaan apista tulokset
         vastaus (api-tyokalut/get-kutsu [(format "/api/analytiikka/suunnitellut-tehtavat/%s" urakka-id)] kayttaja-analytiikka portti)
         encoodattu-body (cheshire/decode (:body vastaus) true)
+        _ (println "************ encoodattu-body" encoodattu-body)
         ekan-vuoden-suunnitelmat (sort-by :maara (:suunnitellut-tehtavat (first encoodattu-body)))]
 
     (is (= 200 (:status vastaus)))

--- a/test/clj/harja/palvelin/integraatiot/api/analytiikka_materiaalit_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/analytiikka_materiaalit_test.clj
@@ -60,10 +60,8 @@
   (let [urakat-kannasta (q-map (str "SELECT id FROM urakka"))
         ;; Varmista käyttäjän oikeudet kannasta
         kayttajadb (q-map (format "SELECT * from kayttaja where kayttajanimi = '%s'" "analytiikka-testeri"))
-        _ (println "***************** kayttajadb: " kayttajadb)
         vastaus (api-tyokalut/get-kutsu [(str "/api/analytiikka/urakat")] kayttaja-analytiikka portti)
-        encoodattu-body (cheshire/decode (:body vastaus) true)
-        _ (println "***************** encoodattu-body: " encoodattu-body)]
+        encoodattu-body (cheshire/decode (:body vastaus) true)]
     (is (= 200 (:status vastaus)))
     (is (= (count urakat-kannasta) (count (:urakat encoodattu-body))))))
 
@@ -222,7 +220,6 @@
         ;; Hae suunnitellut materiaalit
         vastaus (api-tyokalut/get-kutsu [(format "/api/analytiikka/suunnitellut-materiaalit/%s" urakka-id)] kayttaja-analytiikka portti)
         encoodattu-body (cheshire/decode (:body vastaus) true)
-        _ (println "hae-suunnitellut-materiaalimaarat-MH-urakalle-onnistuu-test :: encoodattu-body" (pr-str encoodattu-body))
         ensimmainen-hoitovuosi (:suunnitellut-materiaalit (first encoodattu-body))
         ;; Järjestetään materiaalit id:n mukaan
         ensimmainen-hoitovuosi (sort-by :materiaali_id ensimmainen-hoitovuosi)]
@@ -281,8 +278,7 @@
         loppuvuosi 2040
         ;; Hae suunnitellut materiaalit
         vastaus (api-tyokalut/get-kutsu [(format "/api/analytiikka/suunnitellut-materiaalit/%s/%s" alkuvuosi loppuvuosi)] kayttaja-analytiikka portti)
-        encoodattu-body (cheshire/decode (:body vastaus) true)
-        _ (println "encoodattu-body:" (pr-str encoodattu-body))]
+        encoodattu-body (cheshire/decode (:body vastaus) true)]
 
     (is (= 200 (:status vastaus)))
     (is (not (nil? encoodattu-body)))
@@ -360,7 +356,6 @@
         ;; Haetaan apista tulokset
         vastaus (api-tyokalut/get-kutsu [(format "/api/analytiikka/suunnitellut-tehtavat/%s" urakka-id)] kayttaja-analytiikka portti)
         encoodattu-body (cheshire/decode (:body vastaus) true)
-        _ (println "************ encoodattu-body" encoodattu-body)
         ekan-vuoden-suunnitelmat (sort-by :maara (:suunnitellut-tehtavat (first encoodattu-body)))]
 
     (is (= 200 (:status vastaus)))

--- a/test/clj/harja/palvelin/integraatiot/api/analytiikka_materiaalit_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/analytiikka_materiaalit_test.clj
@@ -58,6 +58,9 @@
 
 (deftest hae-urakat-onnistuu-test
   (let [urakat-kannasta (q-map (str "SELECT id FROM urakka"))
+        ;; Varmista käyttäjän oikeudet kannasta
+        kayttajadb (q-map (format "SELECT * from kayttaja where kayttajanimi = '%s'" "analytiikka-testeri"))
+        _ (println "***************** kayttajadb: " kayttajadb)
         vastaus (api-tyokalut/get-kutsu [(str "/api/analytiikka/urakat")] kayttaja-analytiikka portti)
         encoodattu-body (cheshire/decode (:body vastaus) true)]
     (is (= 200 (:status vastaus)))
@@ -276,7 +279,8 @@
         loppuvuosi 2040
         ;; Hae suunnitellut materiaalit
         vastaus (api-tyokalut/get-kutsu [(format "/api/analytiikka/suunnitellut-materiaalit/%s/%s" alkuvuosi loppuvuosi)] kayttaja-analytiikka portti)
-        encoodattu-body (cheshire/decode (:body vastaus) true)]
+        encoodattu-body (cheshire/decode (:body vastaus) true)
+        _ (println "encoodattu-body:" (pr-str encoodattu-body))]
 
     (is (= 200 (:status vastaus)))
     (is (not (nil? encoodattu-body)))

--- a/test/clj/harja/palvelin/integraatiot/api/analytiikka_materiaalit_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/analytiikka_materiaalit_test.clj
@@ -63,7 +63,7 @@
         _ (println "***************** kayttajadb: " kayttajadb)
         vastaus (api-tyokalut/get-kutsu [(str "/api/analytiikka/urakat")] kayttaja-analytiikka portti)
         encoodattu-body (cheshire/decode (:body vastaus) true)
-        (println "***************** encoodattu-body: " encoodattu-body)]
+        _ (println "***************** encoodattu-body: " encoodattu-body)]
     (is (= 200 (:status vastaus)))
     (is (= (count urakat-kannasta) (count (:urakat encoodattu-body))))))
 

--- a/test/clj/harja/palvelin/integraatiot/api/analytiikka_materiaalit_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/analytiikka_materiaalit_test.clj
@@ -222,6 +222,7 @@
         ;; Hae suunnitellut materiaalit
         vastaus (api-tyokalut/get-kutsu [(format "/api/analytiikka/suunnitellut-materiaalit/%s" urakka-id)] kayttaja-analytiikka portti)
         encoodattu-body (cheshire/decode (:body vastaus) true)
+        _ (println "hae-suunnitellut-materiaalimaarat-MH-urakalle-onnistuu-test :: encoodattu-body" (pr-str encoodattu-body))
         ensimmainen-hoitovuosi (:suunnitellut-materiaalit (first encoodattu-body))
         ;; Järjestetään materiaalit id:n mukaan
         ensimmainen-hoitovuosi (sort-by :materiaali_id ensimmainen-hoitovuosi)]

--- a/test/clj/harja/palvelin/integraatiot/api/analytiikka_materiaalit_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/analytiikka_materiaalit_test.clj
@@ -450,5 +450,5 @@
         vaara-vuodet-vastaus (api-tyokalut/get-kutsu [(format "/api/analytiikka/suunnitellut-tehtavat/%s/%s" "l" 200)] kayttaja-analytiikka portti)]
     (is (not (nil? uri-virhe)))
     (is (str/includes? uri-virhe "java.net.URISyntaxException"))
-    (is (str/includes? virheellinen-kayttaja-vastaus "tuntematon-kayttaja"))
+    (is (str/includes? virheellinen-kayttaja-vastaus "kayttajalla-puutteelliset-oikeudet"))
     (is (str/includes? vaara-vuodet-vastaus "puutteelliset-parametrit"))))

--- a/test/clj/harja/palvelin/integraatiot/api/analytiikka_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/analytiikka_test.clj
@@ -91,7 +91,7 @@
     (is (= 403 (:status vastaus)))
     (is (str/includes? (:body vastaus) "virheet"))
     (is (str/includes? (:body vastaus) "koodi"))
-    (is (str/includes? (:body vastaus) "tuntematon-kayttaja"))))
+    (is (str/includes? (:body vastaus) "kayttajalla-puutteelliset-oikeudet"))))
 
 (deftest hae-toteumat-test-vaara-paivamaaraformaatti
   (let [alkuaika "2005-01-01T00:00:00"
@@ -190,7 +190,7 @@
         vastaus (api-tyokalut/get-kutsu [(str "/api/analytiikka/turvallisuuspoikkeamat/" alkuaika "/" loppuaika)]
                   kayttaja-yit portti)]
     (is (= 403 (:status vastaus)))
-    (is (str/includes? (:body vastaus) "tuntematon-kayttaja"))))
+    (is (str/includes? (:body vastaus) "kayttajalla-puutteelliset-oikeudet"))))
 
 (deftest hae-turvallisuuspoikkeamat-analytiikalle-onnistuu
   (let [;; Luo väliaikainen turvallisuuspoikkeama

--- a/test/clj/harja/palvelin/integraatiot/api/tieluvat_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/tieluvat_test.clj
@@ -59,6 +59,8 @@
 
 (deftest kirjaa-uusi-mainoslupa
   (let [db (luo-testitietokanta)
+        ;; Lisää väliaikaisesti kayttaja :lle tielupa -oikeudet tietokantaan
+        _ (u (format "update kayttaja set api_oikeus = 'tielupa' WHERE kayttajanimi = '%s'" kayttaja))
         tunniste 3453455
         tielupa-json (.replace (slurp "test/resurssit/api/tieluvan-kirjaus-mainoslupa.json") "<TUNNISTE>" (str tunniste))
         odotettu {::tielupa/tienpitoviranomainen-sahkopostiosoite "teijo.tienpitaja@example.com"
@@ -112,6 +114,8 @@
 
 (deftest kirjaa-uusi-suojaalue-lupa
   (let [db (luo-testitietokanta)
+        ;; Lisää väliaikaisesti kayttaja :lle tielupa -oikeudet tietokantaan
+        _ (u (format "update kayttaja set api_oikeus = 'tielupa' WHERE kayttajanimi = '%s'" kayttaja))
         tunniste 373773
         tielupa-json (.replace (slurp "test/resurssit/api/tieluvan-kirjaus-suojaalue.json") "<TUNNISTE>" (str tunniste))
         odotettu #:harja.domain.tielupa{:urakoitsija-yhteyshenkilo
@@ -177,6 +181,8 @@
 
 (deftest kirjaa-uusi-liittymalupalupa
   (let [db (luo-testitietokanta)
+        ;; Lisää väliaikaisesti kayttaja :lle tielupa -oikeudet tietokantaan
+        _ (u (format "update kayttaja set api_oikeus = 'tielupa' WHERE kayttajanimi = '%s'" kayttaja))
         tunniste 43858
         tielupa-json (.replace (slurp "test/resurssit/api/tieluvan-kirjaus-liittymalupa.json") "<TUNNISTE>" (str tunniste))
         odotettu #:harja.domain.tielupa{:urakoitsija-yhteyshenkilo

--- a/test/clj/harja/palvelin/palvelut/api_jarjestelmatunnukset_test.clj
+++ b/test/clj/harja/palvelin/palvelut/api_jarjestelmatunnukset_test.clj
@@ -31,7 +31,7 @@
   (let [vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
                                 :hae-jarjestelmatunnukset +kayttaja-jvh+ nil)]
     (is (vector? vastaus))
-    (is (= (count vastaus) 8))))
+    (is (= (count vastaus) 9))))
 
 (deftest jarjestelmatunnuksien-haku-ei-toimi-ilman-oikeuksia
   (try+

--- a/test/clj/harja/palvelin/palvelut/toteumat_test.clj
+++ b/test/clj/harja/palvelin/palvelut/toteumat_test.clj
@@ -243,8 +243,7 @@
 
     (is (not (contains? summat-ennen-lisaysta 1368)))
 
-    (let [_ (println "tyo ::::::::::::::::." (pr-str tyo))
-          lisatty (kutsu-palvelua (:http-palvelin jarjestelma)
+    (let [lisatty (kutsu-palvelua (:http-palvelin jarjestelma)
                                   :tallenna-urakan-toteuma-ja-yksikkohintaiset-tehtavat
                                   +kayttaja-jvh+ tyo)
           summat-lisayksen-jalkeen (hae-summat)]
@@ -337,8 +336,7 @@
 
     (is (not (contains? summat-ennen-lisaysta 1368)))
 
-    (let [_ (println "tyo ::::::::::::::::." (pr-str tyo))
-          lisatty (kutsu-palvelua (:http-palvelin jarjestelma)
+    (let [lisatty (kutsu-palvelua (:http-palvelin jarjestelma)
                     :tallenna-urakan-toteuma-ja-yksikkohintaiset-tehtavat
                     +kayttaja-jvh+ tyo)
           summat-lisayksen-jalkeen (hae-summat)]

--- a/test/clj/harja/palvelin/raportointi/ymparistoraportti_test.clj
+++ b/test/clj/harja/palvelin/raportointi/ymparistoraportti_test.clj
@@ -504,7 +504,6 @@ VALUES
           teksti "Oulun alueurakka 2014-2019 (1238), Ympäristöraportti ajalta 01.01.2018 - 31.12.2018"
           otsikko-oulu "Talvisuolat"
           taulukko-oulu (apurit/taulukko-otsikolla vastaus-oulu otsikko-oulu)
-          _ (println "taulukko-oulu: " taulukko-oulu)
           oulu-talvisuola-luokka-kaikki-hoitoluokat-02-18 (apurit/raporttisolun-arvo (apurit/taulukon-solu taulukko-oulu 3 0))
           oulu-talvisuola-luokka-IsE-02-18 (apurit/raporttisolun-arvo (apurit/taulukon-solu taulukko-oulu 3 1))
           oulu-talvisuola-luokka-Is-02-18 (apurit/raporttisolun-arvo (apurit/taulukon-solu taulukko-oulu 3 2))

--- a/tietokanta/src/main/resources/db/migration/V1_1031__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1031__.sql
@@ -1,0 +1,21 @@
+-- Määrittele erilaisia api-oikeuksia enumin kautta
+CREATE TYPE api_oikeudet AS ENUM ('analytiikka','tielupa');
+-- Lisää uusi kolumni määrittelemään tarkemmin käyttäjän oikeuksia
+ALTER TABLE kayttaja
+    ADD COLUMN api_oikeus api_oikeudet;
+
+-- Siivotaan olemassa olevat analytiikka-oikeudet tälle uudelle formaatille
+DO $$
+    DECLARE
+        rivi record;
+    BEGIN
+        FOR rivi in (SELECT id FROM kayttaja WHERE "analytiikka-oikeus" IS TRUE)
+            loop
+                update kayttaja set api_oikeus = 'analytiikka';
+            end loop;
+    end
+$$ language plpgsql;
+
+-- Poistetaan turhaksi jäänyt kolumni
+ALTER TABLE kayttaja
+    DROP COLUMN "analytiikka-oikeus";

--- a/tietokanta/testidata/kayttajat.sql
+++ b/tietokanta/testidata/kayttajat.sql
@@ -43,5 +43,6 @@ INSERT INTO kayttaja (kayttajanimi,etunimi,sukunimi,sahkoposti,puhelin, organisa
 ('tilaaja','ELY','tilaaja','tilaaja@example.org', '434532345',
  (SELECT id  FROM organisaatio  WHERE lyhenne = 'LAP'));
 -- Analytiikan apien testaamiseksi tarvittava käyttäjä
-INSERT INTO kayttaja (etunimi, sukunimi, kayttajanimi, organisaatio, "analytiikka-oikeus") VALUES
-          ('etunimi','sukunimi', 'analytiikka-testeri', (SELECT id FROM organisaatio WHERE nimi = 'Liikennevirasto'), true);
+INSERT INTO kayttaja (etunimi, sukunimi, kayttajanimi, organisaatio, api_oikeus) VALUES
+          ('etunimi', 'sukunimi', 'analytiikka-testeri', (SELECT id FROM organisaatio WHERE nimi = 'Liikennevirasto'),
+           'analytiikka');

--- a/tietokanta/testidata/kayttajat.sql
+++ b/tietokanta/testidata/kayttajat.sql
@@ -43,6 +43,6 @@ INSERT INTO kayttaja (kayttajanimi,etunimi,sukunimi,sahkoposti,puhelin, organisa
 ('tilaaja','ELY','tilaaja','tilaaja@example.org', '434532345',
  (SELECT id  FROM organisaatio  WHERE lyhenne = 'LAP'));
 -- Analytiikan apien testaamiseksi tarvittava käyttäjä
-INSERT INTO kayttaja (etunimi, sukunimi, kayttajanimi, organisaatio, api_oikeus) VALUES
+INSERT INTO kayttaja (etunimi, sukunimi, kayttajanimi, organisaatio, api_oikeus, jarjestelma) VALUES
           ('etunimi', 'sukunimi', 'analytiikka-testeri', (SELECT id FROM organisaatio WHERE nimi = 'Liikennevirasto'),
-           'analytiikka');
+           'analytiikka', true);


### PR DESCRIPTION
Analytiikka_oikeus kolumni poistettu käyttäjiltä.
Se on korvattu api_oikeus kolumnilla, joka ottaa enumin, jossa voidaan määritellä joko tielupa tai analytiikka oikeus käyttäjälle.
APIen kutsumaa kutsukäsittelyä muokattu niin, että kutsuille voidaan antaa parametrina, että minkä oikeuden ne käyttäjiltä vaativat. Jos käyttäjillä ei ole vaadittua oikeutta, niin palautetaan virhe "puutteelliset oikeudet".

Ennen tuotantoonvientiä muutamalle tuotannon käyttäjälle pitää käydä käsin lisäämässä näitä oikeuksia, muuten tulee tupenrapinat.