### PR TITLE
Poista yhteensopivuus constraint

### DIFF
--- a/src/clj/harja/kyselyt/kulut.sql
+++ b/src/clj/harja/kyselyt/kulut.sql
@@ -138,7 +138,6 @@ SELECT k.id                   as "id",
        kk.summa               as "summa",
        kk.toimenpideinstanssi as "toimenpideinstanssi",
        kk.tehtavaryhma        as "tehtavaryhma",
-       kk.tehtava             as "tehtava",
        kk.suoritus_alku       as "suoritus-alku",
        kk.suoritus_loppu      as "suoritus-loppu",
        kk.lisatyon_lisatieto  as "lisatyon-lisatieto",
@@ -181,7 +180,6 @@ where k.id = :id
 SELECT kk.id                  as "kohdistus-id",
        kk.rivi                as "rivi",
        kk.summa               as "summa",
-       kk.tehtava             as "tehtava",
        kk.tehtavaryhma        as "tehtavaryhma",
        kk.toimenpideinstanssi as "toimenpideinstanssi",
        kk.suoritus_alku       as "suoritus-alku",
@@ -280,3 +278,6 @@ FROM toimenpideinstanssi tpi
 WHERE tpi.urakka = :urakka
   AND tp2.koodi = '23150'
 limit 1;
+
+-- name: tarkista-kohdistuksen-yhteensopivuus
+select * from tarkista_t_tr_ti_yhteensopivuus(:tehtava-id::INTEGER, :tehtavaryhma-id::INTEGER, :toimenpideinstanssi-id::INTEGER);

--- a/src/clj/harja/kyselyt/kustannusten_seuranta.sql
+++ b/src/clj/harja/kyselyt/kustannusten_seuranta.sql
@@ -308,7 +308,7 @@ SELECT 0                          AS budjetoitu_summa,
                THEN 'Hoitokauden päättäminen'
            END                   AS toimenpideryhma,
        CASE
-           WHEN lk.tehtavaryhma IS NULL AND lk.tehtava IS NULL AND lk.maksueratyyppi::TEXT = 'lisatyo' THEN tk.nimi
+           WHEN lk.tehtavaryhma IS NULL AND lk.maksueratyyppi::TEXT = 'lisatyo' THEN tk.nimi
            ELSE tr.nimi
            END                   AS tehtava_nimi,
        CASE

--- a/src/clj/harja/kyselyt/kustannusten_seuranta.sql
+++ b/src/clj/harja/kyselyt/kustannusten_seuranta.sql
@@ -257,7 +257,7 @@ SELECT 0                          AS budjetoitu_summa,
        MIN(lk.luotu)              AS luotu,
        MIN(l.erapaiva)::TEXT      AS ajankohta,
        'toteutunut'               AS toteutunut,
-       tk_tehtava.jarjestys       AS jarjestys,
+       tr.jarjestys       AS jarjestys,
        CASE
            WHEN lk.maksueratyyppi::TEXT = 'akillinen-hoitotyo' THEN 'rahavaraukset'
            WHEN lk.maksueratyyppi::TEXT = 'muu' THEN 'rahavaraukset' -- muu = vahinkojen-korjaukset
@@ -270,7 +270,6 @@ SELECT 0                          AS budjetoitu_summa,
            END                    AS paaryhma,
        NOW()                     AS indeksikorjaus_vahvistettu -- kuluja ei indeksivahvisteta, joten ne on aina "true"
 FROM kulu_kohdistus lk
-         LEFT JOIN tehtava tk_tehtava ON tk_tehtava.id = lk.tehtava
          LEFT JOIN tehtavaryhma tr ON tr.id = lk.tehtavaryhma,
      toimenpideinstanssi tpi,
      toimenpide tk,
@@ -286,7 +285,7 @@ WHERE l.urakka = :urakka
   AND (tk.koodi = '23104' OR tk.koodi = '23116'
     OR tk.koodi = '23124' OR tk.koodi = '20107' OR tk.koodi = '20191' OR
        tk.koodi = '14301')
-GROUP BY tr.nimi, tk.nimi, lk.maksueratyyppi, tk.koodi, tk_tehtava.jarjestys, tr.yksiloiva_tunniste
+GROUP BY tr.nimi, tk.nimi, lk.maksueratyyppi, tk.koodi, tr.jarjestys, tr.yksiloiva_tunniste
 UNION ALL
 -- Toteutuneet erillishankinnat, hoidonjohdonpalkkio, johto- ja hallintokorvaukset
 -- ja vuoden päättämiseen liittyvät kulut lasku_kohdistus taulusta.
@@ -297,10 +296,9 @@ SELECT 0                          AS budjetoitu_summa,
        lk.maksueratyyppi::TEXT    AS maksutyyppi,
        CASE
            WHEN tr.nimi = 'Erillishankinnat (W)' THEN 'erillishankinnat'
-           WHEN tk_tehtava.yksiloiva_tunniste = '8376d9c4-3daf-4815-973d-cd95ca3bb388' THEN 'toimistokulut'
            WHEN tr.nimi = 'Johto- ja hallintokorvaus (J)' THEN 'toimistokulut'
            WHEN tr.nimi = 'Hoidonjohtopalkkio (G)' THEN 'hoidonjohdonpalkkio'
