### PR TITLE
Korjaa asiat-pisteessa varoitus 

### DIFF
--- a/src/cljs-dev/harja/ui/kartta_debug.cljs
+++ b/src/cljs-dev/harja/ui/kartta_debug.cljs
@@ -17,6 +17,16 @@
 
 (declare aseta-kartta-debug-sijainti pakota-paivitys)
 
+;; Määrittelee asiat, jotka ovat nykyisessä pisteessä.
+;; Avaimet:
+;; :koordinaatti  klikatun pisteen koordinatti (tai nil, jos ei valintaa)
+;; :asiat         sekvenssi asioita, joita pisteestä löytyy
+;; :haetaan?      true kun haku vielä kesken
+(defonce asiat-pisteessa (atom {:koordinaatti nil
+                                :haetaan? true
+                                :asiat nil}))
+
+
 (defonce tila (atom {:nayta-kartan-debug? false
                      :nayta-kaikki-layerit? false
                      :nayta-kartan-ylaosassa? true
@@ -145,23 +155,21 @@
 (defn- nayta-infopaneelin-tiedot []
   (when (and (:nayta-infopaneelin-tiedot? @tila)
              @kartta/infopaneeli-nakyvissa?)
-    (let [linkki-funkitot-vektori? (vector? @kartta/infopaneelin-linkkifunktiot)
-          metan-asettaminen-linkkifunktioille #(into {} (map (fn [[avain arvo]]
+    (let [metan-asettaminen-linkkifunktioille #(into {} (map (fn [[avain arvo]]
                                                                [avain (if (vector? arvo)
                                                                         (mapv (fn [mappi] (with-meta mappi {:ylin-taso? true})) arvo)
                                                                         (with-meta arvo {:ylin-taso? true}))])
-                                                             @kartta/infopaneelin-linkkifunktiot))
-          ;; harja.views.kartta viittauksesta tulee warningia käännösvaiheessa,
-          ;; mutta ilmeisesti ajon aikana toimii
-          metan-asettaminen-asioille-raaka #(update @harja.views.kartta/asiat-pisteessa :asiat (fn [asiat]
-                                                                                                 (mapv (fn [asia]
-                                                                                                         (with-meta asia {:ylin-taso? true}))
-                                                                                                       asiat)))
-          metan-asettaminen-asioille-kasitelty #(->> @harja.views.kartta/asiat-pisteessa
-                                                     :asiat
-                                                     info/skeemamuodossa
-                                                     (mapv (fn [asia]
-                                                             (with-meta asia {:ylin-taso? true}))))]
+                                                          @kartta/infopaneelin-linkkifunktiot))
+
+          metan-asettaminen-asioille-raaka #(update @asiat-pisteessa :asiat (fn [asiat]
+                                                                              (mapv (fn [asia]
+                                                                                      (with-meta asia {:ylin-taso? true}))
+                                                                                asiat)))
+          metan-asettaminen-asioille-kasitelty #(->> @asiat-pisteessa
+                                                  :asiat
+                                                  info/skeemamuodossa
+                                                  (mapv (fn [asia]
+                                                          (with-meta asia {:ylin-taso? true}))))]
       [:div {:style {:display "flex"
                      :flex-flow "column wrap"
                      :pointer-events "none"}}

--- a/src/cljs-dev/harja/ui/kartta_debug.cljs
+++ b/src/cljs-dev/harja/ui/kartta_debug.cljs
@@ -9,22 +9,11 @@
             [harja.tiedot.navigaatio :as nav]
             [harja.tiedot.kartta :as kartta]
             [harja.fmt :as fmt]
-            [harja.ui.kentat :as kentat]
             [harja.ui.kartta.infopaneelin-sisalto :as info]
-            [clojure.string :as clj-str]
             [clojure.set :as set])
   (:require-macros [reagent.ratom :refer [reaction]]))
 
 (declare aseta-kartta-debug-sijainti pakota-paivitys)
