### PR TITLE
VHAR-8233 Palauta sama urakka hausta vain kerran

### DIFF
--- a/test/clj/harja/palvelin/integraatiot/api/urakat_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/urakat_test.clj
@@ -130,27 +130,17 @@
     ;; Poistetaan väliaikainen päällystyspalvelusopimus
     (poista-paallytyspalvelusopimus "por1"))
 
-
-  (comment
-    ;; Testi otettu pois käytöstä, kunnes päällystysurakoiden sijaintihaku kokonaisurakoiden osalta selviää.
-    ;; Varsinainen haku on toteutettu urakat.sql 'hae-urakka-sijainnilla' kyselyssä.
-    ;; Sieltä on nyt kommentoitu pois kokonaisurakka-sopimukseen kuuluvien päällystysurakoiden haku sijainnin perusteella
-    ;; ja TODO-kommentti aiheeseen liittyen lisätty.
-    ;; Ominaisuus on pois käytöstä sen takia, että t-loik ilmoitusten urakoiden haussa (hae-lahin-urakka-id-sijainnilla)
-    ;; oletetaan osumia tulevan vain 'palvelusopimus' sopimustyyppisiin päällystysurakoihin.
-    ;; Ilmoitusten urakkahaku antaa väärän tuloksen mikäli tulee osuma 'kokonaisurakka' päällystysurakkaan.
-    ;; Ilmoitusten suhteen ollaan ilmeisesti kiinnostuneita vain palvelusopimuksen piirissä olevista urakoista.
-    (testing "Urakkatyyppi: paallystys (sopimustyyppi = kokonaisurakka)"
-      (let [urakkatyyppi "paallystys"
-            _ (anna-lukuoikeus (:kayttajanimi +kayttaja-paakayttaja-skanska+))
-            vastaus (api-tyokalut/get-kutsu ["/api/urakat/haku/sijainnilla"] (:kayttajanimi +kayttaja-paakayttaja-skanska+)
+    (testing "Urakkatyyppi: valaistus liikennepäivystjäjäoikeuksilla"
+      (let [urakkatyyppi "valaistus"
+            _ (anna-lukuoikeus (:kayttajanimi +kayttaja-jvh+))
+            vastaus (api-tyokalut/get-kutsu ["/api/urakat/haku/sijainnilla"] (:kayttajanimi +kayttaja-jvh+)
                       {"urakkatyyppi" urakkatyyppi
                               ;; Oulun lähiseutu (EPSG:3067)
-                       "x" 427232.596 "y" 7211474.342} portti)
+                       "x" 436162.5962 "y" 7225820.6809} portti)
             enkoodattu-body (cheshire/decode (:body vastaus) true)]
         (is (= 200 (:status vastaus)))
         (is (= 1 (count (map #(get-in % [:urakka :tiedot :nimi]) (:urakat enkoodattu-body)))))
-        (is (= "Muhoksen päällystysurakka" (get-in (first (:urakat enkoodattu-body)) [:urakka :tiedot :nimi])))))))
+        (is (= "Oulun valaistuksen palvelusopimus 2013-2050" (get-in (first (:urakat enkoodattu-body)) [:urakka :tiedot :nimi]))))))
 
 (deftest hae-urakka-pelkalla-sijainnilla
   (testing "Sijainti (epsg:3067): 427232.596,7211474.342"


### PR DESCRIPTION
Viilattu toteutusta niin, että SQL palauttaa vain yhden rivin per urakka. Esim. valaistusurakka-taulussa on useita rivejä yhtä urakkaa kohden ja rajapinnasta palautui aiemmin monta riviä saman urakan tietoja.

Testeihin lisätty valaistusurakkakeissi liikennepäivystäjäksi merkityllä käyttäjällä.

Poistettu kokonaisurakka-tyyppisen päällystysurakkaan liittyvät kommentoidut koodit. Näitä urakoita ei palauteta rajapinnan kautta, koska ne eivät vastaa tieliikenneilmoituksiin reagoinnista.