### PR TITLE
VHAR-8429 - Github Actions testitulosraportit menevät väärille workflow-tuloksille ja hälyjen lisäyksiä

### DIFF
--- a/.github/actions/start-fargate-tasks/action.yml
+++ b/.github/actions/start-fargate-tasks/action.yml
@@ -24,18 +24,9 @@ runs:
         aws ecs update-service --cluster "${CLUSTER_NAME}" --service $AVAILABLE_SERVICE \
         --desired-count "${DESIRED_COUNT}" --region eu-west-1  1> /dev/null
         
-         while true; do
-            runningTasks=$(aws ecs list-tasks --cluster "${CLUSTER_NAME}" --service-name "$AVAILABLE_SERVICE" --region eu-west-1 | jq '.taskArns')
-        
-            if [ $(echo "$runningTasks" | jq length) -eq 0 ]; then
-              echo "No running Fargate tasks found. Waiting ${WAIT_TIME_SEC} seconds..."
-              sleep "${WAIT_TIME_SEC}"
-            else
-              echo "Fargate service restart successful."
-              break
-            fi
-          done
-        
+        echo "Waiting for services to be stable..."
+        aws ecs wait services-stable \
+          --cluster "${CLUSTER_NAME}" --services "${AVAILABLE_SERVICE}" --region eu-west-1
         echo "Done."
       shell: bash
 

--- a/.github/workflows/harja_build_and_deploy.yml
+++ b/.github/workflows/harja_build_and_deploy.yml
@@ -89,6 +89,7 @@ jobs:
     #       kuin kutsuva workflowikin.
     secrets:
       aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   # Automaattinen matrix-deployment useaan ympäristöön (workflow_run triggerillä)
   deploy-to-ecs-matrix:
@@ -116,4 +117,5 @@ jobs:
     #       kuin kutsuva workflowikin.
     secrets:
       aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/.github/workflows/harja_build_and_deploy.yml
+++ b/.github/workflows/harja_build_and_deploy.yml
@@ -67,6 +67,30 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      # Docs: https://github.com/slackapi/slack-github-action
+      - name: Send deploy failure message to Slack
+        id: slack
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117
+        if: failure()
+        with:
+          # Slack Block Kit -tyyppinen rikastettu viesti
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alert-slow: Harjan build epäonnistui! Automaattista deploymenttia ei tehdä.\n${{ env.JOB_RUN_URL }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          JOB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
 
   # -- Deployment -- #
 

--- a/.github/workflows/harja_test_develop.yml
+++ b/.github/workflows/harja_test_develop.yml
@@ -70,13 +70,12 @@ jobs:
           # Slack Block Kit -tyyppinen rikastettu viesti
           payload: |
             {
-              "text": ":alert-slow: Develop-branchin testeissä tapahtui virhe, commit: ${{ github.event.head_commit.url }}",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":alert-slow: Develop-branchin testeissä tapahtui virhe, commit: ${{ github.event.head_commit.url }}"
+                    "text": ":alert-slow: Develop-branchin testeissä tapahtui virhe!\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
                   }
                 }
               ]

--- a/.github/workflows/harja_test_develop.yml
+++ b/.github/workflows/harja_test_develop.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         # Katso saatavilla olevat harjadb servicet docker-compose.yml:stä
         configs: [
-          { testDBService: "harjadb-latest", e2eBrowsers: ['chrome'], artifactPrefix: 'harjadb-latest_' },
+          { testDBService: "harjadb-latest", e2eBrowsers: [ 'chrome' ], artifactPrefix: 'harjadb-latest_' },
           #{ testDBService: "harjadb-13-3.1", e2eBrowsers: ['chrome'], artifactPrefix: 'harjadb-13-3.1_' },
         ]
 
@@ -52,3 +52,35 @@ jobs:
       lint-clj: 'false'
       # Develop-branchille ajetaan täysi Harja-build, joka kestää pidempään.
       build-harja: 'full'
