### PR TITLE
HARJA-311-populoidaan-lupausryhma-urakka-taulu 

### DIFF
--- a/tietokanta/src/main/resources/db/migration/V1_1094__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1094__.sql
@@ -1,0 +1,6 @@
+-- Siirtymä vanhasta urakan alkuvuosi perustaisesta lupausryhmien määräytymisestä lupausryhma_urakka taulun käyttöön
+
+INSERT INTO lupausryhma_urakka (lupausryhma_id, urakka_id)
+SELECT lupausryhma.id AS "lupausryhma_id", urakka.id  AS "urakka_id"
+FROM urakka
+    JOIN lupausryhma ON lupausryhma."urakan-alkuvuosi" = EXTRACT(YEAR FROM urakka.alkupvm);


### PR DESCRIPTION
Lisää siirtymä (insert) vanhasta urakan alkuvuosi perustaisesta lupausryhmien määräytymisestä lupausryhma_urakka taulun käyttöön.

Ei tee testikantaan liitoksia koska migraatiot ajetaan ennen testidataa.