### PR TITLE
Poista tai korvaa viittaukset jira-tiketteihin kommenteista

### DIFF
--- a/cypress/e2e/mhu_kustannussuunnitelma.cy.js
+++ b/cypress/e2e/mhu_kustannussuunnitelma.cy.js
@@ -463,7 +463,6 @@ describe('Hankintakustannukset osio', function () {
                 .contains('1.')
 
             // Varmista, että "Kopioi kuluvan hoitovuoden määrät tuleville vuosille" ei ole aktiivinen.
-            // FIXME: Tämä vaihe muuttuu tarpeettomaksi, kun toteutetaan: https://issues.solita.fi/browse/VHAR-5213
             cy.get('div[data-cy="hankintakustannukset-rahavaraukset-suodattimet"]')
                 .find('input[id*="kopioi-tuleville-hoitovuosille"]')
                 .should('not.be.checked')
@@ -638,7 +637,6 @@ describe('Hankintakustannukset osio', function () {
                 .click();
 
             // Disabloi "Kopioi hankinnat tuleville hoitovuosille".
-            // FIXME: Tämä vaihe muuttuu tarpeettomaksi, kun toteutetaan: https://issues.solita.fi/browse/VHAR-5213
             cy.get('div[data-cy="hankintakustannukset-rahavaraukset-suodattimet"]')
                 .find('input[id*="kopioi-tuleville-hoitovuosille"]')
                 .should('be.checked')
@@ -667,7 +665,6 @@ describe('Erillishankinnat osio', function () {
                 .contains('1.')
 
             // Varmista, että "Kopioi kuluvan hoitovuoden määrät tuleville vuosille" ei ole aktiivinen.
-            // FIXME: Tämä vaihe muuttuu tarpeettomaksi, kun toteutetaan: https://issues.solita.fi/browse/VHAR-5213
             cy.get('div[data-cy="erillishankinnat-taulukko-suodattimet"]')
                 .find('input[id*="kopioi-tuleville-hoitovuosille"]')
                 .should('not.be.checked')
@@ -848,7 +845,6 @@ describe('Erillishankinnat osio', function () {
                 .click();
 
             // Disabloi "Kopioi hankinnat tuleville hoitovuosille".
-            // FIXME: Tämä vaihe muuttuu tarpeettomaksi, kun toteutetaan: https://issues.solita.fi/browse/VHAR-5213
             cy.get('div[data-cy="erillishankinnat-taulukko-suodattimet"]')
                 .find('input[id*="kopioi-tuleville-hoitovuosille"]')
                 .should('be.checked')
@@ -878,7 +874,6 @@ describe.skip('Johto- ja hallintokorvaus osio', function () {
                 .contains('1.')
 
             // Varmista, että "Kopioi kuluvan hoitovuoden määrät tuleville vuosille" ei ole aktiivinen.
-            // FIXME: Tämä vaihe muuttuu tarpeettomaksi, kun toteutetaan: https://issues.solita.fi/browse/VHAR-5213
             cy.get('div[data-cy="tuntimaarat-ja-palkat-taulukko-suodattimet"]')
                 .find('input[id*="kopioi-tuleville-hoitovuosille"]')
                 .should('not.be.checked')
@@ -1113,7 +1108,6 @@ describe.skip('Johto- ja hallintokorvaus osio', function () {
                 .click();
 
             // Disabloi "Kopioi hankinnat tuleville hoitovuosille".
-            // FIXME: Tämä vaihe muuttuu tarpeettomaksi, kun toteutetaan: https://issues.solita.fi/browse/VHAR-5213
             cy.get('div[data-cy="tuntimaarat-ja-palkat-taulukko-suodattimet"]')
                 .find('input[id*="kopioi-tuleville-hoitovuosille"]')
                 .should('be.checked')
@@ -1305,7 +1299,6 @@ describe.skip('Johto- ja hallintokorvaus osio', function () {
                 .contains('1.')
 
             // Varmista, että "Kopioi kuluvan hoitovuoden määrät tuleville vuosille" ei ole aktiivinen.
-            // FIXME: Tämä vaihe muuttuu tarpeettomaksi, kun toteutetaan: https://issues.solita.fi/browse/VHAR-5213
             cy.get('div[data-cy="johto-ja-hallinto-muut-kulut-taulukko-suodattimet"]')
                 .find('input[id*="kopioi-tuleville-hoitovuosille"]')
                 .should('not.be.checked')
@@ -1492,7 +1485,6 @@ describe.skip('Johto- ja hallintokorvaus osio', function () {
                 .click();
 
             // Disabloi "Kopioi hankinnat tuleville hoitovuosille".
-            // FIXME: Tämä vaihe muuttuu tarpeettomaksi, kun toteutetaan: https://issues.solita.fi/browse/VHAR-5213
             cy.get('div[data-cy="johto-ja-hallinto-muut-kulut-taulukko-suodattimet"]')
                 .find('input[id*="kopioi-tuleville-hoitovuosille"]')
                 .should('be.checked')
@@ -1520,7 +1512,6 @@ describe('Hoidonjohtopalkkio osio', function () {
                 .contains('1.')
 
             // Varmista, että "Kopioi kuluvan hoitovuoden määrät tuleville vuosille" ei ole aktiivinen.
-            // FIXME: Tämä vaihe muuttuu tarpeettomaksi, kun toteutetaan: https://issues.solita.fi/browse/VHAR-5213
             cy.get('div[data-cy="hoidonjohtopalkkio-taulukko-suodattimet"]')
                 .find('input[id*="kopioi-tuleville-hoitovuosille"]')
                 .should('not.be.checked')
@@ -1704,7 +1695,6 @@ describe('Hoidonjohtopalkkio osio', function () {
                 .click();
 
             // Disabloi "Kopioi hankinnat tuleville hoitovuosille".
-            // FIXME: Tämä vaihe muuttuu tarpeettomaksi, kun toteutetaan: https://issues.solita.fi/browse/VHAR-5213
             cy.get('div[data-cy="hoidonjohtopalkkio-taulukko-suodattimet"]')
                 .find('input[id*="kopioi-tuleville-hoitovuosille"]')
                 .should('be.checked')
@@ -1734,7 +1724,6 @@ describe('Tavoitehinnan ulkopuoliset rahavaraukset osio', function () {
                 .contains('1.')
 
             // Varmista, että "Kopioi kuluvan hoitovuoden määrät tuleville vuosille" ei ole aktiivinen.
-            // FIXME: Tämä vaihe muuttuu tarpeettomaksi, kun toteutetaan: https://issues.solita.fi/browse/VHAR-5213
             cy.get('div[data-cy="tilaajan-varaukset-taulukko-suodattimet"]')
                 .find('input[id*="kopioi-tuleville-hoitovuosille"]')
                 .should('not.be.checked')
@@ -1890,7 +1879,6 @@ describe('Tavoitehinnan ulkopuoliset rahavaraukset osio', function () {
                 .click();
 
             // Disabloi "Kopioi hankinnat tuleville hoitovuosille".
-            // FIXME: Tämä vaihe muuttuu tarpeettomaksi, kun toteutetaan: https://issues.solita.fi/browse/VHAR-5213
             cy.get('div[data-cy="tilaajan-varaukset-taulukko-suodattimet"]')
                 .find('input[id*="kopioi-tuleville-hoitovuosille"]')
                 .should('be.checked')

--- a/figwheel_conf/prod.cljs.edn
+++ b/figwheel_conf/prod.cljs.edn
@@ -11,7 +11,7 @@
  :output-dir "resources/public/js/"
  :asset-path "js/"
 
- ;; frontti kaatuu, mm. VHAR-2413 ilman prefixiä
+ ;; frontti kaatuu ilman prefixiä
  :rename-prefix "h"
 
  ;:parallel-build false Failaa randomisti

--- a/generoi_ikonit.clj
+++ b/generoi_ikonit.clj
@@ -6,7 +6,6 @@
       [clojure.string :as string])
     (:require-macros [planck.shell :as shell]))
 
-;; Viralliset värit löytyy täältä: https://issues.solita.fi/browse/HAR-921
 ;; Testin vuoksi voit muuttaa pelkkää värin arvoa, mutta pyritään noudattamaan
 ;; virallista listaa.
 ;; Jos lisäät uuden värin, lisää se myös puhtaat.cljc ja alpha.cljc, ikonit.cljc

--- a/src/clj/harja/kyselyt/sanktiot.sql
+++ b/src/clj/harja/kyselyt/sanktiot.sql
@@ -152,7 +152,7 @@ WHERE
   AND s.sakkoryhma != 'yllapidon_bonus'::SANKTIOLAJI
   AND lp.poistettu IS NOT TRUE AND s.poistettu IS NOT TRUE
   AND (s.perintapvm >= :alku AND s.perintapvm <= :loppu
-   -- VHAR-5849 halutaan että urakan päättymisen jälkeiset sanktiot näkyvät viimeisen hoitokauden listauksessa
+   -- Halutaan että urakan päättymisen jälkeiset sanktiot näkyvät viimeisen hoitokauden listauksessa
    OR
         (CASE
                     date_part('year', :loppu::date)::integer = date_part('year', u.loppupvm)::integer

--- a/src/clj/harja/kyselyt/tilannekuva.sql
+++ b/src/clj/harja/kyselyt/tilannekuva.sql
@@ -720,7 +720,7 @@ FROM urakka u
 WHERE hal.id IN (:hallintayksikot);
 
 -- name: hae-viimeisin-toteuma
--- VHAR-2590 urakkakohtaisesti tarkasteltuna ajaudutaan patologisen hitaaseen kyselyyn
+-- Urakkakohtaisesti tarkasteltuna ajaudutaan patologisen hitaaseen kyselyyn
 -- Tilannekuva tsekkaa tämän nykyisellään kerran minuutissa, joten voidaan hakea uudet
 -- toteumat aina jos Harjaan on tullut uusi toteuma ed. tarkistuksen jälkeen. Se on
 -- pienempi paha kuin täysin jumiutuva max(id) kysely.

--- a/src/clj/harja/palvelin/ajastetut_tehtavat/kanavasiltojen_geometriat.clj
+++ b/src/clj/harja/palvelin/ajastetut_tehtavat/kanavasiltojen_geometriat.clj
@@ -85,7 +85,7 @@
 (defn muodosta-tr-osoite-array [osoitteet]
   (poista-viimeinen-pilkku (pr-str "ARRAY[" (doall (map muunna-tallennettavaan-muotoon osoitteet)) "]")))
 
-;; Avattavat sillat haetaan TREX:sta. TREX:in (= taitorakennerekisteri) rajapinnan kuvaus on liitetty tikettiin HAR-6948.
+;; Avattavat sillat haetaan TREX:sta. TREX:in (= taitorakennerekisteri) rajapinnan kuvaus on liitetty confluenceen Tekninen dokumentaatio > TREX rajapintadokumentaatio
 (defn tallenna-kanavasilta [db kanavasilta sivunro]
   (let [siltanro (kanavasilta :siltanro)
         nimi (kanavasilta :siltanimi)

--- a/src/clj/harja/palvelin/ajastetut_tehtavat/urakan_lupausmuistutukset.clj
+++ b/src/clj/harja/palvelin/ajastetut_tehtavat/urakan_lupausmuistutukset.clj
@@ -84,7 +84,7 @@
 (defn ajastus [db fim email]
   "Ajastetaan muistutukset urakan lupauksista ajettavaksi vain kuukauden ensimmäinen päivä."
   (ajastettu-tehtava/ajasta-paivittain
-    [10 00 0] ; VHAR-5523: lähetetään virka-aikaan, jotta Destian päivystäjä ei herää turhaan
+    [10 00 0] ; Lähetetään virka-aikaan, jotta urakoitsijan päivystäjä ei herää turhaan
     (do
       (log/info "ajasta-paivittain :: muistutus urakan lupauksista :: Alkaa " (pvm/nyt))
       (fn [_]

--- a/src/clj/harja/palvelin/integraatiot/api/reittitoteuma.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/reittitoteuma.clj
@@ -190,7 +190,7 @@ maksimi-linnuntien-etaisyys 200)
                                        (get-in % [:reittitoteuma :toteuma :tehtavat]))
                                     reittitoteumat)]
     (assert (integer? urakka-id) "Oltava urakka-id kun päivitetään materiaalicachet.")
-    ;; HAR-7896 urakoitsijat joskus "poistavat" materiaalitoteumia lähettämällä toteuman uudestaan
+    ;; Urakoitsijat joskus "poistavat" materiaalitoteumia lähettämällä toteuman uudestaan
     ;; tehtävänä suolaus mutta kokonaan ilman materiaalit-payloadia. Tämä siksi käsiteltävä erikseen
     ;; ja varmuuden vuoksi päivitettävä silloinkin materiaalicachet
     (when (or materiaaleja-hyotykuormassa? tehtavissa-suolausta?)

--- a/src/clj/harja/palvelin/integraatiot/sampo/sanomat/maksuera_sanoma.clj
+++ b/src/clj/harja/palvelin/integraatiot/sampo/sanomat/maksuera_sanoma.clj
@@ -54,7 +54,7 @@
                  :finish                (.replace (pvm/aika-iso8601-ilman-millisekunteja (pvm/vuoden-viim-pvm (pvm/vuosi loppupvm))) "00:00:00" "17:00:00")
                  :financialWipClass     "WIPCLASS"
                  :financialDepartment   talousosasto
-                 :managerUserName       "L934498" ;; Aina sama käyttäjä (Testisampo). SAMPO:n määritys. HAR-8804. Vastuuhenkilötietoa ei lähetetä Sampoon takaisin.
+                 :managerUserName       "L934498" ;; Aina sama käyttäjä (Testisampo). SAMPO:n määritys. Vastuuhenkilötietoa ei lähetetä Sampoon takaisin.
                  :objectID              maksueranumero
                  :financialLocation     "Kpito"}
        [:InvestmentAssociations

--- a/src/clj/harja/palvelin/palvelut/budjettisuunnittelu.clj
+++ b/src/clj/harja/palvelin/palvelut/budjettisuunnittelu.clj
@@ -285,7 +285,7 @@
                                   urakan-loppuvuosi (-> loppupvm pvm/joda-timeksi pvm/suomen-aikavyohykkeeseen pvm/vuosi)
                                   vertailu-kk-mhu (fn [urakan-akuvuosi]
                                                     (cond
-                                                      ;; 2023 ja jälkeen alkavilla urakoilla käytetään indeksin tarkastelukuukautena elokuuta (VHAR-6948)
+                                                      ;; 2023 ja jälkeen alkavilla urakoilla käytetään indeksin tarkastelukuukautena elokuuta
                                                       (>= urakan-akuvuosi 2023) 8
                                                       ;; Muihin aikoihin alkavilla urakoilla käytetään tarkastelukuukautena syyskuuta
                                                       :else 9))
@@ -309,9 +309,9 @@
                                 (vec indeksiluvut-urakan-aikana)
                                 (mapv (fn [index]
                                         (if (empty? indeksiluvut-urakan-aikana)
-                                          ;; VHAR-5334: Palautetaan nil indeksikertoimeksi urakoille, jotka eivät ole vielä alkaneet.
+                                          ;;Palautetaan nil indeksikertoimeksi urakoille, jotka eivät ole vielä alkaneet.
                                           nil
-                                          ;; VHAR-5334: Palautetaan indeksit vain hoitovuosille, joilla on indeksejä.
+                                          ;; Palautetaan indeksit vain hoitovuosille, joilla on indeksejä.
                                           ;; Lopuille hoitovuosille nil.
                                           (nth indeksiluvut-urakan-aikana index nil)))
                                       (range 0 5))))))

--- a/src/clj/harja/palvelin/palvelut/tietyoilmoitukset.clj
+++ b/src/clj/harja/palvelin/palvelut/tietyoilmoitukset.clj
@@ -186,7 +186,7 @@
                       q-tietyoilmoitukset/ilmoitus-pdf-kentat
                       {::t/id (:id params)}))
         ;; Vasta kun Tieliikennekeskuksesta on tullut kuittaus, että ilmoitus on kertaalleen tullut perille,
-        ;; voidaan jatkossa PDF:ssä käyttää ilmoituksessa termiä Muutos aiempaan VHAR-2465
+        ;; voidaan jatkossa PDF:ssä käyttää ilmoituksessa termiä Muutos aiempaan
         :lahetetty? (boolean (some :harja.domain.tietyoilmoituksen-email/kuitattu ilmoituksen-emailit))))))
 
 (defn tallenna-tietyoilmoitus [tloik db email pdf user ilmoitus sahkopostitiedot]

--- a/src/clj/harja/palvelin/palvelut/tilannekuva.clj
+++ b/src/clj/harja/palvelin/palvelut/tilannekuva.clj
@@ -111,7 +111,7 @@
     (q/urakoitsijan-urakat db {:organisaatio (get-in user [:organisaatio :id])})))
 
 (defn- urakat-joihin-lukuoikeus-roolin-kautta
-  ;; On urakoita, joissa urakoitsijoita on useasta eri organisaatiosta. (VHAR-8222) Tällöin käyttäjän organisaatioon
+  ;; On urakoita, joissa urakoitsijoita on useasta eri organisaatiosta. Tällöin käyttäjän organisaatioon
   ;; perustuva haku ei riitä, vaan on lisäksi poimittava roolitiedon perusteella urakat joihin käyttäjällä on lukuoikeus
   [user oikeus-nakyma]
   (let [urakka-idt (keys (:urakkaroolit user))]

--- a/src/clj/harja/palvelin/palvelut/yhteyshenkilot.clj
+++ b/src/clj/harja/palvelin/palvelut/yhteyshenkilot.clj
@@ -52,7 +52,7 @@
 
 (defn hae-urakan-yhteyshenkilot [db user urakka-id salli-ristiinnakeminen?]
   (assert (number? urakka-id) "Urakka-id:n pitää olla numero!")
-  ;; HAR-7872 Tilannekuvasta on kyettävä näkemään dialogissa eri urakoiden yhteystietoja
+  ;; Tilannekuvasta on kyettävä näkemään dialogissa eri urakoiden yhteystietoja
   (if salli-ristiinnakeminen?
     (oikeudet/ei-oikeustarkistusta!)
     (oikeudet/vaadi-lukuoikeus oikeudet/urakat-yleiset user urakka-id))

--- a/src/clj/harja/palvelin/palvelut/yllapitokohteet/paikkaukset.clj
+++ b/src/clj/harja/palvelin/palvelut/yllapitokohteet/paikkaukset.clj
@@ -35,7 +35,7 @@
           (let [;; Asiakkaalta saatu lupa olettaa, että paikkaukset kohdistuvat yhdelle tielle joka on sama kuin paikkauskohteella
                 tie (or (:harja.domain.tierekisteri/tie kohde)
                         (:harja.domain.tierekisteri/tie (first (::paikkaus/paikkaukset kohde))))
-                ;; VHAR-7783 Korjataan paikkauksen pituuden laskenta
+                ;; Paikkauksen pituuden laskenta epäonnistui, jos paikkauksen tien osa ei ole tilatun paikkauskohteen sisällä.
                 ;; huomioitava että alkuosa ja loppuosa voivat tulla myös toisin päin, eli haetaan absoluuttisesti
                 ;; pienin ja suurin tien osa
                 tien-osat (apply concat

--- a/src/clj/harja/palvelin/raportointi/raportit/suolasakko.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/suolasakko.clj
@@ -18,7 +18,7 @@
   ; Suolasakko hoitokaudelle 2016-2017 laskutetaan yhtenä kk:na touko-syyskuun aikana vuonna 2017.
   ; Samposta tulee usein hoitourakat niin että urakan loppupvm on 31.12., vaikka oikeasti
   ; viimeinen hoitokausi urakassa loppuikin jo 30.9. Tällöin voi olla sama alueurakka kahteen kertaan
-  ; elykohtaisessa raportissa. Korjataan tästä aiheutuva bugi HAR-6145 tutkimalla urakan loppupvm:ää tarkemmin.
+  ; elykohtaisessa raportissa. Korjataan tästä aiheutuva bugi tutkimalla urakan loppupvm:ää tarkemmin.
   "Kertoo meneekö urakan suolasakon laskutuskk varmuudella ohi valitusta aikavälistä"
   [valitun-hkn-loppupvm urakka]
   (let [urakan-loppupvm (pvm/joda-timeksi (:loppupvm urakka))

--- a/src/clj/harja/palvelin/tyokalut/pdf_tyokalut.clj
+++ b/src/clj/harja/palvelin/tyokalut/pdf_tyokalut.clj
@@ -151,7 +151,7 @@
 (defn generoi-saa-ikoni-pdf [olom]
   ;; Koska meillä ei ole ikoneita PDFään, palautetaan vaan lyhyt string joka kuvaa sää olomuotoa
   ;; Olomuodoksi annetaan NWS / WMO koodi pöydästä SYNOP koodi
-  ;; https://issues.solita.fi/browse/VHAR-7868
+  ;; Dokumentit löytyy väyläviraston confluencesta, Tekninen dokumentaatio > Sateen olomuodon sensoreiden dokumentaatio.
   (cond
     ;; Selkeää
     (olomuoto? olom 0)

--- a/src/clj/harja/shp.clj
+++ b/src/clj/harja/shp.clj
@@ -76,7 +76,16 @@
   [shp kentta-keyword callback]
 
   ;; Tämä pitää tehdä clojuren puolella, jos featureita hakee
-  ;; geotoolsin Sort queryllä, häviää featureita, ks. HAR-4685
+  ;; geotoolsin Sort queryllä, häviää featureita.
+  ;; Tatu Tarvainen, 28.02.2017:
+  ;; Näyttää olevan bugi geotoolsissa:
+
+  ;; > harja.shp> (count (featuret-lazy tv))
+  ;; > 26778
+  ;; > harja.shp> (count (featuret-lazy tv (sort-by-query "TIE" true))
+  ;; > 26026
+
+  ;; Sortattuna iterator hävittää 522 featurea!
 
   (let [ryhmiteltyna (group-by kentta-keyword
                                (map feature-propertyt (featuret-lazy shp)))]

--- a/src/cljc/harja/domain/laadunseuranta/sanktio.cljc
+++ b/src/cljc/harja/domain/laadunseuranta/sanktio.cljc
@@ -173,7 +173,7 @@
 (def +yllapidon-sanktiofraasit+
   (sort-by
     second
-    ;; ao. lista perustuu ylläpidon sopimusasiakirjoihin, ks. HAR-3683
+    ;; ao. lista perustuu ylläpidon sopimusasiakirjoihin vuodelta 2016.
     [[:valitavoitteen-viivastyminen "Välitavoitteen viivästyminen"]
      [:laatusuunnitelman-vastainen-toiminta "Laatusuunnitelman vastainen toiminta työmaalla"]
      [:toistuva-laatusuunnitelman-vastainen-toiminta "Toistuva laatusuunnitelman vastainen toiminta työmaalla"]

--- a/src/cljc/harja/domain/laadunseuranta/tarkastus.cljc
+++ b/src/cljc/harja/domain/laadunseuranta/tarkastus.cljc
@@ -84,10 +84,10 @@
   (boolean (#{"ok" "OK" "Ok" "oK"} (:havainnot data))))
 
 (defn- tyhja-mittaus?* [mittaus]
-  ;; VHAR-1104: On urakoitijoita jotka raportoivat vain hoitoluokan sisältäviä mittauksia
+  ;; On urakoitijoita jotka raportoivat vain hoitoluokan sisältäviä mittauksia
   ;; nämä aiheuttivat tuotannossa räsähdykisä. Poistetaan hoitoluokka ennen tyhjyyden vertailua
   ;; Huom: Kartalle vietäessä mittauksessa on vain string, esim 'Talvihoitomittaus'. Sen dissoc
-  ;; aiheutti paljon ClassCastExceptioneita HAR-9415
+  ;; aiheutti paljon ClassCastExceptioneita.
   (let [mittaus (if (map? mittaus)
                   (dissoc mittaus :hoitoluokka)
                   mittaus)]

--- a/src/cljc/harja/domain/oikeudet.cljc
+++ b/src/cljc/harja/domain/oikeudet.cljc
@@ -100,8 +100,7 @@
   "Tarkistaa :luku, :kirjoitus tai muun tyyppisen oikeuden"
   [tyyppi oikeus urakka-id {:keys [organisaation-urakat roolit organisaatio
                                    urakkaroolit organisaatioroolit] :as kayttaja}]
-  (let [urakka-id (or (:urakka urakka-id) urakka-id) ;; HAR-6409 hotfix
-        ]
+  (let [urakka-id (or (:urakka urakka-id) urakka-id)]
     (when-not (or (nil? urakka-id) (number? urakka-id))
      (#?(:clj  log/error
          :cljs log/debug)

--- a/src/cljc/harja/domain/paikkaus.cljc
+++ b/src/cljc/harja/domain/paikkaus.cljc
@@ -182,7 +182,6 @@
 (s/def ::massamaara number?)
 (s/def ::pinta-ala number?)
 
-;; VHAR-1384, huom. nämä lyhenteitä
 (def paikkaustyomenetelmat-jotka-kiinnostaa-yhaa
   #{"UREM" "KTVA" "REPA" "SIPA" "SIPU"})
 

--- a/src/cljc/harja/domain/yllapitokohde.cljc
+++ b/src/cljc/harja/domain/yllapitokohde.cljc
@@ -664,9 +664,9 @@ yllapitoluokkanimi->numero
        (let [validoitu-muoto (oikean-muotoinen-tr alustatoimenpide tr-vali-spec)
              validoitu-alustatoimenpiteiden-paallekkyys (when (empty? validoitu-muoto)
                                                           (filter #(and (tr-valit-paallekkain? alustatoimenpide %)
-                                                                     ;; VHAR-5627 POT2:ssa halutaan sallia sama päällekkäinen alustatoimenpide
+                                                                     ;; POT2:ssa halutaan sallia sama päällekkäinen alustatoimenpide
                                                                      (when-not pot2?
-                                                                       (= (:kasittelymenetelma alustatoimenpide) (:kasittelymenetelma %)))) ;
+                                                                       (= (:kasittelymenetelma alustatoimenpide) (:kasittelymenetelma %))))
                                                             toiset-alustatoimenpiteet))
              kaikkien-teiden-tiedot (apply concat osien-tiedot muiden-kohteiden-osien-tiedot)
              validoitu-paikka (when (empty? validoitu-muoto)

--- a/src/cljc/harja/fmt.cljc
+++ b/src/cljc/harja/fmt.cljc
@@ -53,7 +53,7 @@
                            (NumberFormat/getNumberInstance))
                        (.setMaximumFractionDigits 2)
                        (.setMinimumFractionDigits 2)
-                       (.setNegativePrefix "\u002D")) eur)     ;; Try to fix VHAR-2391 replacing - with its unicode representation
+                       (.setNegativePrefix "\u002D")) eur) ;; Korvataan "-" sen unicodella. Aiheutti ongelmia pdf-raporteissa.
           #" €" " €")))))
 
 

--- a/src/cljs/harja/tiedot/navigaatio.cljs
+++ b/src/cljs/harja/tiedot/navigaatio.cljs
@@ -487,7 +487,7 @@
                      urakka))
                  urakat))))
 
-;; HAR-5517 takia. Tilannekuvassa halutaan näyttää selite urakkarajoille, jos alueita on valittu. Syklisen riippuvuuden takia
+;; Tilannekuvassa halutaan näyttää selite urakkarajoille, jos alueita on valittu. Syklisen riippuvuuden takia
 ;; piti laittaa tänne.
 (def tilannekuvassa-alueita-valittu? (atom false))
 

--- a/src/cljs/harja/tiedot/tilannekuva/tilannekuva.cljs
+++ b/src/cljs/harja/tiedot/tilannekuva/tilannekuva.cljs
@@ -32,7 +32,8 @@
        :const true}
 bufferi 1000)
 
-;; Vaihdettu 60s etteivät tiedot häviä liian pian tarkastellessa (VHAR-1057)
+;; Vaihdettu 60s etteivät tiedot häviä liian pian tarkastellessa.
+;; Aiemmin saattoi käydä niin, että edellinen lataus oli vielä kesken, kun tehtiin uusi haku.
 (def ^{:doc "Päivitystiheys tilannekuvassa, kun parametrit eivät muutu"
        :const true}
 hakutiheys-nykytilanne 60000)

--- a/src/cljs/harja/tiedot/urakka/suunnittelu/mhu_kustannussuunnitelma.cljs
+++ b/src/cljs/harja/tiedot/urakka/suunnittelu/mhu_kustannussuunnitelma.cljs
@@ -499,7 +499,6 @@
                                    (+ summa
                                      ;; Jos osa-kuukaudesta arvoa ei ole määritelty,
                                      ;; oletetaan sen olevan 1, jotta tunnit eivät ole nil.
-                                     ;; VHAR-3505
                                      (* tunnit (or osa-kuukaudesta 1) tuntipalkka))))
                          0
                          hoitokauden-arvot)]
@@ -1250,13 +1249,11 @@
                                                           ;; Kun tunnit-solua päivitetään, täytyy myös päivittää kaikille kuukausille varmuuden vuoksi myös tuntipalkka.
                                                           ;; Tämä johtuu siitä, että kun vaihdetaan custom-rivi 12-kuukaudesta 7:ään (tai 5:een) ja takaisin 12,
                                                           ;; niin osa kuukausien tuntipalkoista jää nilliksi.
-                                                          ;; VHAR-5520
                                                           (= osa :tunnit)
                                                           (assoc :tuntipalkka (some :tuntipalkka hoitokauden-jh-korvaukset))
 
                                                           ;; Jos osa-kuukaudesta ei ole vielä määritelty, laita siihen oletusarvoksi 1,
                                                           ;; jotta muualla ei käytetä kertolaskuissa vahingossa nil-arvoa.
-                                                          ;; VHAR-3505
                                                           (not (:osa-kuukaudesta kuukauden-jh-korvaus))
                                                           (assoc :osa-kuukaudesta 1))
                                                         #_#__ (println "###\n"
@@ -1447,13 +1444,11 @@
                                                ;; Täytyy myös päivittää kaikille kuukausille varmuuden vuoksi myös tuntipalkka.
                                                ;; Tämä johtuu siitä, että kun vaihdetaan custom-rivi 12-kuukaudesta 7:ään (tai 5:een) ja takaisin 12,
                                                ;; niin osa kuukausien tuntipalkoista jää nilliksi.
-                                               ;; VHAR-5520
                                                (not (:tuntipalkka kuukauden-jh-korvaus))
                                                (assoc :tuntipalkka (some :tuntipalkka hoitokauden-jh-korvaukset))
 
                                                ;; Jos osa-kuukaudesta ei ole vielä määritelty, laita siihen oletusarvoksi 1,
                                                ;; jotta muualla ei käytetä kertolaskuissa vahingossa nil-arvoa.
-                                               ;; VHAR-3505
                                                (not (:osa-kuukaudesta kuukauden-jh-korvaus))
                                                (assoc :osa-kuukaudesta 1)))
                                        hoitokauden-jh-korvaukset)))
@@ -1526,13 +1521,11 @@
                                                ;; Täytyy myös päivittää kaikille kuukausille varmuuden vuoksi myös tuntipalkka.
                                                ;; Tämä johtuu siitä, että kun vaihdetaan custom-rivi 12-kuukaudesta 7:ään (tai 5:een) ja takaisin 12,
                                                ;; niin osa kuukausien tuntipalkoista jää nilliksi.
-                                               ;; VHAR-5520, VHAR-5530
                                                (and (:tunnit kuukauden-jh-korvaus) (not (:tuntipalkka kuukauden-jh-korvaus)))
                                                (assoc :tuntipalkka (some :tuntipalkka hoitokauden-jh-korvaukset))
 
                                                ;; Jos osa-kuukaudesta ei ole vielä määritelty, laita siihen oletusarvoksi 1,
                                                ;; jotta muualla ei käytetä kertolaskuissa vahingossa nil-arvoa.
-                                               ;; VHAR-3505
                                                (not (:osa-kuukaudesta kuukauden-jh-korvaus))
                                                (assoc :osa-kuukaudesta 1)))
                                        hoitokauden-jh-korvaukset)))
@@ -3307,7 +3300,6 @@
                                                                  (if (poistettava-kustannus? kustannus)
                                                                    ;; Poista kustannukset, mutta jätä muut kuukauden tiedot talteen,
                                                                    ;; jotta gridin alitaulukossa kuukausirivit eivät katoa kokonaan kuukausia vaihtaessa.
-                                                                   ;; VHAR-5445
                                                                    (dissoc kustannus :tunnit :tuntipalkka :tuntipalkka-indeksikorjattu)
                                                                    kustannus))
                                                            hoitokausikohtaiset)))

--- a/src/cljs/harja/tiedot/urakka/urakka.cljs
+++ b/src/cljs/harja/tiedot/urakka/urakka.cljs
@@ -443,9 +443,10 @@
              (swap! tila (fn [tila]
                            (-> tila
                                (assoc-in [:yleiset :urakka] (dissoc uusi-urakka :alue))
-                             ;; NOTE: Disabloitu, koska VHAR-4909. Tämä resetoi kustannussuunnitelman tilan ennen kuin un-mount on ehtinyt suorittua
+                             ;; NOTE: Disabloitu räsähdykseen johtavan bugin takia.
+                             ;; Tämä resetoi kustannussuunnitelman tilan ennen kuin un-mount on ehtinyt suorittua
                              ;;       ja kustannussuunnitelman gridit jäävät täten siivoamatta.
                                #_(assoc :suunnittelu suunnittelu-default-arvot))))
              ;dereffataan kursorit, koska ne on laiskoja
-             ;; NOTE: Disabloitu, koska VHAR-4909
+             ;; NOTE: Disabloitu samasta syystä kuin ylempi.
              #_@suunnittelu-kustannussuunnitelma))

--- a/src/cljs/harja/ui/ikonit.cljs
+++ b/src/cljs/harja/ui/ikonit.cljs
@@ -501,7 +501,7 @@
 (defn generoi-saa-ikoni [olom maara aika]
   ;; Sääikoni "moottori" simplifioituna, käytetään työmaapäiväkirjassa
   ;; Olomuodoksi annetaan NWS / WMO koodi pöydästä SYNOP koodi
-  ;; https://issues.solita.fi/browse/VHAR-7868
+  ;; Dokumentit löytyy väyläviraston confluencesta, Tekninen dokumentaatio > Sateen olomuodon sensoreiden dokumentaatio.
   (cond
     ;; Selkeää
     (olomuoto? olom 0)

--- a/src/cljs/harja/ui/kentat.cljs
+++ b/src/cljs/harja/ui/kentat.cljs
@@ -1200,7 +1200,8 @@
       ;; Sulje mahdollisesti auki jäänyt datepicker kun focus poistuu
       {:component-will-receive-props
        (fn [this _ {:keys [focus] :as s} data]
-         ;; VHAR-8149: Jätetään nil-arvo huomiotta, jotta datepicker ei sulkeudu itsestään, kun päivämäärää valitaan ensimmäisen kerran.
+         ;; Jätetään nil-arvo huomiotta, jotta datepicker ei sulkeudu itsestään, kun päivämäärää valitaan ensimmäisen kerran.
+         ;; Aiemmin siis oli bugi, jossa ensimmäistä kertaa päivämäärää valittaessa datepicker sulkeutui eikä päivämäärä tullut valituksi.
          (and (not (nil? focus)) (not focus)
            (reset! auki false)))}
 

--- a/src/cljs/harja/ui/lomake.cljs
+++ b/src/cljs/harja/ui/lomake.cljs
@@ -60,7 +60,7 @@
 
 #_(defn rivi
   "Asettaa annetut skeemat vierekkäin samalle riville"
-   ;; Kommentoitu toistaiseksi pois, koska aiheuttaa joidenkin käyttöliittymäelementtien katoamisen (VHAR-5129)
+   ;; Kommentoitu toistaiseksi pois, koska aiheuttaa joidenkin käyttöliittymäelementtien katoamisen, esim. tieliikenneilmoitusten massakuittaus.
   [& skeemat]
   (let [{{::keys [rivi-optiot]} :optiot skeemat :skeemat} (s/conform ::rivi-optioilla skeemat)]
     (->Ryhma nil (merge {:rivi? true} rivi-optiot) skeemat)))

--- a/src/cljs/harja/views/haku.cljs
+++ b/src/cljs/harja/views/haku.cljs
@@ -110,7 +110,7 @@
           :urakka
           (let [haettu-urakka (<! (k/post! :hae-urakka (:id tulos)))
                 ;; hae hallintayksikön urakat jo tässä, jottei urakkaa aseteta ennen kuin
-                ;; urakkalista on päivittynyt. Muuten voi tulla ajoitusongelma toisinaan HAR-2044
+                ;; urakkalista on päivittynyt. Muuten voi tulla ajoitusongelma toisinaan, mikä johtaa siihen että URL-parametriin ei tule urakan id:tä.
                 hallintayksikon-urakkalista (<! (urakat/hae-hallintayksikon-urakat
                                                   {:id (get-in haettu-urakka [:hallintayksikko :id])}))]
             (reset! nav/hallintayksikon-urakkalista hallintayksikon-urakkalista)

--- a/src/cljs/harja/views/kartta.cljs
+++ b/src/cljs/harja/views/kartta.cljs
@@ -510,16 +510,6 @@
   (hae-asiat-pisteessa! tasot event asiat-pisteessa)
   (tiedot/nayta-infopaneeli!))
 
-(defn- piilota-infopaneeli-jos-muuttunut
-  "Jos annetut geometriat ovat muuttuneet (pl. näkymän geometriat), piilota infopaneeli."
-  [vanha uusi]
-  (when (not= (dissoc vanha :infopaneelin-merkki)
-              (dissoc uusi :infopaneelin-merkki))
-    ;; Kun karttatasoissa muuttuu jotain muuta kuin :nakyman-geometriat
-    ;; (klikattu piste), piilotetaan infopaneeli ja poistetaan
-    ;; klikattu piste näkymän geometrioista.
-    (tiedot/piilota-infopaneeli!)))
-
 (defn- zoomaa-geometrioihin-jos-muuttunut
   "Zoomaa geometrioihin uudelleen, jos ne ovat muuttuneet."
   [vanha uusi]
@@ -549,8 +539,6 @@
 (defn- geometriat-muuttuneet
   "Käsittelee geometrioiden muutoksen. Parametrina vanhat ja uudet geometriat."
   [vanha uusi]
-  ;; HAR-4461: kokeillaan tuleeko tämän poistamisesta haittavaikutuksia.
-  #_(piilota-infopaneeli-jos-muuttunut vanha uusi)
   (zoomaa-geometrioihin-jos-muuttunut vanha uusi))
 
 (defn- nayta-paneelissa?-fn

--- a/src/cljs/harja/views/kartta/tasot.cljs
+++ b/src/cljs/harja/views/kartta/tasot.cljs
@@ -204,7 +204,7 @@
              @nav/valittu-sivu
              (nav/valittu-valilehti @nav/valittu-sivu)
              @nav/urakat-kartalla))
-      ;; koska HAR-5117 Tilannekuva: Selite mustille urakkarajoille
+      ; Selite mustille urakkarajoille tilannekuvassa
       {:selitteet
        (if (and
              (= :tilannekuva @nav/valittu-sivu)

--- a/src/cljs/harja/views/urakka/suunnittelu/kustannussuunnitelma/johto_ja_hallintokorvaus_osio.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/kustannussuunnitelma/johto_ja_hallintokorvaus_osio.cljs
@@ -517,7 +517,7 @@
                                                              (t/pohjadatan-versio)))]]
                                   (rividisable! g index kuukausitasolla?)))))}
 
-              ;; Näyttää tai piilottaa "ennen urakkaa"-rivit. VHAR-3127
+              ;; Näyttää tai piilottaa "ennen urakkaa"-rivit.
               :nayta-tai-piilota-ennen-urakkaa-rivit
               {:polut [[:suodattimet :hoitokauden-numero]]
                :toiminto! (fn [g _ hoitovuoden-nro]
@@ -530,7 +530,7 @@
                             ;; NOTE: ::g-pohjat/data täytyy olla polun alussa, koska taulukko on luotu "g-pohjat/uusi-taulukko"-apufunktion avulla.
                             ;;       Taulukon rivit tulevat tällöin ::g-pohjat/data alle.
                             (let [rivi (grid/get-in-grid g [::g-pohjat/data ::t/data-yhteenveto])
-                                  ;; Piilotetaan "Ennen urakkaa"-rivi mikäli hoitovuosi ei ole ensimmäinen. VHAR-3127
+                                  ;; Piilotetaan "Ennen urakkaa"-rivi mikäli hoitovuosi ei ole ensimmäinen.
                                   piilotetaan? (not= hoitovuoden-nro 1)]
                               (when (grid/rivi? rivi)
                                 (if piilotetaan?

--- a/src/cljs/harja/views/urakka/suunnittelu/kustannussuunnitelma/tavoite_ja_kattohinta_osio.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/kustannussuunnitelma/tavoite_ja_kattohinta_osio.cljs
@@ -118,7 +118,6 @@
 
 (defn osio
   [e! vahvistettu? urakka yhteenvedot kuluva-hoitokausi indeksit suodattimet kantahaku-valmis?]
-  ;; TODO: Toteuta kattohinnalle käsin syöttämisen mahdollisuus myöhemmin: VHAR-4858
   (let [tavoitehinnat (mapv (fn [summa]
                               {:summa summa})
                         (t/tavoitehinnan-summaus yhteenvedot))

--- a/src/cljs/harja/views/urakka/toteumat.cljs
+++ b/src/cljs/harja/views/urakka/toteumat.cljs
@@ -71,7 +71,6 @@
          (when (and (oikeudet/urakat-toteumat-erilliskustannukset id)
                  ;; Piilotetaan Erilliskustannukset-tab 'teiden-hoito' (eli mh-urakoilta), paitsi HJ-urakoilta.
                  ;; HJ-urakat ovat 'teiden-hoito'-urakoita, jotka ovat alkaneet ennen vuotta 2019
-                 ;; VHAR-6675
                  (or hj-urakka? (not mhu-urakka?)))
            [erilliskustannukset/erilliskustannusten-toteumat ur])
 

--- a/src/cljs/harja/views/urakka/toteumat/muut_tyot.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/muut_tyot.cljs
@@ -262,7 +262,7 @@
               :hae #(get-in % [:tehtava :toimenpidekoodi])
               :valinta-arvo #(:id (nth % 3))
               :valinta-nayta #(if % (:nimi (nth % 3))
-                                    ;; näytä myös poistettu toimenopidekoodi lomakkeessa (HAR-2140)
+                                    ;; näytä myös poistettu toimenopidekoodi lomakkeessa
                                     (if (get-in @muokattu [:toteuma :id])
                                       (get-in @muokattu [:tehtava :nimi])
                                       "- Valitse tehtävä -"))
@@ -304,7 +304,7 @@
 
                {:otsikko "Määrä" :nimi :maara
                 :tyyppi :positiivinen-numero
-                :max-desimaalit 7 ; VHAR-5310 / VHAR-5290: salli 7 desimaalia
+                :max-desimaalit 7 ;; Tässä joudutaan joskus syöttämään jopa 7 desimaalia, jotta luvut saadaan täsmäämään.
                 :kokonaisosan-maara 9 ; Laskettu 10->9 koska esim. 9999999999.1234567 ei formatoidu oikein
                 :pakollinen? (= :yksikkohinta (:hinnoittelu @muokattu))
                 :hae #(get-in % [:tehtava :maara])
@@ -321,14 +321,14 @@
                   :yksikko "€"
                   :aseta (fn [rivi arvo] (assoc-in rivi [:tehtava :paivanhinta] arvo))
                   :tyyppi :positiivinen-numero
-                  :max-desimaalit 7 ; VHAR-5310 / VHAR-5290: salli 7 desimaalia
+                  :max-desimaalit 7 ;; Tässä joudutaan joskus syöttämään jopa 7 desimaalia, jotta luvut saadaan täsmäämään.
                   :kokonaisosan-maara 9 ; Laskettu 10->9 koska esim. 9999999999.1234567 ei formatoidu oikein
                   :validoi [[:ei-tyhja "Anna rahamäärä"]]
                   :palstoja 1})
                (when (= (:hinnoittelu @muokattu) :yksikkohinta)
                  {:otsikko "Sopimus\u00ADhinta" :nimi :yksikkohinta
                   :tyyppi :numero
-                  :max-desimaalit 7 ; VHAR-5310 / VHAR-5290: salli 7 desimaalia
+                  :max-desimaalit 7 ;; Tässä joudutaan joskus syöttämään jopa 7 desimaalia, jotta luvut saadaan täsmäämään.
                   :kokonaisosan-maara 9 ; Laskettu 10->9 koska esim. 9999999999.1234567 ei formatoidu oikein
                   :validoi [[:ei-tyhja "Anna rahamäärä"]]
                   :muokattava? #(not (:yksikkohinta-suunniteltu? %))

--- a/test/clj/harja/palvelin/integraatiot/yha/urakan_kohteen_lahetys_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/yha/urakan_kohteen_lahetys_test.clj
@@ -212,14 +212,14 @@
            (is (= (xml/luetun-xmln-tagien-sisalto alustatoimeet
                                                   {:tagi :alustalle-tehty-toimenpide :positio 1} :verkon-sijainti)
                   ["1"]))
-           ;; VHAR-4691 Jos alusta tp on verkko, ei saa olla massamenekkiä eikä käsittelypaksuutta
+           ;; Jos alusta tp on verkko, ei saa olla massamenekkiä eikä käsittelypaksuutta
            (is (= (xml/luetun-xmln-tagien-sisalto alustatoimeet
                                                   {:tagi :alustalle-tehty-toimenpide :positio 1} :kasittelypaksuus)
                   nil))
            (is (= (xml/luetun-xmln-tagien-sisalto alustatoimeet
                                                   {:tagi :alustalle-tehty-toimenpide :positio 1} :massamenekki)
                   nil))
-           ;; HAR-4692 Jos alusta tp on AB, on lähetettävä kg/m2 tieto eli massamenekki
+           ;; Jos alusta tp on AB, on lähetettävä kg/m2 tieto eli massamenekki
            (is (= (xml/luetun-xmln-tagien-sisalto alustatoimeet
                                                   {:tagi :alustalle-tehty-toimenpide :positio 2} :massamenekki)
                   ["34.00"]))

--- a/test/clj/harja/palvelin/palvelut/ilmoitukset_test.clj
+++ b/test/clj/harja/palvelin/palvelut/ilmoitukset_test.clj
@@ -665,7 +665,7 @@
         ilmoitukset-palvelusta (hae parametrit)
         aika-jalkeen (pvm/millisekunteina (pvm/nyt))
         palvelukutsun-kesto-ms (- aika-jalkeen aika-ennen)]
-    ;; patologisella kyselyllä, kuten tuotantoon eksynyt HAR-7003 tämä räjähtää yli 3s kestäväksi.
+    ;; patologisella kyselyllä tämä räjähtää yli 3s kestäväksi.
     ;; Pyritään pitämään silti kestovaatimus tiukempana, niin että mahdolliset vähemmän katastrofaalisetkin
     ;; perffihuonontumiset jäisivät kiinni. Toivottavasti ei ole kovin ajoympäristöherkkä tämä kesto.
     (is (< palvelukutsun-kesto-ms 800) "Ilmoituksien haku kestää liian kauan")

--- a/test/clj/harja/palvelin/palvelut/indeksit_test.clj
+++ b/test/clj/harja/palvelin/palvelut/indeksit_test.clj
@@ -45,14 +45,12 @@
 
 
 
-;; HAR-4035 bugin verifiointi
 (deftest kuukauden-indeksikorotuksen-laskenta
   (let [korotus
         (ffirst (q (str "SELECT korotus from laske_kuukauden_indeksikorotus
  (2016, 10, 'MAKU 2005', 387800, 135.4, false);")))]
     (is (=marginaalissa? korotus 1145.64))))
 
-;; VHAR-6948
 (deftest kuukauden-indeksikorotuksen-laskenta-urakalle
   ;; Testataan, että tuleeko eri korotukset, jos urakan alkuvuosi muuttuu. Pidetään muut parametrit samoina.
   (testing "Ennen 2023 alkaneet urakat (käytetään vertailukuukautena syyskuuta)"
@@ -75,7 +73,6 @@
           korotettu (ffirst (q (str "SELECT * FROM indeksikorjaa(1, 2023, 9, " urakka-id ")")))
           testidata-korotettu (ffirst (q (str "SELECT * FROM testidata_indeksikorjaa(1, 2023, 9, " urakka-id ")")))]
       (is (= 1.352M korotettu testidata-korotettu))))
-  ;; VHAR-6948
   (testing "2023 ja sen jälkeen alkaneet urakat (käytetään vertailukuukautena elokuuta)"
     (let [urakka-id (hae-raahen-maanteiden-hoitourakan-2023-2028-id)
           korotettu (ffirst (q (str "SELECT * FROM indeksikorjaa(1, 2023, 9, " urakka-id ")")))

--- a/test/clj/harja/palvelin/palvelut/laskutusyhteenveto_cache_test.clj
+++ b/test/clj/harja/palvelin/palvelut/laskutusyhteenveto_cache_test.clj
@@ -341,7 +341,6 @@
                (:kaikki_laskutetaan_ind_korotus cachesta-haettu-kysely-triggerin-jalkeen)) ":kaikki_laskutetaan_ind_korotus laskutusyhteenvedossa")))))
 
 
-;; HAR-7520
 (deftest laskutusyhteenvedon-cache-tyhjenee-jos-urakan-kayttama-indeksi-muuttuu
   (testing "laskutusyhteenvedon-cache-tyhjenee-jos-urakan-kayttama-indeksi-muuttuu"
     (let [urakka-id @oulun-alueurakan-2014-2019-id

--- a/test/clj/harja/palvelin/palvelut/laskutusyhteenveto_test.clj
+++ b/test/clj/harja/palvelin/palvelut/laskutusyhteenveto_test.clj
@@ -279,7 +279,8 @@
         (testi/tarkista-map-arvot odotetut-soratiet haetut-tiedot-oulu-soratiet)))))
 
 
-;; HAR-1959: Laskutusyhteenveto ottaa talvisuolasakon väärään hoitokauteen loka-joulukuussa
+;; Varmistetaan, että laskutusyhteenveton ja suolasakkoon liittyvä bugi onn korjaantunut:
+;; Laskutusyhteenveto ottaa talvisuolasakon väärään hoitokauteen loka-joulukuussa
 (deftest suolasakko-oikean-vuoden-laskutusyhteenvedossa
   (testing "suolasakko-oikean-vuoden-laskutusyhteenvedossa"
     (let [haetut-tiedot-oulu (lyv-yhteiset/hae-laskutusyhteenvedon-tiedot
@@ -298,7 +299,7 @@
       (is (= (:suolasakot_laskutetaan_ind_korotettuna haetut-tiedot-oulu-talvihoito) 0.0M) "suolasakko laskutusyhteenvedossa")
       (is (= (:suolasakot_laskutetaan_ind_korotus haetut-tiedot-oulu-talvihoito) 0.0M) "suolasakko laskutusyhteenvedossa"))))
 
-(deftest suolasakko-oikein-hoitokauden-laskutusyhteenvedossa ;HAR-3477
+(deftest suolasakko-oikein-hoitokauden-laskutusyhteenvedossa
   (testing "suolasakko-oikein-hoitokauden-laskutusyhteenvedossa"
     (let [haetut-tiedot-oulu (lyv-yhteiset/hae-laskutusyhteenvedon-tiedot
                                (:db jarjestelma)
@@ -317,7 +318,7 @@
       (is (=marginaalissa? (:suolasakot_laskutetaan_ind_korotus haetut-tiedot-oulu-talvihoito) -104.5M) "suolasakko laskutusyhteenvedossa"))))
 
 
-(deftest kuun-viimeisen-paivan-yht-oikein-laskutusyhteenvedossa ;HAR-3965
+(deftest kuun-viimeisen-paivan-yht-oikein-laskutusyhteenvedossa
   (testing "kuun-viimeisen-paivan-yht-oikein-laskutusyhteenvedossa"
     (let [haetut-tiedot-oulu (lyv-yhteiset/hae-laskutusyhteenvedon-tiedot
                                (:db jarjestelma)

--- a/test/clj/harja/palvelin/palvelut/materiaalit_test.clj
+++ b/test/clj/harja/palvelin/palvelut/materiaalit_test.clj
@@ -73,7 +73,7 @@
                     (= (:id (:materiaali %)) 5))
               vastaus))))
 
-;; VHAR-5571 aiheutti unique constraint poikkeuksen ennen korjausta
+;; Hoitokausi tuli eri muodossa tietokannassa ja käliltä, mikä aiheutti unique constraint poikkeuksen ennen korjausta
 (deftest tallenna-suunniteltu-materiaali-tulevillekin-hoitokausille
   (let [urakka-id @oulun-alueurakan-2014-2019-id
         sopimus-id @oulun-alueurakan-2014-2019-paasopimuksen-id

--- a/test/clj/harja/palvelin/palvelut/tilannekuva_test.clj
+++ b/test/clj/harja/palvelin/palvelut/tilannekuva_test.clj
@@ -497,14 +497,14 @@
 
 ;; tuotannossa (ja singletonia vasten) tuotti bugin ERROR: Relate Operation called with a LWGEOMCOLLECTION type.  This is unsupported.
 ;                                     Hint: Change argument 2: 'GEOMETRYCOLLECTION(POINT(449110.781 6788879.145))'
-#_(def haku-params-vhar-1815
+#_(def haku-params-lwgeomcollection
   {:kuva [256.0 256.0], :extent [440848.0 6787072.0 454944.0 6882976.0], :resoluutio 16.0, :parametrit {:aikavalinta 504, "ind" "n1587995345871", :ilmoitukset {}, :yllapito #{17}, :urakat #{275 65 377 281 363 314 313 258 125 158 378 14 326 147 362}, :nykytilanne? true}})
 
 ;; Ei ole tarkoituskaan ajaa CI:ssä, vaan voi todeta ettei enää tule poikkeusta db-singletonia vasten
 #_(deftest hae-paallystysten-reitit-kartalle-test
   (let [vastaus (<!! (hae-paallystysten-sijainnit-kartalle (:db harja.palvelin.main/harja-jarjestelma)
                                                            +kayttaja-jvh+
-                                                           haku-params-vhar-1815))]))
+                                                           haku-params-lwgeomcollection))]))
 
 
 (deftest laatupoikkeama-ei-saa-nakya-eri-urakoitsijalle

--- a/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
+++ b/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
@@ -1226,7 +1226,7 @@
            (clojure.set/project alustarivit-jalkeen [:pot2a_id :tr-numero])))
     (poista-paallystysilmoitus-paallystyskohtella paallystyskohde-id)))
 
-;; VHAR-5750 Liian herkästi muun kohteen päällekkäisyys vaikka ei ollut
+;; Jossain tilanteessa heitettiin virhe Liian herkästi muun kohteen päällekkäisyydestä vaikka ei ollut
 (deftest tallenna-pot2-jossa-on-alikohde-muulla-tiella-validointi-ottaa-tie-huomioon.
   (let [urakka-id (hae-urakan-id-nimella "Utajärven päällystysurakka")
         sopimus-id (hae-utajarven-paallystysurakan-paasopimuksen-id)

--- a/test/clj/harja/palvelin/raportointi/tehtavamaarat_test.clj
+++ b/test/clj/harja/palvelin/raportointi/tehtavamaarat_test.clj
@@ -295,8 +295,9 @@
   (ffirst (q (str (format "select tehtavamaara from raportti_toteuma_maarat where urakka_id = %s and toimenpidekoodi = %s and alkanut = '%s';" urakka-id tpk-id pvm)))))
 
 
-;; VHAR-7356 vian korjaus: aiemmin materialized view raportti_toteuma_maarat virheellisesti ryhmitteli t.luotu perusteella (kantaan kirjoittamishetki),
+;; vian korjaus: aiemmin materialized view raportti_toteuma_maarat virheellisesti ryhmitteli t.luotu perusteella (kantaan kirjoittamishetki),
 ;; kun täytyy ryhmitellä t.alkanut perusteella (toteuman alkamishetki)
+;; Johti siihen, että vemtr-raportille laskettiin jotkut toteumat useamman kerran.
 (deftest tehtavamaara-raportti-ryhmittelee-toteuman-alkanut-kentan-perusteella
   (let [oulun-mhu-id (hae-urakan-id-nimella "Oulun MHU 2019-2024")
         tpk-id (hae-toimenpidekoodin-id "Pysäkkikatosten puhdistus" "23104")

--- a/test/clj/harja/palvelin/raportointi_test.clj
+++ b/test/clj/harja/palvelin/raportointi_test.clj
@@ -219,7 +219,7 @@
                                        2]]}]]
     (is (= kuvaus-liitetty odotettu-liitetty) "Raporttiin liitetty suorituskonteksti ihan okei")))
 
-;; VHAR-5683 Materialisoitu näkymä unohtui päivittää
+;; Varmistetaan, että korjataan ongelma, jossa materialisoitu näkymä unohtui päivittää
 ;; Kaksi näkymää liittyy Suolauksen Käyttöraja arvon välittymiseen raporteille.
 ;;   pohjavesialue_talvisuola.talvisuolaraja -> Materialized View - pohjavesialue_kooste.suolarajoitus
 ;;   pohjavesialue_kooste.suolarajoitus -> raportti_pohjavesialueiden_suolatoteumat.kayttoraja

--- a/tietokanta/README.md
+++ b/tietokanta/README.md
@@ -18,7 +18,7 @@ sitten psql komento:
 
 ## Tietokantojen salasanat
 
-Kyselepä tiimiläisiltä. Saatat päästä eteenpäin myös tällä: HAR-4599
+Kyselepä tiimiläisiltä.
 
 ## Tietokannan lokitus paikallisessa Docker-kontissa. Tällä sisään kantakoneelle:
 > docker exec -it harjadb /bin/bash

--- a/tietokanta/src/main/resources/db/migration/R__Indeksilaskenta.sql
+++ b/tietokanta/src/main/resources/db/migration/R__Indeksilaskenta.sql
@@ -170,7 +170,7 @@ BEGIN
         -- arvoksi syyskuu, joten tätä kovakoodausta ei ole vielä siksi aktivoitu.
         --indeksi_kk := 9;
 
-        -- 2023 tai sen jälkeen alkavilla urakoilla käytetään indeksin tarkastelukuukautena elokuuta (VHAR-6948)
+        -- 2023 tai sen jälkeen alkavilla urakoilla käytetään indeksin tarkastelukuukautena elokuuta
         IF urakan_alkuvuosi >= 2023
         THEN
             indeksi_kk := 8;
@@ -272,7 +272,7 @@ BEGIN
 
     -- Käytetään vertailukuukauden default-arvona syyskuuta.
     vertailukk := 9;
-    -- 2023 tai sen jälkeen alkaville urakoille vertailuukausi on elokuu (VHAR-6948)
+    -- 2023 tai sen jälkeen alkaville urakoille vertailuukausi on elokuu
     IF urakan_alkuvuosi >= 2023 THEN
         vertailukk := 8;
     END IF;

--- a/tietokanta/src/main/resources/db/migration/R__Materiaalikayton_paivitys.sql
+++ b/tietokanta/src/main/resources/db/migration/R__Materiaalikayton_paivitys.sql
@@ -74,7 +74,7 @@ $$ LANGUAGE plpgsql;
 
 -- Allaoleva funktio päivittää sopimuksen käytetyn materiaalin cachen päivämääräväliltä
 -- Se voidaan suorittaa hätätilanteessa esim. SQL-tulkin avulla tuotantokantaa vasten AINA transaktion sisällä (BEGIN... do stuff; COMMIT/ROLLBACK;)
--- Mahdolliset rivien deletoinnit tehtävä käsin ennen ajoa. Ks. VHAR-1691
+-- Mahdolliset rivien deletoinnit tehtävä käsin ennen ajoa.
 CREATE OR REPLACE FUNCTION paivita_sopimuksen_kaytetty_materiaali_pvm_aikavalille(alku DATE, loppu DATE)
 RETURNS void AS $$
 DECLARE

--- a/tietokanta/testidata/apufunktiot.sql
+++ b/tietokanta/testidata/apufunktiot.sql
@@ -29,7 +29,7 @@ BEGIN
 
     -- Käytetään vertailukuukauden default-arvona syyskuuta.
     vertailukk := 9;
-    -- 2023 tai sen jälkeen alkaville urakoille vertailuukausi on elokuu (VHAR-6948)
+    -- 2023 tai sen jälkeen alkaville urakoille vertailuukausi on elokuu
     IF urakan_alkuvuosi >= 2023 THEN
         vertailukk := 8;
     END IF;

--- a/tietokanta/testidata/vesivaylat/vesivaylien_urakat.sql
+++ b/tietokanta/testidata/vesivaylat/vesivaylien_urakat.sql
@@ -47,7 +47,7 @@ VALUES
     'vesivayla-hoito',
     true, '2017-10-01'::DATE, (SELECT id FROM kayttaja WHERE kayttajanimi = 'tero'),
     '3332,555,3331', 'vv-HAR-124');
--- Huom. Tiedoston lopussa päivitetään vesiväyläurakoiden urakkanumerot ja luodaan urakka-alueet HAR-8439.
+-- Huom. Tiedoston lopussa päivitetään vesiväyläurakoiden urakkanumerot ja luodaan urakka-alueet
 
 
 INSERT INTO urakka (nimi, indeksi, alkupvm, loppupvm, tyyppi,  harjassa_luotu, luotu, luoja, sampoid)
@@ -157,7 +157,7 @@ INSERT INTO toimenpide (taso, emo, nimi)
 VALUES (3, 132, 'Rannikon muut');
 
 -- URAKKA-ALUEET
--- Päivitä olemassaolevien vesiväyläurakoiden urakka-aluetieto vastaamaan uutta toteutusta HAR-8439
+-- Päivitä olemassaolevien vesiväyläurakoiden urakka-aluetieto vastaamaan uutta toteutusta
 INSERT INTO vv_urakka_turvalaiteryhma (urakka, turvalaiteryhmat, alkupvm, loppupvm, luotu, luoja)
   (SELECT id, string_to_array(urakkanro, ','), alkupvm, loppupvm, NOW(),
           (select id from kayttaja where kayttajanimi = 'Integraatio') from urakka where tyyppi = 'vesivayla-hoito' and urakkanro is not null);

--- a/tietokanta/viimeisin_migraatio.sh
+++ b/tietokanta/viimeisin_migraatio.sh
@@ -7,7 +7,7 @@
 # Viimeisimmät migraatiot:
 # develop
 # 892
-# VHAR-4778
+# nykyinen-haara
 # 890
 #
 # ./viimeisin_migraatio.sh develop other-branch


### PR DESCRIPTION
Jiramigraation myötä vanhat tiketit joko katoaa tai jouduttaisiin siirtämään. Käyty läpi kaikki kommenteissa olevat viittaukset tiketteihin ja viittaus poistettu, mikäli sitä ei nähty tarpeelliseksi joko vanhentuneen tiedon tai muuten riittävän dokumentaation takia. Joissain tapauksissa tarvittava tieto tiketiltä siirretty kommenttiin tai väyläviraston confluenceen.

Yleisesti ottaen omasta mielestäni koodissa ei ollut viittauksia tiketteihin, joissa olisi ollut niin tärkeää tietoa tallessa, ettei pärjättäisi ilman sitä.