### PR TITLE
Harja-673 Saavutettavuus-korjaukset, datepickerien kaytto nappaimistolla

### DIFF
--- a/src/cljs/harja/ui/checkbox.cljs
+++ b/src/cljs/harja/ui/checkbox.cljs
@@ -1,6 +1,7 @@
 (ns harja.ui.checkbox
   (:require [reagent.core :refer [atom]]
             [harja.loki :refer [log tarkkaile!]]
+            [harja.ui.dom :as dom]
 
             [cljs.core.async :refer [<!]])
   (:require-macros
@@ -46,7 +47,7 @@ checkbox-tila->luokka {:valittu "harja-checkbox-valittu"
        [:div.harja-checkbox-column
         [:div.harja-checkbox-laatikko {:class (checkbox-tila->luokka tila)
                                        :tabIndex "0"
-                                       :on-key-down #(when (= 32 (-> % .-keyCode))
+                                       :on-key-down #(when (dom/valilyonti? %)
                                                        (vaihda-tila %))}
          [:div.harja-checkbox-laatikko-sisalto
           (when (= :valittu @tila-atom)

--- a/src/cljs/harja/ui/dom.cljs
+++ b/src/cljs/harja/ui/dom.cljs
@@ -78,7 +78,15 @@
         ie-versio (maarita-ie-versio-user-agentista ua)]
     (and (integer? ie-versio) (<= 10 ie-versio))))
 
-(defn enter-nappain? [event] (= 13 (.-keyCode event)))
+(defn enter-nappain? [event] (= "Enter" (-> event .-key)))
+(defn tab+shift-nappaimet? [event] (and (= "Tab" (-> event .-key)) (-> event .-shiftKey)))
+(defn tab-nappain-ilman-shiftia? [event] (and (= "Tab" (-> event .-key)) (not (-> event .-shiftKey))))
+(defn esc-nappain? [event] (= "Escape" (-> event .-key)))
+(defn nuoli-oikealle? [event] (= "ArrowRight" (-> event .-key)))
+(defn nuoli-vasemmalle? [event] (= "ArrowLeft" (-> event .-key)))
+(defn nuoli-ylos? [event] (= "ArrowUp" (-> event .-key)))
+(defn nuoli-alas? [event] (= "ArrowDown" (-> event .-key)))
+(defn valilyonti? [event] (= " " (-> event .-key)))
 
 (defonce korkeus (r/atom (-> js/window .-innerHeight)))
 (defonce leveys (r/atom (-> js/window .-innerWidth)))

--- a/src/cljs/harja/ui/kentat.cljs
+++ b/src/cljs/harja/ui/kentat.cljs
@@ -3,6 +3,7 @@
   (:require [reagent.core :refer [atom] :as r]
             [reagent.ratom :as ratom]
             [harja.pvm :as pvm]
+            [harja.ui.dom :as dom]
             [harja.ui.pvm :as pvm-valinta]
             [harja.ui.protokollat :refer [hae]]
             [harja.ui.komponentti :as komp]
@@ -1113,6 +1114,7 @@
                                 (pvm/->pvm nykyinen-teksti)
                                 nykyinen-pvm
                                 (pvm-tyhjana rivi))
+               elementin-id (str (gensym "pvm-input"))
                input-komponentti [:input {:class (yleiset/luokat (when-not (or kentan-tyylit vayla-tyyli?) "pvm")
                                                                  (cond
                                                                    kentan-tyylit (apply str kentan-tyylit)
@@ -1122,12 +1124,14 @@
                          :value nykyinen-teksti
                          :on-focus #(do (when on-focus (on-focus)) (reset! auki true) %)
                          :on-change #(muuta! data (-> % .-target .-value))
-                         ;; keycode 9 = Tab. Suljetaan datepicker kun painetaan tabia.
-                         :on-key-down #(when (or (= key-code-tab (-> % .-keyCode)) (= key-code-tab (-> % .-which))
-                                                 (= key-code-enter (-> % .-keyCode)) (= key-code-enter (-> % .-which)))
-                                         (teksti-paivamaaraksi! validoi data nykyinen-teksti)
-                                         (reset! auki false)
-                                         true)
+                         ;; Suljetaan datepicker kun painetaan tab + shift tai esc. Enterillä datepickerin saa auki/kiinni.
+                         :on-key-down #(do
+                                         (when (or (dom/tab+shift-nappaimet? %) (dom/esc-nappain? %))
+                                           (teksti-paivamaaraksi! validoi data nykyinen-teksti)
+                                           (reset! auki false))
+                                         (when (dom/enter-nappain? %)
+                                           (teksti-paivamaaraksi! validoi data nykyinen-teksti)
+                                           (reset! auki (not @auki))))
                          :on-blur #(let [arvo (.. % -target -value)
                                          pvm (pvm/->pvm arvo)]
                                      (when on-blur
@@ -1135,7 +1139,8 @@
                                      (if (and pvm (not (validoi pvm)))
                                        (do (muuta-data! nil)
                                            (reset! teksti ""))
-                                       (teksti-paivamaaraksi! validoi data arvo)))}]]
+                                       (teksti-paivamaaraksi! validoi data arvo)))
+                         :id elementin-id}]]
            (swap! vanha-data assoc :data nykyinen-pvm :muokattu-tassa? false)
            [:span.pvm-kentta
             {:on-click #(do (reset! auki true) nil)
@@ -1151,7 +1156,11 @@
                                                  :pvm naytettava-pvm
                                                  :pakota-suunta pakota-suunta
                                                  :valittava?-fn (when validoi?
-                                                                  validoi)}])]))})))
+                                                                  validoi)
+                                                 :sulje-kalenteri #(do
+                                                                     (some-> js/document (.getElementById elementin-id) .focus)
+                                                                     (reset! auki false))
+                                                 :input-id elementin-id}])]))})))
 
 (defmethod nayta-arvo :pvm [{:keys [jos-tyhja]} data]
   [:span (if-let [p @data]
@@ -1262,7 +1271,8 @@
               naytettava-pvm (or
                                (pvm/->pvm nykyinen-pvm-teksti)
                                nykyinen-pvm
-                               (pvm-tyhjana rivi))]
+                               (pvm-tyhjana rivi))
+              elementin-id (str (gensym "pvm-aika-input"))]
           [:span.pvm-aika-kentta
            [:div.inline-block
             [:input.pvm {:class (when lomake? "form-control margin-bottom-4")
@@ -1274,18 +1284,25 @@
                          :value nykyinen-pvm-teksti
                          :on-focus #(do (when on-focus (on-focus)) (reset! auki true) %)
                          :on-change #(muuta-pvm! (-> % .-target .-value))
-                         ;; keycode 9 = Tab. Suljetaan datepicker kun painetaan tabia.
-                         :on-key-down #(when (or (= 9 (-> % .-keyCode)) (= 9 (-> % .-which)))
-                                         (reset! auki false)
-                                         %)
-                         :on-blur #(do (when on-blur (on-blur %)) (koske-pvm!) (aseta! false) %)}]
+                         ;; Suljetaan datepicker kun painetaan tab + shift tai esc. Enterillä datepickerin saa auki/kiinni.
+                         :on-key-down #(do
+                                         (when (or (dom/tab+shift-nappaimet? %) (dom/esc-nappain? %))
+                                           (reset! auki false))
+                                         (when (dom/enter-nappain? %)
+                                           (reset! auki (not @auki))))
+                         :on-blur #(do (when on-blur (on-blur %)) (koske-pvm!) (aseta! false) %)
+                         :id elementin-id}]
             (when @auki
               [pvm-valinta/pvm-valintakalenteri {:valitse #(do (reset! auki false)
                                                                (muuta-pvm! (pvm/pvm %))
                                                                (koske-pvm!)
                                                                (aseta! true))
                                                  :pvm naytettava-pvm
-                                                 :pakota-suunta pakota-suunta}])]
+                                                 :pakota-suunta pakota-suunta
+                                                 :sulje-kalenteri #(do
+                                                                     (some-> js/document (.getElementById elementin-id) .focus)
+                                                                     (reset! auki false))
+                                                 :input-id elementin-id}])]
            [:div.inline-block
             [:input.aika-input {:class (str (when lomake? "form-control")
                                             (when (and (not (re-matches +validi-aika-regex+

--- a/src/cljs/harja/ui/pvm.cljs
+++ b/src/cljs/harja/ui/pvm.cljs
@@ -94,10 +94,21 @@
       (komp/dom-kuuntelija js/window
                            EventType/SCROLL scroll-kuuntelija)
 
-      (fn [{:keys [pvm valitse style valittava?-fn vayla-tyyli?] :as optiot}]
+      (fn [{:keys [pvm valitse style valittava?-fn vayla-tyyli? sulje-kalenteri input-id] :as optiot}]
         (let [[vuosi kk] @nayta
               naytettava-kk (t/date-time vuosi (inc kk) 1)
-              naytettava-kk-paiva? #(pvm/sama-kuukausi? naytettava-kk %)]
+              naytettava-kk-paiva? #(pvm/sama-kuukausi? naytettava-kk %)
+              fokus-paiva (if pvm (t/day pvm) 1)
+              nayta-edellinen-kk #(swap! nayta
+                                    (fn [[vuosi kk]]
+                                      (if (= kk 0)
+                                        [(dec vuosi) 11]
+                                        [vuosi (dec kk)])))
+              nayta-seuraava-kk #(swap! nayta
+                                   (fn [[vuosi kk]]
+                                     (if (= kk 11)
+                                       [(inc vuosi) 0]
+                                       [vuosi (inc kk)])))]
           [:table {:class (str tyyli-kalenteri)
                    :style (merge
                             {:display (if @sijainti-atom "table" "none")
@@ -115,22 +126,33 @@
             [:tr
              [:td.pvm-edellinen-kuukausi.klikattava
               {:on-click #(do (.preventDefault %)
-                              (swap! nayta
-                                     (fn [[vuosi kk]]
-                                       (if (= kk 0)
-                                         [(dec vuosi) 11]
-                                         [vuosi (dec kk)])))
-                              nil)}
+                              (nayta-edellinen-kk)
+                              nil)
+               :tabIndex "0"
+               :on-key-down  #(do
+                                (when (dom/enter-nappain? %)
+                                  (.preventDefault %)
+                                  (nayta-edellinen-kk))
+                                (when (dom/tab+shift-nappaimet? %)
+                                  (.preventDefault %)
+                                  (sulje-kalenteri))
+                                nil)}
               (ikonit/livicon-chevron-left)]
              [:td {:col-span 5} [:span.pvm-kuukausi (nth pvm/+kuukaudet+ kk)] " " [:span.pvm-vuosi vuosi]]
              [:td.pvm-seuraava-kuukausi.klikattava
               {:on-click #(do (.preventDefault %)
-                              (swap! nayta
-                                     (fn [[vuosi kk]]
-                                       (if (= kk 11)
-                                         [(inc vuosi) 0]
-                                         [vuosi (inc kk)])))
-                              nil)}
+                              (nayta-seuraava-kk)
+                              nil)
+               :tabIndex "0"
+               :id "seuraava-kk"
+               :on-key-down #(do
+                               (when (dom/enter-nappain? %)
+                                 (.preventDefault %)
+                                 (nayta-seuraava-kk))
+                               (when (dom/tab-nappain-ilman-shiftia? %)
+                                 (.preventDefault %)
+                                 (r/after-render (fn [] (some-> js/document (.getElementById (str "paiva_" fokus-paiva)) .focus))))
+                               nil)}
               (ikonit/livicon-chevron-right)]]
             [:tr {:class tyyli-otsikkorivi}
              (for [paiva +paivat+]
@@ -161,7 +183,38 @@
                        :on-click #(do (.stopPropagation %)
                                       (when valittava?
                                         (valitse paiva))
-                                      nil)}
+                                      nil)
+                       :tabIndex (if (naytettava-kk-paiva? paiva)
+                                   "0")
+                       :id (when (naytettava-kk-paiva? paiva) (str "paiva_" (t/day paiva)))
+                       :on-key-down #(do
+                                       (.preventDefault %)
+
+                                       (cond
+                                         (and (dom/enter-nappain? %) valittava?)
+                                         (do (valitse paiva) (sulje-kalenteri))
+
+                                         (dom/tab+shift-nappaimet? %)
+                                         (r/after-render (fn [] (some-> js/document (.getElementById "seuraava-kk") .focus)))
+
+                                         (dom/tab-nappain-ilman-shiftia? %)
+                                         (r/after-render (fn [] (some-> js/document (.getElementById "tanaan") .focus)))
+
+                                         (dom/nuoli-oikealle? %)
+                                         (r/after-render (fn [] (some-> js/document (.getElementById (str "paiva_" (inc (t/day paiva)))) .focus)))
+
+                                         (dom/nuoli-vasemmalle? %)
+                                         (r/after-render (fn [] (some-> js/document (.getElementById (str "paiva_" (dec (t/day paiva)))) .focus)))
+
+                                         (dom/nuoli-ylos? %)
+                                         (r/after-render (fn [] (some-> js/document (.getElementById (str "paiva_" (- (t/day paiva) 7))) .focus)))
+
+                                         (dom/nuoli-alas? %)
+                                         (r/after-render (fn [] (some-> js/document (.getElementById (str "paiva_" (+ (t/day paiva) 7))) .focus)))
+
+                                         :else nil)
+
+                                       nil)}
                   (t/day paiva)])])]
            [:tfoot.pvm-tanaan-text
             [:tr [:td {:colSpan 7}
@@ -169,35 +222,51 @@
                                     (.preventDefault %)
                                     (.stopPropagation %)
                                     (when (or (not (some? valittava?-fn))
-                                              (valittava?-fn (pvm/nyt)))
-                                      (valitse (pvm/nyt))))}
+                                            (valittava?-fn (pvm/nyt)))
+                                      (valitse (pvm/nyt))))
+                       :tabIndex "0"
+                       :id "tanaan"
+                       :on-key-down #(do
+                                       (.preventDefault %)
+                                       (when (and (dom/enter-nappain? %)
+                                               (or (not (some? valittava?-fn))
+                                                 (valittava?-fn (pvm/nyt))))
+                                         (valitse (pvm/nyt))
+                                         (sulje-kalenteri))
+                                       (when (dom/tab+shift-nappaimet? %)
+                                         (r/after-render (fn []
+                                                           (some-> js/document (.getElementById (if pvm
+                                                                                                  (str "paiva_" (t/day pvm))
+                                                                                                  (str "paiva_1"))) .focus))))
+                                       (when (dom/tab-nappain-ilman-shiftia? %)
+                                         (sulje-kalenteri))
+                                       nil)}
                    "Tänään"]]]]])))))