-           WHEN lk.tehtavaryhma IS NULL AND lk.tehtava IS NULL AND lk.maksueratyyppi::TEXT = 'lisatyo'
+           WHEN lk.tehtavaryhma IS NULL AND lk.maksueratyyppi::TEXT = 'lisatyo'
                THEN 'lisatyo'
            WHEN tr.yksiloiva_tunniste IN ('55c920e7-5656-4bb0-8437-1999add714a3',
                                            '19907c24-dd26-460f-9cb4-2ed974b891aa',
@@ -313,7 +311,6 @@ SELECT 0                          AS budjetoitu_summa,
            END                   AS tehtava_nimi,
        CASE
            WHEN tr.nimi = 'Erillishankinnat (W)' THEN 'Erillishankinnat'
-           WHEN tk_tehtava.yksiloiva_tunniste = '8376d9c4-3daf-4815-973d-cd95ca3bb388' THEN 'Johto- ja Hallintakorvaus'
            WHEN tr.yksiloiva_tunniste = '55c920e7-5656-4bb0-8437-1999add714a3' THEN 'Tavoitepalkkio'
            WHEN tr.yksiloiva_tunniste = '19907c24-dd26-460f-9cb4-2ed974b891aa' THEN 'Urakoitsija maksaa tavoitehinnan ylityksestä'
            WHEN tr.yksiloiva_tunniste = 'be34116b-2264-43e0-8ac8-3762b27a9557' THEN 'Urakoitsija maksaa kattohinnan ylityksestä'
@@ -322,13 +319,12 @@ SELECT 0                          AS budjetoitu_summa,
        MIN(lk.luotu)             AS luotu,
        MIN(l.erapaiva)::TEXT     AS ajankohta,
        'toteutunut'              AS toteutunut,
-       MIN(tk_tehtava.jarjestys) AS jarjestys,
+       MIN(tr.jarjestys) AS jarjestys,
        CASE
            WHEN tr.nimi = 'Erillishankinnat (W)' THEN 'erillishankinnat'
-           WHEN tk_tehtava.yksiloiva_tunniste = '8376d9c4-3daf-4815-973d-cd95ca3bb388' THEN 'johto-ja-hallintakorvaus'
            WHEN tr.nimi = 'Johto- ja hallintokorvaus (J)' THEN 'johto-ja-hallintakorvaus'
            WHEN tr.nimi = 'Hoidonjohtopalkkio (G)' THEN 'hoidonjohdonpalkkio'
-           WHEN lk.tehtavaryhma IS NULL AND lk.tehtava IS NULL AND lk.maksueratyyppi::TEXT = 'lisatyo'
+           WHEN lk.tehtavaryhma IS NULL AND lk.maksueratyyppi::TEXT = 'lisatyo'
                THEN 'johto-ja-hallintakorvaus'
            WHEN tr.yksiloiva_tunniste = '55c920e7-5656-4bb0-8437-1999add714a3' THEN 'tavoitepalkkio'
            WHEN tr.yksiloiva_tunniste = '19907c24-dd26-460f-9cb4-2ed974b891aa' THEN 'tavoitehinnan-ylitys'
@@ -336,8 +332,7 @@ SELECT 0                          AS budjetoitu_summa,
            END                   AS paaryhma,
        NOW()                     AS indeksikorjaus_vahvistettu -- kuluja ei indeksivahvisteta, joten ne on aina "true"
 FROM kulu_kohdistus lk
-         LEFT JOIN tehtava tk_tehtava ON tk_tehtava.id = lk.tehtava
-         LEFT JOIN tehtavaryhma tr ON tr.id = lk.tehtavaryhma,
+     LEFT JOIN tehtavaryhma tr ON tr.id = lk.tehtavaryhma,
      toimenpideinstanssi tpi,
      toimenpide tk,
      kulu l
@@ -350,7 +345,7 @@ WHERE l.urakka = :urakka
   AND tpi.toimenpide = tk.id
   -- Näillä toimenpidekoodi.koodi rajauksilla rajataan Hankintakustannukset ulos
   AND tk.koodi = '23151'
-GROUP BY tehtava_nimi, tr.nimi, tr.yksiloiva_tunniste, lk.maksueratyyppi, toimenpideryhma, toimenpide, paaryhma, tk_tehtava.yksiloiva_tunniste
+GROUP BY tehtava_nimi, tr.nimi, tr.yksiloiva_tunniste, lk.maksueratyyppi, toimenpideryhma, toimenpide, paaryhma
 UNION ALL
 -- Osa toteutuneista erillishankinnoista, hoidonjohdonpalkkioista ja johdon- hallintakorvauksesta
 -- siirretään kustannusarvoitu_tyo taulusta toteutuneet_kustannukset tauluun aina kuukauden viimeisenä päivänä.

--- a/src/clj/harja/kyselyt/tehtavamaarat.sql
+++ b/src/clj/harja/kyselyt/tehtavamaarat.sql
@@ -109,18 +109,18 @@ WHERE urakka = :urakka
 -- Pois jätetyt lisätyöhön viittaavat tehtäväryhmät ovat ainoastaan toteumien kirjaamista varten.
 -- Nämä dummy-tehtäväryhmät ja niihin liitetyt tehtävät tarvitaan, koska toteumiin on pakko liittää tehtävä.
 -- Lisätöiden kulut voidaan kohdistaa ilman tehtävää ja tehtäväryhmää suoraan toimenpiteelle.
-SELECT distinct tpk3.id       as "toimenpide-id",
-                tpk3.nimi     as "toimenpide",
+SELECT distinct tp.id       as "toimenpide-id",
+                tp.nimi     as "toimenpide",
                 tr.nimi      as "tehtavaryhma-nimi",
                 tr.id        as "tehtavaryhma-id",
                 tr.jarjestys as "jarjestys",
                 tpi.id        as "toimenpideinstanssi"
 FROM tehtavaryhma tr
-       LEFT JOIN tehtava tpk4
-                 ON tr.id = tpk4.tehtavaryhma AND tpk4."mhu-tehtava?" is true AND
-                    tpk4.poistettu is not true AND tpk4.piilota is not true
-       JOIN toimenpide tpk3 ON tpk4.emo = tpk3.id
-       JOIN toimenpideinstanssi tpi on tpi.toimenpide = tpk3.id and tpi.urakka = :urakka
+       LEFT JOIN tehtava t
+                 ON tr.id = t.tehtavaryhma AND t."mhu-tehtava?" is true AND
+                    t.poistettu is not true AND t.piilota is not true
+       JOIN toimenpide tp ON t.emo = tp.id
+       JOIN toimenpideinstanssi tpi on tpi.toimenpide = tp.id and tpi.urakka = :urakka
  WHERE tr.nimi not like ('%Lisätyöt%')
  order by tr.jarjestys;
 

--- a/src/clj/harja/palvelin/main.clj
+++ b/src/clj/harja/palvelin/main.clj
@@ -52,7 +52,7 @@
     [harja.palvelin.palvelut.kokonaishintaiset-tyot :as kokonaishintaiset-tyot]
     [harja.palvelin.palvelut.muut-tyot :as muut-tyot]
     [harja.palvelin.palvelut.tehtavamaarat :as tehtavamaarat]
-    [harja.palvelin.palvelut.kulut :as kulut]
+    [harja.palvelin.palvelut.kulut.kulut :as kulut]
     [harja.palvelin.palvelut.toteumat :as toteumat]
     [harja.palvelin.palvelut.yllapito-toteumat :as yllapito-toteumat]
     [harja.palvelin.palvelut.toimenpidekoodit :as toimenpidekoodit]

--- a/src/clj/harja/palvelin/palvelut/kulut/kulut.clj
+++ b/src/clj/harja/palvelin/palvelut/kulut/kulut.clj
@@ -1,7 +1,8 @@
-(ns harja.palvelin.palvelut.kulut
+(ns harja.palvelin.palvelut.kulut.kulut
   "Nimiavaruutta käytetään vain urakkatyypissä teiden-hoito (MHU)."
   (:require [com.stuartsierra.component :as component]
             [clojure.string :as str]
+            [harja.palvelin.integraatiot.api.tyokalut.virheet :as virheet]
             [taoensso.timbre :as log]
             [harja.kyselyt
              [kulut :as q]
@@ -19,7 +20,9 @@
             [harja.palvelin.komponentit.excel-vienti :as excel-vienti]
             [harja.palvelin.raportointi.excel :as excel]
             [harja.pvm :as pvm]
-            [harja.kyselyt.konversio :as konversio]))
+            [harja.kyselyt.konversio :as konversio]
+            [clojure.java.jdbc :as jdbc])
+  (:use [slingshot.slingshot :only [throw+]]))
 
 
 (defn jarjesta-vuoden-ja-kuukauden-mukaan
@@ -269,61 +272,73 @@
   Päivittää kulun tai kohdistuksen tiedot, jos rivi on jo kannassa.
   Palauttaa tallennetut tiedot."
   [db user urakka-id {:keys [erapaiva kokonaissumma urakka tyyppi laskun-numero
-                             lisatieto koontilaskun-kuukausi id kohdistukset liitteet]}]
+                             lisatieto koontilaskun-kuukausi id kohdistukset liitteet] :as tiedot}]
   (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-laskutus-laskunkirjoitus user urakka-id)
   (varmista-erapaiva-on-koontilaskun-kuukauden-sisalla db koontilaskun-kuukausi erapaiva urakka-id)
