### PR TITLE
VHAR-8395 Korjaa laskutusyhteenvedon johto ja hallintokorvaus

### DIFF
--- a/src/clj/harja/kyselyt/kustannusten_seuranta.sql
+++ b/src/clj/harja/kyselyt/kustannusten_seuranta.sql
@@ -288,7 +288,7 @@ WHERE l.urakka = :urakka
        tk.koodi = '14301')
 GROUP BY tr.nimi, tk.nimi, lk.maksueratyyppi, tk.koodi, tk_tehtava.jarjestys, tr.yksiloiva_tunniste
 UNION ALL
--- Toteutuneet erillishankinnat, hoidonjohdonpalkkio, johto- ja hallintakorvaukset
+-- Toteutuneet erillishankinnat, hoidonjohdonpalkkio, johto- ja hallintokorvaukset
 -- ja vuoden päättämiseen liittyvät kulut lasku_kohdistus taulusta.
 -- Rajaus tehty toimenpidekoodi.koodi = 23151 perusteella
 SELECT 0                          AS budjetoitu_summa,

--- a/src/clj/harja/palvelin/raportointi/raportit/laskutusyhteenveto_tuotekohtainen.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/laskutusyhteenveto_tuotekohtainen.clj
@@ -253,8 +253,8 @@
                  "Soratien hoito"
                  "Päällyste"
                  "MHU Ylläpito"
