### PR TITLE
VHAR-8144 Korjaa välikatselmuksen tietojen lataus

### DIFF
--- a/src/cljs/harja/tiedot/urakka/kulut/mhu_kustannusten_seuranta.cljs
+++ b/src/cljs/harja/tiedot/urakka/kulut/mhu_kustannusten_seuranta.cljs
@@ -63,7 +63,6 @@
                         :paasta-virhe-lapi? true})))
 
 (extend-protocol tuck/Event
-
   HaeKustannukset
   (process-event [{hoitokauden-alkuvuosi :hoitokauden-alkuvuosi
                    aikavali-alkupvm :aikavali-alkupvm aikavali-loppupvm :aikavali-loppupvm} app]
@@ -75,9 +74,9 @@
   (process-event [{vastaus :vastaus} app]
     (let [data (kustannusten-seuranta/jarjesta-tehtavat vastaus)]
       (-> app
-          (assoc-in [:kustannukset-yhteensa] (:yhteensa data))
-          (assoc-in [:kustannukset] (:taulukon-rivit data))
-          (assoc :haku-kaynnissa? false))))
+        (assoc-in [:kustannukset-yhteensa] (:yhteensa data))
+        (assoc-in [:kustannukset] (:taulukon-rivit data))
+        (assoc :haku-kaynnissa? false))))
 
   KustannustenHakuEpaonnistui
   (process-event [{vastaus :vastaus} app]
@@ -87,15 +86,17 @@
   HaeBudjettitavoite
   (process-event [_ app]
     (tuck-apurit/post! :budjettitavoite
-                       {:urakka-id (-> @tila/yleiset :urakka :id)}
-                       {:onnistui ->HaeBudjettitavoiteHakuOnnistui
-                        :epaonnistui ->HaeBudjettitavoiteHakuEpaonnistui
-                        :paasta-virhe-lapi? true})
+      {:urakka-id (-> @tila/yleiset :urakka :id)}
+      {:onnistui ->HaeBudjettitavoiteHakuOnnistui
+       :epaonnistui ->HaeBudjettitavoiteHakuEpaonnistui
+       :paasta-virhe-lapi? true})
     app)
 
   HaeBudjettitavoiteHakuOnnistui
   (process-event [{vastaus :vastaus} app]
-    (assoc app :budjettitavoite vastaus))
+    (assoc app
+      :budjettitavoite vastaus
+      :valittu-urakka (-> @tila/yleiset :urakka :id)))
 
   HaeBudjettitavoiteHakuEpaonnistui
   (process-event [{vastaus :vastaus} app]
@@ -105,9 +106,9 @@
   HaeTavoitehintojenOikaisut
   (process-event [{urakka :urakka} app]
     (tuck-apurit/post! :hae-tavoitehintojen-oikaisut
-                       {::urakka/id urakka}
-                       {:onnistui ->HaeTavoitehintojenOikaisutOnnistui
-                        :epaonnistui ->HaeTavoitehintojenOikaisutEpaonnistui})
+      {::urakka/id urakka}
+      {:onnistui ->HaeTavoitehintojenOikaisutOnnistui
+       :epaonnistui ->HaeTavoitehintojenOikaisutEpaonnistui})
     app)
 
   HaeTavoitehintojenOikaisutOnnistui
