### PR TITLE
VHAR-8020 Muuta tarkastus-taulun indeksi

### DIFF
--- a/src/clj/harja/kyselyt/tarkastukset.sql
+++ b/src/clj/harja/kyselyt/tarkastukset.sql
@@ -334,12 +334,17 @@ SET aika               = :aika,
   nayta_urakoitsijalle = :nayta_urakoitsijalle,
   pisteet              = :pisteet,
   poistettu            = FALSE
-WHERE urakka = :urakka AND id = :id;
+WHERE urakka = :urakka AND id = :id and tyyppi = :tyyppi :: tarkastustyyppi;
 
 -- name: poista-tarkastus!
 UPDATE tarkastus
-SET muokattu = NOW(), muokkaaja = :kayttajanimi, poistettu = TRUE
-WHERE urakka = :urakka-id AND ulkoinen_id IN (:ulkoiset-idt) AND poistettu IS NOT TRUE;
+SET muokattu  = NOW(),
+    muokkaaja = :kayttajanimi,
+    poistettu = TRUE
+WHERE urakka = :urakka - id
+  AND tyyppi = :tyyppi
+  AND ulkoinen_id IN (:ulkoiset-idt)
+  AND poistettu IS NOT TRUE;
 
 -- name: poista-poistetut-liitteet!
 DELETE from tarkastus_liite tl

--- a/src/clj/harja/kyselyt/tarkastukset.sql
+++ b/src/clj/harja/kyselyt/tarkastukset.sql
@@ -346,6 +346,15 @@ WHERE urakka = :urakka-id
   AND ulkoinen_id IN (:ulkoiset-idt)
   AND poistettu IS NOT TRUE;
 
+-- name: poista-yllapitokohteiden-tarkastuksia!
+UPDATE tarkastus
+SET muokattu  = NOW(),
+    muokkaaja = :kayttajanimi,
+    poistettu = TRUE
+WHERE urakka = :urakka-id
+  AND ulkoinen_id IN (:ulkoiset-idt)
+  AND poistettu IS NOT TRUE;
+
 -- name: poista-poistetut-liitteet!
 DELETE from tarkastus_liite tl
 WHERE tl.tarkastus IN (SELECT t.id

--- a/src/clj/harja/kyselyt/tarkastukset.sql
+++ b/src/clj/harja/kyselyt/tarkastukset.sql
@@ -334,15 +334,15 @@ SET aika               = :aika,
   nayta_urakoitsijalle = :nayta_urakoitsijalle,
   pisteet              = :pisteet,
   poistettu            = FALSE
-WHERE urakka = :urakka AND id = :id and tyyppi = :tyyppi :: tarkastustyyppi;
+WHERE urakka = :urakka AND id = :id;
 
 -- name: poista-tarkastus!
 UPDATE tarkastus
 SET muokattu  = NOW(),
     muokkaaja = :kayttajanimi,
     poistettu = TRUE
-WHERE urakka = :urakka - id
-  AND tyyppi = :tyyppi
+WHERE urakka = :urakka-id
+  AND tyyppi = :tyyppi :: tarkastustyyppi
   AND ulkoinen_id IN (:ulkoiset-idt)
   AND poistettu IS NOT TRUE;
 

--- a/src/clj/harja/palvelin/integraatiot/api/tarkastukset.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/tarkastukset.clj
@@ -31,11 +31,11 @@
         kayttajanimi (:kayttajanimi kayttaja)]
     #_ (log/debug (format "Poistetaan tarkastus ulk.id %s tyyppiä: %s käyttäjän: %s toimesta. Data: %s"
                        ulkoiset-idt
-                       tyyppi
+                       (name tyyppi)
                        kayttajanimi
                        data))
     (validointi/tarkista-urakka-ja-kayttaja db urakka-id kayttaja)