-                 "MHU Korvausinvestointi"
-                 "MHU ja HJU hoidon johto"]]
+                 "MHU ja HJU hoidon johto"
+                 "MHU Korvausinvestointi"]]
 
     [:raportti {:nimi (str "Laskutusyhteenveto (" (pvm/pvm alkupvm) " - " (pvm/pvm loppupvm) ")")
                 :otsikon-koko :iso}
@@ -266,20 +266,19 @@
                                                    :hoitokausi (pvm/paivamaaran-hoitokausi alkupvm)}))
      ;; Data on vectorina järjestyksessä, käytetään 'otsikot' indeksiä oikean datan näyttämiseen  
      (concat (for [x otsikot]
-               (do
-                 (let [tiedot-indeksi (.indexOf otsikot x)
-                       data (try
-                              (nth (first laskutusyhteenvedot) tiedot-indeksi)
-                              (catch Throwable t
-                                (println "Tuotekohtainen - " x "tietoja ei löytynyt.")
-                                nil))]
-                   (taulukko {:data data
-                              :otsikko x
-                              :sheet-nimi (when (= (.indexOf otsikot x) 0) sheet-nimi)
-                              :laskutettu-teksti laskutettu-teksti
-                              :laskutetaan-teksti laskutetaan-teksti
-                              :kyseessa-kk-vali? kyseessa-kk-vali?
-                              :alkupvm alkupvm})))))
+               (let [tiedot-indeksi (.indexOf otsikot x)
+                     data (try
+                            (nth (first laskutusyhteenvedot) tiedot-indeksi)
+                            (catch Throwable t
+                              (println "Tuotekohtainen - " x "tietoja ei löytynyt.")
+                              nil))]
+                 (taulukko {:data data
+                            :otsikko x
+                            :sheet-nimi (when (= (.indexOf otsikot x) 0) sheet-nimi)
+                            :laskutettu-teksti laskutettu-teksti
+                            :laskutetaan-teksti laskutetaan-teksti
+                            :kyseessa-kk-vali? kyseessa-kk-vali?
+                            :alkupvm alkupvm}))))
 
      (toteutuneet-taulukko {:data (first koostettu-yhteenveto)
                             :otsikko "Toteutuneet"

--- a/src/clj/harja/palvelin/raportointi/raportit/laskutusyhteenveto_tuotekohtainen.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/laskutusyhteenveto_tuotekohtainen.clj
@@ -74,7 +74,7 @@
                 (remove nil?
                   (cond
                     (= "MHU ja HJU hoidon johto" otsikko)
-                    [(rivi-taulukolle data kyseessa-kk-vali? "Johto- ja hallintakorvaukset" :johto_ja_hallinto_laskutettu :johto_ja_hallinto_laskutetaan false)
+                    [(rivi-taulukolle data kyseessa-kk-vali? "Johto- ja hallintokorvaukset" :johto_ja_hallinto_laskutettu :johto_ja_hallinto_laskutetaan false)
                      (rivi-taulukolle data kyseessa-kk-vali? "Erillishankinnat" :hj_erillishankinnat_laskutettu :hj_erillishankinnat_laskutetaan false)
                      (rivi-taulukolle data kyseessa-kk-vali? "HJ-palkkio" :hj_palkkio_laskutettu :hj_palkkio_laskutetaan false)
                      (rivi-taulukolle data kyseessa-kk-vali? "Bonukset" :bonukset_laskutettu :bonukset_laskutetaan false)

--- a/src/clj/harja/palvelin/raportointi/raportit/laskutusyhteenveto_tuotekohtainen.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/laskutusyhteenveto_tuotekohtainen.clj
@@ -270,7 +270,7 @@
                      data (try
                             (nth (first laskutusyhteenvedot) tiedot-indeksi)
                             (catch Throwable t
-                              (println "Tuotekohtainen - " x "tietoja ei löytynyt.")
+                              (log/error "Tuotekohtaisen laskutusyhteenvedon tietoja ei löytynyt.")
                               nil))]
                  (taulukko {:data data
                             :otsikko x

--- a/src/cljc/harja/domain/kulut/kustannusten_seuranta.cljc
+++ b/src/cljc/harja/domain/kulut/kustannusten_seuranta.cljc
@@ -259,7 +259,7 @@
     rivit))
 
 (defn- summaa-paaryhman-toimenpiteet
-  "Summataan hankintakustannukset, johto ja hallintakorvaukset sekä rahavaraukset"
+  "Summataan hankintakustannukset, johto ja hallintokorvaukset sekä rahavaraukset"
   [taulukko-rivit indeksi toimenpiteet]
   (let [indeksikorjaus-vahvistettu-avain (keyword (str (nth raportin-paaryhmat indeksi) "-indeksikorjaus-vahvistettu"))
         ;; Jos yksikin arvo on false, niin osio on vahvistamatta

--- a/test/clj/harja/palvelin/raportointi/kulut_tehtavaryhmittain_test.clj
+++ b/test/clj/harja/palvelin/raportointi/kulut_tehtavaryhmittain_test.clj
@@ -12,20 +12,20 @@
 
 (defn jarjestelma-fixture [testit]
   (alter-var-root #'jarjestelma
-                  (fn [_]
-                    (component/start
-                      (component/system-map
-                        :db (tietokanta/luo-tietokanta testitietokanta)
-                        :http-palvelin (testi-http-palvelin)
-                        :pdf-vienti (component/using
-                                      (pdf-vienti/luo-pdf-vienti)
-                                      [:http-palvelin])
-                        :raportointi (component/using
-                                       (raportointi/luo-raportointi)
-                                       [:db :pdf-vienti])
-                        :raportit (component/using
-                                    (raportit/->Raportit)
-                                    [:http-palvelin :db :raportointi :pdf-vienti])))))
+    (fn [_]
+      (component/start
+        (component/system-map
+          :db (tietokanta/luo-tietokanta testitietokanta)
+          :http-palvelin (testi-http-palvelin)
+          :pdf-vienti (component/using
+                        (pdf-vienti/luo-pdf-vienti)
+                        [:http-palvelin])
+          :raportointi (component/using
+                         (raportointi/luo-raportointi)
+                         [:db :pdf-vienti])
+          :raportit (component/using
+                      (raportit/->Raportit)
+                      [:http-palvelin :db :raportointi :pdf-vienti])))))
 
   (testit)
   (alter-var-root #'jarjestelma component/stop))
@@ -36,8 +36,11 @@
 
 (def odotettu-raportti
   [:raportti {:nimi "Kulut tehtäväryhmittäin"}
-   [:taulukko {:viimeinen-rivi-yhteenveto? true, :otsikko "Kulut tehtäväryhmittäin ajalla 01.12.2019 - 30.08.2020"}
-    [{:leveys 1, :otsikko "Tehtäväryhmä"} {:leveys 1, :fmt :raha, :otsikko "Hoitokauden alusta 01.10.2019-30.09.2020"} {:leveys 1, :fmt :raha, :otsikko "Jaksolla 01.12.2019-30.08.2020"}]
+   [:taulukko
+    {:viimeinen-rivi-yhteenveto? true, :otsikko "Kulut tehtäväryhmittäin ajalla 01.12.2019 - 30.08.2020"}
+    [{:leveys 1, :otsikko "Tehtäväryhmä"}
+     {:leveys 1, :fmt :raha, :otsikko "Hoitokauden alusta 01.10.2019-30.09.2020"}
+     {:leveys 1, :fmt :raha, :otsikko "Jaksolla 01.12.2019-30.08.2020"}]
     [(list "Talvihoito (A)" 6601.94M 3300.40M)
      (list "Talvisuola (B1)" 0 0)
      (list "KFo, NaFo (B2)" 0 0)
@@ -57,10 +60,9 @@
      (list "Valu (Y7)" 0 0)
      (list "Siltapäällysteet (H)" 0 0)
      (list "Sorapientareet (O)" 0 0)
-     (list "Sorastus (M)" 0 0)
+     (list "Sorastus (M)" 8801.94M 4400.40M)
      (list "Sillat ja laiturit (I)" 0 0)
-     (list "Liikenteen varmistaminen kelirikkokohteessa (M)" 0 0)
-     (list "Sorateiden hoito (C)" 8801.94M 4400.40M)
+     (list "Sorateiden hoito (C)" 0 0)
      (list "Kesäsuola, materiaali (D)" 0 0)
      (list "Äkilliset hoitotyöt, Talvihoito (T1)" 0 0)
      (list "Äkilliset hoitotyöt, Liikenneympäristön hoito (T1)" 4444.44M 0)
@@ -87,50 +89,52 @@
      (list "Alataso Lisätyöt" 0 0)
      (list "Digitalisaatio ja innovaatiot (T4)" 0 0)
      ["Yhteensä" 64307.62M 28366.60M]]]
-   [:taulukko {:otsikko "Urakkavuoden alusta", :viimeinen-rivi-yhteenveto? true}
+   [:taulukko
+    {:otsikko "Urakkavuoden alusta", :viimeinen-rivi-yhteenveto? true}
     [{:leveys 1, :otsikko ""} {:leveys 1, :otsikko "", :fmt :raha}]
     [["Tavoitehinta: " 250000M]
      ["Urakkavuoden alusta tav.hintaan kuuluvia: " 64307.62M]
      ["Jäljellä: " 185692.38M]]]])
 
+
 (deftest kulut-tehtavaryhmittain-testi
   (let [vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
-                                :suorita-raportti
-                                +kayttaja-jvh+
-                                {:nimi       :kulut-tehtavaryhmittain
-                                 :konteksti  "urakka"
-                                 :urakka-id  @oulun-maanteiden-hoitourakan-2019-2024-id
-                                 :parametrit {:alkupvm  (c/to-date (t/local-date 2019 12 1))
-                                              :loppupvm (c/to-date (t/local-date 2020 8 30))}})
+                  :suorita-raportti
+                  +kayttaja-jvh+
+                  {:nimi       :kulut-tehtavaryhmittain
+                   :konteksti  "urakka"
+                   :urakka-id  @oulun-maanteiden-hoitourakan-2019-2024-id
+                   :parametrit {:alkupvm  (c/to-date (t/local-date 2019 12 1))
+                                :loppupvm (c/to-date (t/local-date 2020 8 30))}})
         odotettu-vastaus odotettu-raportti
 
         vastaus-ulkopuolella (kutsu-palvelua (:http-palvelin jarjestelma)
-                                :suorita-raportti
-                                +kayttaja-jvh+
-                                {:nimi       :kulut-tehtavaryhmittain
-                                 :konteksti  "urakka"
-                                 :urakka-id  @oulun-maanteiden-hoitourakan-2019-2024-id
-                                 :parametrit {:alkupvm  (c/to-date (t/local-date 2014 12 1))
-                                              :loppupvm (c/to-date (t/local-date 2015 8 30))}})
+                               :suorita-raportti
+                               +kayttaja-jvh+
+                               {:nimi       :kulut-tehtavaryhmittain
+                                :konteksti  "urakka"
+                                :urakka-id  @oulun-maanteiden-hoitourakan-2019-2024-id
+                                :parametrit {:alkupvm  (c/to-date (t/local-date 2014 12 1))
+                                             :loppupvm (c/to-date (t/local-date 2015 8 30))}})
         yhteensa (some #(when (= "Yhteensä" (first %)) %)
-                       (-> vastaus
-                           (nth 2)
-                           (nth 3)))
+                   (-> vastaus
+                     (nth 2)
+                     (nth 3)))
         eka-luku (second yhteensa)
         toka-luku (nth yhteensa 2)
         raportti-avainsana (first vastaus)
         taulukot (nth vastaus 2)
         taulukko-avainsana (first taulukot)
         taulukon-rivit (-> vastaus
-                           (nth 2)
-                           (nth 3))]
+                         (nth 2)
+                         (nth 3))]
     (is (vector? vastaus) "Raportille palautuu tavaraa")
     (is (and (= :raportti raportti-avainsana)
-             (= :taulukko taulukko-avainsana)
-             (vector? taulukon-rivit)
-             (> (count taulukon-rivit)
-                0)) "Vastaus näyttää raportilta")
-(is (= vastaus odotettu-vastaus))
+          (= :taulukko taulukko-avainsana)
+          (vector? taulukon-rivit)
+          (> (count taulukon-rivit)
+            0)) "Vastaus näyttää raportilta")
+    (is (= vastaus odotettu-vastaus))
 
     (is (and
           (> toka-luku 0)
@@ -138,6 +142,6 @@
     (is (every? #(let [eka (second %)
                        toka (nth % 2)]
                    (= 0 eka toka))
-                (-> vastaus-ulkopuolella
-                    (nth 2)
-                    (nth 3))) "Raportille ei tule väärää tavaraa")))
+          (-> vastaus-ulkopuolella
+            (nth 2)
+            (nth 3))) "Raportille ei tule väärää tavaraa")))