@@ -116,12 +117,12 @@
     ;; Muutetaan se {vuosi {0 {data}
     ;;                      1 {data}}}
     (assoc app :tavoitehinnan-oikaisut
-               ;; Merkitään samalla koskemattomiksi, jotta voidaan välttää turhien päivitysten tekeminen
-               (fmap #(zipmap (range) (map (fn [o] (-> o
-                                                      (assoc :koskematon true)
-                                                      (assoc :lisays-tai-vahennys (if (neg? (::valikatselmus/summa o))
-                                                                                    :vahennys
-                                                                                    :lisays)))) %)) vastaus)))
+      ;; Merkitään samalla koskemattomiksi, jotta voidaan välttää turhien päivitysten tekeminen
+      (fmap #(zipmap (range) (map (fn [o] (-> o
+                                            (assoc :koskematon true)
+                                            (assoc :lisays-tai-vahennys (if (neg? (::valikatselmus/summa o))
+                                                                          :vahennys
+                                                                          :lisays)))) %)) vastaus)))
 
   HaeTavoitehintojenOikaisutEpaonnistui
   (process-event [{vastaus :vastaus} app]
@@ -149,9 +150,9 @@
   HaeUrakanPaatokset
   (process-event [{urakka :urakka} app]
     (tuck-apurit/post! :hae-urakan-paatokset
-                       {::urakka/id urakka}
-                       {:onnistui ->HaeUrakanPaatoksetOnnistui
-                        :epaonnistui ->HaeUrakanPaatoksetEpaonnistui})
+      {::urakka/id urakka}
+      {:onnistui ->HaeUrakanPaatoksetOnnistui
+       :epaonnistui ->HaeUrakanPaatoksetEpaonnistui})
     app)
 
   HaeUrakanPaatoksetOnnistui
@@ -182,12 +183,12 @@
           (e! (->HaeBudjettitavoite))))
       (hae-kustannukset urakka vuosi nil nil)
       (-> app
-          (assoc :valittu-kuukausi nil)
-          ;; Lupaukset on kiinteässä linkissä kustannusten seurannan kanssa joten tarvitaan hoitokaudellekin sama avain
-          (assoc :valittu-hoitokausi [(pvm/hoitokauden-alkupvm vuosi)
-                                      (pvm/paivan-lopussa (pvm/hoitokauden-loppupvm (inc vuosi)))])
-          (assoc :haku-kaynnissa? true)
-          (assoc :hoitokauden-alkuvuosi vuosi))))
+        (assoc :valittu-kuukausi nil)
+        ;; Lupaukset on kiinteässä linkissä kustannusten seurannan kanssa joten tarvitaan hoitokaudellekin sama avain
+        (assoc :valittu-hoitokausi [(pvm/hoitokauden-alkupvm vuosi)
+                                    (pvm/paivan-lopussa (pvm/hoitokauden-loppupvm (inc vuosi)))])
+        (assoc :haku-kaynnissa? true)
+        (assoc :hoitokauden-alkuvuosi vuosi))))
 
   ValitseKuukausi
   (process-event [{urakka :urakka kuukausi :kuukausi vuosi :vuosi} app]
@@ -202,8 +203,8 @@
             (e! (->HaeBudjettitavoite))))
         (hae-kustannukset urakka vuosi (first valittu-kuukausi) (second valittu-kuukausi))
         (-> app
-            (assoc :haku-kaynnissa? true)
-            (assoc-in [:valittu-kuukausi] kuukausi)))))
+          (assoc :haku-kaynnissa? true)
+          (assoc-in [:valittu-kuukausi] kuukausi)))))
 
   AvaaValikatselmusLomake
   (process-event [_ app]

--- a/src/cljs/harja/tiedot/urakka/kulut/valikatselmus.cljs
+++ b/src/cljs/harja/tiedot/urakka/kulut/valikatselmus.cljs
@@ -264,7 +264,6 @@
       (assoc-in [:kattohinnan-oikaisu :uusi-kattohinta] kattohinta)))
 
   ;; Päätökset
