### PR TITLE
VHAR-8083 Korjaa epävakaita Paikkauskohteet.js Cypress-testejä

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,7 @@ jobs:
             mkdir -p ../.harja
             echo aaaa > ../.harja/anti-csrf-token
             touch ../.harja/{mml,google-static-maps-key,turi-salasana,ava-salasana,yha-salasana,yha-api-key,labyrintti-salasana,velho-salasana,velho-varuste-salasana,api-sahkoposti-salasana,digiroad-api-key}
-            touch ../.harja/harjalle_ajorata_kaista_puoli_20210825.csv
+            touch ../.harja/harjalle_ajorata_kaista_puoli_20230519.csv
             java -jar /tmp/harja/target/harja-0.0.1-SNAPSHOT-standalone.jar > harja.out 2>&1 &
             for i in $(seq 10); do
               curl localhost:3000 > /dev/null 2>&1 && break

--- a/cypress/e2e/paikkauskohteet.cy.js
+++ b/cypress/e2e/paikkauskohteet.cy.js
@@ -1,5 +1,5 @@
 // asetuksia
-let clickTimeout = 60000; // Minuutin timeout hitaan ci putken takia
+let clickTimeout = 6000;
 let potRaportoitava = "POT-raportoitava";
 let uniikkiUlkoinenId = "97978911";
 