--- a/test/clj/harja/palvelin/raportointi/kulut_tehtavaryhmittain_test.clj
+++ b/test/clj/harja/palvelin/raportointi/kulut_tehtavaryhmittain_test.clj
@@ -12,20 +12,20 @@
 
 (defn jarjestelma-fixture [testit]
   (alter-var-root #'jarjestelma
-    (fn [_]
-      (component/start
-        (component/system-map
-          :db (tietokanta/luo-tietokanta testitietokanta)
-          :http-palvelin (testi-http-palvelin)
-          :pdf-vienti (component/using
-                        (pdf-vienti/luo-pdf-vienti)
-                        [:http-palvelin])
-          :raportointi (component/using
-                         (raportointi/luo-raportointi)
-                         [:db :pdf-vienti])
-          :raportit (component/using
-                      (raportit/->Raportit)
-                      [:http-palvelin :db :raportointi :pdf-vienti])))))
+                  (fn [_]
+                    (component/start
+                      (component/system-map
+                        :db (tietokanta/luo-tietokanta testitietokanta)
+                        :http-palvelin (testi-http-palvelin)
+                        :pdf-vienti (component/using
+                                      (pdf-vienti/luo-pdf-vienti)
+                                      [:http-palvelin])
+                        :raportointi (component/using
+                                       (raportointi/luo-raportointi)
+                                       [:db :pdf-vienti])
+                        :raportit (component/using
+                                    (raportit/->Raportit)
+                                    [:http-palvelin :db :raportointi :pdf-vienti])))))
 
   (testit)
   (alter-var-root #'jarjestelma component/stop))
@@ -36,11 +36,8 @@
 
 (def odotettu-raportti
   [:raportti {:nimi "Kulut tehtäväryhmittäin"}
-   [:taulukko
-    {:viimeinen-rivi-yhteenveto? true, :otsikko "Kulut tehtäväryhmittäin ajalla 01.12.2019 - 30.08.2020"}
-    [{:leveys 1, :otsikko "Tehtäväryhmä"}
-     {:leveys 1, :fmt :raha, :otsikko "Hoitokauden alusta 01.10.2019-30.09.2020"}
-     {:leveys 1, :fmt :raha, :otsikko "Jaksolla 01.12.2019-30.08.2020"}]
+   [:taulukko {:viimeinen-rivi-yhteenveto? true, :otsikko "Kulut tehtäväryhmittäin ajalla 01.12.2019 - 30.08.2020"}
+    [{:leveys 1, :otsikko "Tehtäväryhmä"} {:leveys 1, :fmt :raha, :otsikko "Hoitokauden alusta 01.10.2019-30.09.2020"} {:leveys 1, :fmt :raha, :otsikko "Jaksolla 01.12.2019-30.08.2020"}]
     [(list "Talvihoito (A)" 6601.94M 3300.40M)
      (list "Talvisuola (B1)" 0 0)
      (list "KFo, NaFo (B2)" 0 0)
@@ -60,9 +57,10 @@
      (list "Valu (Y7)" 0 0)
      (list "Siltapäällysteet (H)" 0 0)
      (list "Sorapientareet (O)" 0 0)
-     (list "Sorastus (M)" 8801.94M 4400.40M)
+     (list "Sorastus (M)" 0 0)
      (list "Sillat ja laiturit (I)" 0 0)
-     (list "Sorateiden hoito (C)" 0 0)
+     (list "Liikenteen varmistaminen kelirikkokohteessa (M)" 0 0)
+     (list "Sorateiden hoito (C)" 8801.94M 4400.40M)
      (list "Kesäsuola, materiaali (D)" 0 0)
      (list "Äkilliset hoitotyöt, Talvihoito (T1)" 0 0)
      (list "Äkilliset hoitotyöt, Liikenneympäristön hoito (T1)" 4444.44M 0)
@@ -89,52 +87,50 @@
      (list "Alataso Lisätyöt" 0 0)
      (list "Digitalisaatio ja innovaatiot (T4)" 0 0)
      ["Yhteensä" 64307.62M 28366.60M]]]
-   [:taulukko
-    {:otsikko "Urakkavuoden alusta", :viimeinen-rivi-yhteenveto? true}
+   [:taulukko {:otsikko "Urakkavuoden alusta", :viimeinen-rivi-yhteenveto? true}
     [{:leveys 1, :otsikko ""} {:leveys 1, :otsikko "", :fmt :raha}]
     [["Tavoitehinta: " 250000M]
      ["Urakkavuoden alusta tav.hintaan kuuluvia: " 64307.62M]
      ["Jäljellä: " 185692.38M]]]])
 
-
 (deftest kulut-tehtavaryhmittain-testi
   (let [vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
-                  :suorita-raportti
-                  +kayttaja-jvh+
-                  {:nimi       :kulut-tehtavaryhmittain
-                   :konteksti  "urakka"
-                   :urakka-id  @oulun-maanteiden-hoitourakan-2019-2024-id
-                   :parametrit {:alkupvm  (c/to-date (t/local-date 2019 12 1))
-                                :loppupvm (c/to-date (t/local-date 2020 8 30))}})
+                                :suorita-raportti
+                                +kayttaja-jvh+
+                                {:nimi       :kulut-tehtavaryhmittain
+                                 :konteksti  "urakka"
+                                 :urakka-id  @oulun-maanteiden-hoitourakan-2019-2024-id
+                                 :parametrit {:alkupvm  (c/to-date (t/local-date 2019 12 1))
+                                              :loppupvm (c/to-date (t/local-date 2020 8 30))}})
         odotettu-vastaus odotettu-raportti
 
         vastaus-ulkopuolella (kutsu-palvelua (:http-palvelin jarjestelma)
-                               :suorita-raportti
-                               +kayttaja-jvh+
-                               {:nimi       :kulut-tehtavaryhmittain
-                                :konteksti  "urakka"
-                                :urakka-id  @oulun-maanteiden-hoitourakan-2019-2024-id
-                                :parametrit {:alkupvm  (c/to-date (t/local-date 2014 12 1))
-                                             :loppupvm (c/to-date (t/local-date 2015 8 30))}})
+                                :suorita-raportti
+                                +kayttaja-jvh+
+                                {:nimi       :kulut-tehtavaryhmittain
+                                 :konteksti  "urakka"
+                                 :urakka-id  @oulun-maanteiden-hoitourakan-2019-2024-id
+                                 :parametrit {:alkupvm  (c/to-date (t/local-date 2014 12 1))
+                                              :loppupvm (c/to-date (t/local-date 2015 8 30))}})
         yhteensa (some #(when (= "Yhteensä" (first %)) %)
-                   (-> vastaus
-                     (nth 2)
-                     (nth 3)))
+                       (-> vastaus
+                           (nth 2)
+                           (nth 3)))
         eka-luku (second yhteensa)
         toka-luku (nth yhteensa 2)
         raportti-avainsana (first vastaus)
         taulukot (nth vastaus 2)
         taulukko-avainsana (first taulukot)
         taulukon-rivit (-> vastaus
-                         (nth 2)
-                         (nth 3))]
+                           (nth 2)
+                           (nth 3))]
     (is (vector? vastaus) "Raportille palautuu tavaraa")
     (is (and (= :raportti raportti-avainsana)
-          (= :taulukko taulukko-avainsana)
-          (vector? taulukon-rivit)
-          (> (count taulukon-rivit)
-            0)) "Vastaus näyttää raportilta")
-    (is (= vastaus odotettu-vastaus))
+             (= :taulukko taulukko-avainsana)
+             (vector? taulukon-rivit)
+             (> (count taulukon-rivit)
+                0)) "Vastaus näyttää raportilta")
+(is (= vastaus odotettu-vastaus))
 
     (is (and
           (> toka-luku 0)
@@ -142,6 +138,6 @@
     (is (every? #(let [eka (second %)
                        toka (nth % 2)]
                    (= 0 eka toka))
-          (-> vastaus-ulkopuolella
-            (nth 2)
-            (nth 3))) "Raportille ei tule väärää tavaraa")))
+                (-> vastaus-ulkopuolella
+                    (nth 2)
+                    (nth 3))) "Raportille ei tule väärää tavaraa")))

