### PR TITLE
Lämpötilaintegraation pilvitoteutus

### DIFF
--- a/src/clj/harja/palvelin/integraatiot/ilmatieteenlaitos.clj
+++ b/src/clj/harja/palvelin/integraatiot/ilmatieteenlaitos.clj
@@ -49,8 +49,7 @@
                                     :url endpoint-url
                                     :parametrit parametrit
                                     :otsikot {"Content-Type" "application/x-www-form-urlencoded"
-                                              "x-api-key" apiavain}})
-                  _ (println "HTTP-ASETUKSET " http-asetukset)]
+                                              "x-api-key" apiavain}})]
               (integraatiotapahtuma/laheta konteksti :http http-asetukset))))]
     (log/debug "STATUS: " status)
     (log/debug "HEADERS: " headers)

--- a/src/clj/harja/palvelin/main.clj
+++ b/src/clj/harja/palvelin/main.clj
@@ -485,7 +485,8 @@
                            [:http-palvelin :db])
       :lampotilat (component/using
                     (lampotilat/->Lampotilat
-                      (:lampotilat-url (:ilmatieteenlaitos asetukset)))
+                      (:lampotilat-url (:ilmatieteenlaitos asetukset))
+                      (:apiavain (:ilmatieteenlaitos asetukset)))
                     [:http-palvelin :db :integraatioloki])
       :maksuerat (component/using
                    (maksuerat/->Maksuerat)

--- a/test/clj/harja/palvelin/palvelut/lampotilat_test.clj
+++ b/test/clj/harja/palvelin/palvelut/lampotilat_test.clj
@@ -16,10 +16,10 @@
                         :db (tietokanta/luo-tietokanta testitietokanta)
                         :http-palvelin (testi-http-palvelin)
                         :hae-teiden-hoitourakoiden-lampotilat (component/using
-                                                                (->Lampotilat "ilmatieteenlaitos-urlin-paikka")
+                                                                (->Lampotilat "ilmatieteenlaitos-urlin-paikka" "apiavaimen-paikka")
                                                                [:http-palvelin :db])
                         :tallenna-teiden-hoitourakoiden-lampotilat (component/using
-                                                                (->Lampotilat "ilmatieteenlaitos-urlin-paikka")
+                                                                (->Lampotilat "ilmatieteenlaitos-urlin-paikka" "")
                                                                 [:http-palvelin :db])))))
 
   (testit)

--- a/test/clj/harja/palvelin/palvelut/suolasakot_test.clj
+++ b/test/clj/harja/palvelin/palvelut/suolasakot_test.clj
@@ -16,7 +16,7 @@
                         :db (tietokanta/luo-tietokanta testitietokanta)
                         :http-palvelin (testi-http-palvelin)
                         :lampotilat (component/using
-                                      (->Lampotilat "ilmatieteenlaitos-urlin-paikka")
+                                      (->Lampotilat "ilmatieteenlaitos-urlin-paikka" "apiavaimen-paikka")
                                       [:http-palvelin :db])))))
 
   (testit)


### PR DESCRIPTION
Pilviympäristössä kutsut Ilmatieteenlaitoksen palveluun välitetään integraatioväylän kautta. Integraatioväylälle tunnistaudutaan api-avaimella. Vanha toteutus jätetään käyttöön ja poistetaan yliheiton jälkeen.