### PR TITLE
Poistetaan valittu toimenpide aina, kun haetaan toimenpiteet uusiksi

### DIFF
--- a/src/cljs/harja/tiedot/kanavat/urakka/toimenpiteet/kokonaishintaiset.cljs
+++ b/src/cljs/harja/tiedot/kanavat/urakka/toimenpiteet/kokonaishintaiset.cljs
@@ -116,7 +116,8 @@
             argumentit
             {:onnistui ->ToimenpiteetHaettu
              :epaonnistui ->ToimenpiteidenHakuEpaonnistui})
-          (assoc :haku-kaynnissa? true)))
+          (assoc :haku-kaynnissa? true)
+          (assoc :avattu-toimenpide nil)))
       app))
 
   ToimenpiteetHaettu

--- a/test/cljs/harja/tiedot/kanavat/urakka/toimenpiteet/kokonaishintaiset_test.cljs
+++ b/test/cljs/harja/tiedot/kanavat/urakka/toimenpiteet/kokonaishintaiset_test.cljs
@@ -55,7 +55,7 @@
 (deftest HaeToimenpiteet
   (vaadi-async-kutsut
     #{tiedot/->ToimenpiteetHaettu tiedot/->ToimenpiteidenHakuEpaonnistui}
-    (is (= {:haku-kaynnissa? true}
+    (is (= {:haku-kaynnissa? true :avattu-toimenpide nil}
            (e! (tiedot/->HaeToimenpiteet {:urakka {:id 1}
                                           :sopimus-id 666
                                           :toimenpide {:id 666}}))))))


### PR DESCRIPTION
Käyttäjä (lähinnä admin/ylipäällikkö) voi valita kanavaurakalle toimenpiteen ja mennä "muokkaamaan"/katselemaan sitä. Jos ylävalikosta vaihtaa urakkaa, niin valittu toimenpide, pysyy valittuna siinä ui:lla. Tiedot lomakkeella muuttuvat lähinnä vääriksi.

Siirrytään siis kokonaan pois valitun toimenpiteen tiedoista, jos urakkaa vaihdetaan, koska sitä ei voida muutenkaan tallentaa ja tiedotkin ovat vääriä.