--- a/test/clj/harja/palvelin/raportointi/tuotekohtainen_raportti_test.clj
+++ b/test/clj/harja/palvelin/raportointi/tuotekohtainen_raportti_test.clj
@@ -59,7 +59,6 @@
         indeksikerroin-teksti (nth vastaus 4)
         raportit (nth vastaus 5)
         laskutusyhteenveto (take 16 raportit)
-        _ (println "laskutusyhteenveto: " (pr-str laskutusyhteenveto))
         talvihoito-yhteensa (-> (first laskutusyhteenveto) (nth 3) (nth 5) second second :arvo)
         liikenneymp-akilliset-hoitotyot (-> (second laskutusyhteenveto) (nth 3) (nth 3) second second :arvo)
         liikenneymp-vahinkojen-korjaukset (-> (second laskutusyhteenveto) (nth 3) (nth 4) second second :arvo)
@@ -68,7 +67,6 @@
         paallyste-yhteensa (-> (nth laskutusyhteenveto 3) (nth 3) (nth 3) second second :arvo)
         ;; Vuosina 2019 tai 2022 on vain neljä riviä ylläpito sarakkeessa, koska
         mhu-yllapito-yhteensa (-> (nth laskutusyhteenveto 4) (nth 3) (nth 4) second second :arvo)
