### PR TITLE
VHAR-8117 POT Korjaukset

### DIFF
--- a/src/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys.clj
+++ b/src/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys.clj
@@ -254,10 +254,6 @@
           rivi-let (:tr-loppuetaisyys rivi)
           rivi-kaista (:tr-kaista rivi)
 
-          ;; Kuinka iso hyppy halutaan näyttää? 
-          ;; (inc 50) = Näytetään hypyt jotka ovat 50 metriä tai alle 
-          hypyn-metriraja (inc yllapitokohteet-domain/+kulutus-hyppy-metriraja+)
-
           seuraava-rivi (get-in data [(inc i)])
           seuraava-rivi-tie (:tr-numero seuraava-rivi)
           seuraava-rivi-ajorata (:tr-ajorata seuraava-rivi)
@@ -269,9 +265,7 @@
                                 (= rivi-tie seuraava-rivi-tie)
                                 (= rivi-ajorata seuraava-rivi-ajorata)
                                 (= rivi-kaista seuraava-rivi-kaista)
-                                (> seuraava-rivi-aet rivi-let)
-                                ;; Onko hyppy X metriä tai alle?
-                                (< (- seuraava-rivi-aet rivi-let) hypyn-metriraja))
+                                (> seuraava-rivi-aet rivi-let))
                             true
                             false)]
       (if hyppy-olemassa?
@@ -300,10 +294,6 @@
           rivi-aet (:tr-alkuetaisyys rivi)
           rivi-let (:tr-loppuetaisyys rivi)
 
-          ;; Kuinka iso hyppy halutaan näyttää? 
-          ;; (inc 50) = Näytetään hypyt jotka ovat 50 metriä tai alle 
-          hypyn-metriraja (inc yllapitokohteet-domain/+kulutus-hyppy-metriraja+)
-
           edellinen-rivi (nth data (dec y) nil)
           edellinen-rivi-tie (:tr-numero edellinen-rivi)
           edellinen-rivi-ajorata (:tr-ajorata edellinen-rivi)
@@ -328,10 +318,7 @@
                    (= rivi-ajorata edellinen-rivi-ajorata)
                    (= rivi-kaista edellinen-rivi-kaista)
                    (> seuraava-rivi-aet rivi-let)
-                   (> rivi-aet edellinen-rivi-let)
-                   ;; Onko hypyt X metriä tai alle?
-                   (< (- seuraava-rivi-aet rivi-let) hypyn-metriraja)
-                   (< (- rivi-aet edellinen-rivi-let) hypyn-metriraja))
+                   (> rivi-aet edellinen-rivi-let))
                  (merge rivi {:aet-hyppy? true :let-hyppy? true})
 
                  ;; Seuraava ja tämä rivi olemassa sekä molemmilla sama tie&ajorata&kaista
@@ -342,9 +329,7 @@
                    (= rivi-tie seuraava-rivi-tie)
                    (= rivi-ajorata seuraava-rivi-ajorata)
                    (= rivi-kaista seuraava-rivi-kaista)
-                   (> seuraava-rivi-aet rivi-let)
-                   ;; Onko hyppy X metriä tai alle?
-                   (< (- seuraava-rivi-aet rivi-let) hypyn-metriraja))
+                   (> seuraava-rivi-aet rivi-let))
                  (merge rivi {:let-hyppy? true})
 
                  ;; Tämä rivi ja edellinen rivi olemassa sekä molemmilla sama tie&ajorata&kaista
@@ -355,9 +340,7 @@
                    (= rivi-tie edellinen-rivi-tie)
                    (= rivi-ajorata edellinen-rivi-ajorata)
                    (= rivi-kaista edellinen-rivi-kaista)
-                   (> rivi-aet edellinen-rivi-let)
-                   ;; Onko hyppy X metriä tai alle?
-                   (< (- rivi-aet edellinen-rivi-let) hypyn-metriraja))
+                   (> rivi-aet edellinen-rivi-let))
                  (merge rivi {:aet-hyppy? true})
 
                  ;; Ei hyppyjä

--- a/src/cljc/harja/domain/yllapitokohde.cljc
+++ b/src/cljc/harja/domain/yllapitokohde.cljc
@@ -16,8 +16,6 @@
           [tieverkko :as q-tieverkko]
           [yllapitokohteet :as q-yllapitokohteet]]])))
 
-(def +kulutus-hyppy-metriraja+ 100)
-
 (s/def ::id ::spec-apurit/postgres-serial)
 (s/def ::kohdenumero (s/nilable string?))
 (s/def ::nimi string?)

--- a/src/cljs/harja/ui/grid/muokkaus.cljs
+++ b/src/cljs/harja/ui/grid/muokkaus.cljs
@@ -262,6 +262,7 @@
                :else
                [ei-muokattava-elementti (y/luokat
                                           "ei-muokattava"
+                                          (when solun-luokka-fn (solun-luokka-fn rivi))
                                           tasaus-luokka
                                           (grid-yleiset/tiivis-tyyli skeema))
                 fmt

--- a/src/cljs/harja/views/urakka/pot2/paallystekerros.cljs
+++ b/src/cljs/harja/views/urakka/pot2/paallystekerros.cljs
@@ -62,6 +62,8 @@
                             (str "Kulutuskerros ei ole yhtenäinen (" hyppyjen-maara " hyppyä)")
                             (= hyppyjen-maara 0)
                             "Kulutuskerros on yhtenäinen (ei hyppyjä)"
+                            (nil? hyppyjen-maara)
+                            ""
                             :else
                             (str "Kulutuskerros ei ole yhtenäinen (" hyppyjen-maara " hyppy)")))
         custom-yla-panel (if-not kulutuskerros-muokattu?

--- a/src/cljs/harja/views/urakka/pot2/paallystekerros.cljs
+++ b/src/cljs/harja/views/urakka/pot2/paallystekerros.cljs
@@ -72,9 +72,10 @@
                               [:div.kulutus-hyppy-ikoni-alert (ikonit/alert-svg)]
                               [:div hyppy-teksti]]
 