@@ -97,7 +97,7 @@ describe('Paikkauskohteet latautuu oikein', function () {
         // siirry paikkauskohteisiin
         avaaPaikkauskohteetSuoraan()
         // Avataan paikkauskohdelomake uuden luomista varten
-        cy.get('button').contains('.nappi-ensisijainen', 'Lisää kohde', {timeout: clickTimeout}).click({force: true})
+        cy.get('[data-cy="lisaa-paikkauskohde"]').click();
         // Varmistetaan, että sivupaneeli aukesi
         cy.get('.overlay-oikealla', {timeout: clickTimeout}).should('be.visible')
         // annetaan nimi
@@ -122,11 +122,11 @@ describe('Paikkauskohteet latautuu oikein', function () {
         cy.get('button').contains('.nappi-ensisijainen', 'Tallenna', {timeout: clickTimeout}).click({force: true})
 
         // Varmista, että tallennus onnistui
-        cy.get('.toast-viesti', {timeout: 60000}).should('be.visible')
+        cy.get('.toast-viesti', {timeout: 6000}).should('be.visible')
 
         // Vaihda oikeaan vuoteen
         cy.get('label[for=filtteri-vuosi] + div').filtteriValitse({valinta: '2021'})
-        cy.contains('.nappi-ensisijainen', 'Hae kohteita').click()
+        cy.get('[data-cy="hae-paikkauskohteita"]').click();
 
         // Ja tarkista, että kohde tuli listaan.
         cy.contains('tr.paikkauskohderivi > td > div > span ', 'CPKohde').should('exist')
@@ -247,158 +247,77 @@ describe('Paikkaustoteumat toimii', function () {
     })
 })
 
-//describe('Päällystysilmoitukset toimii', function () {
+describe('Päällystysilmoitukset toimii', function () {
 
-    // it('Lisää POT-raportoitava paikkauskohde', function () {
-    //     cy.viewport(1100, 2000)
-    //     // siirry paikkauskohteisiin
-    //     avaaPaikkauskohteetSuoraan()
-    //
-    //     // Avataan paikkauskohdelomake uuden luomista varten
-    //     cy.get('button').contains('.nappi-ensisijainen', 'Lisää kohde', {timeout: clickTimeout}).click({force: true})
-    //     // Varmistetaan, että sivupaneeli aukesi
-    //     cy.get('.overlay-oikealla', {timeout: clickTimeout}).should('be.visible')
-    //     // annetaan nimi
-    //     cy.get('label[for=nimi] + input').type(potRaportoitava, {force: true})
-    //     cy.get('label[for=ulkoinen-id] + span > input').type("87654321")
-    //     // Valitse työmenetelmä
-    //     cy.get('label[for=tyomenetelma] + div').valinnatValitse({valinta: 'SMA-paikkaus levittäjällä'})
-    //     cy.get('label[for=tie] + span > input').type("13873")
-    //     cy.get('label[for=ajorata] + div').valinnatValitse({valinta: '0'})
-    //     cy.get('label[for=aosa] + span > input').type("1")
-    //     cy.get('label[for=aet] + span > input').type("0")
-    //     cy.get('label[for=losa] + span > input').type("1")
-    //     cy.get('label[for=let] + span > input').type("1000")
-    //     // Ajankohta
-    //     cy.get('label[for=alkupvm] + .pvm-kentta > .input-default').type("1.8.2021")
-    //     cy.get('label[for=loppupvm] + .pvm-kentta > .input-default').type("1.9.2021")
-    //     //Suunnitellut määrät ja summa
-    //     cy.get('label[for=suunniteltu-maara] + span > input').type("1111")
-    //     cy.get('label[for=yksikko] + div').valinnatValitse({valinta: 'jm'})
-    //     cy.get('label[for=suunniteltu-hinta] + span > input').type("200000")
-    //     cy.get('button').contains('.nappi-ensisijainen', 'Tallenna', {timeout: clickTimeout}).click({force: true})
-    //
-    //     // Varmista, että tallennus onnistui
-    //     cy.get('.toast-viesti', {timeout: 60000}).should('be.visible')
-    // })
-    //
-    // it('Tilaa POT-raportoitava', function () {
-    //     cy.viewport(1100, 2000)
-    //     // siirry paikkauskohteisiin
-    //     avaaPaikkauskohteetSuoraan()
-    //
-    //     cy.server()
-    //     cy.route('POST', '_/tallenna-paikkauskohde-urakalle').as('tilaus')
-    //     cy.route('POST', '_/paikkauskohteet-urakalle').as('kohteet')
-    //
-    //     // Avataan paikkauskohdelomake uuden luomista varten
-    //     cy.contains('tr.paikkauskohderivi > td > div > span ', potRaportoitava).click({force: true})
-    //     // Varmistetaan, että sivupaneeli aukesi
-    //     cy.get('.overlay-oikealla', {timeout: clickTimeout}).should('be.visible')
-    //     // Valitse pot-raportointi
-    //     cy.contains('POT-lomake').click({force: true})
-    //     // Tilaa kohde
-    //     cy.get('button').contains('.nappi-ensisijainen', 'Tilaa', {timout: clickTimeout}).click({force: true})
-    //     // Vahvista tilaus
-    //     cy.get('button').contains('.nappi-ensisijainen', 'Tilaa kohde', {timout: clickTimeout}).click({force: true})
-    //     cy.wait('@tilaus', {timeout: clickTimeout})
-    // })
+    it('Lisää POT-raportoitava paikkauskohde', function () {
+        cy.viewport(1100, 2000)
+        // siirry paikkauskohteisiin
+        avaaPaikkauskohteetSuoraan()
 
-    // it('Avaa POT-lomake', function () {
-    //     cy.viewport(1100, 2000)
-    //     // siirry paikkauskohteisiin
-    //     avaaPaikkauskohteetSuoraan()
-    //
-    //     // Avataan POT lomake
-    //     cy.contains('tr.paikkauskohderivi > td > div > span ', potRaportoitava).click({force: true})
-    //     // Varmistetaan, että sivupaneeli aukesi
-    //     cy.get('.overlay-oikealla', {timeout: clickTimeout}).should('be.visible')
-    //     // Avaa POT lomake
-    //     cy.get('button').contains('.nappi-toissijainen', 'Tee päällystysilmoitus', {timout: clickTimeout}).click({force: true})
-    //     cy.get('H1').contains("Päällystysilmoitus");
-    // })
-    //
-    // it('Tallenna POT-lomake', function () {
-    //
-    //     cy.viewport(1100, 2000)
-    //     cy.server()
-    //     cy.route('POST', '_/hae-urakan-massat-ja-murskeet').as('hae-massat')
-    //     cy.route('POST', '_/tallenna-urakan-massa').as('tallenna-massa')
-    //     cy.route('POST', '_/tallenna-paallystysilmoitus').as('tallenna-paallystysilmoitus')
-    //     // siirry paikkauskohteisiin
-    //     avaaPaikkauskohteetSuoraan()
-    //
-    //     // Avataan POT lomake
-    //     cy.contains('tr.paikkauskohderivi > td > div > span ', potRaportoitava).click({force: true})
-    //     // Varmistetaan, että sivupaneeli aukesi
-    //     cy.get('.overlay-oikealla', {timeout: clickTimeout}).should('be.visible')
-    //     // Avaa POT lomake
-    //     cy.get('button').contains('.nappi-toissijainen', 'Tee päällystysilmoitus', {timout: clickTimeout}).click({force: true})
-    //     cy.get('H1').contains("Päällystysilmoitus");
-    //
-    //     // Valitse takuuaika
-    //     cy.get('label[for=takuuaika] + div').find('div').valinnatValitse({valinta: '2 vuotta'})
-    //
-    //     // Avaa massamodaali
-    //     cy.get('button').contains('.nappi-toissijainen', 'Muokkaa urakan materiaaleja', {timout: clickTimeout}).click({force:true});
-    //     cy.wait('@hae-massat', {timeout: clickTimeout})
-    //     cy.get('h2').contains('Materiaalikirjasto')
-    //     cy.get('.ajax-loader', {timeout: clickTimeout}).should('not.exist')
-    //
-    //     // Lisää massa lomake
-    //     cy.get('button').contains('.lisaa-massa','Lisää massa').click({force:true});
-    //     cy.get('.lomake-otsikko-pieni').contains('Uusi massa',{ matchCase: false })
-    //     cy.get('.ajax-loader', {timeout: clickTimeout}).should('not.exist')
-    //
-    //     // Valitse massatyyppi
-    //     cy.get('label[for=tyyppi] + div').valinnatValitse({valinta: 'AB, Asfalttibetoni'})
-    //     // Valitse Max raekoko
-    //     cy.get('label[for=max-raekoko] + div').valinnatValitse({valinta: '5'})
-    //     //Nimen tarkenne
-    //     cy.get('label[for=nimen-tarkenne] + input').type('AB-bet-5', {force: true})
-    //     // Valitse kuulamyllyluokka
-    //     cy.get('label[for=kuulamyllyluokka] + div').valinnatValitse({valinta: 'AN7'})
-    //     // Valitse litteyslukuluokka
-    //     cy.get('label[for=litteyslukuluokka] + div').valinnatValitse({valinta: 'FI15'})
-    //     //Dop tarkenne
-    //     cy.get('label[for=dop-nro] + input').type('5', {force: true})
-    //     // Runkoaineen materiaali - Valitaan eka, koska helppoa ja toivotaan, että ui ei muutu
-    //     cy.get('label').contains('Kiviaines').prev().check()
-    //     // Ja yritetään löytää sen alta input kentät
-    //     // Kiviainesesiintymä
-    //     cy.get('.aineiden-muokkaustila').contains('span.kentan-label', 'Kiviainesesiintymä').parent().next().type('AB-AN7-FI15')
-    //     cy.get('.aineiden-muokkaustila').contains('span.kentan-label', 'Kuulamyllyarvo').parent().next().type('6')
-    //     cy.get('.aineiden-muokkaustila').contains('span.kentan-label', 'Litteysluku').parent().next().type('12')
-    //     cy.get('.aineiden-muokkaustila').contains('span.kentan-label', 'Massa-%').parent().next().type('17')
-    //
-    //     // Sideaineet
-    //     cy.get('div.sideaine-komponentti').contains('span','Tyyppi').parent().next().valinnatValitse({valinta: 'Bitumi, 35/50'})
-    //     cy.get('div.sideaine-komponentti').contains('.kentan-label', 'Pitoisuus %').parent().next().first().type('17')
-    //     cy.get('.massa-lomake').contains('button', 'Tallenna').click({force: true})
-    //     cy.wait('@tallenna-massa', {timeout: clickTimeout})
-    //
-    //     //Sulje massamodaali
-    //     cy.get('h2').contains('Materiaalikirjasto')
-    //     cy.get('h6').contains('Massat')
-    //     cy.get('button.close').click({force: true})
-    //
-    //     // Yritä valita toimenpide ja muut tärkeät päällystysjutut
-    //     cy.get('div.livi-muokkaus-grid').find('td').find('div.alasveto-gridin-kentta').first().valinnatValitse({valinta: 'LTA'})
-    //     cy.get('div.livi-muokkaus-grid').find('td').find('div.alasveto-gridin-kentta').eq(1).valinnatValitse({valinta: '0'})
-    //     cy.get('div.livi-muokkaus-grid').find('td').find('div.alasveto-gridin-kentta').eq(2).valinnatValitse({valinta: '1'})
-    //     cy.get('div.livi-muokkaus-grid').find('td').find('div.alasveto-gridin-kentta').eq(3).valinnatValitse({valinta: 'AB5 AB-bet-5'})
-    //     cy.get('div.livi-muokkaus-grid').find('td').find('input').eq(5).type('7')
-    //     cy.get('div.livi-muokkaus-grid').find('td').find('input').eq(6).type('10')
-    //
-    //     // Tallenna
-    //     cy.get('#tallenna-paallystysilmoitus').click({force: true})
-    //     cy.wait('@tallenna-paallystysilmoitus')
-    //     // Palattiinko päällystysilmoituslistaan
-    //     cy.get('h1').contains('Paikkauskohteiden päällystysilmoitukset')
-    //
-    // })
+        // Avataan paikkauskohdelomake uuden luomista varten
+        cy.get('button').contains('.nappi-ensisijainen', 'Lisää kohde', {timeout: clickTimeout}).click({force: true})
+        // Varmistetaan, että sivupaneeli aukesi
+        cy.get('.overlay-oikealla', {timeout: clickTimeout}).should('be.visible')
+        // annetaan nimi
+        cy.get('label[for=nimi] + input').type(potRaportoitava, {force: true})
+        cy.get('label[for=ulkoinen-id] + span > input').type("87654321")
+        // Valitse työmenetelmä
+        cy.get('label[for=tyomenetelma] + div').valinnatValitse({valinta: 'SMA-paikkaus levittäjällä'})
+        cy.get('label[for=tie] + span > input').type("13873")
+        cy.get('label[for=ajorata] + div').valinnatValitse({valinta: '0'})
+        cy.get('label[for=aosa] + span > input').type("1")
+        cy.get('label[for=aet] + span > input').type("0")
+        cy.get('label[for=losa] + span > input').type("1")
+        cy.get('label[for=let] + span > input').type("1000")
+        // Ajankohta
+        cy.get('label[for=alkupvm] + .pvm-kentta > .input-default').type("1.8.2021")
+        cy.get('label[for=loppupvm] + .pvm-kentta > .input-default').type("1.9.2021")
+        //Suunnitellut määrät ja summa
+        cy.get('label[for=suunniteltu-maara] + span > input').type("1111")
+        cy.get('label[for=yksikko] + div').valinnatValitse({valinta: 'jm'})
+        cy.get('label[for=suunniteltu-hinta] + span > input').type("200000")
+        cy.get('button').contains('.nappi-ensisijainen', 'Tallenna', {timeout: clickTimeout}).click({force: true})
 
-//})
+        // Varmista, että tallennus onnistui
+        cy.get('.toast-viesti', {timeout: 60000}).should('be.visible')
+    })
+
+    it('Tilaa POT-raportoitava', function () {
+        cy.viewport(1100, 2000)
+        // siirry paikkauskohteisiin
+        avaaPaikkauskohteetSuoraan()
+
+        cy.server()
+        cy.route('POST', '_/tallenna-paikkauskohde-urakalle').as('tilaus')
+        cy.route('POST', '_/paikkauskohteet-urakalle').as('kohteet')
+
+        // Avataan paikkauskohdelomake uuden luomista varten
+        cy.contains('tr.paikkauskohderivi > td > div > span ', potRaportoitava).click({force: true})
+        // Varmistetaan, että sivupaneeli aukesi
+        cy.get('.overlay-oikealla', {timeout: clickTimeout}).should('be.visible')
+        // Valitse pot-raportointi
+        cy.contains('POT-lomake').click({force: true})
+        // Tilaa kohde
+        cy.get('button').contains('.nappi-ensisijainen', 'Tilaa', {timout: clickTimeout}).click({force: true})
+        // Vahvista tilaus
+        cy.get('button').contains('.nappi-ensisijainen', 'Tilaa kohde', {timout: clickTimeout}).click({force: true})
+        cy.wait('@tilaus', {timeout: clickTimeout})
+    })
+
+    it('Avaa POT-lomake', function () {
+        cy.viewport(1100, 2000)
+        // siirry paikkauskohteisiin
+        avaaPaikkauskohteetSuoraan()
+
+        // Avataan POT lomake
+        cy.contains('tr.paikkauskohderivi > td > div > span ', potRaportoitava).click({force: true})
+        // Varmistetaan, että sivupaneeli aukesi
+        cy.get('.overlay-oikealla', {timeout: clickTimeout}).should('be.visible')
+        // Avaa POT lomake
+        cy.get('button').contains('.nappi-toissijainen', 'Tee päällystysilmoitus', {timout: clickTimeout}).click({force: true})
+        cy.get('H1').contains("Päällystysilmoitus");
+    })
+})
 
 describe('Siivotaan lopuksi', function () {
     before(siivoaKanta);

--- a/cypress/e2e/paikkauskohteet.cy.js
+++ b/cypress/e2e/paikkauskohteet.cy.js
@@ -41,7 +41,7 @@ let avaaPaikkauskohteetSuoraan = function () {
 
     cy.route('POST', '_/paikkauskohteet-urakalle').as('2021-kohteet')
     cy.get('[data-cy="hae-paikkauskohteita"]').click();
-    cy.wait('@2021-kohteet', {timeout: clickTimeout})
+    cy.wait('@2021-kohteet', {timeout: 15000})
 }
 
 let avaaToteumat = () => {
@@ -275,7 +275,7 @@ describe('Päällystysilmoitukset toimii', function () {
         cy.get('label[for=suunniteltu-maara] + span > input').type("1111")
         cy.get('label[for=yksikko] + div').valinnatValitse({valinta: 'jm'})
         cy.get('label[for=suunniteltu-hinta] + span > input').type("200000")
-        cy.get('button').contains('.nappi-ensisijainen', 'Tallenna', {timeout: clickTimeout}).click({force: true})
+        cy.get('button').contains('.nappi-ensisijainen', 'Tallenna', {timeout: clickTimeout}).click()
 
         // Varmista, että tallennus onnistui
         cy.get('.toast-viesti', {timeout: 60000}).should('be.visible')

--- a/cypress/e2e/paikkauskohteet.cy.js
+++ b/cypress/e2e/paikkauskohteet.cy.js
@@ -40,9 +40,8 @@ let avaaPaikkauskohteetSuoraan = function () {
     cy.get('label[for=filtteri-vuosi] + div').valinnatValitse({valinta: '2021'})
 
     cy.route('POST', '_/paikkauskohteet-urakalle').as('2021-kohteet')
-    cy.contains('.nappi-ensisijainen', 'Hae kohteita', ).click({force: true})
+    cy.get('[data-cy="hae-paikkauskohteita"]').click();
     cy.wait('@2021-kohteet', {timeout: clickTimeout})
-
 }
 
 let avaaToteumat = () => {
@@ -255,7 +254,7 @@ describe('Päällystysilmoitukset toimii', function () {
         avaaPaikkauskohteetSuoraan()
 
         // Avataan paikkauskohdelomake uuden luomista varten
-        cy.get('button').contains('.nappi-ensisijainen', 'Lisää kohde', {timeout: clickTimeout}).click({force: true})
+        cy.get('[data-cy="lisaa-paikkauskohde"]').click();
         // Varmistetaan, että sivupaneeli aukesi
         cy.get('.overlay-oikealla', {timeout: clickTimeout}).should('be.visible')
         // annetaan nimi


### PR DESCRIPTION
Korjaa paikkauskohteiden taulukon kontrolleja

-Kontrollit luotiin joka renderillä uudestaan. Tämä aiheutti Cypress-testien feilejä, koska koetettiin clickata jo unmountanneita elementtejä.