### PR TITLE
VHAR-8221 T-LOIK rajapintamuutokset aka tiukka ykkönen

### DIFF
--- a/src/clj/harja/kyselyt/urakat.sql
+++ b/src/clj/harja/kyselyt/urakat.sql
@@ -964,7 +964,7 @@ WHERE u.alkupvm + interval '12 hour' <= current_timestamp
   AND u.loppupvm + interval '36 hour' >= current_timestamp
   AND ST_Distance84(au.alue, st_makepoint(:x, :y)) <= :maksimietaisyys 
 ORDER BY etaisyys ASC 
-LIMIT 1;
+LIMIT 50;
 
 -- name: hae-kaynnissaoleva-urakka-urakkanumerolla
 -- single? : true

--- a/src/clj/harja/kyselyt/urakat.sql
+++ b/src/clj/harja/kyselyt/urakat.sql
@@ -9,9 +9,9 @@ SELECT
   u.urakkanro,
   hal.id        AS hallintayksikko_id,
   hal.nimi      AS hallintayksikko_nimi,
-  urk.id        AS urakoitsija_id,
-  urk.nimi      AS urakoitsija_nimi,
-  urk.ytunnus   AS urakoitsija_ytunnus,
+  org.id        AS urakoitsija_id,
+  org.nimi      AS urakoitsija_nimi,
+  org.ytunnus   AS urakoitsija_ytunnus,
   s.nimi        AS sopimus_nimi,
   s.id          AS sopimus_id,
   s.paasopimus  AS "sopimus_paasopimus-id",
@@ -23,7 +23,7 @@ SELECT
   array_to_string(ua.turvalaiteryhmat, ',') AS turvalaiteryhmat
 FROM urakka u
   LEFT JOIN organisaatio hal ON u.hallintayksikko = hal.id
-  LEFT JOIN organisaatio urk ON u.urakoitsija = urk.id
+  LEFT JOIN organisaatio org ON u.urakoitsija = org.id
   LEFT JOIN hanke h ON u.hanke = h.id
   LEFT JOIN sopimus s ON u.id = s.urakka
   LEFT JOIN sahkelahetys sl ON sl.urakka = u.id
@@ -195,9 +195,9 @@ SELECT
   hal.id                                  AS hallintayksikko_id,
   hal.nimi                                AS hallintayksikko_nimi,
   hal.lyhenne                             AS hallintayksikko_lyhenne,
-  urk.id                                  AS urakoitsija_id,
-  urk.nimi                                AS urakoitsija_nimi,
-  urk.ytunnus                             AS urakoitsija_ytunnus,
+  org.id                                  AS urakoitsija_id,
+  org.nimi                                AS urakoitsija_nimi,
+  org.ytunnus                             AS urakoitsija_ytunnus,
   yt.yhatunnus                            AS yha_yhatunnus,
   yt.yhaid                                AS yha_yhaid,
   yt.yhanimi                              AS yha_yhanimi,
@@ -231,7 +231,7 @@ SELECT
 
 FROM urakka u
   LEFT JOIN organisaatio hal ON u.hallintayksikko = hal.id
-  LEFT JOIN organisaatio urk ON u.urakoitsija = urk.id
+  LEFT JOIN organisaatio org ON u.urakoitsija = org.id
   LEFT JOIN alueurakka au ON u.urakkanro = au.alueurakkanro
   LEFT JOIN tekniset_laitteet_urakka tlu ON u.urakkanro = tlu.urakkanro
   LEFT JOIN siltapalvelusopimus sps ON u.urakkanro = sps.urakkanro
