### PR TITLE
Poista testiurakan toteumat ympäristöraportilta

### DIFF
--- a/src/clj/harja/palvelin/raportointi/raportit/ymparisto.sql
+++ b/src/clj/harja/palvelin/raportointi/raportit/ymparisto.sql
@@ -91,6 +91,7 @@ WHERE (:urakka::INTEGER IS NULL OR u.id = :urakka)
                        u.tyyppi = :urakkatyyppi::urakkatyyppi
                END)
       AND mk.materiaalityyppi != 'erityisalue'
+      AND u.urakkanro IS NOT NULL
 GROUP BY u.id, u.nimi, mk.id, mk.nimi, mk.materiaalityyppi, date_trunc('month', umkh.pvm), talvitieluokka, soratieluokka
 
 


### PR DESCRIPTION
Ympäristöraportille nousi osa testiurakan toteumista, koska yhdessä osioissa ei otettu poitettu urakkanumeroittomia urakoita (eli testiurakkaa). Muissa osioissa `JOIN urakka u ON ... u.urakkanumero IS NOT NULL` poistaa sen.