+
+
+  # Tarkistaa testijobin yleisen statuksen ja lähettää notifikaation, mikäli jotain meni pieleen
+  check-status-and-notify:
+    needs: tests
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send deploy failure message to Slack
+        id: slack
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117
+        # Lähetetään virheviesti, mikäli tämä tai tests-jobi ei palauta success
+        if: ${{ job.status != 'success' || needs.tests.result != 'success' }}
+        with:
+          # Slack Block Kit -tyyppinen rikastettu viesti
+          payload: |
+            {
+              "text": ":alert-slow: Develop-branchin testeissä tapahtui virhe, commit: ${{ github.event.head_commit.url }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alert-slow: Develop-branchin testeissä tapahtui virhe, commit: ${{ github.event.head_commit.url }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          JOB_STATUS: ${{ job.status != 'success' || needs.tests.result != 'success' }}

--- a/.github/workflows/harja_test_develop.yml
+++ b/.github/workflows/harja_test_develop.yml
@@ -14,6 +14,7 @@ on:
   push:
     branches:
       - develop
+      - VHAR-8429-junit-report-korjauksia
 
 jobs:
   tests:

--- a/.github/workflows/harja_test_develop.yml
+++ b/.github/workflows/harja_test_develop.yml
@@ -14,7 +14,6 @@ on:
   push:
     branches:
       - develop
-      - VHAR-8429-junit-report-korjauksia
 
 jobs:
   tests:

--- a/.github/workflows/harja_test_develop.yml
+++ b/.github/workflows/harja_test_develop.yml
@@ -75,7 +75,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":warning: Develop-branchin testeissä tapahtui virhe!\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": ":warning: Develop-branchin testeissä tapahtui virhe!\n${{ env.JOB_RUN_URL }}"
                   }
                 }
               ]
@@ -83,4 +83,4 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-          JOB_STATUS: ${{ job.status != 'success' || needs.tests.result != 'success' }}
+          JOB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/harja_test_develop.yml
+++ b/.github/workflows/harja_test_develop.yml
@@ -75,7 +75,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":alert-slow: Develop-branchin testeissä tapahtui virhe!\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                    "text": ":warning: Develop-branchin testeissä tapahtui virhe!\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]

--- a/.github/workflows/harja_test_extra_browsers_cron.yml
+++ b/.github/workflows/harja_test_extra_browsers_cron.yml
@@ -50,3 +50,33 @@ jobs:
       basic-tests: 'false'
       integration-tests: 'false'
 
+  # Tarkistaa testijobin yleisen statuksen ja lähettää notifikaation, mikäli jotain meni pieleen
+  check-status-and-notify:
+    needs: tests
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send deploy failure message to Slack
+        id: slack
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117
+        # Lähetetään virheviesti, mikäli tämä tai tests-jobi ei palauta success
+        if: ${{ job.status != 'success' || needs.tests.result != 'success' }}
+        with:
+          # Slack Block Kit -tyyppinen rikastettu viesti
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":warning: Ajastetuissa selaintesteissä tapahtui virhe!\n${{ env.JOB_RUN_URL }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          JOB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+

--- a/.github/workflows/reusable_deploy-harja-image-to-ecs.yml
+++ b/.github/workflows/reusable_deploy-harja-image-to-ecs.yml
@@ -156,7 +156,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":alert-slow: ECS deploy -> ${{ inputs.environment }}: ${{ job.status }}${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": ":alert-slow: ECS deploy -> ${{ inputs.environment }} epäonnistui!\n${{ env.JOB_RUN_URL }}"
                   }
                 }
               ]
@@ -164,4 +164,5 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          JOB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 

--- a/.github/workflows/reusable_deploy-harja-image-to-ecs.yml
+++ b/.github/workflows/reusable_deploy-harja-image-to-ecs.yml
@@ -13,6 +13,8 @@ on:
     secrets:
       AWS_ACCOUNT_ID:
         required: true
+      SLACK_WEBHOOK_URL:
+        required: true
 
 run-name: Deploy to '${{ inputs.environment }}' AWS env by @${{ github.actor }}
 
