### PR TITLE
Harja-390 Laatupoikkeamat duplikaatit

### DIFF
--- a/src/cljs/harja/tiedot/urakka/laadunseuranta/laatupoikkeamat.cljs
+++ b/src/cljs/harja/tiedot/urakka/laadunseuranta/laatupoikkeamat.cljs
@@ -198,16 +198,19 @@
         laatupoikkeama
         {:onnistui ->TallennaLaatuPoikkeamaOnnistui
          :onnistui-parametrit [laatupoikkeama]
-         :epaonnistui ->TallennaLaatuPoikkeamaEpaonnistui})))
-
+         :epaonnistui ->TallennaLaatuPoikkeamaEpaonnistui})
+      (assoc app :tallennus-kaynnissa? true)))
+  
   TallennaLaatuPoikkeamaOnnistui
   (process-event [_ {:keys [listaus-tyyppi valittu-aikavali] :as app}]
-    ;; Kun poikkeama tallennetaan, päivitetään kaikki tiedot jotta karttaan tulee uusikin reitti näkyviin
+      ;; Kun poikkeama tallennetaan, päivitetään kaikki tiedot jotta karttaan tulee uusikin reitti näkyviin
     (resetoi-ja-hae-poikkeamat listaus-tyyppi (-> @tila/yleiset :urakka :id) valittu-aikavali)
-    (assoc app :laatupoikkeamat nil))
+    (-> app
+      (assoc :laatupoikkeamat nil)
+      (assoc :tallennus-kaynnissa? false)))
 
   TallennaLaatuPoikkeamaEpaonnistui
   (process-event [{vastaus :vastaus} app]
     (log/error "Laatupoikkeaman tallennuksessa virhe!" vastaus)
     (viesti/nayta-toast! "Oikaisun tallennuksessa tapahtui virhe" :varoitus)
-    app))
+    (assoc app :tallennus-kaynnissa? false)))

--- a/src/cljs/harja/tiedot/urakka/urakka.cljs
+++ b/src/cljs/harja/tiedot/urakka/urakka.cljs
@@ -373,6 +373,7 @@
 (def laskutus-default {:kohdistetut-kulut kulut-default})
 (def lupaukset-default {})
 (def laatupoikkeamat-default {:listaus-tyyppi :kaikki
+                              :tallennus-kaynnissa? false
                               :hoitokauden-alkuvuosi (pvm/hoitokauden-alkuvuosi-nykyhetkesta (pvm/nyt))
                               :valittu-hoitokausi [(pvm/hoitokauden-alkupvm (pvm/hoitokauden-alkuvuosi-nykyhetkesta (pvm/nyt)))
                                                    (pvm/paivan-lopussa (pvm/hoitokauden-loppupvm (inc (pvm/hoitokauden-alkuvuosi-nykyhetkesta (pvm/nyt)))))]

--- a/src/cljs/harja/views/urakka/laadunseuranta/laatupoikkeama.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/laatupoikkeama.cljs
@@ -324,6 +324,7 @@ sekä sanktio-virheet atomin, jonne yksittäisen sanktion virheet kirjoitetaan (
                yllapitokohteet (:yllapitokohteet optiot)
                yllapito? @urakka/yllapitourakka?
                nakyma (:nakyma optiot)
+               tallennus-kaynnissa? (:tallennus-kaynnissa? optiot)
                vesivayla? (u-domain/vesivaylaurakkatyyppi? nakyma)
                yllapitokohdeurakka? @urakka/yllapitokohdeurakka?]
            (if (and yllapitokohdeurakka? (nil? yllapitokohteet)) ;; Pakko olla ylläpitokohteet ennen kuin lomaketta voi näyttää
@@ -359,6 +360,7 @@ sekä sanktio-virheet atomin, jonne yksittäisen sanktion virheet kirjoitetaan (
                                     (e! (laatupoikkeamat/->TallennaLaatuPoikkeama (lomake/ilman-lomaketietoja sisalto) nakyma))))
                                 {:ikoni (ikonit/tallenna)
                                  :disabled (or
+                                             tallennus-kaynnissa?
                                              (not (validoi-sanktiotiedot sisalto))
                                              (not (sanktiorivit-ok? sisalto (cond yllapito? :yllapito
                                                                               vesivayla? :vesivayla

--- a/src/cljs/harja/views/urakka/laadunseuranta/laatupoikkeamat.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/laatupoikkeamat.cljs
@@ -148,5 +148,6 @@
          [laatupoikkeamalomake e! laatupoikkeamat/valittu-laatupoikkeama
           (merge optiot
                  {:yllapitokohteet @laadunseuranta/urakan-yllapitokohteet-lomakkeelle
-                  :nakyma (:tyyppi @nav/valittu-urakka)})]
+                  :nakyma (:tyyppi @nav/valittu-urakka)
+                  :tallennus-kaynnissa? (:tallennus-kaynnissa? app)})]
          [laatupoikkeamalistaus e! app optiot])])))


### PR DESCRIPTION
Laatupoikkeama näkymässä on mahdollista tallentaa duplikaatteja tallenna nappia rämpyttämällä.

Korjattu lisäämällä tallennus-kaynnissa? Tuckin ylläpitämään tilaan. Patternit mihin tilaan tuota on tallennettu vaihtelee hieman eli saa kommentoida mikä on todettu fiksuimmaksi