-
-;; Määrittelee asiat, jotka ovat nykyisessä pisteessä.
-;; Avaimet:
-;; :koordinaatti  klikatun pisteen koordinatti (tai nil, jos ei valintaa)
-;; :asiat         sekvenssi asioita, joita pisteestä löytyy
-;; :haetaan?      true kun haku vielä kesken
-(defonce asiat-pisteessa (atom {:koordinaatti nil
-                                :haetaan? true
-                                :asiat nil}))
 
 
 (defonce tila (atom {:nayta-kartan-debug? false
@@ -32,6 +21,7 @@
                      :nayta-kartan-ylaosassa? true
                      :nayta-infopaneelin-tiedot? true
                      :kartan-paikka []}))
+
 (defonce layers (reaction (into {} (map (fn [[kerros kerroksen-tila-atom]]
                                           [kerros @kerroksen-tila-atom])
                                         tasot/tasojen-nakyvyys-atomit))))
@@ -161,11 +151,11 @@
                                                                         (with-meta arvo {:ylin-taso? true}))])
                                                           @kartta/infopaneelin-linkkifunktiot))
 
-          metan-asettaminen-asioille-raaka #(update @asiat-pisteessa :asiat (fn [asiat]
+          metan-asettaminen-asioille-raaka #(update @kartta/asiat-pisteessa :asiat (fn [asiat]
                                                                               (mapv (fn [asia]
                                                                                       (with-meta asia {:ylin-taso? true}))
                                                                                 asiat)))
-          metan-asettaminen-asioille-kasitelty #(->> @asiat-pisteessa
+          metan-asettaminen-asioille-kasitelty #(->> @kartta/asiat-pisteessa
                                                   :asiat
                                                   info/skeemamuodossa
                                                   (mapv (fn [asia]

--- a/src/cljs-prod/harja/ui/kartta_debug.cljs
+++ b/src/cljs-prod/harja/ui/kartta_debug.cljs
@@ -1,12 +1,11 @@
 (ns harja.ui.kartta-debug)
 
 (defn kartta-layers
-  [& args]
-  )
+  [& args])
 
 (defn aseta-kartta-debug-sijainti
-  [& args]
-  )
+  [& args])
 
-(defn nayta-kartan-debug []
-  )
+(defn nayta-kartan-debug [])
+
+(defonce asiat-pisteessa (atom nil))

--- a/src/cljs-prod/harja/ui/kartta_debug.cljs
+++ b/src/cljs-prod/harja/ui/kartta_debug.cljs
@@ -7,5 +7,3 @@
   [& args])
 
 (defn nayta-kartan-debug [])
-
-(defonce asiat-pisteessa (atom nil))

--- a/src/cljs/harja/tiedot/kartta.cljs
+++ b/src/cljs/harja/tiedot/kartta.cljs
@@ -27,6 +27,15 @@
 (defn nayta-infopaneeli! []
   (paneelin-tila/nayta-infopaneeli!))
 
+;; Määrittelee asiat, jotka ovat nykyisessä pisteessä.
+;; Avaimet:
+;; :koordinaatti  klikatun pisteen koordinatti (tai nil, jos ei valintaa)
+;; :asiat         sekvenssi asioita, joita pisteestä löytyy
+;; :haetaan?      true kun haku vielä kesken
+(defonce asiat-pisteessa (atom {:koordinaatti nil
+                                :haetaan? true
+                                :asiat nil}))
+
 (defn kasittele-infopaneelin-linkit!
   "Infopaneelin skeemat saattavat sisältää 'linkkejä', jotka käsitellään
   (tai ei käsitellä) näkymäkohtaisesti. Esimerkiksi toteumanäkymässä voidaan haluta

--- a/src/cljs/harja/views/kartta.cljs
+++ b/src/cljs/harja/views/kartta.cljs
@@ -56,7 +56,7 @@
             [harja.ui.openlayers.edistymispalkki :as edistymispalkki]
             [harja.tiedot.kartta :as tiedot]
             [harja.ui.kartta.ikonit :as kartta-ikonit]
-            [harja.ui.kartta-debug :refer [aseta-kartta-debug-sijainti]])
+            [harja.ui.kartta-debug :refer [aseta-kartta-debug-sijainti asiat-pisteessa]])
 
   (:require-macros [reagent.ratom :refer [reaction run!]]
                    [cljs.core.async.macros :refer [go go-loop]]))
