### PR TITLE
Palauta työkoneenseurannan integraatiolokitus

### DIFF
--- a/src/clj/harja/palvelin/integraatiot/api/tyokoneenseuranta.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/tyokoneenseuranta.clj
@@ -96,17 +96,19 @@
 (defrecord Tyokoneenseuranta []
   component/Lifecycle
   (start [{http :http-palvelin
-           db   :db :as this}]
+           db   :db
+           integraatioloki :integraatioloki
+           :as this}]
     (julkaise-reitti http :tallenna-tyokoneenseurantakirjaus
                      (POST +tyokone-seurantakirjaus-url+ request
-                       (kasittele-kutsu db nil
+                       (kasittele-kutsu db integraatioloki
                                         :tallenna-tyokoneenseurantakirjaus
                                         request json-skeemat/tyokoneenseuranta-kirjaus json-skeemat/kirjausvastaus
                                         tallenna-seurantakirjaus
                          :kirjoitus)))
     (julkaise-reitti http :tallenna-tyokoneen-reitti
                      (POST +tyokone-reitti-url+ request
-                       (kasittele-kutsu db nil
+                       (kasittele-kutsu db integraatioloki
                                         :tallenna-tyokoneen-reitti
                                         request json-skeemat/tyokoneenseuranta-kirjaus-viivageometrialla json-skeemat/kirjausvastaus
                                         tallenna-seurantakirjaus-viivageometriana

--- a/src/clj/harja/palvelin/main.clj
+++ b/src/clj/harja/palvelin/main.clj
@@ -668,7 +668,7 @@
                           [:http-palvelin :db :integraatioloki :liitteiden-hallinta])
       :api-tyokoneenseuranta (component/using
                                (api-tyokoneenseuranta/->Tyokoneenseuranta)
-                               [:http-palvelin :db])
+                               [:http-palvelin :db :integraatioloki])
       :api-tyokoneenseuranta-puhdistus (component/using
                                          (tks-putsaus/->TyokoneenseurantaPuhdistus)
                                          [:db])

--- a/tietokanta/src/main/resources/db/migration/V1_1117__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1117__.sql
@@ -1,0 +1,2 @@
+INSERT INTO integraatio (jarjestelma, nimi)
+VALUES ('api', 'tallenna-tyokoneen-reitti');


### PR DESCRIPTION
 - Lokitus poistettu jossain välissä käytöstä rajapinnan luonteen takia. Data heitetään pois 5 tunnin päästä ja katsottiin, ettei lokitusta tarvita
 - Nyt kuitenkin integraatiolokitus on asynkroninen ja sen suorituskykyä on parannettu, eli siitä ei pitäisi aiheutua haittaa.
 - Työkoneenseurannasta ei jää mitään jälkeä lokeilla tai muualle, joten integraatiolokituksen päälle laitto mahdollistaa varmistuksen siitä, onko rajapinnassa hitautta tai muita ongelmia suuremmalla varmuudella.