-
-(def ^:const
-pvm-popupin-sulkevat-nappaimet
-  "Näppäimet, joille pvm popup suljetaan, kun focus on input-kentässä. Tab, enter ja esc."
-  #{9 13 27})
 
 (defn pvm-valintakalenteri-inputilla
   [_]
   (let [auki? (r/atom false)
         suora-syotto-sisalto (r/atom "")]
     (fn [{:keys [paivamaara valitse luokat valittava?-fn disabled sumeutus-fn placeholder]}]
-      (let [kiinni #(reset! % false)]
+      (let [kiinni #(reset! % false)
+            elementin-id (str (gensym "pvm-pakollinen-input"))]
         [:div.kalenteri-kontti
-         [:input {:disabled    disabled
-                  :type        :text
-                  :class       (apply conj #{} (filter #(not (nil? %)) (conj luokat (when @auki? "auki"))))
-                  :value       (cond
-                                 (seq @suora-syotto-sisalto) @suora-syotto-sisalto
-                                 (not (nil? paivamaara)) (pvm/pvm paivamaara)
-                                 :else "")
+         [:input {:disabled disabled
+                  :type :text
+                  :class (apply conj #{} (filter #(not (nil? %)) (conj luokat (when @auki? "auki"))))
+                  :value (cond
+                           (seq @suora-syotto-sisalto) @suora-syotto-sisalto
+                           (not (nil? paivamaara)) (pvm/pvm paivamaara)
+                           :else "")
                   :placeholder placeholder
-                  :on-change   #(reset! suora-syotto-sisalto (-> % .-target .-value))
-                  :on-click    #(reset! auki? true)
+                  :on-change #(reset! suora-syotto-sisalto (-> % .-target .-value))
+                  :on-click #(reset! auki? true)
                   :on-focus    #(reset! auki? true)
-                  :on-key-down #(when (pvm-popupin-sulkevat-nappaimet (.-keyCode %))
-                                  (kiinni auki?))
+                  :on-key-down #(do
+                                  (when (or (dom/tab+shift-nappaimet? %) (dom/esc-nappain? %))
+                                    (kiinni auki?))
+                                  (when (dom/enter-nappain? %)
+                                    (reset! auki? (not @auki?))))
                   :on-blur     (fn []
                                  (when (not paivamaara) (kiinni auki?)) ; jos ei ole päivämäärää määritelty, niin valintoja ei voi tehdä. droppari jää auki, kunnes koontilaskun kuukausi klikataan. tällä estetään se tilanne.
                                  (when sumeutus-fn (sumeutus-fn))
@@ -205,10 +274,15 @@ pvm-popupin-sulkevat-nappaimet
                                    (let [pvm-sisalto (pvm/->pvm @suora-syotto-sisalto)]
                                      (when (valittava?-fn pvm-sisalto)
                                        (valitse (pvm/->pvm @suora-syotto-sisalto))))
-                                   (reset! suora-syotto-sisalto "")))}]
+                                   (reset! suora-syotto-sisalto "")))
+                  :id elementin-id}]
          (when @auki?
            [pvm-valintakalenteri {:valitse       #(do
                                                     (kiinni auki?)
                                                     (valitse %))
                                   :valittava?-fn valittava?-fn
-                                  :pvm           paivamaara}])]))))
+                                  :pvm           paivamaara
+                                  :sulje-kalenteri #(do
+                                                      (some-> js/document (.getElementById elementin-id) .focus)
+                                                      (reset! auki? false))
+                                  :input-id elementin-id}])]))))

