### PR TITLE
HARJA-445 - Korjaa Fargate restart GH Actions toiminto

### DIFF
--- a/.github/actions/shutdown-fargate-tasks/action.yml
+++ b/.github/actions/shutdown-fargate-tasks/action.yml
@@ -12,13 +12,13 @@ runs:
       env:
         SHA: ${{ inputs.commit-sha }}
         CLUSTER_NAME: ${{ inputs.cluster }}
+        SERVICE_NAME: ${{ inputs.service }}
         WAIT_TIME_SEC: "30"
 
       # Komennon 'update-service' stdout ohjataan /dev/nulliin, koska se voi tulostaa sensitiivisiä tietoja
       run: |
-        echo "Getting available service..."
-        
-        AVAILABLE_SERVICE=$(aws ecs list-services --cluster "${CLUSTER_NAME}" --region eu-west-1 | jq -r '.serviceArns[0]')
+        echo "Getting available service: ${SERVICE_NAME}"
+        AVAILABLE_SERVICE=$(aws ecs list-services --cluster "${CLUSTER_NAME}" --region eu-west-1 --query "serviceArns[?contains(@, \`${SERVICE_NAME}\`) == \`true\`] | [0]" --output text)
         
         echo "Shutting down running tasks..."
         aws ecs update-service --cluster "${CLUSTER_NAME}" --service $AVAILABLE_SERVICE --desired-count 0 --region eu-west-1 1> /dev/null

--- a/.github/actions/start-fargate-tasks/action.yml
+++ b/.github/actions/start-fargate-tasks/action.yml
@@ -12,13 +12,14 @@ runs:
       env:
         SHA: ${{ inputs.commit-sha }}
         CLUSTER_NAME: ${{ inputs.cluster }}
+        SERVICE_NAME: ${{ inputs.service }}
         DESIRED_COUNT: "1"
         WAIT_TIME_SEC: "10"
 
       # Komennon 'update-service' stdout ohjataan /dev/nulliin, koska se voi tulostaa sensitiivisiä tietoja
       run: |
-        echo "Getting available service..."
-        AVAILABLE_SERVICE=$(aws ecs list-services --cluster "${CLUSTER_NAME}" --region eu-west-1 | jq -r '.serviceArns[0]')
+        echo "Getting available service: ${SERVICE_NAME}"        
+        AVAILABLE_SERVICE=$(aws ecs list-services --cluster "${CLUSTER_NAME}" --region eu-west-1 --query "serviceArns[?contains(@, \`${SERVICE_NAME}\`) == \`true\`] | [0]" --output text)
         
         echo "Starting tasks..."
         aws ecs update-service --cluster "${CLUSTER_NAME}" --service $AVAILABLE_SERVICE \

--- a/.github/workflows/reusable_deploy-harja-image-to-ecs.yml
+++ b/.github/workflows/reusable_deploy-harja-image-to-ecs.yml
@@ -97,6 +97,7 @@ jobs:
         if: ${{ contains(fromJson('["dev", "stg"]'), inputs.environment)  }}
         with:
           cluster: ${{ vars.ECS_CLUSTER_NAME }}
+          service: ${{ vars.ECS_SERVICE_NAME }}
 
       - name: Run migrations to RDS
         uses: ./.github/actions/run-migrations-to-rds
@@ -141,6 +142,7 @@ jobs:
         if: always()
         with:
           cluster: ${{ vars.ECS_CLUSTER_NAME }}
+          service: ${{ vars.ECS_SERVICE_NAME }}
 
       # Docs: https://github.com/slackapi/slack-github-action
       - name: Send deploy failure message to Slack

--- a/.github/workflows/shutdown_fargate_tasks.yml
+++ b/.github/workflows/shutdown_fargate_tasks.yml
@@ -57,3 +57,4 @@ jobs:
         timeout-minutes: 15
         with:
           cluster: ${{ vars.ECS_CLUSTER_NAME }}
+          service: ${{ vars.ECS_SERVICE_NAME }}

--- a/.github/workflows/start_fargate_tasks.yml
+++ b/.github/workflows/start_fargate_tasks.yml
@@ -58,3 +58,4 @@ jobs:
         if: always()
         with:
           cluster: ${{ vars.ECS_CLUSTER_NAME }}
+          service: ${{ vars.ECS_SERVICE_NAME }}


### PR DESCRIPTION
* Restart saattoi osua sattumanvaraisesti väärään serviceen ECS klusterissa, koska serviceiden listaus saattoi palautua eri järjestyksessä kuin oletettu
* Aiempi ratkaisu oletti, että klusterissa on vain yksi service, nyt niitä on useampi, joten täytyy kohdistaa restart tiettyyn serviceen klusterissa tunnisteen perusteella