-                             [:div.kulutus-hyppy-info
-                              [:div.kulutus-hyppy-ikoni-ok (ikonit/harja-icon-status-completed)]
-                              [:div hyppy-teksti]])
+                             (when (some? hyppyjen-maara)
+                               [:div.kulutus-hyppy-info
+                                [:div.kulutus-hyppy-ikoni-ok (ikonit/harja-icon-status-completed)]
+                                [:div hyppy-teksti]]))
                            nil)
         voi-muokata? (not= :lukittu (:tila perustiedot))
         ohjauskahva (:paallystekerros ohjauskahvat)

--- a/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
+++ b/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
@@ -944,7 +944,7 @@
                              (assoc-in [:paallystekerros 1 :tr-alkuosa] 1)
                              (assoc-in [:paallystekerros 1 :tr-loppuosa] 1)
                              (assoc-in [:paallystekerros 1 :tr-loppuetaisyys] 3827)
-                             (assoc-in [:paallystekerros 1 :tr-alkuetaisyys] (+ aet yllapitokohteet-domain/+kulutus-hyppy-metriraja+))
+                             (assoc-in [:paallystekerros 1 :tr-alkuetaisyys] (+ aet 100))
                              (assoc-in [:paallystekerros 1 :tr-numero] 20)
                              (assoc-in [:paallystekerros 1 :tr-kaista] 12)
                              (assoc-in [:paallystekerros 1 :tr-ajorata] 1))
@@ -968,13 +968,13 @@
                              (assoc-in [:paallystekerros 1 :tr-alkuosa] 1)
                              (assoc-in [:paallystekerros 1 :tr-loppuosa] 1)
                              (assoc-in [:paallystekerros 1 :tr-loppuetaisyys] 3827)
-                             (assoc-in [:paallystekerros 1 :tr-alkuetaisyys] (+ aet yllapitokohteet-domain/+kulutus-hyppy-metriraja+ 1))
+                             (assoc-in [:paallystekerros 1 :tr-alkuetaisyys] aet)
                              (assoc-in [:paallystekerros 1 :tr-numero] 20)
                              (assoc-in [:paallystekerros 1 :tr-kaista] 12)
                              (assoc-in [:paallystekerros 1 :tr-ajorata] 1))
 
-        paallystys-hyppy-ylittyy (nth (tallenna-pot2-testi-paallystysilmoitus
-                                        urakka-id sopimus-id paallystyskohde-id paallystysilmoitus) 1 nil)]
+        paallystys-ei-hyppyja (nth (tallenna-pot2-testi-paallystysilmoitus
+                                     urakka-id sopimus-id paallystyskohde-id paallystysilmoitus) 1 nil)]
 
     ;; Hyppy seuraavalla rivillä, korostetaan let
     (is (true? (get-in paallystys-hyppy-olemassa [:paallystekerros 0 :let-hyppy?])) "Korostetaan loppuetäisyys")
@@ -986,10 +986,10 @@
     (is (true? (get-in paallystys-hyppy-olemassa [:paallystekerros 1 :aet-hyppy?])) "Korostetaan alkuetäisyys")
     (is (= (get-in paallystys-hyppy-olemassa [:paallystekerros 1 :hyppyjen-maara]) 1) "Hyppyjen määrä löytyy")
 
-    ;; Hyppy ylittää metrirajan, joten korostuksia ei tehdä 
-    (is (nil? (get-in paallystys-hyppy-ylittyy [:paallystekerros 0 :let-hyppy?])) "Loppuetäisyyttä ei korosteta")
-    (is (nil? (get-in paallystys-hyppy-ylittyy [:paallystekerros 0 :aet-hyppy?])) "Alkuetäisyyttä ei korosteta")
-    (is (= (get-in paallystys-hyppy-ylittyy [:paallystekerros 0 :hyppyjen-maara]) 0) "Hyppyjä ei ole")))
+    ;; Hyppyjä ei ole
+    (is (nil? (get-in paallystys-ei-hyppyja [:paallystekerros 0 :let-hyppy?])) "Loppuetäisyyttä ei korosteta")
+    (is (nil? (get-in paallystys-ei-hyppyja [:paallystekerros 0 :aet-hyppy?])) "Alkuetäisyyttä ei korosteta")
+    (is (= (get-in paallystys-ei-hyppyja [:paallystekerros 0 :hyppyjen-maara]) 0) "Hyppyjä ei ole")))
 
 (deftest tallenna-pot2-paallystysilmoitus-kohteen-alku-ja-loppupvm-muuttuvat
   (let [paallystyskohde-id (hae-yllapitokohteen-id-nimella "Aloittamaton kohde mt20")


### PR DESCRIPTION
- Hypyt näkyviin (solun luokka) myös jos muokkaus ei ole käytössä gridissä
> Visuaalinen muutos joka vaikuttaa koko Harjaan, tehty :solun-luokka-fn näkyväksi muokkausgridissä myös jos muokkaus ei ole käytössä. En teidä onko haittaa, jos joku tietää paikkoja mitä tarkastaa niin sano

- Poistettu kulutuskerroksen header teksti jos alikohteita ei ole 
- Poistettu metriraja kokonaan POT hyppyjen visualisoinnista, kaikki hypyt näytetään 
