### PR TITLE
s3-liite-logitustaso

### DIFF
--- a/src/clj/harja/palvelin/komponentit/liitteet.clj
+++ b/src/clj/harja/palvelin/komponentit/liitteet.clj
@@ -82,22 +82,22 @@
   3. S3 tarkistaa onko tiedostossa viruksia ja tagittaa tiedoston"
   [s3-url input-stream-sisalto tiedostonimi]
   (try
-    (let [_ (log/debug "tallenna-s3 :: tiedostonimi: " tiedostonimi)
+    (let [_ (log/info "tallenna-s3 :: tiedostonimi: " tiedostonimi)
           ;; Siirretään tiedostot S3:lle nimettynä uusiksi. Uusi nimi on tallennettu kantaan, jota kautta
           ;; tiedostot saadaan sitten haettua
           s3hash (str/trim (str (pvm/iso8601 (pvm/nyt)) "-" (UUID/randomUUID) "-" tiedostonimi))
           ;; Generoi presignedurl, johon varsinainen liite lähetetään
           vastaus @(http/post s3-url {:body (cheshire.core/encode {"key" s3hash "operation" "put"})
                                       :timeout 50000})
-          _ (log/debug "Generoi presignedurl :: vastaus " vastaus)
+          _ (log/info "Generoi presignedurl :: vastaus " vastaus)
           ;; Vastauksesta parsitaan varsinainen url, johon liite lähetetään
           varsinainen-put-url (when (= 200 (:status vastaus))
                                  (str/trim (get (cheshire.core/decode (:body vastaus)) "url")))
-          _ (log/debug "Lähetetään tiedosto urliin: " varsinainen-put-url)
+          _ (log/info "Lähetetään tiedosto urliin: " varsinainen-put-url)
           liite-vastaus (when varsinainen-put-url
                           @(http/put varsinainen-put-url {:body input-stream-sisalto}))
           _ (if varsinainen-put-url
-              (log/debug "Liitteen tallennuksen vastaus: " liite-vastaus)
+              (log/info "Liitteen tallennuksen vastaus: " liite-vastaus)
               (log/error "Ei saatu yhteyttä S3:seen. Liitetiedosto jää lähettämättä "))]
 
       ;; Jos lataus osoitetta ei saatu, palautetaan nil

--- a/tietokanta/src/main/resources/db/migration/V1_902__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_902__.sql
@@ -250,7 +250,7 @@ UPDATE kustannusarvioitu_tyo
 SET osio = 'hoidonjohtopalkkio'
 WHERE id IN (SELECT id FROM hoidonjohtopalkkio);
 
--- Johto- ja hallintokorvaukset
+-- Johto- ja hallintakorvaukset
 WITH hoidonjohtopalkkio AS
          (SELECT kat.id
           FROM kustannusarvioitu_tyo kat


### PR DESCRIPTION
Muuta debug logitukset infoksi, että näkee, mitä AWS:ssä tapahtuu.
Liitteen tallennus ei toimi AWS STG ympäristössä. Virheestä ei logiteta mitään.
Nostetaan logitustasoa, jotta voidaan ymmärtää, miksi Harja ei saa yhteyttä S3 bukettiin.