-  (let [vanha-erapaiva (when id (:erapaiva (first (q/hae-kulu db {:id id}))))
-        saako-tallentaa (tarkista-saako-kulua-tallentaa db urakka-id erapaiva vanha-erapaiva)
-        _ (when (not saako-tallentaa)
-            (throw (IllegalArgumentException.
-                     (str "Kulu on tai kohdistuu hoitokaudelle, jonka välikatselmus on jo pidetty. Tallentaminen ei enää onnistu!"))))
-        yhteiset-tiedot {:erapaiva              (konv/sql-date erapaiva)
-                         :kokonaissumma         kokonaissumma
-                         :urakka                urakka
-                         :tyyppi                tyyppi
-                         :numero                laskun-numero
-                         :lisatieto             lisatieto
-                         :kayttaja              (:id user)
-                         :koontilaskun-kuukausi koontilaskun-kuukausi}
-        kulu (if (nil? id)
-                (q/luo-kulu<! db yhteiset-tiedot)
-                (q/paivita-kulu<! db (assoc yhteiset-tiedot
+  (jdbc/with-db-transaction [db db]
+    (let [_ (println "luo-tai-paivita-kulukohdistukset :: tiedot" tiedot)
+          vanha-erapaiva (when id (:erapaiva (first (q/hae-kulu db {:id id}))))
+          saako-tallentaa (tarkista-saako-kulua-tallentaa db urakka-id erapaiva vanha-erapaiva)
+          _ (when (not saako-tallentaa)
+              (throw (IllegalArgumentException.
+                       (str "Kulu on tai kohdistuu hoitokaudelle, jonka välikatselmus on jo pidetty. Tallentaminen ei enää onnistu!"))))
+          yhteiset-tiedot {:erapaiva (konv/sql-date erapaiva)
+                           :kokonaissumma kokonaissumma
+                           :urakka urakka
+                           :tyyppi tyyppi
+                           :numero laskun-numero
+                           :lisatieto lisatieto
+                           :kayttaja (:id user)
+                           :koontilaskun-kuukausi koontilaskun-kuukausi}
+          kulu (if (nil? id)
+                 (q/luo-kulu<! db yhteiset-tiedot)
+                 (q/paivita-kulu<! db (assoc yhteiset-tiedot
                                         :id id)))
-        vanhat-kohdistukset (q/hae-kulun-kohdistukset db {:kulu (:id kulu)})
-        sisaan-tulevat-kohdistus-idt (into #{} (map :kohdistus-id kohdistukset))
-        puuttuvat-kohdistukset (remove
-                                 #(sisaan-tulevat-kohdistus-idt (:kohdistus-id %))
-                                 vanhat-kohdistukset)]
-    (when-not (or (nil? liitteet)
+          vanhat-kohdistukset (q/hae-kulun-kohdistukset db {:kulu (:id kulu)})
+          sisaan-tulevat-kohdistus-idt (into #{} (map :kohdistus-id kohdistukset))
+          puuttuvat-kohdistukset (remove
+                                   #(sisaan-tulevat-kohdistus-idt (:kohdistus-id %))
+                                   vanhat-kohdistukset)]
+      (when-not (or (nil? liitteet)
                   (empty? liitteet))
-      (doseq [liite liitteet]
-        (q/linkita-kulu-ja-liite<! db {:kulu-id (:id kulu)
-                                        :liite-id (:liite-id liite)
-                                        :kayttaja (:id user)})))
+        (doseq [liite liitteet]
+          (q/linkita-kulu-ja-liite<! db {:kulu-id (:id kulu)
+                                         :liite-id (:liite-id liite)
+                                         :kayttaja (:id user)})))
 
-    ;; Kannassa on kohdistuksia, joita ei lähetetty kulun päivityksen yhteydessä. Poistetaan ne.
-    (doseq [puuttuva-kohdistus puuttuvat-kohdistukset]
+      ;; Kannassa on kohdistuksia, joita ei lähetetty kulun päivityksen yhteydessä. Poistetaan ne.
+      (doseq [puuttuva-kohdistus puuttuvat-kohdistukset]
         (poista-kulun-kohdistus db user
           {:id id
            :urakka-id urakka-id
            :kohdistuksen-id (:kohdistus-id puuttuva-kohdistus)
            :kohdistus puuttuva-kohdistus}))
 
-    (doseq [kohdistusrivi kohdistukset]
-      (as-> kohdistusrivi r
-            (update r :summa big/unwrap)
-            (assoc r :kulu (:id kulu))
-            (if (true? (:poistettu r))
-              (poista-kulun-kohdistus db user {:id              id
-                                                :urakka-id          urakka-id
-                                                :kohdistuksen-id (:kohdistus-id r)
-                                                :kohdistus r})
-              (luo-tai-paivita-kulun-kohdistus db
-                                                user
-                                                urakka
-                                                (:id kulu)
-                                                r))))
-    (hae-kulu-kohdistuksineen db user {:id (:id kulu)})))
+      (doseq [kohdistusrivi kohdistukset]
+        (let [;; Tarkistetaan kohdistusrivi
+              yhteensopiva? (::tarkista_t_tr_ti_yhteensopivuus
+                              (first (q/tarkista-kohdistuksen-yhteensopivuus db
+                                       {:tehtava-id nil
+                                        :tehtavaryhma-id (:tehtavaryhma kohdistusrivi)
+                                        :toimenpideinstanssi-id (:toimenpideinstanssi kohdistusrivi)})))]
+          (if yhteensopiva?
+            (as-> kohdistusrivi r
+              (update r :summa big/unwrap)
+              (assoc r :kulu (:id kulu))
+              (if (true? (:poistettu r))
+                (poista-kulun-kohdistus db user {:id id
+                                                 :urakka-id urakka-id
+                                                 :kohdistuksen-id (:kohdistus-id r)
+                                                 :kohdistus r})
+                (luo-tai-paivita-kulun-kohdistus db
+                  user
+                  urakka
+                  (:id kulu)
+                  r)))
+            (throw+ {:type virheet/+viallinen-kutsu+
+                     :virheet [{:koodi virheet/+sisainen-kasittelyvirhe+
+                                :viesti (str "Tehtäväryhmä ja toimenpideinstanssi ristiriidassa! ")}]}))))
+      (hae-kulu-kohdistuksineen db user {:id (:id kulu)}))))
 
 (defn poista-kulu-tietokannasta
   "Merkitsee kulun sekä kaikki siihen liittyvät kohdistukset poistetuksi."

--- a/src/clj/harja/palvelin/palvelut/kulut/kulut.clj
+++ b/src/clj/harja/palvelin/palvelut/kulut/kulut.clj
@@ -276,8 +276,7 @@
   (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-laskutus-laskunkirjoitus user urakka-id)
   (varmista-erapaiva-on-koontilaskun-kuukauden-sisalla db koontilaskun-kuukausi erapaiva urakka-id)
   (jdbc/with-db-transaction [db db]
-    (let [_ (println "luo-tai-paivita-kulukohdistukset :: tiedot" tiedot)
-          vanha-erapaiva (when id (:erapaiva (first (q/hae-kulu db {:id id}))))
+    (let [vanha-erapaiva (when id (:erapaiva (first (q/hae-kulu db {:id id}))))
           saako-tallentaa (tarkista-saako-kulua-tallentaa db urakka-id erapaiva vanha-erapaiva)
           _ (when (not saako-tallentaa)
               (throw (IllegalArgumentException.

--- a/src/clj/harja/palvelin/palvelut/kulut/kulut.clj
+++ b/src/clj/harja/palvelin/palvelut/kulut/kulut.clj
@@ -316,7 +316,7 @@
 
       (doseq [kohdistusrivi kohdistukset]
         (let [;; Tarkistetaan kohdistusrivi
-              yhteensopiva? (::tarkista_t_tr_ti_yhteensopivuus
+              yhteensopiva? (:tarkista_t_tr_ti_yhteensopivuus
                               (first (q/tarkista-kohdistuksen-yhteensopivuus db
                                        {:tehtava-id nil
                                         :tehtavaryhma-id (:tehtavaryhma kohdistusrivi)

--- a/src/clj/harja/palvelin/palvelut/kulut/valikatselmukset.clj
+++ b/src/clj/harja/palvelin/palvelut/kulut/valikatselmukset.clj
@@ -14,7 +14,7 @@
     [harja.kyselyt.budjettisuunnittelu :as budjettisuunnittelu-q]
     [harja.palvelin.palvelut.laadunseuranta :as laadunseuranta-palvelu]
     [harja.palvelin.palvelut.toteumat :as toteumat-palvelu]
-    [harja.palvelin.palvelut.kulut :as kulut-palvelu]
+    [harja.palvelin.palvelut.kulut.kulut :as kulut-palvelu]
     [harja.palvelin.palvelut.kulut.paatos-apurit :as paatos-apurit]
     [harja.palvelin.komponentit.http-palvelin :refer [julkaise-palvelu poista-palvelut]]
     [harja.pvm :as pvm]

--- a/test/clj/harja/palvelin/palvelut/kulut/kulut_test.clj
+++ b/test/clj/harja/palvelin/palvelut/kulut/kulut_test.clj
@@ -476,7 +476,7 @@
       (apply conj kaikki rivit))))
 
 (def odotettu-kulu-id-9
-  {:id 9, :tyyppi "laskutettava", :kokonaissumma 400.77M, :erapaiva #inst "2019-10-15T21:00:00.000-00:00", :laskun-numero nil, :koontilaskun-kuukausi "lokakuu/1-hoitovuosi", :liitteet [], :suoritus-alku #inst "2019-09-30T21:00:00.000000000-00:00", :lisatyon-lisatieto nil, :maksueratyyppi "lisatyo", :suoritus-loppu #inst "2019-10-30T22:00:00.000000000-00:00", :tehtava nil, :summa 400.77M, :kohdistus-id 12, :toimenpideinstanssi (ffirst (q "SELECT id FROM toimenpideinstanssi WHERE nimi = 'Oulu MHU Soratien hoito TP'")), :tehtavaryhma 15, :lisatieto nil, :rivi 1})
+  {:id 9, :tyyppi "laskutettava", :kokonaissumma 400.77M, :erapaiva #inst "2019-10-15T21:00:00.000-00:00", :laskun-numero nil, :koontilaskun-kuukausi "lokakuu/1-hoitovuosi", :liitteet [], :suoritus-alku #inst "2019-09-30T21:00:00.000000000-00:00", :lisatyon-lisatieto nil, :maksueratyyppi "lisatyo", :suoritus-loppu #inst "2019-10-30T22:00:00.000000000-00:00", :summa 400.77M, :kohdistus-id 12, :toimenpideinstanssi (ffirst (q "SELECT id FROM toimenpideinstanssi WHERE nimi = 'Oulu MHU Soratien hoito TP'")), :tehtavaryhma 15, :lisatieto nil, :rivi 1})
 
 (deftest hae-aikavalilla-kaikki-kulu-kohdistuksineent
   (testing "hae-aikavalilla-kaikki-kulu-kohdistuksineent"

--- a/test/clj/harja/palvelin/palvelut/kulut/kulut_test.clj
+++ b/test/clj/harja/palvelin/palvelut/kulut/kulut_test.clj
@@ -3,7 +3,7 @@
             [clojure.string :as s]
             [com.stuartsierra.component :as component]
             [harja.testi :refer :all]
-            [harja.palvelin.palvelut.kulut :as kulut]
+            [harja.palvelin.palvelut.kulut.kulut :as kulut]
             [harja.kyselyt.valikatselmus :as valikatselmus-kyselyt]
             [harja.domain.kulut :as tyokalut]
             [harja.pvm :as pvm]))

--- a/test/clj/harja/palvelin/palvelut/kulut/kustannusten_seuranta_test.clj
+++ b/test/clj/harja/palvelin/palvelut/kulut/kustannusten_seuranta_test.clj
@@ -81,7 +81,6 @@
           lk.summa AS toteutunut_summa,
           0 AS budjetoitu_summa
         FROM kulu_kohdistus lk
-                 LEFT JOIN tehtava tk_tehtava ON tk_tehtava.id = lk.tehtava
                  JOIN tehtavaryhma tr ON tr.id = lk.tehtavaryhma,
              toimenpideinstanssi tpi,
              toimenpide tk,
@@ -132,7 +131,6 @@
           lk.summa AS toteutunut_summa,
           0 AS budjetoitu_summa
         FROM kulu_kohdistus lk
-                 LEFT JOIN tehtava tk_tehtava ON tk_tehtava.id = lk.tehtava
                  JOIN tehtavaryhma tr ON tr.id = lk.tehtavaryhma,
              toimenpideinstanssi tpi,
              toimenpide tk,
@@ -191,8 +189,7 @@
           lk.summa AS toteutunut_summa,
           0 AS budjetoitu_summa
         FROM kulu_kohdistus lk
-                 LEFT JOIN tehtava tk_tehtava ON tk_tehtava.id = lk.tehtava
-                 JOIN tehtavaryhma tr ON tr.id = lk.tehtavaryhma,
+             JOIN tehtavaryhma tr ON tr.id = lk.tehtavaryhma,
              toimenpideinstanssi tpi,
              toimenpide tk,
              kulu l
@@ -293,8 +290,7 @@ UNION ALL
            WHEN tk.koodi = '14301' THEN 'MHU Korvausinvestointi'
        END                 AS toimenpide
        FROM kulu_kohdistus lk
-             LEFT JOIN tehtava tk_tehtava ON tk_tehtava.id = lk.tehtava
-             LEFT JOIN tehtavaryhma tr ON tr.id = lk.tehtavaryhma,
+            JOIN tehtavaryhma tr ON tr.id = lk.tehtavaryhma,
             toimenpideinstanssi tpi,
            toimenpide tk,
            kulu l
@@ -326,7 +322,6 @@ UNION ALL
                  WHEN tk.koodi = '23151' THEN 'MHU Hoidonjohto'
              END                 AS toimenpide
         FROM kulu_kohdistus lk
-                 LEFT JOIN tehtava tk_tehtava ON tk_tehtava.id = lk.tehtava
                  LEFT JOIN tehtavaryhma tr ON tr.id = lk.tehtavaryhma,
              toimenpideinstanssi tpi,
              toimenpide tk,

--- a/test/clj/harja/palvelin/palvelut/kulut/kustannusten_seuranta_test.clj
+++ b/test/clj/harja/palvelin/palvelut/kulut/kustannusten_seuranta_test.clj
@@ -91,7 +91,7 @@
           AND lk.toimenpideinstanssi = tpi.id
           AND tpi.toimenpide = tk.id
           AND tr.nimi = 'Erillishankinnat (W)'
-          AND (tk.koodi = '23151' OR tk_tehtava.yksiloiva_tunniste = '8376d9c4-3daf-4815-973d-cd95ca3bb388')
+          AND (tk.koodi = '23151')
         UNION ALL
         SELECT
         coalesce(sum(t.summa_indeksikorjattu), 0) AS toteutunut_summa,
@@ -141,7 +141,7 @@
           AND lk.toimenpideinstanssi = tpi.id
           AND tpi.toimenpide = tk.id
           AND tr.nimi = 'Hoidonjohtopalkkio (G)'
-          AND (tk.koodi = '23151' OR tk_tehtava.yksiloiva_tunniste = '8376d9c4-3daf-4815-973d-cd95ca3bb388')
+          AND (tk.koodi = '23151')
         UNION ALL
         SELECT
           coalesce(sum(t.summa_indeksikorjattu), 0) AS toteutunut_summa,
@@ -198,8 +198,8 @@
           AND lk.kulu = l.id
           AND lk.toimenpideinstanssi = tpi.id
           AND tpi.toimenpide = tk.id
-          AND (tr.nimi = 'Johto- ja hallintokorvaus (J)' OR tk_tehtava.yksiloiva_tunniste = '8376d9c4-3daf-4815-973d-cd95ca3bb388')
-          AND (tk.koodi = '23151' OR tk_tehtava.yksiloiva_tunniste = '8376d9c4-3daf-4815-973d-cd95ca3bb388')
+          AND (tr.nimi = 'Johto- ja hallintokorvaus (J)')
+          AND (tk.koodi = '23151')
         UNION ALL
         SELECT
         coalesce(sum(t.summa_indeksikorjattu), 0) AS toteutunut_summa,

--- a/test/clj/harja/palvelin/palvelut/kulut/kustannusten_seuranta_test.clj
+++ b/test/clj/harja/palvelin/palvelut/kulut/kustannusten_seuranta_test.clj
@@ -3,7 +3,7 @@
             [harja.palvelin.komponentit.tietokanta :as tietokanta]
             [harja.palvelin.komponentit.excel-vienti :as excel-vienti]
             [harja.palvelin.palvelut.kulut.kustannusten-seuranta :as kustannusten-seuranta]
-            [harja.palvelin.palvelut.kulut :as kulut]
+            [harja.palvelin.palvelut.kulut.kulut :as kulut]
             [harja.pvm :as pvm]
             [harja.testi :refer :all]
             [com.stuartsierra.component :as component]

--- a/test/clj/harja/palvelin/raportointi/laskutusyhteenveto_tyomaaraportti_test.clj
+++ b/test/clj/harja/palvelin/raportointi/laskutusyhteenveto_tyomaaraportti_test.clj
@@ -12,7 +12,7 @@
             [harja.palvelin.komponentit.pdf-vienti :as pdf-vienti]
             [harja.palvelin.raportointi :as raportointi]
             [harja.palvelin.palvelut.raportit :as raportit]
-            [harja.palvelin.palvelut.kulut :as kulut]
+            [harja.palvelin.palvelut.kulut.kulut :as kulut]
             [harja.fmt :as fmt]
             [harja.pvm :as pvm]))
 

--- a/test/clj/harja/palvelin/raportointi/tuotekohtainen_raportti_test.clj
+++ b/test/clj/harja/palvelin/raportointi/tuotekohtainen_raportti_test.clj
@@ -67,7 +67,10 @@
         paallyste-yhteensa (-> (nth laskutusyhteenveto 3) (nth 3) (nth 3) second second :arvo)
         ;; Vuosina 2019 tai 2022 on vain neljä riviä ylläpito sarakkeessa, koska
         mhu-yllapito-yhteensa (-> (nth laskutusyhteenveto 4) (nth 3) (nth 4) second second :arvo)
-        mhu-bonukset (-> (nth laskutusyhteenveto 6) (nth 3) (nth 3) second second :arvo)]
+        mhu-korvausinvestointi-yhteensa (-> (nth laskutusyhteenveto 6) (nth 3) (nth 3) second second :arvo)
+        mhu-korvausinvestointi-hankinnat (-> (nth laskutusyhteenveto 6) (nth 3) (nth 0) second second :arvo)
+        mhu-korvausinvestointi-lisatyot (-> (nth laskutusyhteenveto 6) (nth 3) (nth 1) second second :arvo)
+        mhu-korvausinvestointi-sanktiot (-> (nth laskutusyhteenveto 6) (nth 3) (nth 2) second second :arvo)]
 
     (is (= raportin-nimi "Laskutusyhteenveto (01.10.2019 - 30.09.2020)"))
     (is (= perusluku-teksti [:teksti "Indeksilaskennan perusluku: 110,8"]) "perusluku")
@@ -79,4 +82,7 @@
     (is (= soratiet-yhteensa 8801.94M))
     (is (= paallyste-yhteensa 11001.94M))
     (is (= mhu-yllapito-yhteensa 15401.94M))
-    (is (= mhu-bonukset 5544.254000M))))
+    (is (= mhu-korvausinvestointi-yhteensa 13201.94M))
+    (is (= mhu-korvausinvestointi-hankinnat 12000.97M))
+    (is (= mhu-korvausinvestointi-lisatyot 1200.97M))
+    (is (= mhu-korvausinvestointi-sanktiot 0.0M))))

--- a/test/clj/harja/testi.clj
+++ b/test/clj/harja/testi.clj
@@ -1802,7 +1802,6 @@
 
 (defn poista-kulut-aikavalilta [urakka-id hk_alkupvm hk_loppupvm]
   (let [kulut (flatten (q (format "SELECT id FROM kulu k WHERE k.urakka = %s and k.erapaiva BETWEEN '%s'::DATE AND '%s'::DATE;" urakka-id hk_alkupvm hk_loppupvm)))
-        _ (println "kulut: " kulut)
         _ (when-not (empty? kulut) (u (format "DELETE FROM kulu_kohdistus WHERE kulu IN (%s)" (str/join "," kulut))))
         _ (when-not (empty? kulut) (u (format "DELETE FROM kulu_liite WHERE kulu IN (%s)" (str/join "," kulut))))
         _ (when-not (empty? kulut) (u (format "delete from kulu k where k.urakka = %s and k.erapaiva BETWEEN '%s'::DATE AND '%s'::DATE; " urakka-id hk_alkupvm hk_loppupvm)))]))

--- a/test/clj/harja/testi.clj
+++ b/test/clj/harja/testi.clj
@@ -1801,7 +1801,6 @@
     (map vector edellinen (next edellinen) loput-seq)))
 
 (defn poista-kulut-aikavalilta [urakka-id hk_alkupvm hk_loppupvm]
-
   (let [kulut (flatten (q (format "SELECT id FROM kulu k WHERE k.urakka = %s and k.erapaiva BETWEEN '%s'::DATE AND '%s'::DATE;" urakka-id hk_alkupvm hk_loppupvm)))
         _ (when-not (empty? kulut) (u (format "DELETE FROM kulu_kohdistus WHERE kulu IN (%s)" (str/join "," kulut))))
         _ (when-not (empty? kulut) (u (format "DELETE FROM kulu_liite WHERE kulu IN (%s)" (str/join "," kulut))))

--- a/test/clj/harja/testi.clj
+++ b/test/clj/harja/testi.clj
@@ -1801,6 +1801,7 @@
     (map vector edellinen (next edellinen) loput-seq)))
 
 (defn poista-kulut-aikavalilta [urakka-id hk_alkupvm hk_loppupvm]
+
   (let [kulut (flatten (q (format "SELECT id FROM kulu k WHERE k.urakka = %s and k.erapaiva BETWEEN '%s'::DATE AND '%s'::DATE;" urakka-id hk_alkupvm hk_loppupvm)))
         _ (when-not (empty? kulut) (u (format "DELETE FROM kulu_kohdistus WHERE kulu IN (%s)" (str/join "," kulut))))
         _ (when-not (empty? kulut) (u (format "DELETE FROM kulu_liite WHERE kulu IN (%s)" (str/join "," kulut))))

--- a/test/clj/harja/testi.clj
+++ b/test/clj/harja/testi.clj
@@ -26,6 +26,7 @@
     [clojure.string :as str]
     [harja.palvelin.komponentit.pdf-vienti :as pdf-vienti]
     [harja.kyselyt.konversio :as konv]
+    [harja.domain.kulut :as kulut-domain]
     [harja.pvm :as pvm]
     [clj-gatling.core :as gatling]
     [clojure.java.jdbc :as jdbc]
@@ -1801,9 +1802,10 @@
 
 (defn poista-kulut-aikavalilta [urakka-id hk_alkupvm hk_loppupvm]
   (let [kulut (flatten (q (format "SELECT id FROM kulu k WHERE k.urakka = %s and k.erapaiva BETWEEN '%s'::DATE AND '%s'::DATE;" urakka-id hk_alkupvm hk_loppupvm)))
-        _ (u (format "DELETE FROM kulu_kohdistus WHERE kulu IN (%s)" (str/join "," kulut)))
-        _ (u (format "DELETE FROM kulu_liite WHERE kulu IN (%s)" (str/join "," kulut)))
-        _ (u (format "delete from kulu k where k.urakka = %s and k.erapaiva BETWEEN '%s'::DATE AND '%s'::DATE; " urakka-id hk_alkupvm hk_loppupvm))]))
+        _ (println "kulut: " kulut)
+        _ (when-not (empty? kulut) (u (format "DELETE FROM kulu_kohdistus WHERE kulu IN (%s)" (str/join "," kulut))))
+        _ (when-not (empty? kulut) (u (format "DELETE FROM kulu_liite WHERE kulu IN (%s)" (str/join "," kulut))))
+        _ (when-not (empty? kulut) (u (format "delete from kulu k where k.urakka = %s and k.erapaiva BETWEEN '%s'::DATE AND '%s'::DATE; " urakka-id hk_alkupvm hk_loppupvm)))]))
 
 (defn poista-bonukset-ja-sanktiot-aikavalilta [urakka-id hk_alkupvm hk_loppupvm]
   (let [toimenpideinstanssit (flatten (q (format "SELECT tpi.id as is
@@ -1812,6 +1814,58 @@
         _ (u (format "DELETE FROM erilliskustannus WHERE urakka = %s AND pvm BETWEEN '%s'::DATE AND '%s'::DATE;" urakka-id hk_alkupvm hk_loppupvm))
         ;; Sanktioihin ei ole tallennettu urakkaa, niin se pitää niputtaa toimenpideinstanssien kautta
         _ (u (format "DELETE FROM sanktio WHERE toimenpideinstanssi IN (%s) AND perintapvm BETWEEN '%s'::DATE AND '%s'::DATE;" (str/join "," toimenpideinstanssit) hk_alkupvm hk_loppupvm))]))
+
+(defn lisaa-kulu-urakalle
+  "Anna summa muodossa integer
+  Anna eräpäivä stringinä muodossa yyyy-MM-dd
+  Anna urakan-id muodossa integer
+  Anna tpi-id muodossa integer
+  Anna tryhma-id muodossa integer
+  Anna maksueratyyppi kokonaishintainen/lisatyo"
+  [summa erapaiva urakka-id tpi-id tryhma-id maksueratyyppi]
+  (let [urakan-tiedot (first (q-map (format "SELECT alkupvm FROM urakka WHERE id = %s" urakka-id)))
+        laskutuspvm (pvm/iso-8601->pvm erapaiva)
+        koontilaskun-kuukausi (kulut-domain/pvm->koontilaskun-kuukausi laskutuspvm (:alkupvm urakan-tiedot))
+
+        _ (u (format "INSERT INTO kulu (tyyppi, kokonaissumma, erapaiva, urakka, koontilaskun_kuukausi, luotu)
+                      VALUES ('laskutettava'::LASKUTYYPPI, %s, '%s'::DATE, %s, '%s', NOW());"
+               summa erapaiva urakka-id koontilaskun-kuukausi))
+
+        ;; HAetaan viimeisin id
+        kulu-id (:id (first (q-map (format "SELECT id FROM kulu
+                                            WHERE kokonaissumma = %s AND urakka = %s
+                                            ORDER BY ID DESC LIMIT 1"
+                                     summa urakka-id))))
+
+        _ (u (format "INSERT INTO kulu_kohdistus (rivi, kulu, summa, toimenpideinstanssi, tehtavaryhma, maksueratyyppi,
+                                                  suoritus_alku, suoritus_loppu, luotu)
+                      VALUES (0, %s, %s, %s, %s, '%s', '%s'::TIMESTAMP, '%s'::TIMESTAMP, now());"
+               kulu-id summa tpi-id tryhma-id maksueratyyppi laskutuspvm laskutuspvm))]))
+
+(defn lisaa-sanktio-urakalle
+  "Anna sakkoryhma 'C'
+  Anna määrä integerina
+  pvm on perintäpäivämäärä
+  urakka-id on urakan id
+  tpi on toimenpideinstanssi, jolle sanktio laitetaan, anna integer.
+  sanktiotyyppi taulusta id, "
+  [maara sakkoryhma pvm urakka-id tpi sanktiotyyppi-id]
+  (let [;; Lisätään ensin laatupoikkeama, jotta voidaan lisätä sanktio
+        aika (pvm/iso-8601->pvm pvm)
+        _ (u (format "INSERT INTO laatupoikkeama (kohde, tekija, kasittelytapa, paatos, perustelu, luotu, aika,
+        kasittelyaika, urakka, lahde)
+        VALUES ('xx', 'tilaaja','puhelin','sanktio', 'xx', now(), '%s', '%s', %s, 'harja-ui');"
+               aika aika urakka-id))
+
+        ;; HAetaan viimeisin id
+        laatupoikkeama-id (:id (first (q-map (format "SELECT id FROM laatupoikkeama
+                                            WHERE urakka = %s
+                                            ORDER BY ID DESC LIMIT 1" urakka-id))))
+
+        _ (u (format "INSERT INTO sanktio (maara, perintapvm, laatupoikkeama, toimenpideinstanssi, tyyppi, suorasanktio,
+        luotu, sakkoryhma)
+        VALUES (%s, '%s', %s, %s, %s, true, now(), '%s');"
+               maara pvm laatupoikkeama-id tpi sanktiotyyppi-id sakkoryhma))]))
 
 (defn lahes-sama?
   "Laske Levenshtein Distance -arvon kahden tekstin välille ja kertoo, onko se sallitun thresholdin puitteissa.

--- a/tietokanta/src/main/resources/db/migration/R__Laskutusyhteenveto_mhu.sql
+++ b/tietokanta/src/main/resources/db/migration/R__Laskutusyhteenveto_mhu.sql
@@ -661,6 +661,7 @@ BEGIN
                           JOIN toimenpide tpk2 ON tpk3.emo = tpk2.id,
                       maksuera m
                  WHERE tpi.urakka = ur AND m.toimenpideinstanssi = tpi.id
+                 ORDER BY m.numero asc
         LOOP
             RAISE NOTICE '*************************************** Laskutusyhteenvedon laskenta alkaa toimenpiteelle: % , ID % *****************************************', t.nimi, t.tpi;
 

--- a/tietokanta/src/main/resources/db/migration/V1_1077__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1077__.sql
@@ -1,0 +1,5 @@
+-- Contstraint check on siirretty koodiin, jotta pg_dump -> pg_restore putki toimisi oikein
+-- Samalla poistetaan turha viittaus tehtävä tauluun.
+ALTER TABLE kulu_kohdistus
+    DROP CONSTRAINT lasku_kohdistus_tehtava_tehtavaryhma_toimenpideinstanssi_oikein,
+    DROP COLUMN tehtava;

--- a/tietokanta/testidata/laskut.sql
+++ b/tietokanta/testidata/laskut.sql
@@ -5,14 +5,14 @@ VALUES ('2019-10-15', 6666.66, (select id from urakka where nimi = 'Oulun MHU 20
 INSERT INTO kulu (erapaiva, kokonaissumma, urakka, tyyppi, luotu, luoja, koontilaskun_kuukausi)
 VALUES ('2019-09-15', 3666.66, (select id from urakka where nimi = 'Oulun MHU 2019-2024'), 'kiinteasti-hinnoiteltu', current_timestamp, (select id from kayttaja where kayttajanimi = 'Integraatio'), 'lokakuu/1-hoitovuosi');
 
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES ((select id from kulu where kokonaissumma = 666.66), 1, (select id from toimenpideinstanssi where nimi = 'Oulu MHU Liikenneympäristön hoito TP'),(select id from tehtavaryhma where nimi = 'Vesakonraivaukset ja puun poisto (V)'), null, 'kokonaishintainen'::MAKSUERATYYPPI, 333.33, '2019-11-15', '2019-11-18', current_timestamp, (select id from kayttaja where kayttajanimi = 'Integraatio'));
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES ((select id from kulu where kokonaissumma = 666.66), 2, (select id from toimenpideinstanssi where nimi = 'Oulu MHU Liikenneympäristön hoito TP'),(select id from tehtavaryhma where nimi = 'Nurmetukset ja muut vihertyöt (N)'), null, 'kokonaishintainen'::MAKSUERATYYPPI, 222.22, '2019-11-22', '2019-11-25', current_timestamp, (select id from kayttaja where kayttajanimi = 'Integraatio'));
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES ((select id from kulu where kokonaissumma = 666.66), 3, (select id from toimenpideinstanssi where nimi = 'Oulu MHU Liikenneympäristön hoito TP'),(select id from tehtavaryhma where nimi = 'Puhtaanapito (P)'), null, 'kokonaishintainen'::MAKSUERATYYPPI, 111.11, '2019-11-28', '2019-11-30', current_timestamp, (select id from kayttaja where kayttajanimi = 'Integraatio'));
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES ((select id from kulu where kokonaissumma = 666.66), 1, (select id from toimenpideinstanssi where nimi = 'Oulu MHU Liikenneympäristön hoito TP'),(select id from tehtavaryhma where nimi = 'Vesakonraivaukset ja puun poisto (V)'), 'kokonaishintainen'::MAKSUERATYYPPI, 333.33, '2019-11-15', '2019-11-18', current_timestamp, (select id from kayttaja where kayttajanimi = 'Integraatio'));
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES ((select id from kulu where kokonaissumma = 666.66), 2, (select id from toimenpideinstanssi where nimi = 'Oulu MHU Liikenneympäristön hoito TP'),(select id from tehtavaryhma where nimi = 'Nurmetukset ja muut vihertyöt (N)'), 'kokonaishintainen'::MAKSUERATYYPPI, 222.22, '2019-11-22', '2019-11-25', current_timestamp, (select id from kayttaja where kayttajanimi = 'Integraatio'));
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES ((select id from kulu where kokonaissumma = 666.66), 3, (select id from toimenpideinstanssi where nimi = 'Oulu MHU Liikenneympäristön hoito TP'),(select id from tehtavaryhma where nimi = 'Puhtaanapito (P)'), 'kokonaishintainen'::MAKSUERATYYPPI, 111.11, '2019-11-28', '2019-11-30', current_timestamp, (select id from kayttaja where kayttajanimi = 'Integraatio'));
 
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES ((select id from kulu where kokonaissumma = 6666.66), 1, (select id from toimenpideinstanssi where nimi = 'Oulu MHU Liikenneympäristön hoito TP'), (select id from tehtavaryhma where nimi = 'Kuivatusjärjestelmät (K)'), (SELECT id FROM tehtava WHERE nimi = 'Rumpujen tarkastus' and tehtavaryhma is not null), 'kokonaishintainen'::MAKSUERATYYPPI, 2222.22, '2019-08-01', '2019-08-31', current_timestamp, (select id from kayttaja where kayttajanimi = 'Integraatio'));
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES ((select id from kulu where kokonaissumma = 6666.66), 2, (select id from toimenpideinstanssi where nimi = 'Oulu MHU Liikenneympäristön hoito TP'), (select id from tehtavaryhma where nimi = 'Äkilliset hoitotyöt, Liikenneympäristön hoito (T1)'), (SELECT id FROM tehtava WHERE nimi = 'Äkillinen hoitotyö (l.ymp.hoito)' and tehtavaryhma is not null and emo = 612), 'akillinen-hoitotyo'::MAKSUERATYYPPI, 4444.44, '2019-12-01T06:15:00.000000', '2019-12-01T09:45:00.000000', current_timestamp, (select id from kayttaja where kayttajanimi = 'Integraatio'));
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES ((select id from kulu where kokonaissumma = 6666.66), 1, (select id from toimenpideinstanssi where nimi = 'Oulu MHU Liikenneympäristön hoito TP'), (select id from tehtavaryhma where nimi = 'Kuivatusjärjestelmät (K)'), 'kokonaishintainen'::MAKSUERATYYPPI, 2222.22, '2019-08-01', '2019-08-31', current_timestamp, (select id from kayttaja where kayttajanimi = 'Integraatio'));
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES ((select id from kulu where kokonaissumma = 6666.66), 2, (select id from toimenpideinstanssi where nimi = 'Oulu MHU Liikenneympäristön hoito TP'), (select id from tehtavaryhma where nimi = 'Äkilliset hoitotyöt, Liikenneympäristön hoito (T1)'), 'akillinen-hoitotyo'::MAKSUERATYYPPI, 4444.44, '2019-12-01T06:15:00.000000', '2019-12-01T09:45:00.000000', current_timestamp, (select id from kayttaja where kayttajanimi = 'Integraatio'));
 
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES ((select id from kulu where kokonaissumma = 3666.66), 1, (select id from toimenpideinstanssi where nimi = 'Oulu MHU Talvihoito TP'), (select id from tehtavaryhma where nimi = 'Talvihoito (A)'), NULL, 'kokonaishintainen'::MAKSUERATYYPPI, 3666.66, '2020-07-01', '2020-07-31', current_timestamp, (select id from kayttaja where kayttajanimi = 'Integraatio'));
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES ((select id from kulu where kokonaissumma = 3666.66), 1, (select id from toimenpideinstanssi where nimi = 'Oulu MHU Talvihoito TP'), (select id from tehtavaryhma where nimi = 'Talvihoito (A)'), 'kokonaishintainen'::MAKSUERATYYPPI, 3666.66, '2020-07-01', '2020-07-31', current_timestamp, (select id from kayttaja where kayttajanimi = 'Integraatio'));
 
 INSERT INTO liite (nimi, tyyppi, lahde, urakka, luotu, luoja) VALUES ('pensas-2019080019.jpg', 'image/png', 'harja-ui'::lahde, (select id from urakka where nimi = 'Oulun MHU 2019-2024'), current_timestamp, (select id from kayttaja where kayttajanimi = 'Integraatio'));
 INSERT INTO kulu_liite (kulu, liite, luotu, luoja) VALUES ((select id from kulu where kokonaissumma = 666.66), (select id from liite where nimi = 'pensas-2019080019.jpg'), current_timestamp, (select id from kayttaja where kayttajanimi = 'Integraatio'));
@@ -86,40 +86,40 @@ VALUES ('2019-10-16', 700.77, urakka_id, 'laskutettava', current_timestamp, kayt
 
 -- Kohdistukset - 15.10.2019 - Laskutuskausi alkaa 1.10
 -- Talvihoito
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
 ((select id from kulu where kokonaissumma = 3000.77 AND tyyppi = 'kiinteasti-hinnoiteltu' AND erapaiva = '2019-10-16'), 1, tinst_talvihoito,
- tehtava_talvihoito, NULL, 'kokonaishintainen'::MAKSUERATYYPPI, 3000.77, '2019-10-01', '2019-10-31', current_timestamp, kayttaja_id);
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+ tehtava_talvihoito, 'kokonaishintainen'::MAKSUERATYYPPI, 3000.77, '2019-10-01', '2019-10-31', current_timestamp, kayttaja_id);
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
 ((select id from kulu where kokonaissumma = 300.77 AND tyyppi = 'laskutettava' AND erapaiva = '2019-10-16'), 1, tinst_talvihoito,
- tehtava_talvihoito, NULL, 'lisatyo'::MAKSUERATYYPPI, 300.77, '2019-10-01', '2019-10-31', current_timestamp, kayttaja_id);
+ tehtava_talvihoito, 'lisatyo'::MAKSUERATYYPPI, 300.77, '2019-10-01', '2019-10-31', current_timestamp, kayttaja_id);
 -- Soratiet Oulu MHU Soratien hoito TP
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
 ((select id from kulu where kokonaissumma = 4000.77 AND tyyppi = 'kiinteasti-hinnoiteltu' AND erapaiva = '2019-10-16'), 1, tinst_soratie,
- tehtava_soratie, NULL, 'kokonaishintainen'::MAKSUERATYYPPI, 4000.77, '2019-10-01', '2019-10-31', current_timestamp, kayttaja_id);
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+ tehtava_soratie, 'kokonaishintainen'::MAKSUERATYYPPI, 4000.77, '2019-10-01', '2019-10-31', current_timestamp, kayttaja_id);
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
 ((select id from kulu where kokonaissumma = 400.77 AND tyyppi = 'laskutettava' AND erapaiva = '2019-10-16'), 1, tinst_soratie,
- tehtava_soratie, NULL, 'lisatyo'::MAKSUERATYYPPI, 400.77, '2019-10-01', '2019-10-31', current_timestamp, kayttaja_id);
+ tehtava_soratie, 'lisatyo'::MAKSUERATYYPPI, 400.77, '2019-10-01', '2019-10-31', current_timestamp, kayttaja_id);
 -- Päällyste Oulu MHU Soratien hoito TP
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
 ((select id from kulu where kokonaissumma = 5000.77 AND tyyppi = 'kiinteasti-hinnoiteltu' AND erapaiva = '2019-10-16'), 1, tinst_paallystys,
- tehtava_paikkaus, NULL, 'kokonaishintainen'::MAKSUERATYYPPI, 5000.77, '2019-10-01', '2019-10-31', current_timestamp, kayttaja_id);
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+ tehtava_paikkaus, 'kokonaishintainen'::MAKSUERATYYPPI, 5000.77, '2019-10-01', '2019-10-31', current_timestamp, kayttaja_id);
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
 ((select id from kulu where kokonaissumma = 500.77 AND tyyppi = 'laskutettava' AND erapaiva = '2019-10-16'), 1, tinst_paallystys,
- tehtava_paikkaus, NULL, 'lisatyo'::MAKSUERATYYPPI, 500.77, '2019-10-01', '2019-10-31', current_timestamp, kayttaja_id);
+ tehtava_paikkaus, 'lisatyo'::MAKSUERATYYPPI, 500.77, '2019-10-01', '2019-10-31', current_timestamp, kayttaja_id);
 -- Korvausinvestoinnit Oulu MHU MHU Korvausinvestointi TP
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
 ((select id from kulu where kokonaissumma = 6000.77 AND tyyppi = 'kiinteasti-hinnoiteltu' AND erapaiva = '2019-10-16'), 1, tinst_korvaus,
- tehtava_korvaus, NULL, 'kokonaishintainen'::MAKSUERATYYPPI, 6000.77, '2019-10-01', '2019-10-31', current_timestamp, kayttaja_id);
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+ tehtava_korvaus, 'kokonaishintainen'::MAKSUERATYYPPI, 6000.77, '2019-10-01', '2019-10-31', current_timestamp, kayttaja_id);
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
 ((select id from kulu where kokonaissumma = 600.77 AND tyyppi = 'laskutettava' AND erapaiva = '2019-10-16'), 1, tinst_korvaus,
- tehtava_korvaus, NULL, 'lisatyo'::MAKSUERATYYPPI, 600.77, '2019-10-01', '2019-10-31', current_timestamp, kayttaja_id);
+ tehtava_korvaus, 'lisatyo'::MAKSUERATYYPPI, 600.77, '2019-10-01', '2019-10-31', current_timestamp, kayttaja_id);
 -- Ylläpito -  Oulu MHU MHU Ylläpito TP
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
 ((select id from kulu where kokonaissumma = 7000.77 AND tyyppi = 'kiinteasti-hinnoiteltu' AND erapaiva = '2019-10-16'), 1, tinst_yllapito,
- tehtava_yllapito, NULL, 'kokonaishintainen'::MAKSUERATYYPPI, 7000.77, '2019-10-01', '2019-10-31', current_timestamp, kayttaja_id);
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+ tehtava_yllapito, 'kokonaishintainen'::MAKSUERATYYPPI, 7000.77, '2019-10-01', '2019-10-31', current_timestamp, kayttaja_id);
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
 ((select id from kulu where kokonaissumma = 700.77 AND tyyppi = 'laskutettava' AND erapaiva = '2019-10-16'), 1, tinst_yllapito,
- tehtava_yllapito, NULL, 'lisatyo'::MAKSUERATYYPPI, 700.77, '2019-10-01', '2019-10-31', current_timestamp,kayttaja_id);
+ tehtava_yllapito, 'lisatyo'::MAKSUERATYYPPI, 700.77, '2019-10-01', '2019-10-31', current_timestamp,kayttaja_id);
 
 
 -- Laskut 20.03.2020
@@ -149,30 +149,30 @@ INSERT INTO kulu (erapaiva, kokonaissumma, urakka, tyyppi, luotu, luoja, koontil
   VALUES ('2020-03-20', 700.20, urakka_id, 'laskutettava', current_timestamp, kayttaja_id, 'maaliskuu/1-hoitovuosi');
 
 -- Kohdistukset 1.3.2020 - 31.3.2020
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
-((select id from kulu where kokonaissumma = 3000.20 AND tyyppi = 'kiinteasti-hinnoiteltu' AND erapaiva = '2020-03-20'), 1, tinst_talvihoito, tehtava_talvihoito, NULL, 'kokonaishintainen'::MAKSUERATYYPPI, 3000.20, '2020-03-15', '2020-03-20', current_timestamp, kayttaja_id);
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
-((select id from kulu where kokonaissumma = 300.20 AND tyyppi = 'laskutettava' AND erapaiva = '2020-03-20'), 1, tinst_talvihoito, tehtava_talvihoito, NULL, 'lisatyo'::MAKSUERATYYPPI, 300.20, '2020-03-15', '2020-03-20', current_timestamp, kayttaja_id);
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+((select id from kulu where kokonaissumma = 3000.20 AND tyyppi = 'kiinteasti-hinnoiteltu' AND erapaiva = '2020-03-20'), 1, tinst_talvihoito, tehtava_talvihoito, 'kokonaishintainen'::MAKSUERATYYPPI, 3000.20, '2020-03-15', '2020-03-20', current_timestamp, kayttaja_id);
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+((select id from kulu where kokonaissumma = 300.20 AND tyyppi = 'laskutettava' AND erapaiva = '2020-03-20'), 1, tinst_talvihoito, tehtava_talvihoito, 'lisatyo'::MAKSUERATYYPPI, 300.20, '2020-03-15', '2020-03-20', current_timestamp, kayttaja_id);
 -- Soratiet
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
-((select id from kulu where kokonaissumma = 4000.20 AND tyyppi = 'kiinteasti-hinnoiteltu' AND erapaiva = '2020-03-20'), 1, tinst_soratie, tehtava_soratie, NULL, 'kokonaishintainen'::MAKSUERATYYPPI, 4000.20, '2020-03-15', '2020-03-20', current_timestamp, kayttaja_id);
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
-((select id from kulu where kokonaissumma = 400.20 AND tyyppi = 'laskutettava' AND erapaiva = '2020-03-20'), 1, tinst_soratie, tehtava_soratie, NULL, 'lisatyo'::MAKSUERATYYPPI, 400.20, '2020-03-15', '2020-03-20', current_timestamp, kayttaja_id);
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+((select id from kulu where kokonaissumma = 4000.20 AND tyyppi = 'kiinteasti-hinnoiteltu' AND erapaiva = '2020-03-20'), 1, tinst_soratie, tehtava_soratie, 'kokonaishintainen'::MAKSUERATYYPPI, 4000.20, '2020-03-15', '2020-03-20', current_timestamp, kayttaja_id);
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+((select id from kulu where kokonaissumma = 400.20 AND tyyppi = 'laskutettava' AND erapaiva = '2020-03-20'), 1, tinst_soratie, tehtava_soratie, 'lisatyo'::MAKSUERATYYPPI, 400.20, '2020-03-15', '2020-03-20', current_timestamp, kayttaja_id);
 -- Soratiet
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
-((select id from kulu where kokonaissumma = 5000.20 AND tyyppi = 'kiinteasti-hinnoiteltu' AND erapaiva = '2020-03-20'), 1, tinst_paallystys, tehtava_paikkaus, NULL, 'kokonaishintainen'::MAKSUERATYYPPI, 5000.20, '2020-03-15', '2020-03-20', current_timestamp, kayttaja_id);
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
-((select id from kulu where kokonaissumma = 500.20 AND tyyppi = 'laskutettava' AND erapaiva = '2020-03-20'), 1, tinst_paallystys, tehtava_paikkaus, NULL, 'lisatyo'::MAKSUERATYYPPI, 500.20, '2020-03-15', '2020-03-20', current_timestamp, kayttaja_id);
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+((select id from kulu where kokonaissumma = 5000.20 AND tyyppi = 'kiinteasti-hinnoiteltu' AND erapaiva = '2020-03-20'), 1, tinst_paallystys, tehtava_paikkaus, 'kokonaishintainen'::MAKSUERATYYPPI, 5000.20, '2020-03-15', '2020-03-20', current_timestamp, kayttaja_id);
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+((select id from kulu where kokonaissumma = 500.20 AND tyyppi = 'laskutettava' AND erapaiva = '2020-03-20'), 1, tinst_paallystys, tehtava_paikkaus, 'lisatyo'::MAKSUERATYYPPI, 500.20, '2020-03-15', '2020-03-20', current_timestamp, kayttaja_id);
 -- Korvausinvestoinnit
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
-((select id from kulu where kokonaissumma = 6000.20 AND tyyppi = 'kiinteasti-hinnoiteltu' AND erapaiva = '2020-03-20'), 1, tinst_korvaus, tehtava_korvaus, NULL, 'kokonaishintainen'::MAKSUERATYYPPI, 6000.20, '2020-03-15', '2020-03-20', current_timestamp, kayttaja_id);
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
-((select id from kulu where kokonaissumma = 600.20 AND tyyppi = 'laskutettava' AND erapaiva = '2020-03-20'), 1, tinst_korvaus, tehtava_korvaus, NULL, 'lisatyo'::MAKSUERATYYPPI, 600.20, '2020-03-15', '2020-03-20', current_timestamp, kayttaja_id);
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+((select id from kulu where kokonaissumma = 6000.20 AND tyyppi = 'kiinteasti-hinnoiteltu' AND erapaiva = '2020-03-20'), 1, tinst_korvaus, tehtava_korvaus, 'kokonaishintainen'::MAKSUERATYYPPI, 6000.20, '2020-03-15', '2020-03-20', current_timestamp, kayttaja_id);
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+((select id from kulu where kokonaissumma = 600.20 AND tyyppi = 'laskutettava' AND erapaiva = '2020-03-20'), 1, tinst_korvaus, tehtava_korvaus, 'lisatyo'::MAKSUERATYYPPI, 600.20, '2020-03-15', '2020-03-20', current_timestamp, kayttaja_id);
 -- Ylläpito
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
-((select id from kulu where kokonaissumma = 7000.20 AND tyyppi = 'kiinteasti-hinnoiteltu' AND erapaiva = '2020-03-20'), 1, tinst_yllapito, tehtava_yllapito, NULL, 'kokonaishintainen'::MAKSUERATYYPPI, 7000.20, '2020-03-15', '2020-03-20', current_timestamp, kayttaja_id);
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
-((select id from kulu where kokonaissumma = 700.20 AND tyyppi = 'laskutettava' AND erapaiva = '2020-03-20'), 1, tinst_yllapito, tehtava_yllapito, NULL, 'lisatyo'::MAKSUERATYYPPI, 700.20, '2020-03-15', '2020-03-20', current_timestamp, kayttaja_id);
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+((select id from kulu where kokonaissumma = 7000.20 AND tyyppi = 'kiinteasti-hinnoiteltu' AND erapaiva = '2020-03-20'), 1, tinst_yllapito, tehtava_yllapito, 'kokonaishintainen'::MAKSUERATYYPPI, 7000.20, '2020-03-15', '2020-03-20', current_timestamp, kayttaja_id);
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+((select id from kulu where kokonaissumma = 700.20 AND tyyppi = 'laskutettava' AND erapaiva = '2020-03-20'), 1, tinst_yllapito, tehtava_yllapito, 'lisatyo'::MAKSUERATYYPPI, 700.20, '2020-03-15', '2020-03-20', current_timestamp, kayttaja_id);
 
 -- Poikkeuskulut MHU ja Hoidon johdon hallinnolle - 04/2020
 -- Normaalisti näitä ei pitäisi lisätä, mutta koska se on käyttöliittymästä mahdollista, niin tehdään testiaineisto
@@ -183,12 +183,12 @@ INSERT into kulu (erapaiva, kokonaissumma, urakka, tyyppi, luotu, luoja, koontil
 INSERT into kulu (erapaiva, kokonaissumma, urakka, tyyppi, luotu, luoja, koontilaskun_kuukausi)
   VALUES ('2020-04-22', 10.20, urakka_id, 'laskutettava', current_timestamp, kayttaja_id, 'huhtikuu/1-hoitovuosi');
 -- Kohdistukset
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
-((select id from kulu where kokonaissumma = 10.20 AND tyyppi = 'laskutettava' AND erapaiva = '2020-04-20'), 1, tinst_mhu_hoidon_johto, tehtava_palkkio, NULL, 'kokonaishintainen'::MAKSUERATYYPPI, 10.20, '2020-04-15', '2020-04-20', current_timestamp, kayttaja_id);
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
-((select id from kulu where kokonaissumma = 10.20 AND tyyppi = 'laskutettava' AND erapaiva = '2020-04-21'), 1, tinst_mhu_hoidon_johto, tehtava_mhu_hoidon_johto, NULL, 'kokonaishintainen'::MAKSUERATYYPPI, 10.20, '2020-04-15', '2020-04-20', current_timestamp, kayttaja_id);
-INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
-((select id from kulu where kokonaissumma = 10.20 AND tyyppi = 'laskutettava' AND erapaiva = '2020-04-22'), 1, tinst_mhu_hoidon_johto, tehtava_erillishankinnat, NULL, 'kokonaishintainen'::MAKSUERATYYPPI, 10.20, '2020-04-15', '2020-04-20', current_timestamp, kayttaja_id);
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+((select id from kulu where kokonaissumma = 10.20 AND tyyppi = 'laskutettava' AND erapaiva = '2020-04-20'), 1, tinst_mhu_hoidon_johto, tehtava_palkkio, 'kokonaishintainen'::MAKSUERATYYPPI, 10.20, '2020-04-15', '2020-04-20', current_timestamp, kayttaja_id);
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+((select id from kulu where kokonaissumma = 10.20 AND tyyppi = 'laskutettava' AND erapaiva = '2020-04-21'), 1, tinst_mhu_hoidon_johto, tehtava_mhu_hoidon_johto, 'kokonaishintainen'::MAKSUERATYYPPI, 10.20, '2020-04-15', '2020-04-20', current_timestamp, kayttaja_id);
+INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja) VALUES
+((select id from kulu where kokonaissumma = 10.20 AND tyyppi = 'laskutettava' AND erapaiva = '2020-04-22'), 1, tinst_mhu_hoidon_johto, tehtava_erillishankinnat, 'kokonaishintainen'::MAKSUERATYYPPI, 10.20, '2020-04-15', '2020-04-20', current_timestamp, kayttaja_id);
 
         END
 $$ LANGUAGE plpgsql;

--- a/tietokanta/testidata/laskutusyhteenveto_mhu.sql
+++ b/tietokanta/testidata/laskutusyhteenveto_mhu.sql
@@ -213,9 +213,9 @@ $$
         -- Kulut - tavoitepalkkio
         INSERT INTO kulu (erapaiva, kokonaissumma, urakka, tyyppi, luotu, luoja, koontilaskun_kuukausi)
         VALUES ('2019-10-13', 1000, urakka_id, 'laskutettava', '2019-10-13'::TIMESTAMP, kayttaja_id, 'lokakuu/1-hoitovuosi');
-        INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja)
+        INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja)
         VALUES ((select id from kulu where kokonaissumma = 1000 AND urakka=urakka_id), 0, (select id from toimenpideinstanssi where nimi = 'Oulu MHU Hallinnolliset toimenpiteet TP'),
-                (select id from tehtavaryhma where nimi = 'Hoitovuoden päättäminen / Tavoitepalkkio'), null, 'kokonaishintainen'::MAKSUERATYYPPI, 1000,
+                (select id from tehtavaryhma where nimi = 'Hoitovuoden päättäminen / Tavoitepalkkio'), 'kokonaishintainen'::MAKSUERATYYPPI, 1000,
                 null, null, '2019-10-13'::TIMESTAMP, kayttaja_id);
 
         -- Bonukset - 03/2020
@@ -231,9 +231,9 @@ $$
         -- Kulut - tavoitepalkkio
         INSERT INTO kulu (erapaiva, kokonaissumma, urakka, tyyppi, luotu, luoja, koontilaskun_kuukausi)
         VALUES ('2020-3-13', 500, urakka_id, 'laskutettava', '2020-3-13'::TIMESTAMP, kayttaja_id, 'maaliskuu/1-hoitovuosi');
-        INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, tehtava, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja)
+        INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, summa, suoritus_alku, suoritus_loppu, luotu, luoja)
         VALUES ((select id from kulu where kokonaissumma = 500 AND urakka=urakka_id), 0, (select id from toimenpideinstanssi where nimi = 'Oulu MHU Hallinnolliset toimenpiteet TP'),
-                (select id from tehtavaryhma where nimi = 'Hoitovuoden päättäminen / Tavoitepalkkio'), null, 'kokonaishintainen'::MAKSUERATYYPPI, 500,
+                (select id from tehtavaryhma where nimi = 'Hoitovuoden päättäminen / Tavoitepalkkio'), 'kokonaishintainen'::MAKSUERATYYPPI, 500,
                 null, null, '2020-3-13'::TIMESTAMP, kayttaja_id);
 
         -- Hoidonjohdon palkkiot - 10/2019


### PR DESCRIPTION
Constraint lasku_kohdistus_tehtava_tehtavaryhma_toimenpideinstanssi_oikein esti pg_restoren toiminnan.
Itse tarkistus on jätetty. Se on nyt vain koodin puolella.

Poistin myös tehtava sarakkeen kulu_kohdistus taulusta. Sitä ei käytetä tuotannossa, sitä käytettiin vain testiaineistossa. Tästä syystä muutamat siivoukset sinne.

Tehtävä sarakkeen poiston yhteydessä testasin kuluja ja laskutusyhteenvetoa. Tuotekohtaisessa laskutusyhteenvedossa oli bugi kovakoodattujen toimenpideinstanssien indeksien kanssa. Siellä oletettiin, että instanssit tulevat kannasta aina samassa järjestyksessä. Mutta eivät ne aina tule. Niinpä poistin kovakoodatun indeksin ja rakensin siihen vaikean hässäkän, jolla koitetaan päätellä, että mikä instanssi on missäkin indeksissä. 
Samposta tulee toimenpideinstanssien nimet ihan miten sattuu, joten mitään kovin hyvää nimen etsimislogiikkaa ei ole olemassa. Ja tuo systeemi saattaa epäonnistua joskus. Mutta se on nyt ainakin paljon parempi, kuin kovakoodattu indeksi.

Tuo toimenpideinstanssi homma kyllä tosi hankala Harjassa. Niiden vapaa nimeäminen tietokantaan, mutta kovakoodatut nimet raportilla aiheuttaa ongelmia ihan varmasti.

 