@@ -394,15 +394,6 @@
 (def paivitetaan-karttaa-tila (atom false))
 (defonce kuvatason-lataus (atom nil))
 (defonce geometriatason-lataus (atom nil))
-
-;; Määrittelee asiat, jotka ovat nykyisessä pisteessä.
-;; Avaimet:
-;; :koordinaatti  klikatun pisteen koordinatti (tai nil, jos ei valintaa)
-;; :asiat         sekvenssi asioita, joita pisteestä löytyy
-;; :haetaan?      true kun haku vielä kesken
-(defonce asiat-pisteessa (atom {:koordinaatti nil
-                                :haetaan? true
-                                :asiat nil}))
 
 (defn paivitetaan-karttaa
   []

--- a/src/cljs/harja/views/kartta.cljs
+++ b/src/cljs/harja/views/kartta.cljs
@@ -56,7 +56,7 @@
             [harja.ui.openlayers.edistymispalkki :as edistymispalkki]
             [harja.tiedot.kartta :as tiedot]
             [harja.ui.kartta.ikonit :as kartta-ikonit]
-            [harja.ui.kartta-debug :refer [aseta-kartta-debug-sijainti asiat-pisteessa]])
+            [harja.ui.kartta-debug :refer [aseta-kartta-debug-sijainti]])
 
   (:require-macros [reagent.ratom :refer [reaction run!]]
                    [cljs.core.async.macros :refer [go go-loop]]))
@@ -458,7 +458,7 @@
   (openlayers/extent-sisaltaa-extent? +koko-suomi-extent+ (geo/extent alue)))
 
 (defn- nayta-infopaneelissa! [& items]
-  (apply swap! asiat-pisteessa update :asiat conj items))
+  (apply swap! tiedot/asiat-pisteessa update :asiat conj items))
 
 (defn- hae-asiat-pisteessa! [tasot event atomi]
   (let [koordinaatti (js->clj (.-coordinate event))
@@ -679,7 +679,7 @@
 
      (when avaa-paneeli? (kaynnista-infopaneeliin-haku-pisteesta! @tasot/geometriat-kartalle
                                                                   event
-                                                                  asiat-pisteessa))
+                                                                  tiedot/asiat-pisteessa))
 
      (when-not (empty? nayta-nama-paneelissa)
        (apply nayta-infopaneelissa! nayta-nama-paneelissa))
@@ -757,7 +757,7 @@
                        :default
                        (kaynnista-infopaneeliin-haku-pisteesta! @tasot/geometriat-kartalle
                          event
-                         asiat-pisteessa))
+                         tiedot/asiat-pisteessa))
                      (.stopPropagation event)
                      (.preventDefault event))
          :on-select kasittele-select!
@@ -814,7 +814,7 @@
    [kartan-ohjelaatikko]
    (when @tiedot/infopaneeli-nakyvissa?
      [:div.kartan-infopaneeli
-      [infopaneeli/infopaneeli @asiat-pisteessa tiedot/piilota-infopaneeli!
+      [infopaneeli/infopaneeli @tiedot/asiat-pisteessa tiedot/piilota-infopaneeli!
        tiedot/infopaneelin-linkkifunktiot]])
    (when-not @tiedot/infopaneeli-nakyvissa? ;; Peittää selitelaatikon, otetaan pois
      [kartan-ikonien-selitykset])


### PR DESCRIPTION
Tuhannen branchin kunniaksi korjattu legendaarinen dev varoitus, joka on vuosien varrella kehittynyt lähes omaksi featurekseen. RIP varoitus, 2017-2024. Olit meille kuin vanha tuttavuus, jota kukaan ei kaivannut mutta kaikki tunsivat, enää et kummittele replissä 

Siirretty asiat-pisteessa muuttuja harja.tiedot.kartta namespaceen, tästä ei tule circular dependencyä ja korjaa samalla front käännöksen virheen.

![image](https://github.com/user-attachments/assets/1dc08a0f-4203-41bf-990f-397379c11b46)