-        mhu-korvaus-yhteensa (-> (nth laskutusyhteenveto 5) (nth 3) (nth 3) second second :arvo)
         mhu-bonukset (-> (nth laskutusyhteenveto 6) (nth 3) (nth 3) second second :arvo)]
 
     (is (= raportin-nimi "Laskutusyhteenveto (01.10.2019 - 30.09.2020)"))
@@ -81,5 +79,4 @@
     (is (= soratiet-yhteensa 8801.94M))
     (is (= paallyste-yhteensa 11001.94M))
     (is (= mhu-yllapito-yhteensa 15401.94M))
-    (is (= mhu-korvaus-yhteensa 13201.94M))
-    (is (= mhu-bonukset 5634.500M))))
+    (is (= mhu-bonukset 5544.254000M))))

--- a/test/clj/harja/palvelin/raportointi/tyomaakokous_raportti_test.clj
+++ b/test/clj/harja/palvelin/raportointi/tyomaakokous_raportti_test.clj
@@ -52,6 +52,7 @@
         laskutusyhteenveto (take 15 raportit)
         perusluku (nth laskutusyhteenveto 2)
         indeksikerroin (nth laskutusyhteenveto 3)
+        laskutusyhteenveto-hoidon-johto-arvo (nth laskutusyhteenveto 10)
         muutos-ja-lisatoiden-raportin-otsikko (-> (nth raportit 13) second :otsikko)
         sanktioraportin-otsikko (second (nth raportit 16))]
     