-
   HaeUrakanPaatokset
   (process-event [{urakka :urakka} app]
     (do

--- a/src/cljs/harja/tiedot/urakka/kulut/yhteiset.cljs
+++ b/src/cljs/harja/tiedot/urakka/kulut/yhteiset.cljs
@@ -103,7 +103,6 @@
 (defrecord NollaaValikatselmuksenPaatokset [])
 
 (extend-protocol tuck/Event
-
   NollaaValikatselmuksenPaatokset
   (process-event [_ app]
     (dissoc app :kattohinnan-ylitys-lomake :lupausbonus-lomake :lupaussanktio-lomake :kattohinnan-oikaisu)))

--- a/src/cljs/harja/views/urakka/kulut/mhu_kustannusten_seuranta.cljs
+++ b/src/cljs/harja/views/urakka/kulut/mhu_kustannusten_seuranta.cljs
@@ -454,8 +454,8 @@
         valikatselmus-tekematta? (t-yhteiset/valikatselmus-tekematta? app)]
 
     ;; Jos haku vielä käynnissä näytetään hyrrä
-    (if (:haku-kaynnissa? app)
-      [:div {:style {:padding "16px"}}
+    (if (:haku-kaynnissa? app) 
+      [:div.padding-16
        [ajax-loader-pieni (str "Haetaan tietoja...")]]
       
       ;; Tiedot ladattu 

--- a/src/cljs/harja/views/urakka/kulut/mhu_kustannusten_seuranta.cljs
+++ b/src/cljs/harja/views/urakka/kulut/mhu_kustannusten_seuranta.cljs
@@ -531,20 +531,19 @@
                             {:keys [valittu-kuukausi hoitokauden-alkuvuosi]} app
                             valittu-urakka-id @nav/valittu-urakka-id
                             alkuvuosi (pvm/vuosi alkupvm)]
-                        (do
-                          (e! (kustannusten-seuranta-tiedot/->SuljeValikatselmusLomake))
-                          (e! (kustannusten-seuranta-tiedot/->HaeBudjettitavoite))
-                          (e! (kustannusten-seuranta-tiedot/->HaeKustannukset hoitokauden-alkuvuosi
-                                (if (= "Kaikki" valittu-kuukausi)
-                                  nil
-                                  (first valittu-kuukausi))
-                                (if (= "Kaikki" valittu-kuukausi)
-                                  nil
-                                  (second valittu-kuukausi))))
-                          (e! (kustannusten-seuranta-tiedot/->HaeTavoitehintojenOikaisut valittu-urakka-id))
-                          (e! (kustannusten-seuranta-tiedot/->HaeKattohintojenOikaisut valittu-urakka-id))
-                          (e! (kustannusten-seuranta-tiedot/->HaeUrakanPaatokset valittu-urakka-id))
-                          (e! (kustannusten-seuranta-tiedot/->ValitseHoitokausi valittu-urakka-id alkuvuosi))))))
+                        (e! (kustannusten-seuranta-tiedot/->SuljeValikatselmusLomake))
+                        (e! (kustannusten-seuranta-tiedot/->HaeBudjettitavoite))
+                        (e! (kustannusten-seuranta-tiedot/->HaeKustannukset hoitokauden-alkuvuosi
+                              (if (= "Kaikki" valittu-kuukausi)
+                                nil
+                                (first valittu-kuukausi))
+                              (if (= "Kaikki" valittu-kuukausi)
+                                nil
+                                (second valittu-kuukausi))))
+                        (e! (kustannusten-seuranta-tiedot/->HaeTavoitehintojenOikaisut valittu-urakka-id))
+                        (e! (kustannusten-seuranta-tiedot/->HaeKattohintojenOikaisut valittu-urakka-id))
+                        (e! (kustannusten-seuranta-tiedot/->HaeUrakanPaatokset valittu-urakka-id))
+                        (e! (kustannusten-seuranta-tiedot/->ValitseHoitokausi valittu-urakka-id alkuvuosi)))))
     (fn [e! {:keys [valikatselmus-auki?] :as app}]
       [:div {:id "vayla"}
        (if valikatselmus-auki?

--- a/src/cljs/harja/views/urakka/kulut/mhu_kustannusten_seuranta.cljs
+++ b/src/cljs/harja/views/urakka/kulut/mhu_kustannusten_seuranta.cljs
@@ -527,10 +527,14 @@
   (komp/luo
     (komp/lippu tila/kustannusten-seuranta-nakymassa?)
     (komp/piirretty (fn [this]
-                      (let [{:keys [alkupvm]} (-> @tila/tila :yleiset :urakka)
-                            {:keys [valittu-kuukausi hoitokauden-alkuvuosi]} app
+                      (let [{:keys [valittu-kuukausi hoitokauden-alkuvuosi]} app
                             valittu-urakka-id @nav/valittu-urakka-id
-                            alkuvuosi (pvm/vuosi alkupvm)]
+                            urakan-hoitokaudet (urakka-tiedot/hoito-tai-sopimuskaudet (-> @tila/yleiset :urakka))
+                            kuluva-hoitokausi (first (filter #(pvm/valissa? (pvm/nyt) (first %) (second %)) urakan-hoitokaudet))
+                            kuluva-hoitokausi (if (nil? kuluva-hoitokausi)
+                                                (first urakan-hoitokaudet)
+                                                kuluva-hoitokausi)
+                            kuluva-vuosi (pvm/vuosi (first kuluva-hoitokausi))]
                         (e! (kustannusten-seuranta-tiedot/->SuljeValikatselmusLomake))
                         (e! (kustannusten-seuranta-tiedot/->HaeBudjettitavoite))
                         (e! (kustannusten-seuranta-tiedot/->HaeKustannukset hoitokauden-alkuvuosi
@@ -543,7 +547,7 @@
                         (e! (kustannusten-seuranta-tiedot/->HaeTavoitehintojenOikaisut valittu-urakka-id))
                         (e! (kustannusten-seuranta-tiedot/->HaeKattohintojenOikaisut valittu-urakka-id))
                         (e! (kustannusten-seuranta-tiedot/->HaeUrakanPaatokset valittu-urakka-id))
-                        (e! (kustannusten-seuranta-tiedot/->ValitseHoitokausi valittu-urakka-id alkuvuosi)))))
+                        (e! (kustannusten-seuranta-tiedot/->ValitseHoitokausi valittu-urakka-id kuluva-vuosi)))))
     (fn [e! {:keys [valikatselmus-auki?] :as app}]
       [:div {:id "vayla"}
        (if valikatselmus-auki?

--- a/src/cljs/harja/views/urakka/kulut/mhu_kustannusten_seuranta.cljs
+++ b/src/cljs/harja/views/urakka/kulut/mhu_kustannusten_seuranta.cljs
@@ -11,7 +11,7 @@
             [harja.fmt :as fmt]
             [harja.ui.debug :as debug]
             [harja.ui.protokollat :refer [Haku hae]]
-            [harja.ui.yleiset :refer [ajax-loader linkki livi-pudotusvalikko +korostuksen-kesto+]]
+            [harja.ui.yleiset :refer [ajax-loader linkki livi-pudotusvalikko +korostuksen-kesto+ ajax-loader-pieni]]
             [harja.ui.yleiset :as yleiset]
             [harja.ui.komponentti :as komp]
             [harja.transit :as transit]
@@ -452,86 +452,99 @@
                         (second valittu-kuukausi)
                         (pvm/iso8601 (pvm/hoitokauden-loppupvm (inc valittu-hoitokausi))))
         valikatselmus-tekematta? (t-yhteiset/valikatselmus-tekematta? app)]
-    [:div.kustannusten-seuranta.margin-top-16
-     ;[debug/debug app]
-     [:div
-      [:div.row.header
+
+    ;; Jos haku vielä käynnissä näytetään hyrrä
+    (if (:haku-kaynnissa? app)
+      [:div {:style {:padding "16px"}}
+       [ajax-loader-pieni (str "Haetaan tietoja...")]]
+      
+      ;; Tiedot ladattu 
+      [:div.kustannusten-seuranta.margin-top-16
        [:div
-        [:h1 "Kustannusten seuranta"]
-        [:p.urakka (:nimi @nav/valittu-urakka)]
-        [:p "Tavoite- ja kattohinnat sekä budjetit on suunniteltu Suunnittelu-puolella.
+        [:div.row.header
+         [:div
+          [:h1 "Kustannusten seuranta"]
+          [:p.urakka (:nimi @nav/valittu-urakka)]
+          [:p "Tavoite- ja kattohinnat sekä budjetit on suunniteltu Suunnittelu-puolella.
      Toteutumissa näkyy ne kustannukset, jotka ovat Laskutus-osiossa syötetty järjestelmään."]
-        [:p "Taulukossa näkyvät luvut ovat indeksikorjattuja, mikäli indeksit ovat saatavilla."]]] ;; Ei speksissä, voi poistaa jos ei ole tarpeellinen.
+          [:p "Taulukossa näkyvät luvut ovat indeksikorjattuja, mikäli indeksit ovat saatavilla."]]] ;; Ei speksissä, voi poistaa jos ei ole tarpeellinen.
 
-      [:div.row.filtterit-container
-       [:div.filtteri
-        [:span.alasvedon-otsikko-vayla "Hoitovuosi"]
-        [yleiset/livi-pudotusvalikko {:valinta valittu-hoitokausi
-                                      :vayla-tyyli? true
-                                      :data-cy "hoitokausi-valinta"
-                                      :valitse-fn #(do (e! (kustannusten-seuranta-tiedot/->ValitseHoitokausi (:id @nav/valittu-urakka) %))
+        [:div.row.filtterit-container
+         [:div.filtteri
+          [:span.alasvedon-otsikko-vayla "Hoitovuosi"]
+          [yleiset/livi-pudotusvalikko {:valinta valittu-hoitokausi
+                                        :vayla-tyyli? true
+                                        :data-cy "hoitokausi-valinta"
+                                        :valitse-fn #(do (e! (kustannusten-seuranta-tiedot/->ValitseHoitokausi (:id @nav/valittu-urakka) %))
                                                        (e! (t-yhteiset/->NollaaValikatselmuksenPaatokset)))
-                                      :format-fn #(fmt/hoitokauden-jarjestysluku-ja-vuodet % hoitokaudet)
-                                      :klikattu-ulkopuolelle-params {:tarkista-komponentti? true}}
-         hoitokaudet]]
-       [:div.filtteri.kuukausi
-        [:span.alasvedon-otsikko-vayla "Kuukausi"]
-        [yleiset/livi-pudotusvalikko {:valinta valittu-kuukausi
-                                      :vayla-tyyli? true
-                                      :valitse-fn #(e! (kustannusten-seuranta-tiedot/->ValitseKuukausi (:id @nav/valittu-urakka) % valittu-hoitokausi))
-                                      :format-fn #(if %
-                                                    (if (= "Kaikki" %)
-                                                      "Kaikki"
-                                                      (let [[alkupvm _] %
-                                                            kk-teksti (pvm/kuukauden-nimi (pvm/kuukausi alkupvm))]
-                                                        (str (str/capitalize kk-teksti) " " (pvm/vuosi alkupvm))))
-                                                    "Kaikki")
-                                      :klikattu-ulkopuolelle-params {:tarkista-komponentti? true}}
-         hoitokauden-kuukaudet]]
-       [:div.filtteri {:style {:padding-top "21px"}}
-        ^{:key "raporttixls"}
-        [:form {:style {:margin-left "auto"}
-                :target "_blank" :method "POST"
-                :action (k/excel-url :kustannukset)}
-         [:input {:type "hidden" :name "parametrit"
-                  :value (transit/clj->transit {:urakka-id (:id @nav/valittu-urakka)
-                                                :urakka-nimi (:nimi @nav/valittu-urakka)
-                                                :hoitokauden-alkuvuosi valittu-hoitokausi
-                                                :alkupvm haun-alkupvm
-                                                :loppupvm haun-loppupvm})}]
-         [:button {:type "submit"
-                   :class "nappi-toissijainen"}
-          [ikonit/ikoni-ja-teksti [ikonit/livicon-download] "Tallenna Excel"]]]]
-       [:div.filtteri {:style {:padding-top "21px"}}
-        (if valikatselmus-tekematta?
-          [napit/yleinen-ensisijainen
-           "Tee välikatselmus"
-           #(e! (kustannusten-seuranta-tiedot/->AvaaValikatselmusLomake))]
+                                        :format-fn #(fmt/hoitokauden-jarjestysluku-ja-vuodet % hoitokaudet)
+                                        :klikattu-ulkopuolelle-params {:tarkista-komponentti? true}}
+           hoitokaudet]]
+         [:div.filtteri.kuukausi
+          [:span.alasvedon-otsikko-vayla "Kuukausi"]
+          [yleiset/livi-pudotusvalikko {:valinta valittu-kuukausi
+                                        :vayla-tyyli? true
+                                        :valitse-fn #(e! (kustannusten-seuranta-tiedot/->ValitseKuukausi (:id @nav/valittu-urakka) % valittu-hoitokausi))
+                                        :format-fn #(if %
+                                                      (if (= "Kaikki" %)
+                                                        "Kaikki"
+                                                        (let [[alkupvm _] %
+                                                              kk-teksti (pvm/kuukauden-nimi (pvm/kuukausi alkupvm))]
+                                                          (str (str/capitalize kk-teksti) " " (pvm/vuosi alkupvm))))
+                                                      "Kaikki")
+                                        :klikattu-ulkopuolelle-params {:tarkista-komponentti? true}}
+           hoitokauden-kuukaudet]]
+         
+         [:div.filtteri {:style {:padding-top "21px"}}
+          ^{:key "raporttixls"}
+          [:form {:style {:margin-left "auto"}
+                  :target "_blank" :method "POST"
+                  :action (k/excel-url :kustannukset)}
+           [:input {:type "hidden" :name "parametrit"
+                    :value (transit/clj->transit {:urakka-id (:id @nav/valittu-urakka)
+                                                  :urakka-nimi (:nimi @nav/valittu-urakka)
+                                                  :hoitokauden-alkuvuosi valittu-hoitokausi
+                                                  :alkupvm haun-alkupvm
+                                                  :loppupvm haun-loppupvm})}]
+           [:button {:type "submit"
+                     :class "nappi-toissijainen"}
+            [ikonit/ikoni-ja-teksti [ikonit/livicon-download] "Tallenna Excel"]]]]
+         
+         [:div.filtteri {:style {:padding-top "21px"}}
+          (if valikatselmus-tekematta?
+            [napit/yleinen-ensisijainen
+             "Tee välikatselmus"
+             #(e! (kustannusten-seuranta-tiedot/->AvaaValikatselmusLomake))]
+            [napit/yleinen-ensisijainen "Avaa välikatselmus" #(e! (kustannusten-seuranta-tiedot/->AvaaValikatselmusLomake)) {:luokka "napiton-nappi tumma" :ikoni (ikonit/harja-icon-action-show)}])]]]
 
-          [napit/yleinen-ensisijainen "Avaa välikatselmus" #(e! (kustannusten-seuranta-tiedot/->AvaaValikatselmusLomake)) {:luokka "napiton-nappi tumma" :ikoni (ikonit/harja-icon-action-show)}])]]]
-
-     (if (:haku-kaynnissa? app)
-       [:div {:style {:padding-left "20px"}} [yleiset/ajax-loader "Haetaan käynnissä"]]
-       [:div
-        [kustannukset-taulukko e! app taulukon-rivit]
-        [yhteenveto-laatikko e! app taulukon-rivit :kustannusten-seuranta]])]))
+       (if (:haku-kaynnissa? app)
+         [:div {:style {:padding-left "20px"}} [yleiset/ajax-loader "Haetaan käynnissä"]]
+         [:div
+          [kustannukset-taulukko e! app taulukon-rivit]
+          [yhteenveto-laatikko e! app taulukon-rivit :kustannusten-seuranta]])])))
 
 (defn kustannusten-seuranta* [e! app]
   (komp/luo
     (komp/lippu tila/kustannusten-seuranta-nakymassa?)
     (komp/piirretty (fn [this]
-                      (do
-                        (e! (kustannusten-seuranta-tiedot/->HaeBudjettitavoite))
-                        (e! (kustannusten-seuranta-tiedot/->HaeKustannukset (:hoitokauden-alkuvuosi app)
-                                                                            (if (= "Kaikki" (:valittu-kuukausi app))
-                                                                              nil
-                                                                              (first (:valittu-kuukausi app)))
-                                                                            (if (= "Kaikki" (:valittu-kuukausi app))
-                                                                              nil
-                                                                              (second (:valittu-kuukausi app)))))
-                        (e! (kustannusten-seuranta-tiedot/->HaeTavoitehintojenOikaisut (:id @nav/valittu-urakka)))
-                        (e! (kustannusten-seuranta-tiedot/->HaeKattohintojenOikaisut (:id @nav/valittu-urakka)))
-                        (e! (kustannusten-seuranta-tiedot/->HaeUrakanPaatokset (:id @nav/valittu-urakka))))))
+                      (let [{:keys [alkupvm]} (-> @tila/tila :yleiset :urakka)
+                            {:keys [valittu-kuukausi hoitokauden-alkuvuosi]} app
+                            valittu-urakka-id (:id @nav/valittu-urakka)
+                            alkuvuosi (pvm/vuosi alkupvm)]
+                        (do
+                          (e! (kustannusten-seuranta-tiedot/->SuljeValikatselmusLomake))
+                          (e! (kustannusten-seuranta-tiedot/->HaeBudjettitavoite))
+                          (e! (kustannusten-seuranta-tiedot/->HaeKustannukset hoitokauden-alkuvuosi
+                                (if (= "Kaikki" valittu-kuukausi)
+                                  nil
+                                  (first valittu-kuukausi))
+                                (if (= "Kaikki" valittu-kuukausi)
+                                  nil
+                                  (second valittu-kuukausi))))
+                          (e! (kustannusten-seuranta-tiedot/->HaeTavoitehintojenOikaisut valittu-urakka-id))
+                          (e! (kustannusten-seuranta-tiedot/->HaeKattohintojenOikaisut valittu-urakka-id))
+                          (e! (kustannusten-seuranta-tiedot/->HaeUrakanPaatokset valittu-urakka-id))
+                          (e! (kustannusten-seuranta-tiedot/->ValitseHoitokausi valittu-urakka-id alkuvuosi))))))
     (fn [e! {:keys [valikatselmus-auki?] :as app}]
       [:div {:id "vayla"}
        (if valikatselmus-auki?

--- a/src/cljs/harja/views/urakka/kulut/mhu_kustannusten_seuranta.cljs
+++ b/src/cljs/harja/views/urakka/kulut/mhu_kustannusten_seuranta.cljs
@@ -529,7 +529,7 @@
     (komp/piirretty (fn [this]
                       (let [{:keys [alkupvm]} (-> @tila/tila :yleiset :urakka)
                             {:keys [valittu-kuukausi hoitokauden-alkuvuosi]} app
-                            valittu-urakka-id (:id @nav/valittu-urakka)
+                            valittu-urakka-id @nav/valittu-urakka-id
                             alkuvuosi (pvm/vuosi alkupvm)]
                         (do
                           (e! (kustannusten-seuranta-tiedot/->SuljeValikatselmusLomake))


### PR DESCRIPTION
Urakkaa vaihdettaessa ainakin ongelmia välikatselmuksessa, tavoitehinnan / kattohinnan ylitystiedot katoaa. Ongelmia myös sivun päivityksessä mitä en saanut kunnolla toistettua, mutta tämä voisi ehkä korjata senkin. 

- Lataa valitun urakan tiedot oikein 
- Lisää näkymään ajax loader jos tietoja ladataan vielä 
- Sulje välikatselmus urakkaa vaihtaessa 
- Valitse urakan e̶n̶s̶i̶m̶m̶ä̶i̶n̶e̶n̶  kuluva hoitokausi automaattisesti 