### PR TITLE
Disabloi develop psql 12 testit

### DIFF
--- a/.github/workflows/harja_test_develop.yml
+++ b/.github/workflows/harja_test_develop.yml
@@ -39,7 +39,7 @@ jobs:
         # Katso saatavilla olevat harjadb servicet docker-compose.yml:stä
         configs: [
           { testDBService: "harjadb-latest", e2eBrowsers: ['chrome'], artifactPrefix: 'harjadb-latest_' },
-          { testDBService: "harjadb-12-3.1", e2eBrowsers: ['chrome'], artifactPrefix: 'harjadb-12-3.1_' },
+          #{ testDBService: "harjadb-13-3.1", e2eBrowsers: ['chrome'], artifactPrefix: 'harjadb-13-3.1_' },
         ]
 
     with:

--- a/.github/workflows/harja_test_extra_browsers_cron.yml
+++ b/.github/workflows/harja_test_extra_browsers_cron.yml
@@ -1,0 +1,52 @@
+# Security hardening for GitHub Actions
+# https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
+
+# Pääasiassa E2E-testit ajetaan chromea vasten Pull Requesteissa defaulttina.
+# Tässä workflowssa ajetaan säännölisesti ajastettuna Cypress-testejä muita suosittuja selaimia vasten selainyhteensopivuuden
+# varmistamiseksi.
+
+# Tällä hetkellä testataan selaimilla: Microsoft Edge
+# Muita selaimia voidaan lisätä Cypress Dockerimageen tarpeen vaatiessa
+
+name: '[Scheduled] Harja: E2E test extra browsers'
+run-name: 'Harja: E2E test extra browsers: Edge'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+on:
+  # Manuaalisen käynnistyksen asetukset
+  workflow_dispatch:
+  # Ajastettu käynnistys (Ajetaan testit joka maanantai klo 9)
+  schedule:
+    - cron: '0 9 * * MON'
+
+
+jobs:
+  tests:
+    uses: ./.github/workflows/reusable_run_app_tests.yml
+    # Permissions
+    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+    # https://docs.github.com/en/actions/using-workflows/reusing-workflows#access-and-permissions
+    permissions:
+      # Contents read lupaa tarvitaan checkout actionissa
+      contents: read
+      # Packages read lupaa tarvitaan Harjan testaukseen tarkoitettujen Docker imageiden pullaamiseen
+      packages: read
+      # Actions write oikeudella voidaan esim. listata ja poistaa artifacteja
+      actions: write
+      # Tarvitaan test-reportin julkaisuun PR:ssä
+      checks: write
+
+    with:
+      test-db-service: harjadb-latest
+      e2e-browsers: "['edge']"
+      e2e-tests: 'true'
+      build-harja: 'light'
+      # Disabloidaan kaikki muut testit
+      lint-clj: 'false'
+      backend-tests: 'false'
+      basic-tests: 'false'
+      integration-tests: 'false'
+


### PR DESCRIPTION
* Disabloi develop-testimatriisista psql 12-yhteensopivuustestit.
    * PR-branchit testataan nyt vanhempaa psql versiota vasten ja develop-branch versiota 15 vasten.
       Tämän pitäisi olla riittävä ratkaisu yhteensopivuuden varmistamiseksi on-prem ja aws ympäristöiden suhteen siirtymän ajan, mutta samalla varmistaen testien vakaan läpiajon.
 * Lisää kokeellinen ajastettu workflow, joka ajaa E2E-testit joka maanantai "ylimääräisille" selaimille. Tällä hetkellä ylimääräisenä testiselaimena on Microsoft Edge. 
      * Muut E2E-testit ajetaan vain chromea vasten, jotta PR:n läpimenoaika ei olisi liian hidas.