### PR TITLE
VHAR-8413 - Korjaile lokikontekstiin ja headereiden prosessointiin liittyviä asioita

### DIFF
--- a/src/clj/harja/palvelin/integraatiot/api/ilmoitukset.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/ilmoitukset.clj
@@ -142,9 +142,7 @@
               odota-uusia? :odota-uusia?
               sulje-vastauksen-jalkeen? :sulje-vastauksen-jalkeen?} parametrit
              tapahtuma-id (lokita-kutsu integraatioloki :hae-ilmoitukset request nil)
-             kayttaja (hae-kayttaja db (get
-                                         (todennus/prosessoi-kayttaja-headerit (:headers request))
-                                         "oam_remote_user"))]
+             kayttaja (hae-kayttaja db (get (:headers request) "oam_remote_user"))]
          (validointi/tarkista-urakka-ja-kayttaja db urakka-id kayttaja)
          (with-channel request kanava
                        (let [laheta-ilmoitukset (ilmoituslahettaja integraatioloki kanava tapahtuma-id sulje-vastauksen-jalkeen?)

--- a/src/clj/harja/palvelin/integraatiot/api/tyokalut/kutsukasittely.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/tyokalut/kutsukasittely.clj
@@ -415,9 +415,7 @@
                     headerit
                     body
                     #(let
-                       [kayttaja (hae-kayttaja db (get
-                                                    (todennus/prosessoi-kayttaja-headerit (:headers request))
-                                                    "oam_remote_user"))
+                       [kayttaja (hae-kayttaja db (get (:headers request) "oam_remote_user"))
                         ;; Tarkista api oikeus mikäli halutaan tarkistaa 
                         vaadittu-api-oikeus (if-not (= vaadittu-api-oikeus :ei-api-oikeustarkastusta)
                                               (do
@@ -463,9 +461,7 @@
                     headerit
                     body
                     #(let
-                       [kayttaja (hae-kayttaja db (get
-                                                    (todennus/prosessoi-kayttaja-headerit (:headers request))
-                                                    "oam_remote_user"))
+                       [kayttaja (hae-kayttaja db (get (:headers request) "oam_remote_user"))
                         origin-header (get (:headers request) "origin")
                         kutsun-data (lue-kutsu xml? kutsun-skeema request body)
                         vastauksen-data (kasittele-kutsu-fn parametrit kutsun-data kayttaja db)
@@ -493,9 +489,7 @@
     {:status 415
      :headers {"Content-Type" "text/plain"}
      :body "Virhe: Saatiin kutsu lomakedatan content-typellä\n"}
-    (let [kayttaja (hae-kayttaja db (get
-                                      (todennus/prosessoi-kayttaja-headerit (:headers request))
-                                      "oam_remote_user"))
+    (let [kayttaja (hae-kayttaja db (get (:headers request) "oam_remote_user"))
           xml? (= (kutsun-formaatti request) "xml")
           tapahtuma-id (when integraatioloki
                          (lokita-kutsu integraatioloki resurssi request nil))
@@ -530,9 +524,7 @@
      :body "Virhe: Saatiin kutsu lomakedatan content-typellä\n"}
     (let [kutsun-kesto-alkaa (System/currentTimeMillis)
           request-origin (get (:headers request) "origin")
-          kayttaja (hae-kayttaja db (get
-                                      (todennus/prosessoi-kayttaja-headerit (:headers request))
-                                      "oam_remote_user"))
+          kayttaja (hae-kayttaja db (get (:headers request) "oam_remote_user"))
           tapahtuma-id (when integraatioloki
                          (lokita-kutsu integraatioloki resurssi request nil))
           parametrit (:params request)
@@ -601,9 +593,7 @@
                     body
                     #(let
                        [kayttaja (hae-kayttaja db
-                                   (get
-                                     (todennus/prosessoi-kayttaja-headerit (:headers request))
-                                     "oam_remote_user"))
+                                   (get (:headers request) "oam_remote_user"))
                         origin-header (get (:headers request) "origin")
                         kutsun-data (lue-kutsu xml? kutsun-skeema request body)
                         vastauksen-data (kasittele-kutsu-fn db kutsun-data tapahtuma-id)

--- a/src/clj/harja/palvelin/komponentit/http_palvelin.clj
+++ b/src/clj/harja/palvelin/komponentit/http_palvelin.clj
@@ -76,13 +76,13 @@
   "Wrappaa kyselyyn liittyvän koodin lokituskontekstilla."
   [req & body]
   `(log/with-context
-    (merge {:korrelaatio-id (UUID/randomUUID)
-            :client-ip (client-ip ~req)
-            :kayttajatunnus (or (get-in ~req [:headers "oam_remote_user"]) :tuntematon-kayttaja)}
-      ;; Jos käyttäjä-objekti on annettu, poimitaan siitä mukaan relevantteja tietoja.
-      (when (:kayttaja ~req)
-        ;; Admin (jarjestelmavastuuhenkilo)?
-        {:jvh? (roolit/jvh? (:kayttaja ~req))}))
+     (merge {:korrelaatio-id (UUID/randomUUID)
+             :client-ip (client-ip ~req)
+             :kayttajatunnus (or (get-in ~req [:headers "oam_remote_user"]) :tuntematon-kayttaja)}
+       ;; Jos käyttäjä-objekti on annettu, poimitaan siitä mukaan relevantteja tietoja.
+       (when (:kayttaja ~req)
+         ;; Admin (jarjestelmavastuuhenkilo)?
+         {:jvh? (roolit/jvh? (:kayttaja ~req))}))
 
      ~@body))
 
@@ -335,6 +335,23 @@
 
       (handler req))))
 
+(defn- wrap-prosessoi-headerit
+  "Palauttaa headerit sellaisenaan, mikäli headereiden joukosta löytyy jokin OAM_-headeri.
+  Muutoin, yritetään purkaa AWS Cognitolta saadut headerit, jotka mapataan OAM_-headereiksi ja lisätään
+  muiden headereiden joukkoon."
+  [handler]
+  (fn [req]
+    (->
+      (assoc req :headers (todennus/prosessoi-kayttaja-headerit (:headers req)))
+      (handler))))
+
+(defn- wrap-with-common-wrappers
+  "Käärii HTTP-pääkäsittelijän ympärille yleisiä wrappereita."
+  [handler]
+  (-> handler
+    (cookies/wrap-cookies)
+    (wrap-prosessoi-headerit)))
+
 (defn- jaa-todennettaviin-ja-ei-todennettaviin [kasittelijat]
   (let [{ei-todennettavat true
          todennettavat false} (group-by #(or (:ei-todennettava %) false) kasittelijat)]
@@ -342,16 +359,10 @@
 
 (defn korvaa-ehka-oletuskayttajalla [kutsu]
   ;; Jos asetukset mahdollistaa ja kutsussa ei ole käyttäjätietoja, käytetään oletuskäyttöoikeuksia
-  (let [headers (todennus/prosessoi-kayttaja-headerit (:headers kutsu))]
+  (let [headers (:headers kutsu)]
     (if (empty? (get headers "oam_remote_user"))
       (assoc kutsu :headers (conj headers {"oam_remote_user" "oletus-kaytto-oikeudet"}))
       kutsu)))
-
-(defn- wrap-with-common-wrappers
-  "Käärii HTTP-pääkäsittelijän ympärille yleisiä wrappereita."
-  [handler]
-  (-> handler
-    (cookies/wrap-cookies)))
 
 (defrecord HttpPalvelin [asetukset kasittelijat sessiottomat-kasittelijat
                          http-server kehitysmoodi
@@ -379,9 +390,7 @@
                               (korvaa-ehka-oletuskayttajalla req)
                               req)
                         ui-kasittelijat (mapv :fn @kasittelijat)
-                        oam-kayttajanimi (get
-                                           (todennus/prosessoi-kayttaja-headerit (:headers req))
-                                           "oam_remote_user")
+                        oam-kayttajanimi (get (:headers req) "oam_remote_user")
                         random-avain (get (:headers req) "x-csrf-token")
                         csrf-token (when random-avain (index/muodosta-csrf-token random-avain anti-csrf-token-secret-key))
                         _ (when csrf-token (anti-csrf-q/virkista-csrf-sessio-jos-voimassa db oam-kayttajanimi csrf-token (time/now)))

--- a/src/clj/harja/palvelin/komponentit/http_palvelin.clj
+++ b/src/clj/harja/palvelin/komponentit/http_palvelin.clj
@@ -335,7 +335,7 @@
 
       (handler req))))
 
-(defn- wrap-prosessoi-headerit
+(defn wrap-prosessoi-headerit
   "Palauttaa headerit sellaisenaan, mikäli headereiden joukosta löytyy jokin OAM_-headeri.
   Muutoin, yritetään purkaa AWS Cognitolta saadut headerit, jotka mapataan OAM_-headereiksi ja lisätään
   muiden headereiden joukkoon."
@@ -345,7 +345,7 @@
       (assoc req :headers (todennus/prosessoi-kayttaja-headerit (:headers req)))
       (handler))))
 
-(defn- wrap-with-common-wrappers
+(defn wrap-with-common-wrappers
   "Käärii HTTP-pääkäsittelijän ympärille yleisiä wrappereita."
   [handler]
   (-> handler

--- a/src/clj/harja/palvelin/komponentit/todennus.clj
+++ b/src/clj/harja/palvelin/komponentit/todennus.clj
@@ -290,7 +290,7 @@ req mäpin, jossa käyttäjän tiedot on lisätty avaimella :kayttaja."))
 
   Todennus
   (todenna-pyynto [{db :db :as this} req]
-    (let [headerit (prosessoi-kayttaja-headerit (:headers req))
+    (let [headerit (:headers req)
           kayttaja-id (headerit "oam_remote_user")]
       (if (nil? kayttaja-id)
         (do

--- a/test/clj/harja/palvelin/komponentit/todennus_test.clj
+++ b/test/clj/harja/palvelin/komponentit/todennus_test.clj
@@ -113,10 +113,14 @@
         jwt (str (str/join "." jwt) "." (nth x-iam-data 2))]
     {"x-iam-data" jwt}))
 (deftest cognito-headereiden-purku
-  (let [todenna #(todennus/todenna-pyynto (:todennus jarjestelma) %)
+  (let [handler (->
+                  (fn [req] req)
+                  (harja.palvelin.komponentit.http-palvelin/wrap-with-common-wrappers))
+        todenna #(todennus/todenna-pyynto (:todennus jarjestelma) %)
         destia-id (first (first (q "SELECT id FROM organisaatio WHERE nimi = 'Destia Oy'")))]
     (testing "Cognito headeri: x-iam-data on purettu oikein ja tarvittava OAM-data on saatu"
-      (let [req (todenna {:headers (testi-cognito-headerit)})]
+      (let [req (handler {:headers (testi-cognito-headerit)})
+            req (todenna req)]
 
         (is (= (get-in req [:kayttaja :organisaatio :id]) destia-id))
         (is (= (get-in req [:kayttaja :sahkoposti]) "daniel@example.com"))


### PR DESCRIPTION
1.  Prosessoidaan headerit mahdollisimman alussa kutsun käsittelyä, jotta oikea header-tieto on helposti esimerkiksi lokikontekstin saatavilla