### PR TITLE
Korjaa paikkauskohteiden lähetys yhaan

### DIFF
--- a/src/clj/harja/kyselyt/paikkaus.clj
+++ b/src/clj/harja/kyselyt/paikkaus.clj
@@ -38,9 +38,10 @@
 (defn hae-paikkaukset-materiaalit [db hakuehdot]
   (fetch db
          ::paikkaus/paikkaus
-         (conj paikkaus/paikkauksen-perustiedot
-               [::paikkaus/materiaalit paikkaus/materiaalit-perustiedot])
-         hakuehdot))
+    (-> paikkaus/paikkauksen-perustiedot
+      (disj ::paikkaus/pinta-ala ::paikkaus/massamaara)
+      (conj [::paikkaus/materiaalit paikkaus/materiaalit-perustiedot]))
+    hakuehdot))
 
 (defn hae-paikkaukset-paikkauskohde [db hakuehdot]
   (fetch db

--- a/tietokanta/testidata/paikkaukset.sql
+++ b/tietokanta/testidata/paikkaukset.sql
@@ -153,58 +153,70 @@ DO $$ DECLARE
 BEGIN
   INSERT INTO paikkaus ("luoja-id", luotu, "muokkaaja-id", muokattu, "poistaja-id", poistettu, "urakka-id", "paikkauskohde-id",
                         "ulkoinen-id", alkuaika, loppuaika, tierekisteriosoite, tyomenetelma, massatyyppi, leveys, massamenekki,
-                        raekoko, kuulamylly, sijainti)
+                        raekoko, kuulamylly, sijainti, "pinta-ala", massamaara)
   VALUES -- 20 tien paikkaukset
     (destia_kayttaja, NOW(), NULL, NULL, NULL, FALSE, oulun_alueurakan_id, hoito_paikkauskohde_id,
                       6661, NOW() + INTERVAL '1 day', NOW() + INTERVAL '10 day',
      ROW (20, 1, 1, 1, 100, NULL) :: TR_OSOITE,
-     8, 'AB, Asfalttibetoni', 1.3, 2, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(20, 1, 1, 1, 100))),
+     8, 'AB, Asfalttibetoni', 1.3, 2, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(20, 1, 1, 1, 100)),
+         130, 15),
 
     (destia_kayttaja, NOW() + TIME '00:01:00', NULL, NULL, NULL, FALSE, oulun_alueurakan_id, hoito_paikkauskohde_id,
                       6662, NOW() + INTERVAL '5 day', NOW() +
                                                       INTERVAL '15 day', ROW (20, 1, 50, 1, 150, NULL) :: TR_OSOITE,
-     8, 'AB, Asfalttibetoni', 1.4, 3, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(20, 1, 50, 1, 150))),
+     8, 'AB, Asfalttibetoni', 1.4, 3, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(20, 1, 50, 1, 150)),
+     130, 15.385),
 
     (destia_kayttaja, NOW() + TIME '00:02:00', NULL, NULL, NULL, FALSE, oulun_alueurakan_id, hoito_paikkauskohde_id,
                       6663, NOW() + INTERVAL '10 day', NOW() +
                                                        INTERVAL '20 day', ROW (20, 3, 1, 3, 200, NULL) :: TR_OSOITE,
-     8, 'AB, Asfalttibetoni', 1.2, 4, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(20, 3, 1, 3, 200))),
+     8, 'AB, Asfalttibetoni', 1.2, 4, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(20, 3, 1, 3, 200)),
+    130, 15.385),
     (destia_kayttaja, NOW(), NULL, NULL, NULL, FALSE, oulun_alueurakan_id, hoito_paikkauskohde_id,
                       6664, NOW() - INTERVAL '1 day', NOW() +
                                                       INTERVAL '9 day', ROW (20, 1, 50, 1, 150, NULL) :: TR_OSOITE,
-     8, 'AB, Asfalttibetoni', 1.3, 2, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(20, 1, 50, 1, 150))),
+     8, 'AB, Asfalttibetoni', 1.3, 2, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(20, 1, 50, 1, 150)),
+     130, 15.385),
     (destia_kayttaja, NOW(), NULL, NULL, NULL, FALSE, oulun_alueurakan_id, hoito_paikkauskohde_id,
                       6665, NOW() - INTERVAL '1 day', NOW() +
                                                       INTERVAL '9 day', ROW (20, 3, 100, 3, 250, NULL) :: TR_OSOITE,
-     8, 'AB, Asfalttibetoni', 1.3, 2, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(20, 3, 100, 3, 250))),
+     8, 'AB, Asfalttibetoni', 1.3, 2, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(20, 3, 100, 3, 250)),
+     130, 15.385),
     (destia_kayttaja, NOW(), NULL, NULL, destia_kayttaja, TRUE, oulun_alueurakan_id, hoito_paikkauskohde_id,
           6666, NOW() - INTERVAL '1 day', NOW() +
                                           INTERVAL '9 day', ROW (20, 3, 100, 3, 250, NULL) :: TR_OSOITE,
-          8, 'AB, Asfalttibetoni', 1.3, 2, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(20, 3, 100, 3, 250))),
+          8, 'AB, Asfalttibetoni', 1.3, 2, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(20, 3, 100, 3, 250)),
+     130, 15.385),
     (destia_kayttaja, NOW() + TIME '00:03:00', NULL, NULL, NULL, FALSE, oulun_alueurakan_id, hoito_paikkauskohde_2_id,
                       133, NOW() + INTERVAL '10 day', NOW() +
                                                       INTERVAL '20 day', ROW (20, 3, 200, 3, 300, NULL) :: TR_OSOITE,
-     8, 'AB, Asfalttibetoni', 1.2, 4, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(20, 3, 200, 3, 300))),
+     8, 'AB, Asfalttibetoni', 1.2, 4, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(20, 3, 200, 3, 300)),
+     130, 15.385),
     -- 22 tien paikkaukset
     (destia_kayttaja, NOW(), NULL, NULL, NULL, FALSE, oulun_alueurakan_id, hoito_paikkauskohde_22_id,
                       221, NOW() - INTERVAL '1 day', NOW() +
                                                      INTERVAL '9 day', ROW (22, 3, 1, 3, 100, NULL) :: TR_OSOITE,
-     8, 'AB, Asfalttibetoni', 1.3, 2, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(22, 3, 1, 3, 100))),
+     8, 'AB, Asfalttibetoni', 1.3, 2, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(22, 3, 1, 3, 100)),
+     130, 15.385),
     (destia_kayttaja, NOW(), NULL, NULL, NULL, FALSE, oulun_alueurakan_id, hoito_paikkauskohde_22_id,
                       222, NOW() - INTERVAL '1 day', NOW() +
                                                      INTERVAL '9 day', ROW (22, 3, 200, 3, 300, NULL) :: TR_OSOITE,
-     8, 'AB, Asfalttibetoni', 1.3, 2, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(22, 3, 200, 3, 300))),
+     8, 'AB, Asfalttibetoni', 1.3, 2, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(22, 3, 200, 3, 300)),
+     130, 15.385),
     (destia_kayttaja, NOW(), NULL, NULL, NULL, FALSE, oulun_alueurakan_id, hoito_paikkauskohde_22_id,
                       223, NOW() - INTERVAL '1 day', NOW() +
                                                      INTERVAL '9 day', ROW (22, 3, 400, 3, 450, NULL) :: TR_OSOITE,
-     8, 'AB, Asfalttibetoni', 1.3, 2, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(22, 3, 400, 3, 450))),
+     8, 'AB, Asfalttibetoni', 1.3, 2, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(22, 3, 400, 3, 450)),
+     130, 15.385),
     (destia_kayttaja, NOW(), NULL, NULL, NULL, FALSE, oulun_alueurakan_id, hoito_paikkauskohde_22_id,
                       224, NOW() - INTERVAL '1 day', NOW() + INTERVAL '9 day', ROW (22, 4, 1, 5, 1, NULL) :: TR_OSOITE,
-     8, 'AB, Asfalttibetoni', 1.3, 2, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(22, 4, 1, 5, 1))),
+     8, 'AB, Asfalttibetoni', 1.3, 2, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(22, 4, 1, 5, 1)),
+     130, 15.385),
  -- Tehdään paikkaus jolle ei ole paikkaustoteumaa
     (destia_kayttaja, NOW(), NULL, NULL, NULL, FALSE, oulun_alueurakan_id, hoito_paikkauskohde_3_id,
      225, NOW() - INTERVAL '1 day', NOW() + INTERVAL '9 day', ROW (22, 4, 1, 5, 1, NULL) :: TR_OSOITE,
-     8, 'AB, Asfalttibetoni', 1.3, 2, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(22, 4, 1, 5, 1)));
+     8, 'AB, Asfalttibetoni', 1.3, 2, 5, 'AN7', (SELECT tierekisteriosoitteelle_viiva(22, 4, 1, 5, 1)),
+     130, 15.385);
   --- Laitetaan iso kasa paikkauksia Muhoksen päällystysurakkaan. Näkee sivutuksen tällä tapaa.
   FOR counter IN 1..250 LOOP
     INSERT INTO paikkaus ("luoja-id", luotu, "muokkaaja-id", muokattu, "poistaja-id", poistettu, "urakka-id", "paikkauskohde-id",


### PR DESCRIPTION
YHA-lähetys kaatui validaatiovirheeseen. Haettujen tietojen sekaan oli mennyt uusia kenttiä, jotka ei ole skeemassa.

Tämä ei jäänyt testiin kiinni, koska testidatassa näitä uusia kenttiä ei ollut.

Korjauksen voi varmistaa ajamalla ajamalla testin siten, että `disj` on kommentoitu pois, jolloin korjattu testi ajetaan vanhalla koodilla.