### PR TITLE
Ota käyttöön restore-keys Trivy cachelle

### DIFF
--- a/.github/actions/scan-docker-image/action.yml
+++ b/.github/actions/scan-docker-image/action.yml
@@ -108,7 +108,7 @@ runs:
       with:
         path: .trivy
         key: ${{ runner.os }}-trivy-${{ steps.trivy-db-hash.outputs.sha }}-${{ steps.trivy-java-db-hash.outputs.sha }}
-        #restore-keys: ${{ runner.os }}-trivy-
+        restore-keys: ${{ runner.os }}-trivy-
 
     # Note: Currently, the trivy action must be run multiple times to achieve different goals
     # Run a full scan and show results


### PR DESCRIPTION
Otetaan käyttöön restore-keys optio cacheen, jota käytetään mikäli tulee "cache miss"