### PR TITLE
VHAR- 7964 Korjaa hoitokauden viim. päivälle luotava toistuva välitavoite

### DIFF
--- a/src/clj/harja/palvelin/palvelut/valitavoitteet/valtakunnalliset_valitavoitteet.clj
+++ b/src/clj/harja/palvelin/palvelut/valitavoitteet/valtakunnalliset_valitavoitteet.clj
@@ -10,7 +10,8 @@
             [harja.domain.oikeudet :as oikeudet]
             [harja.pvm :as pvm]
             [clj-time.coerce :as c]
-            [clj-time.core :as t]))
+            [clj-time.core :as t]
+            [clj-time.coerce :as tc]))
 
 (defn hae-valtakunnalliset-valitavoitteet [db user]
   (oikeudet/vaadi-lukuoikeus oikeudet/hallinta-valitavoitteet user)
@@ -127,13 +128,12 @@
                                                       (t/year (c/from-date (:alkupvm urakka))))
                                                  (inc (t/year (c/from-date (:loppupvm urakka)))))]
         (doseq [vuosi urakan-jaljella-olevat-vuodet]
-          (let [tarkka-takaraja (t/local-date vuosi takaraja-toistokuukausi takaraja-toistopaiva)]
-            (when (and (t/after? tarkka-takaraja pvm/kayttoonottto)
-                       (pvm/valissa? tarkka-takaraja
-                                     (c/from-date (:alkupvm urakka))
-                                     (c/from-date (:loppupvm urakka))))
+          (let [tarkka-takaraja (tc/to-date (t/date-time vuosi takaraja-toistokuukausi takaraja-toistopaiva))]
+            (when (pvm/valissa? tarkka-takaraja
+                    (konv/java-date (:alkupvm urakka))
+                    (konv/java-date (:loppupvm urakka)))
               (log/debug "Lisätään toistuva välitavoite " nimi " urakkaan " (:nimi urakka) " takarajalla "
-                         vuosi "-" takaraja-toistokuukausi "-" takaraja-toistopaiva)
+                vuosi "-" takaraja-toistokuukausi "-" takaraja-toistopaiva)
               (q/lisaa-urakan-valitavoite<! db {:urakka (:id urakka)
                                                 :aloituspvm nil
                                                 :takaraja (konv/sql-date (c/to-date tarkka-takaraja))

--- a/src/cljs/harja/ui/validointi.cljs
+++ b/src/cljs/harja/ui/validointi.cljs
@@ -375,7 +375,8 @@
 (defn validoi-ja-anna-virheet
   ([gridin-tiedot skeema rivivalidointi taulukkovalidointi tyyppi] (validoi-ja-anna-virheet gridin-tiedot skeema rivivalidointi taulukkovalidointi tyyppi nil))
   ([gridin-tiedot skeema rivivalidointi taulukkovalidointi tyyppi poistettu-avain]
-   (let [virheet (into {}
+   (let [skeema (remove nil? skeema)
+         virheet (into {}
                        (keep (fn [[index rivi]]
                                (let [kenttien-virheet (validoi-rivin-kentat gridin-tiedot rivi skeema tyyppi)
                                      rivin-virheet (when rivivalidointi

--- a/src/cljs/harja/views/urakka/valitavoitteet.cljs
+++ b/src/cljs/harja/views/urakka/valitavoitteet.cljs
@@ -95,6 +95,7 @@
                  "Ei takarajaa")
          :validoi [[:pvm-kentan-jalkeen :aloituspvm
                     "Takaraja ei voi olla ennen aloituspäivää."]]
+         :varoita [[:urakan-aikana]]
          :tyyppi :pvm}
         {:otsikko "Tila" :leveys 20 :tyyppi :string :muokattava? (constantly false)
          :nimi :valmiustila :hae identity :fmt vt-domain/valmiustilan-kuvaus}
@@ -141,6 +142,7 @@
       {:otsikko "Taka\u00ADraja" :leveys 20 :nimi :takaraja :fmt #(if %
                                                                     (pvm/pvm-opt %)
                                                                     "Ei takarajaa")
+       :varoita [[:urakan-aikana]]
        :tyyppi :pvm}
       {:otsikko "Tila" :leveys 20 :tyyppi :string :muokattava? (constantly false)
        :nimi :valmiustila :hae identity :fmt vt-domain/valmiustilan-kuvaus}

--- a/src/cljs/harja/views/urakka/valitavoitteet.cljs
+++ b/src/cljs/harja/views/urakka/valitavoitteet.cljs
@@ -93,9 +93,7 @@
          :fmt #(if %
                  (pvm/pvm-opt %)
                  "Ei takarajaa")
-         :validoi [[:pvm-kentan-jalkeen :aloituspvm
-                    "Takaraja ei voi olla ennen aloituspäivää."]]
-         :varoita [[:urakan-aikana]]
+         :validoi [[:urakan-aikana]]
          :tyyppi :pvm}
         {:otsikko "Tila" :leveys 20 :tyyppi :string :muokattava? (constantly false)
          :nimi :valmiustila :hae identity :fmt vt-domain/valmiustilan-kuvaus}
@@ -142,7 +140,7 @@
       {:otsikko "Taka\u00ADraja" :leveys 20 :nimi :takaraja :fmt #(if %
                                                                     (pvm/pvm-opt %)
                                                                     "Ei takarajaa")
-       :varoita [[:urakan-aikana]]
+       :validoi [[:urakan-aikana]]
        :tyyppi :pvm}
       {:otsikko "Tila" :leveys 20 :tyyppi :string :muokattava? (constantly false)
        :nimi :valmiustila :hae identity :fmt vt-domain/valmiustilan-kuvaus}

--- a/test/clj/harja/palvelin/palvelut/valitavoitteet_test.clj
+++ b/test/clj/harja/palvelin/palvelut/valitavoitteet_test.clj
@@ -193,6 +193,40 @@
     (u (str "DELETE FROM valitavoite WHERE valtakunnallinen_valitavoite IS NOT NULL"))
     (u (str "DELETE FROM valitavoite WHERE urakka IS NULL"))))
 
+(def valtakunnallinen-valitavoite-hoitokauden-lopussa
+  [{:id -99 :nimi "Pyyhi pölyt ja sammuta valot hoitokauden lopussa", :takaraja nil, :tyyppi :toistuva, :urakkatyyppi :hoito, :takaraja-toistopaiva 30, :takaraja-toistokuukausi 9}])
+
+(deftest valtakunnallinen-valitavoite-hoitokauden-viimeiselle-paivalle
+  (let [raahen-mhu-urakan-id (hae-urakan-id-nimella "Raahen MHU 2023-2028")
+        vastaus (kutsu-palvelua
+                  (:http-palvelin jarjestelma)
+                  :tallenna-valtakunnalliset-valitavoitteet
+                  +kayttaja-jvh+
+                  {:valitavoitteet valtakunnallinen-valitavoite-hoitokauden-lopussa})
+        ei-luoda-urakan-ulkopuolelle (first (q (str "SELECT takaraja, nimi from valitavoite where nimi = 'Pyyhi pölyt ja sammuta valot hoitokauden lopussa' AND takaraja = '2023-09-30' AND urakka = " raahen-mhu-urakan-id ";")))
+        raahen-valitavoitteet (kutsu-palvelua (:http-palvelin jarjestelma)
+                                :hae-urakan-valitavoitteet +kayttaja-jvh+
+                                raahen-mhu-urakan-id)
+        tallennetut (filter #(and
+                               (= raahen-mhu-urakan-id (:urakka-id %))
+                               (= (:nimi %) "Pyyhi pölyt ja sammuta valot hoitokauden lopussa")) raahen-valitavoitteet)]
+    (is (empty? ei-luoda-urakan-ulkopuolelle) "Ei saa edes luoda urakan ulkopuolelle")
+    (is (= 5 (count tallennetut)) "Viidelle hoitokaudelle replikoitu")
+    (is (nil? (some #(= (:takaraja %)
+                       (pvm/->pvm "30.9.2023")) raahen-valitavoitteet)) "2023 tiedot oikein")
+    (is (some? (some #(= (:takaraja %)
+                        (pvm/->pvm "30.9.2024")) raahen-valitavoitteet)) "2024 tiedot oikein")
+    (is (some? (some #(= (:takaraja %)
+                        (pvm/->pvm "30.9.2025")) raahen-valitavoitteet)) "2025 tiedot oikein")
+    (is (some? (some #(= (:takaraja %)
+                        (pvm/->pvm "30.9.2026")) raahen-valitavoitteet)) "2026 tiedot oikein")
+    (is (some? (some #(= (:takaraja %)
+                        (pvm/->pvm "30.9.2027")) raahen-valitavoitteet)) "2027 tiedot oikein")
+    (is (some? (some #(= (:takaraja %)
+                        (pvm/->pvm "30.9.2028")) raahen-valitavoitteet)) "2028 tiedot oikein"))
+
+
+  (u "DELETE from valitavoite where nimi = 'Pyyhi pölyt ja sammuta valot hoitokauden lopussa'"))
 
 (deftest valtakunnallisten-valitavoitteiden-kasittely-toimii
   (let [rovaniemen-urakan-vanhat-valitavoitteet (kutsu-palvelua (:http-palvelin jarjestelma)


### PR DESCRIPTION
Aiemmin 30.9. luotu toistuva välitavoite virheellisesti loi ensimmäisen ilmentymän 1. hoitokautta edeltävälle vuodelle ja
    puolestaan viimeinen hoitokausi jäi luomatta.