-    (let [poistettujen-maara (q-tarkastukset/poista-tarkastus! db kayttaja-id urakka-id ulkoiset-idt)
+    (let [poistettujen-maara (q-tarkastukset/poista-tarkastus! db kayttaja-id urakka-id (name tyyppi) ulkoiset-idt)
           poistettujen-liitteiden-maara (q-tarkastukset/poista-poistetut-liitteet! db {:urakka-id urakka-id})]
       (let [ilmoitukset (if (pos? poistettujen-maara)
                           (format "Tarkastukset poistettu onnistuneesti. Poistettiin: %s tarkastusta." poistettujen-maara)

--- a/src/clj/harja/palvelin/integraatiot/api/tarkastukset.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/tarkastukset.clj
@@ -66,7 +66,7 @@
    {:palvelu :lisaa-tieturvallisuustarkastus
     :polku "/api/urakat/:id/tarkastus/tieturvallisuustarkastus"
     :pyynto-skeema json-skeemat/tieturvallisuustarkastuksen-kirjaus
-    :tyyppi :talvihoito
+    :tyyppi :tieturvallisuus
     :metodi :post}
    {:palvelu :poista-tieturvallisuustarkastus
     :polku "/api/urakat/:id/tarkastus/tieturvallisuustarkastus"

--- a/src/clj/harja/palvelin/integraatiot/api/yllapitokohteet.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/yllapitokohteet.clj
@@ -389,7 +389,7 @@
                        kayttaja
                        data))
     (validointi/tarkista-urakka-ja-kayttaja db urakka-id kayttaja)
-    (let [poistettujen-maara (tarkastukset-q/poista-tarkastus! db kayttaja-id urakka-id ulkoiset-idt)
+    (let [poistettujen-maara (tarkastukset-q/poista-yllapitokohteiden-tarkastuksia! db kayttaja-id urakka-id   ulkoiset-idt)
           poistettujen-liitteiden-maara (tarkastukset-q/poista-poistetut-liitteet! db {:urakka-id urakka-id})]
       (let [ilmoitukset (if (pos? poistettujen-maara)
                           (format "Tarkastukset poistettu onnistuneesti. Poistettiin: %s tarkastusta." poistettujen-maara)

--- a/tietokanta/src/main/resources/db/migration/V1_1040__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1040__.sql
@@ -1,0 +1,9 @@
+-- Muutetaan uniikit indeksit käyttäämän luoja-sarakkeen sijaan urakka-saraketta
+ALTER TABLE tarkastus
+    DROP CONSTRAINT tarkastus_ulkoinen_id_luoja_uniikki;
+CREATE UNIQUE INDEX tarkastus_ulkoinen_id_urakka_uniikki ON tarkastus (ulkoinen_id, urakka);
+
+ALTER TABLE tarkastus_ennen_2015
+    DROP CONSTRAINT tarkastus_ennen_2015_ulkoinen_id_luoja_tyyppi_idx;
+CREATE UNIQUE INDEX tarkastus_ennen_2015_ulkoinen_id_urakka_tyyppi_uniikki ON tarkastus_ennen_2015 (ulkoinen_id, urakka, tyyppi);
+

--- a/tietokanta/src/main/resources/db/migration/V1_1040__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1040__.sql
@@ -2,8 +2,3 @@
 ALTER TABLE tarkastus
     DROP CONSTRAINT tarkastus_ulkoinen_id_luoja_uniikki;
 CREATE UNIQUE INDEX tarkastus_ulkoinen_id_urakka_uniikki ON tarkastus (ulkoinen_id, urakka);
-
-ALTER TABLE tarkastus_ennen_2015
-    DROP CONSTRAINT tarkastus_ennen_2015_ulkoinen_id_luoja_tyyppi_idx;
-CREATE UNIQUE INDEX tarkastus_ennen_2015_ulkoinen_id_urakka_tyyppi_uniikki ON tarkastus_ennen_2015 (ulkoinen_id, urakka, tyyppi);
-

--- a/tietokanta/src/main/resources/db/migration/V1_1040__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1040__.sql
@@ -1,4 +1,22 @@
 -- Muutetaan uniikit indeksit käyttäämän luoja-sarakkeen sijaan urakka-saraketta
-ALTER TABLE tarkastus
-    DROP CONSTRAINT tarkastus_ulkoinen_id_luoja_uniikki;
-CREATE UNIQUE INDEX tarkastus_ulkoinen_id_urakka_uniikki ON tarkastus (ulkoinen_id, urakka);
+-- Partitioiduissa tauluissa muutos on jo tehty migraatiossa V1_1029.
+CREATE UNIQUE INDEX tarkastus_ulkoinen_id_urakka_poistettu_tyyppi_uindex ON tarkastus (ulkoinen_id, urakka, poistettu, tyyppi);
+CREATE UNIQUE INDEX tarkastus_ennen_2015_ulkoinen_id_urakka_poistettu_tyyppi_uindex ON tarkastus_ennen_2015 (ulkoinen_id, urakka, poistettu, tyyppi);
+
+-- Poistetaan päivitysoikeuksia näihin vanhimipiin tauluihin
+REVOKE INSERT, UPDATE, DELETE ON tarkastus_ennen_2015 FROM harja;
+
+REVOKE INSERT, UPDATE, DELETE ON tarkastus_2015_q1 FROM harja;
+REVOKE INSERT, UPDATE, DELETE ON tarkastus_2015_q2 FROM harja;
+REVOKE INSERT, UPDATE, DELETE ON tarkastus_2015_q3 FROM harja;
+REVOKE INSERT, UPDATE, DELETE ON tarkastus_2015_q4 FROM harja;
+
+REVOKE INSERT, UPDATE, DELETE ON tarkastus_2016_q1 FROM harja;
+REVOKE INSERT, UPDATE, DELETE ON tarkastus_2016_q2 FROM harja;
+REVOKE INSERT, UPDATE, DELETE ON tarkastus_2016_q3 FROM harja;
+REVOKE INSERT, UPDATE, DELETE ON tarkastus_2016_q4 FROM harja;
+
+REVOKE INSERT, UPDATE, DELETE ON tarkastus_2017_q1 FROM harja;
+REVOKE INSERT, UPDATE, DELETE ON tarkastus_2017_q2 FROM harja;
+REVOKE INSERT, UPDATE, DELETE ON tarkastus_2017_q3 FROM harja;
+REVOKE INSERT, UPDATE, DELETE ON tarkastus_2017_q4 FROM harja;

--- a/tietokanta/src/main/resources/db/migration/V1_1040__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1040__.sql
@@ -3,20 +3,65 @@
 CREATE UNIQUE INDEX tarkastus_ulkoinen_id_urakka_poistettu_tyyppi_uindex ON tarkastus (ulkoinen_id, urakka, poistettu, tyyppi);
 CREATE UNIQUE INDEX tarkastus_ennen_2015_ulkoinen_id_urakka_poistettu_tyyppi_uindex ON tarkastus_ennen_2015 (ulkoinen_id, urakka, poistettu, tyyppi);
 
--- Poistetaan päivitysoikeuksia näihin vanhimipiin tauluihin
-REVOKE INSERT, UPDATE, DELETE ON tarkastus_ennen_2015 FROM harja;
+-- Poistetaan luoja uniikista indeksistä, koska urakka on tekemässä uniikkia indeksiä
+DROP INDEX tarkastus_ennen_2015_ulkoinen_id_luoja_tyyppi_idx;
 
-REVOKE INSERT, UPDATE, DELETE ON tarkastus_2015_q1 FROM harja;
-REVOKE INSERT, UPDATE, DELETE ON tarkastus_2015_q2 FROM harja;
-REVOKE INSERT, UPDATE, DELETE ON tarkastus_2015_q3 FROM harja;
-REVOKE INSERT, UPDATE, DELETE ON tarkastus_2015_q4 FROM harja;
+DROP INDEX tarkastus_2015_q1_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2015_q2_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2015_q3_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2015_q4_ulkoinen_id_luoja_tyyppi_idx;
 
-REVOKE INSERT, UPDATE, DELETE ON tarkastus_2016_q1 FROM harja;
-REVOKE INSERT, UPDATE, DELETE ON tarkastus_2016_q2 FROM harja;
-REVOKE INSERT, UPDATE, DELETE ON tarkastus_2016_q3 FROM harja;
-REVOKE INSERT, UPDATE, DELETE ON tarkastus_2016_q4 FROM harja;
+DROP INDEX tarkastus_2016_q1_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2016_q2_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2016_q3_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2016_q4_ulkoinen_id_luoja_tyyppi_idx;
 
-REVOKE INSERT, UPDATE, DELETE ON tarkastus_2017_q1 FROM harja;
-REVOKE INSERT, UPDATE, DELETE ON tarkastus_2017_q2 FROM harja;
-REVOKE INSERT, UPDATE, DELETE ON tarkastus_2017_q3 FROM harja;
-REVOKE INSERT, UPDATE, DELETE ON tarkastus_2017_q4 FROM harja;
+DROP INDEX tarkastus_2017_q1_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2017_q2_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2017_q3_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2017_q4_ulkoinen_id_luoja_tyyppi_idx;
+
+DROP INDEX tarkastus_2018_q1_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2018_q2_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2018_q3_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2018_q4_ulkoinen_id_luoja_tyyppi_idx;
+
+DROP INDEX tarkastus_2019_q1_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2019_q2_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2019_q3_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2019_q4_ulkoinen_id_luoja_tyyppi_idx;
+
+DROP INDEX tarkastus_2020_q1_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2020_q2_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2020_q3_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2020_q4_ulkoinen_id_luoja_tyyppi_idx;
+
+DROP INDEX tarkastus_2021_q1_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2021_q2_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2021_q3_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2021_q4_ulkoinen_id_luoja_tyyppi_idx;
+
+DROP INDEX tarkastus_2022_q1_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2022_q2_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2022_q3_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2022_q4_ulkoinen_id_luoja_tyyppi_idx;
+
+DROP INDEX tarkastus_2023_q1_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2023_q2_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2023_q3_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2023_q4_ulkoinen_id_luoja_tyyppi_idx;
+
+DROP INDEX tarkastus_2024_q1_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2024_q2_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2024_q3_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2024_q4_ulkoinen_id_luoja_tyyppi_idx;
+
+DROP INDEX tarkastus_2025_q1_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2025_q2_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2025_q3_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2025_q4_ulkoinen_id_luoja_tyyppi_idx;
+
+DROP INDEX tarkastus_2026_q1_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2026_q2_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2026_q3_ulkoinen_id_luoja_tyyppi_idx;
+DROP INDEX tarkastus_2026_q4_ulkoinen_id_luoja_tyyppi_idx;


### PR DESCRIPTION
Lisätty partitiotauluista jo löytyvä uniikki indeksi (ulkoinen id, urakka, tyyppi, poistettu) myös juuritauluun ja ennen 2015-tauluun.

Poistettu kirjoitusoikeuksia vanhoista tarkastustauluista.

Lisätty tyyppi update SQL:ään rajaamaan tarkastusten päivitystä uniikin indeksin mukaisesti.