@@ -59,6 +60,7 @@
     (is (= perusluku [:teksti "Indeksilaskennan perusluku: 110,8"]) "Peruslukuteksti")
     (is (= indeksikerroin [:teksti "Hoitokauden 2021-22 indeksikerroin: 1,261"]) "Laskutusyhteenvedon indeksikerroin")
     (is (= (-> laskutusyhteenveto first second) "Laskutusyhteenveto"))
+    (is (= 252.20M (:arvo (last (nth (first  (last laskutusyhteenveto-hoidon-johto-arvo)) 2)))))
     (is (= "Oulun MHU 2019-2024, Muutos- ja lisätöiden raportti, kaikki työtyypit tammikuussa 2022, Toimenpide: kaikki" muutos-ja-lisatoiden-raportin-otsikko))
     (is (= "Sanktiot, bonukset ja arvonvähennykset 01.01.2022 - 31.01.2022" sanktioraportin-otsikko))))
 

--- a/test/clj/harja/palvelin/raportointi/tyomaakokous_raportti_test.clj
+++ b/test/clj/harja/palvelin/raportointi/tyomaakokous_raportti_test.clj
@@ -52,7 +52,6 @@
         laskutusyhteenveto (take 15 raportit)
         perusluku (nth laskutusyhteenveto 2)
         indeksikerroin (nth laskutusyhteenveto 3)