@@ -242,7 +242,7 @@ WHERE hallintayksikko = :hallintayksikko
            OR (('hallintayksikko' :: organisaatiotyyppi = :kayttajan_org_tyyppi :: organisaatiotyyppi OR
                 'liikennevirasto' :: organisaatiotyyppi = :kayttajan_org_tyyppi :: organisaatiotyyppi)
                OR ('urakoitsija' :: organisaatiotyyppi = :kayttajan_org_tyyppi :: organisaatiotyyppi AND
-                   :kayttajan_org_id = urk.id)));
+                   :kayttajan_org_id = org.id)));
 
 -- name: hae-urakkatiedot-laskutusyhteenvetoon
 -- Listaa ELY-kohtaista laskutusyhteenvetoa varten aikavälillä käynnissäolevat hoitourakat
@@ -290,9 +290,9 @@ SELECT
   hal.id                        AS hallintayksikko_id,
   hal.nimi                      AS hallintayksikko_nimi,
   hal.lyhenne                   AS hallintayksikko_lyhenne,
-  urk.id                        AS urakoitsija_id,
-  urk.nimi                      AS urakoitsija_nimi,
-  urk.ytunnus                   AS urakoitsija_ytunnus,
+  org.id                        AS urakoitsija_id,
+  org.nimi                      AS urakoitsija_nimi,
+  org.ytunnus                   AS urakoitsija_ytunnus,
   (SELECT array_agg(concat(id, '=', sampoid))
    FROM sopimus s
    WHERE urakka = u.id
@@ -300,11 +300,11 @@ SELECT
   ST_Simplify(au.alue, 50)      AS alueurakan_alue
 FROM urakka u
   LEFT JOIN organisaatio hal ON u.hallintayksikko = hal.id
-  LEFT JOIN organisaatio urk ON u.urakoitsija = urk.id
+  LEFT JOIN organisaatio org ON u.urakoitsija = org.id
   LEFT JOIN alueurakka au ON u.urakkanro = au.alueurakkanro
 WHERE u.nimi ILIKE :teksti
       OR hal.nimi ILIKE :teksti
-      OR urk.nimi ILIKE :teksti;
+      OR org.nimi ILIKE :teksti;
 
 -- name: hae-organisaation-urakat
 -- Hakee organisaation "omat" urakat, joko urakat joissa annettu hallintayksikko on tilaaja
@@ -322,9 +322,9 @@ SELECT
   hal.id                        AS hallintayksikko_id,
   hal.nimi                      AS hallintayksikko_nimi,
   hal.lyhenne                   AS hallintayksikko_lyhenne,
-  urk.id                        AS urakoitsija_id,
-  urk.nimi                      AS urakoitsija_nimi,
-  urk.ytunnus                   AS urakoitsija_ytunnus,
+  org.id                        AS urakoitsija_id,
+  org.nimi                      AS urakoitsija_nimi,
+  org.ytunnus                   AS urakoitsija_ytunnus,
   (SELECT array_agg(concat(id, '=', sampoid))
    FROM sopimus s
    WHERE urakka = u.id
@@ -332,9 +332,9 @@ SELECT
   ST_Simplify(au.alue, 50)      AS alueurakan_alue
 FROM urakka u
   LEFT JOIN organisaatio hal ON u.hallintayksikko = hal.id
-  LEFT JOIN organisaatio urk ON u.urakoitsija = urk.id
+  LEFT JOIN organisaatio org ON u.urakoitsija = org.id
   LEFT JOIN alueurakka au ON u.urakkanro = au.alueurakkanro
-WHERE urk.id = :organisaatio
+WHERE org.id = :organisaatio
    OR hal.id = :organisaatio;
 
 -- name: tallenna-urakan-sopimustyyppi!
@@ -369,13 +369,13 @@ SELECT
   u.hallintayksikko,
   u.sampoid
 FROM urakka u
-  LEFT JOIN organisaatio urk ON u.urakoitsija = urk.id
+  LEFT JOIN organisaatio org ON u.urakoitsija = org.id
 WHERE (u.nimi ILIKE :teksti
        OR u.sampoid ILIKE :teksti)
       AND (('hallintayksikko' :: organisaatiotyyppi = :kayttajan_org_tyyppi :: organisaatiotyyppi OR
             'liikennevirasto' :: organisaatiotyyppi = :kayttajan_org_tyyppi :: organisaatiotyyppi)
            OR ('urakoitsija' :: organisaatiotyyppi = :kayttajan_org_tyyppi :: organisaatiotyyppi AND
-               :kayttajan_org_id = urk.id))
+               :kayttajan_org_id = org.id))
 LIMIT 11;
 
 -- name: hae-urakka