@@ -139,4 +141,28 @@ jobs:
         if: always()
         with:
           cluster: ${{ vars.ECS_CLUSTER_NAME }}
+
+      # Docs: https://github.com/slackapi/slack-github-action
+      - name: Send deploy failure message to Slack
+        id: slack
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117
+        if: failure()
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "text": "ECS deploy -> ${{ inputs.environment }}: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "ECS deploy -> ${{ inputs.environment }}: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 

--- a/.github/workflows/reusable_deploy-harja-image-to-ecs.yml
+++ b/.github/workflows/reusable_deploy-harja-image-to-ecs.yml
@@ -148,16 +148,16 @@ jobs:
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117
         if: failure()
         with:
-          # For posting a rich message using Block Kit
+          # Slack Block Kit -tyyppinen rikastettu viesti
           payload: |
             {
-              "text": "ECS deploy -> ${{ inputs.environment }}: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
+              "text": ":alert-slow: ECS deploy -> ${{ inputs.environment }}: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "ECS deploy -> ${{ inputs.environment }}: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                    "text": ":alert-slow: ECS deploy -> ${{ inputs.environment }}: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
                   }
                 }
               ]

--- a/.github/workflows/reusable_deploy-harja-image-to-ecs.yml
+++ b/.github/workflows/reusable_deploy-harja-image-to-ecs.yml
@@ -156,7 +156,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":alert-slow: ECS deploy -> ${{ inputs.environment }}: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                    "text": ":alert-slow: ECS deploy -> ${{ inputs.environment }}: ${{ job.status }}${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]

