### PR TITLE
Harja-673 Saavutettavuus: navigointi ja valikot nappaimistolla

### DIFF
--- a/src/cljs/harja/ui/bootstrap.cljs
+++ b/src/cljs/harja/ui/bootstrap.cljs
@@ -2,6 +2,7 @@
   "Common Bootstrap components for Reagent UI."
   (:require [reagent.core :refer [atom]]
             [harja.loki :refer [log]]
+            [harja.ui.dom :as dom]
             [harja.ui.komponentti :as komp]
             [clojure.string :as clj-str]))
 
@@ -34,7 +35,10 @@ The following keys are supported in the configuration:
                           (partition 3 alternating-title-and-component))
              [active-tab-title active-tab-keyword active-component]
              (or (first (filter #(= @active (nth % 1)) tabs))
-                 (first tabs))]
+                 (first tabs))
+             vaihda-aktiivinen-tabi (fn [keyword event]
+                                      (.preventDefault event)
+                                      (reset! active keyword))]
          (if (empty? tabs)
            [:span "Ei käyttöoikeutta."]
            [:span
@@ -45,9 +49,10 @@ The following keys are supported in the configuration:
                      :class (when (= keyword active-tab-keyword)
                               "active")}
                 [:a.klikattava (merge
-                                 {:on-click #(do
-                                               (.preventDefault %)
-                                               (reset! active keyword))}
+                                 {:tabIndex "0"
+                                  :on-click #(vaihda-aktiivinen-tabi keyword %)
+                                  :on-key-down #(when (dom/enter-nappain? %)
+                                                  (vaihda-aktiivinen-tabi keyword %))}
                                  (let [tabs-taso (re-find #"tabs-taso\d" (str classes))
                                        cy-title (-> title
                                                     str

--- a/src/cljs/harja/ui/checkbox.cljs
+++ b/src/cljs/harja/ui/checkbox.cljs
@@ -31,21 +31,23 @@ checkbox-tila->luokka {:valittu "harja-checkbox-valittu"
   ([tila-atom nimi] (checkbox tila-atom nimi {}))
   ([tila-atom nimi {:keys [on-change width otsikon-luokka] :as optiot}]
    (let [tila @tila-atom
-         vaihda-tila (fn []
+         vaihda-tila (fn [event]
                        (let [uusi-tila (case tila
                                          :valittu :ei-valittu
                                          :ei-valittu :valittu
                                          :osittain-valittu :ei-valittu)]
                          (reset! tila-atom uusi-tila)
                          (when on-change
-                           (on-change uusi-tila))))]
+                           (on-change uusi-tila))
+                         (.stopPropagation event)))]
      [:div.harja-checkbox
       [:div.harja-checkbox-sisalto {:style {:width (or width "100%")}
-                                    :on-click (fn [event]
-                                                (vaihda-tila)
-                                                (.stopPropagation event))}
+                                    :on-click #(vaihda-tila %)}
        [:div.harja-checkbox-column
-        [:div.harja-checkbox-laatikko {:class (checkbox-tila->luokka tila)}
+        [:div.harja-checkbox-laatikko {:class (checkbox-tila->luokka tila)
+                                       :tabIndex "0"
+                                       :on-key-down #(when (= 32 (-> % .-keyCode))
+                                                       (vaihda-tila %))}
          [:div.harja-checkbox-laatikko-sisalto
           (when (= :valittu @tila-atom)
             [:img.harja-checkbox-rasti {:src "images/rasti.svg"}])]]]

--- a/src/cljs/harja/ui/dom.cljs
+++ b/src/cljs/harja/ui/dom.cljs
@@ -78,6 +78,8 @@
         ie-versio (maarita-ie-versio-user-agentista ua)]
     (and (integer? ie-versio) (<= 10 ie-versio))))
 
+(defn enter-nappain? [event] (= 13 (.-keyCode event)))
+
 (defonce korkeus (r/atom (-> js/window .-innerHeight)))
 (defonce leveys (r/atom (-> js/window .-innerWidth)))
 

--- a/src/cljs/harja/ui/taulukko/impl/solu.cljs
+++ b/src/cljs/harja/ui/taulukko/impl/solu.cljs
@@ -3,6 +3,7 @@
   (:refer-clojure :exclude [atom])
   (:require [reagent.core :refer [atom] :as r]
             [harja.loki :refer [warn]]
+            [harja.ui.dom :as ui.dom]
             [harja.ui.ikonit :as ikonit]
             [harja.ui.yleiset :as yleiset]
             [harja.ui.taulukko.protokollat.grid-osa :as gop]
@@ -461,16 +462,20 @@
                                         ikonit/oi-caret-top)
                            ikoni-kiinni (if (= ikoni "chevron")
                                           ikonit/livicon-chevron-down
-                                          ikonit/oi-caret-bottom)]
+                                          ikonit/oi-caret-bottom)
+                           avaa-tai-sulje-haitari (fn [event]
+                                            (.preventDefault event)
+                                            (swap! auki? not)
+                                            (aukaise-fn this @auki?))]
                        [:span.solu.klikattava.solu-laajenna
                         {:class (when class
                                   (apply str (interpose " " class)))
                          :id id
                          :data-cy (:id this)
-                         :on-click
-                         #(do (.preventDefault %)
-                              (swap! auki? not)
-                              (aukaise-fn this @auki?))}
+                         :tabIndex "0"
+                         :on-click #(avaa-tai-sulje-haitari %)
+                         :on-key-down #(when (ui.dom/enter-nappain? %)
+                                         (avaa-tai-sulje-haitari %))}
                         [:span.laajenna-teksti ((::fmt this) arvo)]
                         (if @auki?
                           ^{:key "laajenna-auki"}

--- a/src/cljs/harja/ui/yleiset.cljs
+++ b/src/cljs/harja/ui/yleiset.cljs
@@ -532,15 +532,18 @@ lisätään eri kokoluokka jokaiselle mäpissä mainitulle koolle."
                  (partition 2 otsikot-ja-arvot))])
 
 (defn- luo-haitarin-rivi [piiloita? rivi]
-  ^{:key (:otsikko @rivi)}
-  [:div.haitari-rivi
-   [:div.haitari-heading.klikattava
-    {:on-click #(do
-                  (swap! rivi assoc :auki (not (:auki @rivi)))
-                  (.preventDefault %))}
-    [:span.haitarin-tila (if (:auki @rivi) (ikonit/livicon-chevron-down) (ikonit/livicon-chevron-right))]
-    [:div.haitari-title (when piiloita? {:class "haitari-piilossa"}) (or (:otsikko @rivi) "")]]
-   [:div.haitari-sisalto (if (:auki @rivi) {:class "haitari-auki"} {:class "haitari-kiinni"}) (:sisalto @rivi)]])
+  (let [avaa-tai-sulje-haitari (fn [event]
+                         (.preventDefault event)
+                         (swap! rivi assoc :auki (not (:auki @rivi))))]
+    ^{:key (:otsikko @rivi)}
+    [:div.haitari-rivi
+     [:div.haitari-heading.klikattava
+      {:on-click #(avaa-tai-sulje-haitari %)
+       :on-key-down #(when (dom/enter-nappain? %)
+                       (avaa-tai-sulje-haitari %))}
+      [:span.haitarin-tila {:tabIndex "0"} (if (:auki @rivi) (ikonit/livicon-chevron-down) (ikonit/livicon-chevron-right))]
+      [:div.haitari-title (when piiloita? {:class "haitari-piilossa"}) (or (:otsikko @rivi) "")]]
+     [:div.haitari-sisalto (if (:auki @rivi) {:class "haitari-auki"} {:class "haitari-kiinni"}) (:sisalto @rivi)]]))
 
 (defn- pakota-haitarin-rivi-auki
   ([rivit] (pakota-haitarin-rivi-auki rivit (first (keys @rivit))))

--- a/src/cljs/harja/ui/yleiset.cljs
+++ b/src/cljs/harja/ui/yleiset.cljs
@@ -575,14 +575,18 @@ lisätään eri kokoluokka jokaiselle mäpissä mainitulle koolle."
    [:div.haitari
     (doall
       (for [[otsikko avain komponentti] (partition 3 otsikko-avain-ja-komponentti)
-            :let [auki? (auki avain)]]
+            :let [auki? (auki avain)
+                  avaa-tai-sulje-haitari (fn [event]
+                                 (do
+                                   (.preventDefault event)
+                                   (toggle-osio! avain)))]]
         ^{:key (str avain)}
         [:div.haitari-rivi
          [:div.haitari-heading.klikattava
-          {:on-click #(do
-                        (toggle-osio! avain)
-                        (.preventDefault %))}
-          [:span.haitarin-tila
+          {:on-click #(avaa-tai-sulje-haitari %)
+           :on-key-down #(when (dom/enter-nappain? %)
+                           (avaa-tai-sulje-haitari %))}
+          [:span.haitarin-tila {:tabIndex "0"}
            (if auki?
              (ikonit/livicon-chevron-down)
              (ikonit/livicon-chevron-right))]

--- a/src/cljs/harja/ui/yleiset.cljs
+++ b/src/cljs/harja/ui/yleiset.cljs
@@ -309,7 +309,7 @@ joita kutsutaan kun niiden näppäimiä paineetaan."
                                          (valitse-fn (nth vaihtoehdot (inc nykyinen-valittu-idx))))
 
                                        13                   ;; enter
-                                       (reset! auki? false)))))
+                                       (reset! auki? (not @auki?))))))
 
                                (do                          ;; Valitaan inputtia vastaava vaihtoehto
                                  (reset! term (char kc))

--- a/src/cljs/harja/views/tilannekuva/tilannekuva.cljs
+++ b/src/cljs/harja/views/tilannekuva/tilannekuva.cljs
@@ -106,23 +106,27 @@
                               (and kokoelma-atom
                                    (= otsikko @kokoelma-atom))))
              valittujen-lkm (count (filter true? (vals (get-in @suodattimet-atom ryhma-polku))))