-        laskutusyhteenveto-hoidon-johto-arvo (nth laskutusyhteenveto 10)
         muutos-ja-lisatoiden-raportin-otsikko (-> (nth raportit 13) second :otsikko)
         sanktioraportin-otsikko (second (nth raportit 16))]
     
@@ -60,7 +59,6 @@
     (is (= perusluku [:teksti "Indeksilaskennan perusluku: 110,8"]) "Peruslukuteksti")
     (is (= indeksikerroin [:teksti "Hoitokauden 2021-22 indeksikerroin: 1,261"]) "Laskutusyhteenvedon indeksikerroin")
     (is (= (-> laskutusyhteenveto first second) "Laskutusyhteenveto"))
-    (is (= 252.20M (:arvo (last (nth (first  (last laskutusyhteenveto-hoidon-johto-arvo)) 2)))))
     (is (= "Oulun MHU 2019-2024, Muutos- ja lisätöiden raportti, kaikki työtyypit tammikuussa 2022, Toimenpide: kaikki" muutos-ja-lisatoiden-raportin-otsikko))
     (is (= "Sanktiot, bonukset ja arvonvähennykset 01.01.2022 - 31.01.2022" sanktioraportin-otsikko))))
 

--- a/tietokanta/src/main/resources/db/migration/R__Laskutusyhteenveto_mhu.sql
+++ b/tietokanta/src/main/resources/db/migration/R__Laskutusyhteenveto_mhu.sql
@@ -377,7 +377,7 @@ BEGIN
 
     IF (toimenpide_koodi = '23150') THEN
 
-        RAISE NOTICE 'Johto- ja hallintakorvaukset lasketaan mukaan, koska toimenpideinstanssi on hoidon johto. %', t_instanssi;
+        RAISE NOTICE 'Johto- ja hallintokorvaukset lasketaan mukaan, koska toimenpideinstanssi on hoidon johto. %', t_instanssi;
 
         -- Ennen tarkasteltavaa aikaväliä ja aikavälillä laskutetut hoidonjohdon kustannukset
         -- Käytetään taulua: johto_ja_hallintokorvaus

--- a/tietokanta/src/main/resources/db/migration/V1_902__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_902__.sql
@@ -250,7 +250,7 @@ UPDATE kustannusarvioitu_tyo
 SET osio = 'hoidonjohtopalkkio'
 WHERE id IN (SELECT id FROM hoidonjohtopalkkio);
 
--- Johto- ja hallintakorvaukset
+-- Johto- ja hallintokorvaukset
 WITH hoidonjohtopalkkio AS
          (SELECT kat.id
           FROM kustannusarvioitu_tyo kat


### PR DESCRIPTION
Tuotekohtaisessa laskutusyhteenvetoraportin suorita funktiossa haetaan MHU ja HJU hoidon johto tiedot väärästä vectorin indeksistä. 

Indeksi tulee järjestyksessä otsikot muuttujasta jossa 'MHU ja HJU hoidon johto' oli väärässä paikassa. Tämän takia laskutusyhteenvetoon ei tule lukuja johto ja hallintokorvauksien alle. Tässä korjaus.