### PR TITLE
Älä asenna nodejs dependencyjä defaulttina

### DIFF
--- a/.github/actions/build-harja-app/action.yml
+++ b/.github/actions/build-harja-app/action.yml
@@ -20,7 +20,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup clojure environment ja asenna nodejs depsut
+    - name: Setup clojure environment and install nodejs deps
       uses: ./.github/actions/setup-build-env-and-tools
       with:
         # Front-endin buildaamisessa tarvitaan nodejs dependencyjä

--- a/.github/actions/build-harja-app/action.yml
+++ b/.github/actions/build-harja-app/action.yml
@@ -20,10 +20,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup clojure environment
+    - name: Setup clojure environment ja asenna nodejs depsut
       uses: ./.github/actions/setup-build-env-and-tools
       with:
-        # Front-endin buildaamisesa tarvitaa nodejs dependencyjä
+        # Front-endin buildaamisessa tarvitaan nodejs dependencyjä
         install-node-deps: true
 
     - name: Build back-end

--- a/.github/actions/setup-build-env-and-tools/action.yml
+++ b/.github/actions/setup-build-env-and-tools/action.yml
@@ -13,7 +13,7 @@ inputs:
   install-node-deps:
     description: 'Asennetaanko nodejs dependencyt? (less.js ym.)'
     # Huom, composite actionit eivät tue tyyppimäärityksiä inputeille.
-    default: 'true'
+    default: 'false'
 
 runs:
   using: "composite"


### PR DESCRIPTION
Nodejs-depsut asennettiin vahingossa defaulttina joka jobissa, missä build-ympäristöstön asennus käynnistettiin.
Tällä hetkellä vain front-end build job tarvii nodejs depsujen asennusta build-ympäristön setupin kautta.