-             kokonais-lkm (count (vals (get-in @suodattimet-atom ryhma-polku)))]
+             kokonais-lkm (count (vals (get-in @suodattimet-atom ryhma-polku)))
+             avaa-tai-sulje-ryhma (fn []
+                               (if kokoelma-atom
+                                 ;; Osa kokoelmaa, vain yksi kokoelman jäsen voi olla kerrallaan auki
+                                 (if (= otsikko @kokoelma-atom)
+                                   (reset! kokoelma-atom nil)
+                                   (reset! kokoelma-atom otsikko))
+                                 ;; Ylläpitää itse omaa auki/kiinni-tilaansa
+                                 (swap! auki-tila not))
+                               (aseta-hallintapaneelin-max-korkeus (dom/elementti-idlla "tk-suodattimet")))]
          (when-not (empty? ryhman-elementtien-avaimet)
            [:div {:class (str "tk-checkbox-ryhma" (when luokka (str " " luokka)))}
             [:div
              {:class (str "tk-checkbox-ryhma-otsikko klikattava " (when (auki?) "alaraja"))
-              :on-click (fn [_]
-                          (if kokoelma-atom
-                            ;; Osa kokoelmaa, vain yksi kokoelman jäsen voi olla kerrallaan auki
-                            (if (= otsikko @kokoelma-atom)
-                              (reset! kokoelma-atom nil)
-                              (reset! kokoelma-atom otsikko))
-                            ;; Ylläpitää itse omaa auki/kiinni-tilaansa
-                            (swap! auki-tila not))
-                          (aseta-hallintapaneelin-max-korkeus (dom/elementti-idlla "tk-suodattimet")))}
+              :on-click #(avaa-tai-sulje-ryhma)
+              :on-key-down #(when (dom/enter-nappain? %)
+                              (avaa-tai-sulje-ryhma))}
              [:span {:class (str
                               "tk-chevron-ryhma-tila chevron-rotate "
-                              (when-not (auki?) "chevron-rotate-down"))}
+                              (when-not (auki?) "chevron-rotate-down"))
+                     :tabIndex "0"}
               (if (auki?)
                 (ikonit/livicon-chevron-down) (ikonit/livicon-chevron-right))]
              [:div.tk-checkbox-ryhma-checkbox {:on-click #(.stopPropagation %)}
@@ -158,7 +162,10 @@
            [:div {:class (str
                            "tk-chevron-ryhma-tila chevron-rotate chevron-tk-asetuskokoelma "
                            (when-not @auki? "chevron-rotate-down"))
-                  :on-click #(swap! auki? not)}
+                  :tabIndex "0"
+                  :on-click #(swap! auki? not)
+                  :on-key-down #(when (dom/enter-nappain? %)
+                                  (swap! auki? not))}
             (if @auki?
               (ikonit/livicon-chevron-down)
               (ikonit/livicon-chevron-right))])

