### PR TITLE
Harja 260 huoltokohde suodatin

### DIFF
--- a/cypress/e2e/valikatselmus.cy.js
+++ b/cypress/e2e/valikatselmus.cy.js
@@ -3,6 +3,7 @@ const testiaika = new Date(2021, 9, 15, 12).getTime() // Urakan 1. vuoden loppu
 
 describe('Välikatselmus aukeaa', () => {
     it('Välikatselmuksen voi avata kustannusten seurannasta', () => {
+        cy.intercept('POST', 'urakan-kustannusten-seuranta-paaryhmittain' ).as('hae-kustannukset')
         cy.viewport(1100, 2000)
         cy.visit('/')
         cy.contains('.haku-lista-item', 'Pohjois-Pohjanmaa', {timeout}).click()
@@ -10,6 +11,7 @@ describe('Välikatselmus aukeaa', () => {
         cy.contains('[data-cy=urakat-valitse-urakka] li', 'Iin MHU 2021-2026', {timeout}).click()
         cy.get('[data-cy=tabs-taso1-Kulut]').click()
         cy.get('[data-cy="tabs-taso2-Kustannusten seuranta"]').click()
+        cy.wait('@hae-kustannukset')
         cy.get('[data-cy=hoitokausi-valinta]').valinnatValitse({valinta: '1. hoitovuosi (2021—2022)'})
         cy.contains('Tee välikatselmus').click()
         cy.contains('Välikatselmuksen päätökset')

--- a/src/clj/harja/kyselyt/kanavat/kanavan_toimenpide.sql
+++ b/src/clj/harja/kyselyt/kanavat/kanavan_toimenpide.sql
@@ -9,4 +9,5 @@ WHERE kt.urakka = :urakka AND
       (kt.pvm BETWEEN :alkupvm AND :loppupvm) AND
       (:toimenpidekoodi :: INTEGER IS NULL OR tpk3.id = :toimenpidekoodi) AND
       (kt.tyyppi = :tyyppi :: KAN_TOIMENPIDETYYPPI) AND
-      (:kohde :: INTEGER IS NULL OR "kohde-id" = :kohde);
+      (:kohde :: INTEGER IS NULL OR "kohde-id" = :kohde) AND
+      (:huoltokohde :: INTEGER IS NULL OR huoltokohde = :huoltokohde);

--- a/src/clj/harja/palvelin/palvelut/kanavat/kanavatoimenpiteet.clj
+++ b/src/clj/harja/palvelin/palvelut/kanavat/kanavatoimenpiteet.clj
@@ -106,7 +106,8 @@
                                        alkupvm :alkupvm loppupvm :loppupvm
                                        toimenpidekoodi ::toimenpidekoodi/id
                                        tyyppi ::toimenpide/kanava-toimenpidetyyppi
-                                       kohde ::toimenpide/kohde-id}]
+                                       kohde ::toimenpide/kohde-id
+                                       huoltokohde-id ::toimenpide/huoltokohde-id}]
   (tarkista-kutsu user urakka-id tyyppi)
   (let [tyyppi (name tyyppi)]
     (q-toimenpide/hae-kanavatomenpiteet-jeesql
@@ -117,7 +118,8 @@
        :loppupvm loppupvm
        :toimenpidekoodi toimenpidekoodi
        :tyyppi tyyppi
-       :kohde kohde})))
+       :kohde kohde
+       :huoltokohde huoltokohde-id})))
 
 (defn siirra-kanavatoimenpiteet [db user tiedot]
   (let [urakka-id (::toimenpide/urakka-id tiedot)

--- a/src/cljs/harja/tiedot/kanavat/urakka/toimenpiteet.cljs
+++ b/src/cljs/harja/tiedot/kanavat/urakka/toimenpiteet.cljs
@@ -26,7 +26,8 @@
    ::kanavatoimenpide/kanava-toimenpidetyyppi tyyppi
    :alkupvm (first (:aikavali valinnat))
    :loppupvm (second (:aikavali valinnat))
-   ::kanavatoimenpide/kohde-id (:kanava-kohde-id valinnat)})
+   ::kanavatoimenpide/kohde-id (:kanava-kohde-id valinnat)
+   ::kanavatoimenpide/huoltokohde-id (:huoltokohde-id valinnat)})
 
 (defn esitaytetty-toimenpidelomake [kayttaja urakka]
   {::kanavatoimenpide/sopimus-id (:paasopimus urakka)

--- a/src/cljs/harja/tiedot/kanavat/urakka/toimenpiteet/kokonaishintaiset.cljs
+++ b/src/cljs/harja/tiedot/kanavat/urakka/toimenpiteet/kokonaishintaiset.cljs
@@ -75,6 +75,7 @@
 (defn alkuvalinnat []
   {:urakka @navigaatio/valittu-urakka
    :sopimus-id (first @urakkatiedot/valittu-sopimusnumero)
+   :urakkavuosi @urakkatiedot/valittu-hoitokausi
    :aikavali @urakkatiedot/valittu-aikavali
    :toimenpide @urakkatiedot/valittu-toimenpideinstanssi})
 

--- a/src/cljs/harja/ui/valinnat.cljs
+++ b/src/cljs/harja/ui/valinnat.cljs
@@ -517,6 +517,15 @@
                          :valitse-fn #(reset! valittu-aluslaji-atom %)}
     kohteet]])
 
