### PR TITLE
Harja 661 tavoitehinnan ylitysmerkki

### DIFF
--- a/src/cljs/harja/views/urakka/kulut/yhteiset.cljs
+++ b/src/cljs/harja/views/urakka/kulut/yhteiset.cljs
@@ -14,6 +14,13 @@
             [harja.pvm :as pvm]
             [harja.ui.grid :as grid]))
 
+;; Tavoitehinta ei voi olla yhteenvetolaatikossa esitettynä negatiivinen, mutta laskennoissa voi.
+;; Joten muokataan luku esitystä varten
+(defn- ei-negatiivinen-numero [arvo]
+  (if (neg? arvo)
+    (- arvo)
+    arvo))
+
 (defn fmt->big
   ([arvo] (fmt->big arvo false))
   ([arvo on-big?]
@@ -112,7 +119,7 @@
         [:div.rivi
          [:span "Tavoitehinnan ylitys"]
          [:span.negatiivinen-numero
-          (str "+ " (fmt/euro-opt tavoitehinnan-ylitys))]]
+          (str "+ " (fmt/euro-opt (ei-negatiivinen-numero tavoitehinnan-ylitys)))]]
         (when tavoitehinnan-ylitys-paatos
           [:<>
            (when (pos? (::valikatselmus/urakoitsijan-maksu tavoitehinnan-ylitys-paatos))

--- a/src/cljs/harja/views/urakka/kulut/yhteiset.cljs
+++ b/src/cljs/harja/views/urakka/kulut/yhteiset.cljs
@@ -14,13 +14,6 @@
             [harja.pvm :as pvm]
             [harja.ui.grid :as grid]))
 
-;; Tavoitehinta ei voi olla yhteenvetolaatikossa esitettynä negatiivinen, mutta laskennoissa voi.
-;; Joten muokataan luku esitystä varten
-(defn- ei-negatiivinen-numero [arvo]
-  (if (neg? arvo)
-    (- arvo)
-    arvo))
-
 (defn fmt->big
   ([arvo] (fmt->big arvo false))
   ([arvo on-big?]
@@ -119,7 +112,7 @@
         [:div.rivi
          [:span "Tavoitehinnan ylitys"]
          [:span.negatiivinen-numero
-          (str "+ " (fmt/euro-opt (ei-negatiivinen-numero tavoitehinnan-ylitys)))]]
+          (str "+ " (fmt/euro-opt (Math/abs tavoitehinnan-ylitys)))]]
         (when tavoitehinnan-ylitys-paatos
           [:<>
            (when (pos? (::valikatselmus/urakoitsijan-maksu tavoitehinnan-ylitys-paatos))

--- a/tietokanta/testidata/laskutusyhteenveto_mhu.sql
+++ b/tietokanta/testidata/laskutusyhteenveto_mhu.sql
@@ -106,8 +106,8 @@ $$
                     (SELECT id FROM materiaalikoodi WHERE nimi = 'Talvisuola, rakeinen NaCl'), 1300, kayttaja_id, urakka_id);
 
 
-        INSERT INTO urakka_tavoite (urakka, hoitokausi, tavoitehinta, tavoitehinta_indeksikorjattu, tarjous_tavoitehinta, tavoitehinta_siirretty, kattohinta, luotu, luoja)
-            VALUES (urakka_id, 1, 250000, 250000, 240000, NULL, 1.1 * 250000, NOW(), kayttaja_id);
+        INSERT INTO urakka_tavoite (urakka, hoitokausi, tavoitehinta, tavoitehinta_indeksikorjattu, tarjous_tavoitehinta, tavoitehinta_siirretty, kattohinta, kattohinta_indeksikorjattu, luotu, luoja)
+            VALUES (urakka_id, 1, 250000, 250000, 240000, NULL, 1.1 * 250000, 1.1 * 250000, NOW(), kayttaja_id);
 
 
         -- MHU Hoidonjohto - SANKTIOT: vastuuhenkilön vaihtosanktio (tämän lopullinen summa indeksilaskennan kautta), arvonvähennykset


### PR DESCRIPTION
Tavoitehinnan ylityksen lukua käytetään prosenttilaskuissa taustalla ja näytöllä. Näytölle luku tulee väärin, jos se on negatiivinen. Varmistetaan nyt, että näytöllä ei näytetä negatiivista merkkiä vahingossa. Ylitys on aina positiivinen. Vaikka tapahtumana negatiivinen :)

Samalla lisätty vähän paremmin testiaineistoa.