### PR TITLE
Älä laske muita kuluja hankintojen alle, työmaakokous

### DIFF
--- a/tietokanta/src/main/resources/db/migration/R__Laskutusyhteenveto_tyomaakokous.sql
+++ b/tietokanta/src/main/resources/db/migration/R__Laskutusyhteenveto_tyomaakokous.sql
@@ -419,6 +419,7 @@ BEGIN
             WHERE lk.rahavaraus_id IS NULL 
               AND lk.poistettu IS NOT TRUE
               AND l.erapaiva BETWEEN hk_alkupvm AND aikavali_loppupvm
+              AND lk.tyyppi != 'muukulu'
 
         LOOP
 


### PR DESCRIPTION
**Työmaakokous laskutus**
Tämä tulee duplikaattina myös hankintojen alle:
![image](https://github.com/user-attachments/assets/98b6d944-4b4f-4c83-af90-fbdb1c0d01ec)

Tässä korjaus