+(defn kanava-huoltokohde
+  [valittu-huoltokohde-atom kohteet format-fn]
+  [:div.label-ja-alasveto
+   [:span.alasvedon-otsikko "Huoltokohde"]
+   [livi-pudotusvalikko {:valinta @valittu-huoltokohde-atom
+                         :format-fn format-fn
+                         :valitse-fn #(reset! valittu-huoltokohde-atom %)}
+    kohteet]])
+
 (defn urakkavalinnat [{:keys [urakka]} & sisalto]
   [:div.urakkavalinnat (when (and urakka (not (u-domain/vesivaylaurakka? urakka)))
                          {:class "urakkavalinnat-tyyliton"})

--- a/src/cljs/harja/ui/valinnat.cljs
+++ b/src/cljs/harja/ui/valinnat.cljs
@@ -170,26 +170,17 @@
                              aikavali
                              (if-not aikavalin-rajoitus
                               (pvm/varmista-aikavali-opt aikavali paa)
-                              (pvm/varmista-aikavali-opt aikavali aikavalin-rajoitus paa)))))
-         tarkasta-esitettavat-arvot! (fn [uusi-aikavali]
-                                       (r/next-tick (fn []
-                                                      (let [[uusi-alku uusi-loppu] uusi-aikavali]
-                                                        (when-not (= @aikavalin-alku uusi-alku)
-                                                          (reset! aikavalin-alku uusi-alku))
-                                                        (when-not (= @aikavalin-loppu uusi-loppu)
-                                                          (reset! aikavalin-loppu uusi-loppu))))))]
+                              (pvm/varmista-aikavali-opt aikavali aikavalin-rajoitus paa)))))]
      (komp/luo
        (komp/sisaan-ulos #(do
                             (add-watch aikavalin-alku :ui-valinnat-aikavalin-alku
                                        (fn [_ _ vanha-arvo uusi-arvo]
                                          (let [uusi-arvo (uusi-aikavali :alku uusi-arvo)]
-                                           (tarkasta-esitettavat-arvot! uusi-arvo)
                                            (when-not (= vanha-arvo uusi-arvo)
                                              (reset! valittu-aikavali-atom uusi-arvo)))))
                             (add-watch aikavalin-loppu :ui-valinnat-aikavalin-loppu
                                        (fn [_ _ vanha-arvo uusi-arvo]
                                          (let [uusi-arvo (uusi-aikavali :loppu uusi-arvo)]
-                                           (tarkasta-esitettavat-arvot! uusi-arvo)
                                            (when-not (= vanha-arvo uusi-arvo)
                                              (reset! valittu-aikavali-atom uusi-arvo)))))
                             (add-watch valittu-aikavali-atom

--- a/src/cljs/harja/views/kanavat/urakka/toimenpiteet/kokonaishintaiset.cljs
+++ b/src/cljs/harja/views/kanavat/urakka/toimenpiteet/kokonaishintaiset.cljs
@@ -26,6 +26,7 @@
             [harja.ui.varmista-kayttajalta :as varmista-kayttajalta]
             [harja.ui.yleiset :as yleiset]
             [harja.domain.kanavat.kohde :as kohde]
+            [harja.domain.kanavat.kanavan-huoltokohde :as huoltokohde]
             [reagent.core :as r]
             [taoensso.timbre :as log]
             [harja.tiedot.kartta :as kartta-tiedot])
@@ -33,7 +34,7 @@
     [cljs.core.async.macros :refer [go]]
     [harja.makrot :refer [defc fnc]]))
 
