### PR TITLE
HARJA-635 Salli paikallaanolon ilmaisu suunta-arvolla null

### DIFF
--- a/resources/api/api.raml
+++ b/resources/api/api.raml
@@ -1,7 +1,7 @@
 #%RAML 0.8
 # https://github.com/raml-org/raml-spec/blob/master/versions/raml-08/raml-08.md
 title: Harja API
-version: 1.0.63
+version: 1.0.64
 baseUri: https://testiapi.vayla.fi/harja/api (testi) & https://api.vayla.fi/harja/api (tuotanto)
 protocols: [HTTPS]
 mediaType: application/json
@@ -1209,7 +1209,7 @@ documentation:
   /tyokone:
     post:
       is: [secured]
-      description: Työkoneen seurantatiedon kirjaus. Työkoneelle voidaan kirjata sijainti sekä vaihtoehtoisesti suoritettava työtehtävä. Sijantitiedot lähetetään maksimissaan 5 sekunnin välein ja mahdollisuuksien mukaan mieluusti 5-15 sekunnin intervalilla ja otoskoolla. Ylläpito-urakoissa seuraavat kirjattavat työkone-tyypit näytetään Tilannekuvassa Ylläpito-osiossa paaasfalttilevitin, remix-laite, sekoitus-ja-stabilointijyrsin, tma-laite.
+      description: Työkoneen seurantatiedon kirjaus. Sijantitiedot lähetetään maksimissaan 5 sekunnin välein ja mahdollisuuksien mukaan mieluusti 5-15 sekunnin intervalilla. Mikäli työkone on paikallaan, suunta-tiedon voi jättää pois tai suunnaksi voi välittää arvon null. Ylläpito-urakoissa Tilannekuvassa näytetään työkonetyypit: paaasfalttilevitin, remix-laite, sekoitus-ja-stabilointijyrsin, tma-laite.
       body:
         application/json:
           example: !include examples/tyokoneenseurannan-kirjaus-request.json
@@ -1233,7 +1233,7 @@ documentation:
     /reitti:
       post:
         is: [secured]
-        description: Työkoneen seurantatiedon kirjaus viivageometrialla. Työkoneelle voidaan kirjata sijainti viivageometriana sekä vaihtoehtoisesti suoritettava työtehtävä. Sijantitiedot lähetetään maksimissaan 5 sekunnin välein ja mahdollisuuksien mukaan mieluusti 5-15 sekunnin intervalilla ja otoskoolla. Ylläpito-urakoissa seuraavat kirjattavat työkone-tyypit näytetään Tilannekuvassa Ylläpito-osiossa paaasfalttilevitin, remix-laite, sekoitus-ja-stabilointijyrsin, tma-laite.
+        description: Työkoneen seurantatiedon kirjaus viivageometrialla. Sijantitiedot lähetetään maksimissaan 5 sekunnin välein ja mahdollisuuksien mukaan mieluusti 5-15 sekunnin intervalilla ja otoskoolla. Mikäli työkone on paikallaan, suunta-tiedon voi jättää pois tai suunnaksi voi välittää arvon null. Ylläpito-urakoissa Tilannekuvassa näytetään työkonetyypit: paaasfalttilevitin, remix-laite, sekoitus-ja-stabilointijyrsin, tma-laite.
         body:
           application/json:
             example: !include examples/tyokoneenseurannan-kirjaus-viivageometrialla-request.json

--- a/resources/api/schemas/tyokoneenseurannan-kirjaus-request.schema.json
+++ b/resources/api/schemas/tyokoneenseurannan-kirjaus-request.schema.json
@@ -56,7 +56,10 @@
               },
               "suunta": {
                 "id": "urn:harja/havainnot/0/suunta",
-                "type": "number"
+                "anyOf": [
+                  {"type": "number"},
+                  {"type": "null"}
+                ]
               },
               "urakkaid": {
                 "id": "urn:harja/havainnot/0/urakkaid",

--- a/resources/api/schemas/tyokoneenseurannan-kirjaus-viivageometrialla-request.schema.json
+++ b/resources/api/schemas/tyokoneenseurannan-kirjaus-viivageometrialla-request.schema.json
@@ -56,7 +56,10 @@
               },
               "suunta": {
                 "id": "urn:harja/havainnot/0/suunta",
-                "type": "number"
+                "anyOf": [
+                  {"type": "number"},
+                  {"type": "null"}
+                ]
               },
               "urakkaid": {
                 "id": "urn:harja/havainnot/0/urakkaid",


### PR DESCRIPTION
Työkoneen paikallaanoloa on voinut ilmaista jättämällä suunta-attribuutti kokonaan pois. Salli myös null-arvo.