--- a/src/cljs/harja/views/urakka/kulut/mhu_kustannusten_seuranta.cljs
+++ b/src/cljs/harja/views/urakka/kulut/mhu_kustannusten_seuranta.cljs
@@ -9,6 +9,7 @@
             [harja.loki :refer [log logt]]
             [harja.pvm :as pvm]
             [harja.fmt :as fmt]
+            [harja.ui.dom :as dom]
             [harja.ui.debug :as debug]
             [harja.ui.protokollat :refer [Haku hae]]
             [harja.ui.yleiset :refer [ajax-loader linkki livi-pudotusvalikko +korostuksen-kesto+ ajax-loader-pieni]]
@@ -184,7 +185,10 @@
                     (big/->big (or ((keyword (str (name paaryhma-avain) "-toteutunut")) rivit-paaryhmittain) 0))
                     (big/->big (or ((keyword (str (name paaryhma-avain) "-budjetoitu-indeksikorjattu")) rivit-paaryhmittain) 0))
                     neg?)
-        vahvistettu (get rivit-paaryhmittain (keyword (str (name paaryhma-avain) "-indeksikorjaus-vahvistettu")))]
+        vahvistettu (get rivit-paaryhmittain (keyword (str (name paaryhma-avain) "-indeksikorjaus-vahvistettu")))
+        avaa-tai-sulje-haitari (fn [event]
+                    (when (dom/enter-nappain? event)
+                      (e! (kustannusten-seuranta-tiedot/->AvaaRivi paaryhma-avain))))]
     (doall (concat
              [^{:key (str paaryhma "-" (hash toimenpiteet))}
               [:tr.bottom-border.selectable {:on-click #(e! (kustannusten-seuranta-tiedot/->AvaaRivi paaryhma-avain))
@@ -192,9 +196,15 @@
                [:td.paaryhma-center {:style {:width (:caret-paaryhma leveydet)}}
                 (if (and (> (count toimenpiteet) 0)
                       (contains? (:avatut-rivit app) paaryhma-avain))
-                  [:img {:alt "Expander" :src "images/expander-down.svg"}]
+                  [:img {:alt "Expander"
+                         :src "images/expander-down.svg"
+                         :tabIndex "0"
+                         :on-key-down #(avaa-tai-sulje-haitari %)}]
                   (when (> (count toimenpiteet) 0)
-                    [:img {:alt "Expander" :src "images/expander.svg"}]))]
+                    [:img {:alt "Expander"
+                           :src "images/expander.svg"
+                           :tabIndex "0"
+                           :on-key-down #(avaa-tai-sulje-haitari %)}]))]
                [:td.paaryhma-center {:style {:width (:paaryhma-vari leveydet)}}]
                [:td {:style {:width (:tehtava leveydet)
                              :font-weight "700"}} paaryhma]

--- a/src/cljs/harja/views/urakka/suunnittelu/kustannussuunnitelma/osion_vahvistus.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/kustannussuunnitelma/osion_vahvistus.cljs
@@ -3,6 +3,7 @@
             [harja.tiedot.urakka.suunnittelu.mhu-kustannussuunnitelma :as t]
             [harja.ui.yleiset :as yleiset]
             [harja.views.urakka.suunnittelu.kustannussuunnitelma.yhteiset :as ks-yhteiset :refer [e!]]
+            [harja.ui.dom :as dom]
             [harja.ui.modal :as modal]
             [harja.ui.debug :as debug]
             [harja.domain.roolit :as roolit]
@@ -72,7 +73,7 @@
         kumoa-osion-vahvistus-fn (fn [tyyppi hoitovuosi]
                                    (e! (t/->KumoaOsionVahvistusVuodelta {:tyyppi tyyppi
                                                                          :hoitovuosi hoitovuosi})))
-        avaa-tai-sulje #(swap! auki? not)]
+        avaa-tai-sulje-haitari #(swap! auki? not)]
     (fn [osio-kw {:keys [osioiden-tilat vahvistus-vaadittu-osiot hoitovuosi-nro indeksit-saatavilla? osiossa-virheita?] :as opts}]
       (let [vahvistettu? (osio-vahvistettu? osioiden-tilat osio-kw hoitovuosi-nro)
             vaaditut-vahvistettu? (vaaditut-osiot-vahvistettu? osioiden-tilat vahvistus-vaadittu-osiot hoitovuosi-nro)
@@ -89,7 +90,7 @@
                                       vahvistettu?
                                       "vahvistettu")
                              :data-cy (str "vahvista-osio-" (name osio-kw))
-                             :on-click avaa-tai-sulje}
+                             :on-click avaa-tai-sulje-haitari}
 
          ;; Laatikon otsikko
          [:div.otsikko
@@ -122,7 +123,10 @@
           ;; Laatikon voi laajentaa vain jos indeksit ovat saatavilla ja vaaditut osiot on vahvistettu.
           (when (and indeksit-saatavilla? vaaditut-vahvistettu?)
             [:div.laajenna-btn
-             {:class (when vahvistettu? "vahvistettu")}
+             {:class (when vahvistettu? "vahvistettu")
+              :tabIndex "0"
+              :on-key-down #(when (dom/enter-nappain? %)
+                              (avaa-tai-sulje-haitari))}
              (if @auki?
                [:<> [ikonit/livicon-chevron-up] "Pienennä"]
                [:<> [ikonit/livicon-chevron-down] "Lisätiedot"])])]

--- a/src/cljs/harja/views/urakka/toteumat/maarien_toteumat.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/maarien_toteumat.cljs
@@ -1,6 +1,7 @@
 (ns harja.views.urakka.toteumat.maarien-toteumat
   "Urakan 'Toteumat' välilehden Määrien toteumat osio"
   (:require [reagent.core :refer [atom] :as r]
+            [harja.ui.dom :as dom]
             [harja.ui.ikonit :as ikonit]
             [harja.ui.yleiset :refer [ajax-loader linkki livi-pudotusvalikko +korostuksen-kesto+]]
             [harja.ui.napit :as napit]
@@ -112,12 +113,15 @@
                                         ;; Tyyppi on joko kokonaishintainen tai lisätyö
                                         tehtava-tyyppi (first (second rivi))
                                         ;; Rahavaraukselle ei näytetä suunniteltuja määriä eikä toteumaprosenttia
-                                        rahavaraus? (not (nil? (:rahavaraus (first (second rivi)))))]
+                                        rahavaraus? (not (nil? (:rahavaraus (first (second rivi)))))
+                                        avaa-tai-sulje-rivi (fn [rivi] (e! (maarien-toteumat/->HaeTehtavanToteumat (first (second rivi)))))]
                                     (concat
                                       [^{:key (hash rivi)}
                                        [:tr (merge
                                               (when kasin-lisattava?
-                                                {:on-click #(e! (maarien-toteumat/->HaeTehtavanToteumat (first (second rivi))))})
+                                                {:on-click #(avaa-tai-sulje-rivi rivi)
+                                                 :on-key-down #(when (dom/enter-nappain? %)
+                                                                 (avaa-tai-sulje-rivi rivi))})
                                               {:class (str "table-default-" (if (odd? @row-index-atom) "even" "odd") " " (when kasin-lisattava? "klikattava"))})
                                         [:td.strong {:style {:width (:tehtava leveydet)}} (first rivi) (when (and (:haetut-toteumat-lataa app)
                                                                                                                   (= (:avattu-tehtava app) (first rivi)))
@@ -125,9 +129,9 @@
                                         [:td {:style {:width (:caret leveydet)}} (if
                                                                                    (= (:avattu-tehtava app) (first rivi))
                                                                                    (when kasin-lisattava?
-                                                                                     [ikonit/livicon-chevron-up])
+                                                                                     [:span.livicon-chevron-up {:tabIndex "0"}])
                                                                                    (when kasin-lisattava?
-                                                                                     [ikonit/livicon-chevron-down]))]
+                                                                                     [:span.livicon-chevron-down {:tabIndex "0"}]))]
                                         [:td {:style {:width (:toteuma leveydet)}} (str (big/fmt toteutunut-maara 1) " " (maarita-yksikko (first (second rivi))))]
                                         [:td {:style {:width (:suunniteltu leveydet)
                                                       :color fontin-vari}} (cond


### PR DESCRIPTION
Tässä branchissä on muutettu välilehdillä navigointi toimimaan näppäimistöllä (tab-näppäin) ja välilehti aukeamaan enterillä. Pudotusvalikot aukeavat myös enterillä ja niissä pystyy siirtymään riviltä toiselle nuolinäppäimellä, paitsi checkbox-pudotusvalikoissa se ei vielä onnistu, mutta tab-näppäimellä pystyy liikkumaan niissä. Myös haitareiden avaaminen ja sulkeminen onnistuu nyt enterillä näillä sivuilla: Kustannussuunnitelma, Tehtävät ja määrät, Kustannusten seuranta, Toteumat/Tehtävät ja Hallinta/Urakkatiedot/Tehtävät. Ja Tilannekuva-näkymässä toimii myös tab-näppäimellä navigointi, ja checkboxit pystyy laittamaan päälle ja pois välilyönnillä sekä haitarit aukeaa enterillä.