--- a/.github/workflows/reusable_deploy-harja-image-to-ecs.yml
+++ b/.github/workflows/reusable_deploy-harja-image-to-ecs.yml
@@ -151,7 +151,6 @@ jobs:
           # Slack Block Kit -tyyppinen rikastettu viesti
           payload: |
             {
-              "text": ":alert-slow: ECS deploy -> ${{ inputs.environment }}: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
               "blocks": [
                 {
                   "type": "section",

--- a/.github/workflows/reusable_run_app_tests.yml
+++ b/.github/workflows/reusable_run_app_tests.yml
@@ -208,6 +208,11 @@ jobs:
           report_paths: 'test2junit/xml/*.xml'
           require_passed_tests: true
           check_name: 'Test Report: ${{ env.NAME_PREFIX }}Backend'
+          # https://github.com/mikepenz/action-junit-report/issues/40#issuecomment-1607743568
+          # Kiertotie sille, että test result checkit menevät väärän workflown tuloksiin
+          # develop-branchin mergen tai muun samantyyppisesti triggeröityjen workflowien kohdalla
+          annotate_only: true
+          detailed_summary: true
 
   basic-tests:
     if: ${{ inputs.basic-tests == 'true' }}
@@ -254,6 +259,11 @@ jobs:
           report_paths: 'test2junit/xml/*.xml'
           require_passed_tests: true
           check_name: 'Test Report: ${{ env.NAME_PREFIX }}Slow'
+          # https://github.com/mikepenz/action-junit-report/issues/40#issuecomment-1607743568
+          # Kiertotie sille, että test result checkit menevät väärän workflown tuloksiin
+          # develop-branchin mergen tai muun samantyyppisesti triggeröityjen workflowien kohdalla
+          annotate_only: true
+          detailed_summary: true
 
       - name: Setup test tools
         uses: ./.github/actions/setup-test-tools
@@ -319,6 +329,11 @@ jobs:
           report_paths: 'test2junit/xml/*.xml'
           require_passed_tests: true
           check_name: 'Test Report: ${{ env.NAME_PREFIX }}Integration'
+          # https://github.com/mikepenz/action-junit-report/issues/40#issuecomment-1607743568
+          # Kiertotie sille, että test result checkit menevät väärän workflown tuloksiin
+          # develop-branchin mergen tai muun samantyyppisesti triggeröityjen workflowien kohdalla
+          annotate_only: true
+          detailed_summary: true
 
   e2e-tests:
     if: ${{ inputs.e2e-tests == 'true' }}
@@ -456,6 +471,11 @@ jobs:
           report_paths: 'cypress/test-results/*.xml'
           require_passed_tests: true
           check_name: 'Test Report: Cypress (${{ env.NAME_PREFIX }}${{ matrix.browser }})'
+          # https://github.com/mikepenz/action-junit-report/issues/40#issuecomment-1607743568
+          # Kiertotie sille, että test result checkit menevät väärän workflown tuloksiin
+          # develop-branchin mergen tai muun samantyyppisesti triggeröityjen workflowien kohdalla
+          annotate_only: true
+          detailed_summary: true
 
       # Mikäli testit epäonnistuvat, tallenna cypress screenshotit ja videot artifakteina
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/reusable_run_app_tests.yml
+++ b/.github/workflows/reusable_run_app_tests.yml
@@ -211,7 +211,6 @@ jobs:
           # https://github.com/mikepenz/action-junit-report/issues/40#issuecomment-1607743568
           # Kiertotie sille, että test result checkit menevät väärän workflown tuloksiin
           # develop-branchin mergen tai muun samantyyppisesti triggeröityjen workflowien kohdalla
-          annotate_only: true
           detailed_summary: true
 
   basic-tests:
@@ -262,7 +261,6 @@ jobs:
           # https://github.com/mikepenz/action-junit-report/issues/40#issuecomment-1607743568
           # Kiertotie sille, että test result checkit menevät väärän workflown tuloksiin
           # develop-branchin mergen tai muun samantyyppisesti triggeröityjen workflowien kohdalla
-          annotate_only: true
           detailed_summary: true
 
       - name: Setup test tools
@@ -332,7 +330,6 @@ jobs:
           # https://github.com/mikepenz/action-junit-report/issues/40#issuecomment-1607743568
           # Kiertotie sille, että test result checkit menevät väärän workflown tuloksiin
           # develop-branchin mergen tai muun samantyyppisesti triggeröityjen workflowien kohdalla
-          annotate_only: true
           detailed_summary: true
 
   e2e-tests:
@@ -474,7 +471,6 @@ jobs:
           # https://github.com/mikepenz/action-junit-report/issues/40#issuecomment-1607743568
           # Kiertotie sille, että test result checkit menevät väärän workflown tuloksiin
           # develop-branchin mergen tai muun samantyyppisesti triggeröityjen workflowien kohdalla
-          annotate_only: true
           detailed_summary: true
 
       # Mikäli testit epäonnistuvat, tallenna cypress screenshotit ja videot artifakteina

--- a/test/clj/harja/palvelin/main_test.clj
+++ b/test/clj/harja/palvelin/main_test.clj
@@ -92,8 +92,7 @@
 (use-fixtures :once testiasetukset)
 
 (def halutut-komponentit
-  #{:FAIL
-    :metriikka
+  #{:metriikka
     :info
     :db :db-replica
     :todennus :http-palvelin

--- a/test/clj/harja/palvelin/main_test.clj
+++ b/test/clj/harja/palvelin/main_test.clj
@@ -92,7 +92,8 @@
 (use-fixtures :once testiasetukset)
 
 (def halutut-komponentit
-  #{:metriikka
+  #{:FAIL
+    :metriikka
     :info
     :db :db-replica
     :todennus :http-palvelin


### PR DESCRIPTION
Lisätään kiertotie ongelmaan, jossa junit-raportit ohjautuivat väärään workflowiin develop-branchin automaattisten testien yhteydessä
* VHAR-8429
* `github.com/mikepenz/action-junit-report/issues/40#issuecomment-1607743568`
* VHAR-8029
   * Aktivoidaan slack-hälyt perustoiminnoille
      * Warning-häly tulee: Develop-branchin testeistä ja ajastetuista selaintesteistä (chrome, firefox)
      * Alert-häly tulee, jos jonkin aws ympäristön deployment epäonnistuu (ympäristö ei esimerkiksi saavuta stabiilia tilaa deploymentin jälkeen tai migraatio menee pieleen), tai jos deploymenttia edeltävä build-vaihe epäonnistu. 