-(defn hakuehdot [e! app kohteet]
+(defn hakuehdot [e! {:keys [huoltokohteet] :as app} kohteet]
   (let [urakka-map (get-in app [:valinnat :urakka])]
     [valinnat/urakkavalinnat {:urakka urakka-map}
      ^{:key "valinnat"}
@@ -45,7 +46,12 @@
                  (e! (tiedot/->PaivitaValinnat {:kanava-kohde-id (::kohde/id uusi)}))))
        (into [nil] kohteet)
        #(let [nimi (kohde/fmt-kohteen-nimi %)]
-          (if (empty? nimi) "Kaikki" nimi))]]
+          (if (empty? nimi) "Kaikki" nimi))]
+      [valinnat/kanava-huoltokohde
+       (r/wrap (first (filter #(= (::huoltokohde/id %) (get-in app [:valinnat :huoltokohde-id])) huoltokohteet))
+         #(e! (tiedot/->PaivitaValinnat {:huoltokohde-id (::huoltokohde/id %)})))
+       (into [nil] huoltokohteet)
+       #(or (::huoltokohde/nimi %) "Kaikki")]]
      ^{:key "toiminnot"}
      [valinnat/urakkatoiminnot {:urakka urakka-map :sticky? true}
       

--- a/test/clj/harja/kyselyt/kanavat/kanavan_toimenpide_test.clj
+++ b/test/clj/harja/kyselyt/kanavat/kanavan_toimenpide_test.clj
@@ -21,7 +21,8 @@
                    :loppupvm (harja.pvm/luo-pvm 2018 1 1)
                    :toimenpidekoodi 597
                    :tyyppi "kokonaishintainen"
-                   :kohde nil})]
+                   :kohde nil
+                   :huoltokohde nil})]
     (is (every? ::kanavan-toimenpide/id vastaus))
     (is (every? ::kanavan-toimenpide/kohde vastaus))
     (is (every? ::kanavan-toimenpide/toimenpidekoodi vastaus))

--- a/test/cljs/harja/tiedot/kanavat/urakka/toimenpiteet/kokonaishintaiset_test.cljs
+++ b/test/cljs/harja/tiedot/kanavat/urakka/toimenpiteet/kokonaishintaiset_test.cljs
@@ -22,7 +22,8 @@
                   ::kanavan-toimenpide/kohde-id nil
                   ::kanavan-toimenpide/kanava-toimenpidetyyppi :kokonaishintainen
                   :alkupvm (pvm/luo-pvm 2017 1 1)
-                  :loppupvm (pvm/luo-pvm 2018 1 1)}]
+                  :loppupvm (pvm/luo-pvm 2018 1 1)
+                  :huoltokohde nil}]
     (is (= (toimenpiteet/muodosta-kohteiden-hakuargumentit {:urakka {:id 666}
                                                             :sopimus-id 666
                                                             :toimenpide {:id 666}

--- a/test/cljs/harja/tiedot/kanavat/urakka/toimenpiteet/kokonaishintaiset_test.cljs
+++ b/test/cljs/harja/tiedot/kanavat/urakka/toimenpiteet/kokonaishintaiset_test.cljs
@@ -26,7 +26,8 @@
     (is (= (toimenpiteet/muodosta-kohteiden-hakuargumentit {:urakka {:id 666}
                                                             :sopimus-id 666
                                                             :toimenpide {:id 666}
-                                                            :aikavali aikavali}
+                                                            :aikavali aikavali
+                                                            :huoltokohde nil}
                                                            :kokonaishintainen)
            odotettu))
     (is (s/valid? ::kanavan-toimenpide/hae-kanavatoimenpiteet-kysely odotettu))))

--- a/test/cljs/harja/tiedot/kanavat/urakka/toimenpiteet/kokonaishintaiset_test.cljs
+++ b/test/cljs/harja/tiedot/kanavat/urakka/toimenpiteet/kokonaishintaiset_test.cljs
@@ -23,7 +23,7 @@
                   ::kanavan-toimenpide/kanava-toimenpidetyyppi :kokonaishintainen
                   :alkupvm (pvm/luo-pvm 2017 1 1)
                   :loppupvm (pvm/luo-pvm 2018 1 1)
-                  :huoltokohde nil}]
+                  ::kanavan-toimenpide/huoltokohde-id nil}]
     (is (= (toimenpiteet/muodosta-kohteiden-hakuargumentit {:urakka {:id 666}
                                                             :sopimus-id 666
                                                             :toimenpide {:id 666}


### PR DESCRIPTION
Samalla korjattu infinite loop tuolta sivulta. Johtui siis siitä, että samalla sivulla oli hoitokausi- ja aikavali-valinnat. Aikavälivalinnassa oli omituinen kuuntelija, joka sitten resetoi itsensä toistuvasti.  Kommenttien mukaan se oli tehty korjaamaan jokin toinen ongelma, mutta tämä korjaus ei mielestäni ollut kovin järkevä, ja aiheutti ainoastaan tuon ikiloopin. Omalla testailulla tuo aikaväli-valinta toimi kuitenkin kaikkialla normaalisti.