### PR TITLE
Formatoi "yhteensä"-teksti oikein raportilla

### DIFF
--- a/src/clj/harja/palvelin/raportointi/raportit/pohjavesialueiden_suolat.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/pohjavesialueiden_suolat.clj
@@ -19,7 +19,7 @@
 (defqueries "harja/palvelin/raportointi/raportit/pohjavesialueiden_suolat.sql")
 
 (defn loppusumma [tulos]
-  (vec (concat tulos [{:tie "Yhteensä" :yhteensa (reduce + (map :yhteensa tulos))}])))
+  (vec (concat tulos [{:tie [:arvo {:arvo "Yhteensä"}] :yhteensa (reduce + (map :yhteensa tulos))}])))
 
 (defn rivi-xf [rivi]
   [(:tie rivi)

--- a/test/clj/harja/palvelin/raportointi/pohjavesialueiden_suolat_test.clj
+++ b/test/clj/harja/palvelin/raportointi/pohjavesialueiden_suolat_test.clj
@@ -91,4 +91,4 @@
                nil]
               [[18637 1 0 1 8953 9324.379134279012 5M 0.5362287320148329 nil]
                [28409 56 0 56 605 573.3889406769638 3M 5.2320506852784625 nil]
-               ["Yhteensä" nil nil nil nil nil 8M nil nil]]]])))))
+               [[:arvo {:arvo "Yhteensä"}] nil nil nil nil nil 8M nil nil]]]])))))


### PR DESCRIPTION
Wrappaamalla raportin sarakkeen [:arvo {:arvo "jotain"}], saadaan ohitettua sarakkeen määräämä formatointi. Toinen vaihtoehto olisi heittää `harja.fmt/kokonaisluku-opt`-funktiosta error jos numeroa ei saa parsittua, jolloin virhe otettaisiin kiinni ja formatoinnin tulos ohitettaisiin. Tätä arvo-mallia käytettiin kuitenkin jo toisessa raportissa, joten päädyin tähän.