@@ -389,10 +389,10 @@ SELECT
   u.indeksi,
   u.takuu_loppupvm,
   u.urakkanro AS alueurakkanumero,
-  urk.nimi    AS urakoitsija_nimi,
-  urk.ytunnus AS urakoitsija_ytunnus
+  org.nimi    AS urakoitsija_nimi,
+  org.ytunnus AS urakoitsija_ytunnus
 FROM urakka u
-  LEFT JOIN organisaatio urk ON u.urakoitsija = urk.id
+  LEFT JOIN organisaatio org ON u.urakoitsija = org.id
 WHERE u.id = :id;
 
 -- name: hae-urakoiden-organisaatiotiedot
@@ -421,11 +421,11 @@ SELECT
   u.loppupvm,
   u.takuu_loppupvm,
   u.urakkanro AS alueurakkanumero,
-  urk.nimi    AS urakoitsija_nimi,
-  urk.ytunnus AS urakoitsija_ytunnus
+  org.nimi    AS urakoitsija_nimi,
+  org.ytunnus AS urakoitsija_ytunnus
 FROM urakka u
-  JOIN organisaatio urk ON u.urakoitsija = urk.id
-                           AND urk.ytunnus = :ytunnus;
+  JOIN organisaatio org ON u.urakoitsija = org.id
+                           AND org.ytunnus = :ytunnus;
 
 -- name: hae-urakan-sopimukset
 -- Hakee urakan sopimukset urakan id:llä.
@@ -663,9 +663,9 @@ SELECT
   hal.id                        AS hallintayksikko_id,
   hal.nimi                      AS hallintayksikko_nimi,
   hal.lyhenne                   AS hallintayksikko_lyhenne,
-  urk.id                        AS urakoitsija_id,
-  urk.nimi                      AS urakoitsija_nimi,
-  urk.ytunnus                   AS urakoitsija_ytunnus,
+  org.id                        AS urakoitsija_id,
+  org.nimi                      AS urakoitsija_nimi,
+  org.ytunnus                   AS urakoitsija_ytunnus,
   yt.yhatunnus                  AS yha_yhatunnus,
   yt.yhaid                      AS yha_yhaid,
   yt.yhanimi                    AS yha_yhanimi,
@@ -680,7 +680,7 @@ SELECT
   ST_Simplify(au.alue, 50)      AS alueurakan_alue
 FROM urakka u
   LEFT JOIN organisaatio hal ON u.hallintayksikko = hal.id
-  LEFT JOIN organisaatio urk ON u.urakoitsija = urk.id
+  LEFT JOIN organisaatio org ON u.urakoitsija = org.id
   LEFT JOIN alueurakka au ON u.urakkanro = au.alueurakkanro
   LEFT JOIN yhatiedot yt ON u.id = yt.urakka
 WHERE u.id = :urakka_id;
@@ -756,8 +756,8 @@ SELECT u.id,
        u.loppupvm,
        u.takuu_loppupvm,
        u.urakkanro AS alueurakkanumero,
-       urk.nimi    AS urakoitsija_nimi,
-       urk.ytunnus AS urakoitsija_ytunnus,
+       org.nimi    AS urakoitsija_nimi,
+       org.ytunnus AS urakoitsija_ytunnus,
        COALESCE(ST_Distance84(u.alue, st_makepoint(:x, :y)),
                 ST_Distance84(vua.alue, st_makepoint(:x, :y)),
                 ST_Distance84(pua.alue, st_makepoint(:x, :y))) AS etaisyys
