### PR TITLE
Käytä tarkempaa versiota pohja-imagen versiona, korjaa dependabot docker path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,7 @@ updates:
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"
-    # Look for a `Dockerfile` in the `root` directory
-    directory: "/.github/docker"
+    directory: "/aws/fargate/"
     # Check for updates once a week
     schedule:
       interval: "weekly"

--- a/aws/fargate/Dockerfile
+++ b/aws/fargate/Dockerfile
@@ -1,6 +1,7 @@
 # -- Run-time vaihe --
 # Käytetään Eclipse Temurin 11 (OpenJDK) imagea
-FROM eclipse-temurin:11
+# Pohjalla Ubuntu Jammy (Ubuntu 22.04 LTS)
+FROM eclipse-temurin:11.0.20.1_1-jre-jammy
 
 # Lisää labeleita AWS ECR:ää varten
 LABEL description="Harja app"


### PR DESCRIPTION
* Käytetään uusinta Java 11 versiota
* Määritellään haluttu Javan versio tarkasti
* Määritellään pohjalla oleva ubuntun versio (Jammy)
-> Minimoidaan rikkoutumisen riski versiopäivitysten myötä.

* Ohjataan dependabot skannaamaan image, jotta uusista versiopäivityksistä tulee automaattinen PR