--- a/src/cljs/harja/views/murupolku.cljs
+++ b/src/cljs/harja/views/murupolku.cljs
@@ -153,9 +153,10 @@
               [:div.col-sm-6.murupolku-vasen
                [koko-maa] [hallintayksikko valinta-auki] [urakka valinta-auki]]
               [:div.col-sm-6.murupolku-oikea
-               (when-not urakoitsija?
-                 [urakoitsija])
-               [urakkatyyppi]]]
+               [:div
+                [urakkatyyppi]
+                (when-not urakoitsija?
+                  [urakoitsija])]]]
              [:ol.murupolku
               [:div.col-sm-12.murupolku-vasen
                [koko-maa] [hallintayksikko valinta-auki] [urakka valinta-auki]]])])))))


### PR DESCRIPTION
Muutettu datepickerin käyttö onnistumaan näppäimistöllä. Datepicker aukeaa, kun päiväyskenttä saa fokuksen (hiirellä käytettäessä aukeaa kun klikkaa eli toiminnot suunnilleen vastaavat nyt toisiaan). Joissakin päiväyskentissä on mukana kalenteri-ikoni, mutta siihen ei ollut hiirellä käytettäessä liitetty mitään toimintoa, niin ei nyt myöskään näppäimistöllä käytettäessä. Datepickerin saa suljettua ja uudelleen avattua enterillä. Muutettu myös murupolussa Urakkatyyppi- ja Urakoitsija-kenttien tab-järjestys kun meni väärinpäin tähän asti.