@@ -765,7 +765,7 @@ FROM urakka u
          LEFT JOIN urakoiden_alueet ua ON u.id = ua.id
          LEFT JOIN valaistusurakka vua ON vua.valaistusurakkanro = u.urakkanro
          LEFT JOIN paallystyspalvelusopimus pua ON pua.paallystyspalvelusopimusnro = u.urakkanro
-         JOIN organisaatio urk ON u.urakoitsija = urk.id
+         JOIN organisaatio org ON u.urakoitsija = org.id
 WHERE (CASE
            WHEN (:urakkatyyppi = 'hoito' OR :urakkatyyppi = 'teiden-hoito') THEN
                (u.tyyppi IN ('hoito', 'teiden-hoito') AND
@@ -953,12 +953,12 @@ SELECT
       u.loppupvm,
       u.takuu_loppupvm,
       u.urakkanro AS alueurakkanumero,
-      urk.nimi    AS urakoitsija_nimi,
-      urk.ytunnus AS urakoitsija_ytunnus,
+      org.nimi    AS urakoitsija_nimi,
+      org.ytunnus AS urakoitsija_ytunnus,
       ST_Distance84(au.alue, st_makepoint(:x, :y)) AS etaisyys 
 FROM urakka u
       LEFT JOIN urakoiden_alueet ua ON u.id = ua.id
-      JOIN organisaatio urk ON u.urakoitsija = urk.id
+      JOIN organisaatio org ON u.urakoitsija = org.id
       JOIN alueurakka au ON au.alueurakkanro = u.urakkanro AND u.tyyppi IN ('hoito', 'teiden-hoito')
 WHERE u.alkupvm + interval '12 hour' <= current_timestamp
   AND u.loppupvm + interval '36 hour' >= current_timestamp
@@ -1103,10 +1103,10 @@ SELECT
   u.loppupvm,
   u.takuu_loppupvm,
   u.urakkanro AS alueurakkanumero,
-  urk.nimi    AS urakoitsija_nimi,
-  urk.ytunnus AS urakoitsija_ytunnus
+  org.nimi    AS urakoitsija_nimi,
+  org.ytunnus AS urakoitsija_ytunnus
 FROM urakka u
-  JOIN organisaatio urk ON u.urakoitsija = urk.id
+  JOIN organisaatio org ON u.urakoitsija = org.id
   JOIN kayttajan_lisaoikeudet_urakkaan klu ON klu.urakka = u.id
   JOIN kayttaja k ON klu.kayttaja = k.id
 WHERE k.kayttajanimi = :kayttajanimi
@@ -1127,10 +1127,10 @@ SELECT
   u.loppupvm,
   u.takuu_loppupvm,
   u.urakkanro AS alueurakkanumero,
-  urk.nimi    AS urakoitsija_nimi,
-  urk.ytunnus AS urakoitsija_ytunnus
+  org.nimi    AS urakoitsija_nimi,
+  org.ytunnus AS urakoitsija_ytunnus
 FROM urakka u
-  JOIN organisaatio urk ON u.urakoitsija = urk.id
+  JOIN organisaatio org ON u.urakoitsija = org.id
 WHERE (exists(SELECT klu.id
               FROM kayttajan_lisaoikeudet_urakkaan klu
                 JOIN kayttaja k ON klu.kayttaja = k.id
@@ -1141,7 +1141,7 @@ WHERE (exists(SELECT klu.id
        exists(SELECT o.id
               FROM organisaatio o
                 JOIN kayttaja k ON o.id = k.organisaatio
-              WHERE o.id = urk.id
+              WHERE o.id = org.id
                     AND k.kayttajanimi = :kayttajanimi
                     AND k.jarjestelma)
        OR

--- a/src/clj/harja/kyselyt/urakat.sql
+++ b/src/clj/harja/kyselyt/urakat.sql
@@ -945,15 +945,25 @@ VALUES (ST_GeomFromText(:alue) :: GEOMETRY, :paallystyssopimus, current_timestam
 
 -- name: hae-lahin-hoidon-alueurakka
 -- Päättyvän urakan vastuu tieliikenneilmoituksista loppuu 1.10. klo 12. Siksi alkupvm ja loppupvm laskettu tunteja lisää.
-SELECT
-  u.id,
-  ST_Distance84(au.alue, st_makepoint(:x, :y)) AS etaisyys
+SELECT 
+      u.id,
+      u.nimi,
+      u.tyyppi,
+      u.alkupvm,
+      u.loppupvm,
+      u.takuu_loppupvm,
+      u.urakkanro AS alueurakkanumero,
+      urk.nimi    AS urakoitsija_nimi,
+      urk.ytunnus AS urakoitsija_ytunnus,
+      ST_Distance84(au.alue, st_makepoint(:x, :y)) AS etaisyys 
 FROM urakka u
-         JOIN alueurakka au ON au.alueurakkanro = u.urakkanro AND u.tyyppi IN ('hoito', 'teiden-hoito')
+      LEFT JOIN urakoiden_alueet ua ON u.id = ua.id
+      JOIN organisaatio urk ON u.urakoitsija = urk.id
+      JOIN alueurakka au ON au.alueurakkanro = u.urakkanro AND u.tyyppi IN ('hoito', 'teiden-hoito')
 WHERE u.alkupvm + interval '12 hour' <= current_timestamp
   AND u.loppupvm + interval '36 hour' >= current_timestamp
-  AND ST_Distance84(au.alue, st_makepoint(:x, :y)) <= :maksimietaisyys
-ORDER BY etaisyys ASC
+  AND ST_Distance84(au.alue, st_makepoint(:x, :y)) <= :maksimietaisyys 
+ORDER BY etaisyys ASC 
 LIMIT 1;
 
 -- name: hae-kaynnissaoleva-urakka-urakkanumerolla

--- a/src/clj/harja/palvelin/integraatiot/api/urakat.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/urakat.clj
@@ -128,9 +128,9 @@
           x-easting (try+
                       (muunnos/str->double x)
                       (catch NumberFormatException _
-                             (throw+ {:type virheet/+viallinen-kutsu+
-                                      :virheet [{:koodi virheet/+virheellinen-sijainti+
-                                                 :viesti "Virheellinen X-koordinaatti"}]})))
+                        (throw+ {:type virheet/+viallinen-kutsu+
+                                 :virheet [{:koodi virheet/+virheellinen-sijainti+
+                                            :viesti "Virheellinen X-koordinaatti"}]})))
           y-northing (try+
                        (muunnos/str->double y)
                        (catch NumberFormatException _
@@ -182,26 +182,25 @@
                                      (empty? urakat-sijainilla))
             ;; Jos halutaan etsiä lähin hoitourakka
             urakat (if hae-lahin-hoitourakka?
-                     ;; Palauttaa 50 urakkaa kilometrisäteellä
-                     (q-urakat/hae-lahin-hoidon-alueurakka db {:x x-easting :y y-northing :maksimietaisyys (* kilometrit 1000)})
+                     ;; Suodatetaan tietokannasta haetut 50 urakkaa kilometrisäteellä oikeuksien perusteella
+                     (fn-suodata-urakat-oikeuksilla
+                       (q-urakat/hae-lahin-hoidon-alueurakka db {:x x-easting :y y-northing :maksimietaisyys (* kilometrit 1000)}))
                      urakat-sijainilla)
-            ;; Suodata kaikki urakat johon ei ole oikeuksia 
-            urakat-suodatettu (fn-suodata-urakat-oikeuksilla urakat)
             ;; Jos halutaan palauttaa lähin urakka, palauta (first)
-            urakat-suodatettu (cond
-                                (and
-                                  hae-lahin-hoitourakka?
-                                  (first urakat-suodatettu))
-                                [(first urakat-suodatettu)]
+            urakat (cond
+                     (and
+                       hae-lahin-hoitourakka?
+                       (first urakat))
+                     [(first urakat)]
 
-                                (and
-                                  hae-lahin-hoitourakka?
-                                  (nil? (first urakat-suodatettu)))
-                                []
+                     (and
+                       hae-lahin-hoitourakka?
+                       (nil? (first urakat)))
+                     []
 
-                                :else
-                                urakat-suodatettu)]
-        (muodosta-vastaus-urakoiden-haulle urakat-suodatettu)))))
+                     :else
+                     urakat)]
+        (muodosta-vastaus-urakoiden-haulle urakat)))))
 
 (def hakutyypit
   [{:palvelu :hae-urakka

--- a/src/clj/harja/palvelin/integraatiot/api/urakat.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/urakat.clj
@@ -123,7 +123,7 @@
                                                        :y "Y-koordinaatti puuttuu"})
 
   (jdbc/with-db-transaction [db db]
-    (let [{:keys [x y urakkatyyppi]} parametrit
+    (let [{:keys [x y urakkatyyppi palauta-lahin-hoitourakka]} parametrit
           x-easting (try+
                       (muunnos/str->double x)
                       (catch NumberFormatException _
@@ -150,10 +150,20 @@
       (when urakkatyyppi
         (validointi/tarkista-urakkatyyppi urakkatyyppi))
 
-      (let [urakat (hae-urakka-sijainnilla* db {:x x-easting :y y-northing
+      (let [kilometrit 100 
+            _ (println "bool: " palauta-lahin-hoitourakka)
+            urakat (if palauta-lahin-hoitourakka 
+                     (q-urakat/hae-lahin-hoidon-alueurakka db {:x x-easting :y y-northing :maksimietaisyys (* kilometrit 1000)})
+                     (hae-urakka-sijainnilla* db {:x x-easting :y y-northing
                                                 :aloitustoleranssi aloitustoleranssi
                                                 :maksimitoleranssi maksimitolenranssi
-                                                :urakkatyyppi urakkatyyppi})
+                                                :urakkatyyppi urakkatyyppi}))
+            _ (println "\n\n urakat: " (q-urakat/hae-lahin-hoidon-alueurakka db {:x x-easting :y y-northing :maksimietaisyys (* kilometrit 1000)}))
+            _ (println "\n\n urakat: " (hae-urakka-sijainnilla* db {:x x-easting :y y-northing
+                                                                    :aloitustoleranssi aloitustoleranssi
+                                                                    :maksimitoleranssi maksimitolenranssi
+                                                                    :urakkatyyppi urakkatyyppi}))
+
             urakat (konv/vector-mappien-alaviiva->rakenne urakat)
             urakat-suodatettu (into []
                                 (filter (fn [urakka]

--- a/src/clj/harja/palvelin/integraatiot/api/urakat.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/urakat.clj
@@ -8,6 +8,7 @@
             [harja.palvelin.integraatiot.api.tyokalut.json-skeemat :as json-skeemat]
             [harja.palvelin.integraatiot.api.tyokalut.validointi :as validointi]
             [harja.kyselyt.urakat :as q-urakat]
+            [clojure.string :as str]
             [harja.kyselyt.toimenpidekoodit :as q-toimenpidekoodit]
             [harja.kyselyt.materiaalit :as q-materiaalit]
             [harja.kyselyt.konversio :as konv]
@@ -174,8 +175,10 @@
             urakat-sijainilla (fn-suodata-urakat-oikeuksilla urakat-sijainilla)
             ;; Jos sijainnilla ei löydy tuloksia ja palauta-lahin-hoitourakka on true, haetaan lähin hoitourakka
             hae-lahin-hoitourakka? (and
-                                     ;; Kun parametri on true, palautetaan lähin hoitourakka jos sijainnilla ei löydy urakoita
-                                     (= palauta-lahin-hoitourakka "true")
+                                     ;; Palautetaan lähin hoitourakka jos sijainnilla ei löydy urakoita, ja palauta-lahin-hoitourakka ei ole false
+                                     (or
+                                       (nil? palauta-lahin-hoitourakka)
+                                       (not= (str/lower-case palauta-lahin-hoitourakka) "false"))
                                      (empty? urakat-sijainilla))
             ;; Jos halutaan etsiä lähin hoitourakka
             urakat (if hae-lahin-hoitourakka?

--- a/src/clj/harja/palvelin/integraatiot/api/urakat.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/urakat.clj
@@ -175,18 +175,28 @@
             ;; Jos sijainnilla ei löydy tuloksia ja palauta-lahin-hoitourakka on true, haetaan lähin hoitourakka
             hae-lahin-hoitourakka? (and
                                      ;; Kun parametri on true, palautetaan lähin hoitourakka jos sijainnilla ei löydy urakoita
-                                     palauta-lahin-hoitourakka
+                                     (= palauta-lahin-hoitourakka "true")
                                      (empty? urakat-sijainilla))
             ;; Jos halutaan etsiä lähin hoitourakka
             urakat (if hae-lahin-hoitourakka?
-                     ;; Hakee 50 urakkaa kilometrisäteellä
+                     ;; Palauttaa 50 urakkaa kilometrisäteellä
                      (q-urakat/hae-lahin-hoidon-alueurakka db {:x x-easting :y y-northing :maksimietaisyys (* kilometrit 1000)})
                      urakat-sijainilla)
             ;; Suodata kaikki urakat johon ei ole oikeuksia 
             urakat-suodatettu (fn-suodata-urakat-oikeuksilla urakat)
             ;; Jos halutaan palauttaa lähin urakka, palauta (first)
-            urakat-suodatettu (if hae-lahin-hoitourakka?
+            urakat-suodatettu (cond
+                                (and
+                                  hae-lahin-hoitourakka?
+                                  (first urakat-suodatettu))
                                 [(first urakat-suodatettu)]
+
+                                (and
+                                  hae-lahin-hoitourakka?
+                                  (nil? (first urakat-suodatettu)))
+                                []
+
+                                :else
                                 urakat-suodatettu)]
         (muodosta-vastaus-urakoiden-haulle urakat-suodatettu)))))
 

--- a/test/clj/harja/palvelin/integraatiot/api/urakat_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/urakat_test.clj
@@ -84,6 +84,33 @@
               (some #(clojure.string/includes? nimi %) #{"Oulun MHU" "Aktiivinen Oulu Testi"}))
             (map #(get-in % [:urakka :tiedot :nimi]) (:urakat enkoodattu-body))))))
 
+  (testing "palauta-lahin-hoitourakka"
+    (let [urakkatyyppi "hoito"
+          fn-vastaus (fn [palauta-lahin-hoitourakka]
+                       (api-tyokalut/get-kutsu ["/api/urakat/haku/sijainnilla"] "yit-rakennus"
+                         {"urakkatyyppi" urakkatyyppi
+                          "x" 486225.3013260806    ;; Piste Pohjois-Pohjanmaan ulkopuolella  
+                          "y" 7086935.066015409
+                          "palauta-lahin-hoitourakka" palauta-lahin-hoitourakka} portti))
+          
+          ;; Palauta lähin hoitourakka == false 
+          vastaus (fn-vastaus false)
+          ;; Tuloksia ei löydy koska sijainti on liian kaukana 
+          enkoodattu-body (cheshire/decode (:body vastaus) true)
+          _ (is (= 0 (count (map #(get-in % [:urakka :tiedot :nimi]) (:urakat enkoodattu-body)))))
+
+          ;; Palauta lähin hoitourakka == true 
+          vastaus (fn-vastaus true)
+          enkoodattu-body (cheshire/decode (:body vastaus) true)
+          ;; Yksi tulos löytyy 
+          _ (is (= 1 (count (map #(get-in % [:urakka :tiedot :nimi]) (:urakat enkoodattu-body)))))]
+      
+      (is (= 200 (:status vastaus)))
+      (is (every?
+            (fn [nimi]
+              (some #(clojure.string/includes? nimi %) #{"Oulun MHU"}))
+            (map #(get-in % [:urakka :tiedot :nimi]) (:urakat enkoodattu-body))))))
+
   (testing "Urakkatyyppi: paallystys (sopimustyyppi = palvelusopimus)"
     ;; Lisätään väliaikainen päällystyspalvelusopimus Porvoon päällystysurakalle (testisopimuksen geometria on Kouvolassa)
     (lisaa-paallystyspalvelusopimus "por1")
@@ -114,16 +141,16 @@
     ;; Ilmoitusten urakkahaku antaa väärän tuloksen mikäli tulee osuma 'kokonaisurakka' päällystysurakkaan.
     ;; Ilmoitusten suhteen ollaan ilmeisesti kiinnostuneita vain palvelusopimuksen piirissä olevista urakoista.
     (testing "Urakkatyyppi: paallystys (sopimustyyppi = kokonaisurakka)"
-             (let [urakkatyyppi "paallystys"
-                   _ (anna-lukuoikeus (:kayttajanimi +kayttaja-paakayttaja-skanska+))
-                   vastaus (api-tyokalut/get-kutsu ["/api/urakat/haku/sijainnilla"] (:kayttajanimi +kayttaja-paakayttaja-skanska+)
-                             {"urakkatyyppi" urakkatyyppi
+      (let [urakkatyyppi "paallystys"
+            _ (anna-lukuoikeus (:kayttajanimi +kayttaja-paakayttaja-skanska+))
+            vastaus (api-tyokalut/get-kutsu ["/api/urakat/haku/sijainnilla"] (:kayttajanimi +kayttaja-paakayttaja-skanska+)
+                      {"urakkatyyppi" urakkatyyppi
                               ;; Oulun lähiseutu (EPSG:3067)
-                              "x" 427232.596 "y" 7211474.342} portti)
-                   enkoodattu-body (cheshire/decode (:body vastaus) true)]
-               (is (= 200 (:status vastaus)))
-               (is (= 1 (count (map #(get-in % [:urakka :tiedot :nimi]) (:urakat enkoodattu-body)))))
-               (is (= "Muhoksen päällystysurakka" (get-in (first (:urakat enkoodattu-body)) [:urakka :tiedot :nimi])))))))
+                       "x" 427232.596 "y" 7211474.342} portti)
+            enkoodattu-body (cheshire/decode (:body vastaus) true)]
+        (is (= 200 (:status vastaus)))
+        (is (= 1 (count (map #(get-in % [:urakka :tiedot :nimi]) (:urakat enkoodattu-body)))))
+        (is (= "Muhoksen päällystysurakka" (get-in (first (:urakat enkoodattu-body)) [:urakka :tiedot :nimi])))))))
 
 (deftest hae-urakka-pelkalla-sijainnilla
   (testing "Sijainti (epsg:3067): 427232.596,7211474.342"


### PR DESCRIPTION
- Lisätty /api/urakat/haku/sijainnilla kutsulle uusi parametri palauta-lahin-hoitourakka 
- Lisätty hae-lahin-hoidon-alueurakka kyselyyn lisää palautettavia sarakkeita sekä rivejä 
```Rajapinnassa on suodatin joka suodataa urakat vastauksesta joihin käyttäjällä ei ole oikeuksia, jos me palautetaan aina 1 rivi, vastaukseksi tulee luultavasti urakka johon ei ole oikeuksia. Tämän takia lisätty 50 tulosta kyselyyn mikä pitäisi olla riittävä.```

Kun parametri true, palautetaan lähin hoitourakka johon käyttäjällä oikeus 100km säteellä jos sijainnilla ei löydy urakoita.
Kun parametri false, vastaa vanhaa rajapinnan toteutusta, jolloin haetaan vaan sijainnilla, ja palautetaan [ ] mikäli mitään ei löydy.