### PR TITLE
HARJA-432 Piilota tieturvallisuusverkko tuotannosta

### DIFF
--- a/src/cljs/harja/tiedot/urakka/laadunseuranta/tarkastukset.cljs
+++ b/src/cljs/harja/tiedot/urakka/laadunseuranta/tarkastukset.cljs
@@ -14,13 +14,7 @@
 
 (defonce nakymassa? (atom false))
 
-(def +tarkastustyyppi->nimi+
-  ;; Piilotetaan toistaiseksi tieturvallisuus kirjaus tuotannosta
-  ;; Kun kaikki valmista, tämän koodin voi muuttaa vaan: (def +tarkastustyyppi->nimi+ tarkastukset/+tarkastustyyppi->nimi+)
-  (let [tarkastukset tarkastukset/+tarkastustyyppi->nimi+]
-    (if-not (k/kehitysymparistossa?)
-      (dissoc tarkastukset :tieturvallisuus)
-      tarkastukset)))
+(def +tarkastustyyppi->nimi+ tarkastukset/+tarkastustyyppi->nimi+)
 
 (defonce tienumero (atom nil)) ;; tienumero, tai kaikki
 (defonce tarkastustyyppi (atom nil)) ;; nil = kaikki, :tiesto, :talvihoito, :soratie

--- a/src/cljs/harja/views/urakka/laadunseuranta/tarkastukset.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/tarkastukset.cljs
@@ -44,11 +44,18 @@
 (def +tarkastustyyppi-hoidolle+ [:tieturvallisuus :tiesto :talvihoito :soratie :laatu])
 (def +tarkastustyyppi-yllapidolle+ [:katselmus :pistokoe :vastaanotto :takuu])
 
+(defn hoito-tarkastustyypit []
+  ;; Ei näytetä tieturvallisuusverkkoa vielä tuotannossa
+  ;; Kun halutaan näyttää, tämän funktiokutsun voi muuttaa vaan -> +tarkastustyyppi-hoidolle+
+  (if-not (k/kehitysymparistossa?)
+    (vec (remove #(= :tieturvallisuus %) +tarkastustyyppi-hoidolle+))
+    +tarkastustyyppi-hoidolle+))
+
 (defn tarkastustyypit-hoidon-tekijalle [tekija]
   (case tekija
     :tilaaja [:laatu]
     :urakoitsija [:tieturvallisuus :tiesto :talvihoito :soratie]
-    +tarkastustyyppi-hoidolle+))
+    (hoito-tarkastustyypit)))
 
 (defn tarkastustyypit-urakkatyypille-ja-tekijalle [urakkatyyppi tekija]
   (if (some #(= urakkatyyppi %) [:paallystys :paikkaus :tiemerkinta])
@@ -60,7 +67,7 @@
 (defn tarkastustyypit-urakkatyypille [urakkatyyppi]
   (if (some #(= urakkatyyppi %) [:paallystys :paikkaus :tiemerkinta])
     +tarkastustyyppi-yllapidolle+
-    +tarkastustyyppi-hoidolle+))
+    (hoito-tarkastustyypit)))
 
 (defn uusi-tarkastus [urakkatyyppi]
   {:uusi? true


### PR DESCRIPTION
Tieturvallisuusverkko väärällä tavalla piilotettu, tässä oikea tapa, toivottavasti. Tieturvallisuusverkkoa ei haluta vielä tuotannossa näyttää. Tiketillä lukee detailssit.