### PR TITLE
Harja 857 osa1

### DIFF
--- a/src/clj/harja/kyselyt/indeksit.sql
+++ b/src/clj/harja/kyselyt/indeksit.sql
@@ -9,7 +9,7 @@ SELECT nimi, vuosi, kuukausi, arvo
   SELECT nimi, vuosi, kuukausi, arvo
     FROM indeksi
    WHERE nimi = :nimi
-ORDER BY nimi, vuosi, kuukausi
+ORDER BY nimi, vuosi, kuukausi;
 
 --name: hae-urakan-kuukauden-indeksiarvo
 SELECT arvo, nimi
@@ -20,7 +20,7 @@ SELECT arvo, nimi
 -- name: luo-indeksi<!
 -- Tekee uuden indeksin
 INSERT INTO indeksi (nimi, vuosi, kuukausi, arvo)
-     VALUES (:nimi, :vuosi, :kuukausi, :arvo)
+     VALUES (:nimi, :vuosi, :kuukausi, :arvo);
 
 -- name: paivita-indeksi!
 -- Päivittää indeksin tiedot

--- a/src/clj/harja/palvelin/palvelut/budjettisuunnittelu.clj
+++ b/src/clj/harja/palvelin/palvelut/budjettisuunnittelu.clj
@@ -1012,8 +1012,10 @@
                                       kuukausimaara (count kt-rahavaraus-kuukaudet)
                                       kuukausisumma (when-not (nil? summa) (round2 2 (/ summa kuukausimaara))) ;; Tallenna nil kantaan, jos nil arvo on syötetty
                                       viimeinen-kuukausisumma (when-not (nil? summa) (round2 2 (- summa (* (dec kuukausimaara) kuukausisumma))))
-                                      kuukausi-indeksisumma (when-not (nil? summa) (round2 2 (/ indeksisumma kuukausimaara)))
-                                      viimeinen-indeksisumma (when-not (nil? summa) (round2 2 (- indeksisumma (* (dec kuukausimaara) kuukausi-indeksisumma))))]]
+                                      kuukausi-indeksisumma (when (and summa indeksisumma)
+                                                              (nil? summa) (round2 2 (/ indeksisumma kuukausimaara)))
+                                      viimeinen-indeksisumma (when (and summa indeksisumma)
+                                                               (round2 2 (- indeksisumma (* (dec kuukausimaara) kuukausi-indeksisumma))))]]
                           (update! db ::bs/kustannusarvioitu-tyo
                             ;; Jos muokattavia kuukausia on 9 tai enemmän, niin laitetaan viimeinen mahdollisesti suurempi
                             ;; summa syyskuulle, eli hoitokauden viimeiselle kuukaudelle
@@ -1025,8 +1027,8 @@
                       (doseq [kk (range 1 13)
                               :let [kuukausisumma (when-not (nil? summa) (round2 2 (/ summa 12)))
                                     viimeinen-kuukausisumma (when-not (nil? summa) (round2 2 (- summa (* 11 kuukausisumma))))
-                                    kuukausi-indeksisumma (when-not (nil? summa) (round2 2 (/ indeksisumma 12)))
-                                    viimeinen-indeksisumma (when-not (nil? summa) (round2 2 (- indeksisumma (* 11 kuukausi-indeksisumma))))
+                                    kuukausi-indeksisumma (when (and summa indeksisumma) (round2 2 (/ indeksisumma 12)))
+                                    viimeinen-indeksisumma (when (and summa indeksisumma) (round2 2 (- indeksisumma (* 11 kuukausi-indeksisumma))))
                                     db-vuosi (if (>= kk 10 ) vuosi (inc vuosi))]]
                         (insert! db ::bs/kustannusarvioitu-tyo
                           {::bs/summa (if (= kk 9) viimeinen-kuukausisumma kuukausisumma) ;; Mahdollinen suurin summa hoitokauden viimeiselle kuukaudelle

--- a/src/clj/harja/palvelin/palvelut/budjettisuunnittelu.clj
+++ b/src/clj/harja/palvelin/palvelut/budjettisuunnittelu.clj
@@ -1013,7 +1013,7 @@
                                       kuukausisumma (when-not (nil? summa) (round2 2 (/ summa kuukausimaara))) ;; Tallenna nil kantaan, jos nil arvo on syötetty
                                       viimeinen-kuukausisumma (when-not (nil? summa) (round2 2 (- summa (* (dec kuukausimaara) kuukausisumma))))
                                       kuukausi-indeksisumma (when (and summa indeksisumma)
-                                                              (nil? summa) (round2 2 (/ indeksisumma kuukausimaara)))
+                                                              (round2 2 (/ indeksisumma kuukausimaara)))
                                       viimeinen-indeksisumma (when (and summa indeksisumma)
                                                                (round2 2 (- indeksisumma (* (dec kuukausimaara) kuukausi-indeksisumma))))]]
                           (update! db ::bs/kustannusarvioitu-tyo

--- a/src/cljs/harja/tiedot/urakka/suunnittelu/mhu_kustannussuunnitelma.cljs
+++ b/src/cljs/harja/tiedot/urakka/suunnittelu/mhu_kustannussuunnitelma.cljs
@@ -3295,7 +3295,7 @@
                                          (get-in app [:domain :tavoitehintaiset-rahavaraukset])))]
       ;; Ei yritetä tallentaa, jos mitään ei ole annettu
       ;; Paitsi, jos poistetaan jo olemassa oleva summa
-      (if (or (and summa)
+      (if (or summa
             (and (nil? summa) (not (nil? (:summa muokattava-rahavaraus)))))
         (tallenna-ja-odota-vastaus app
           {:palvelu :tallenna-tavoitehintainen-rahavaraus

--- a/src/cljs/harja/tiedot/urakka/suunnittelu/mhu_kustannussuunnitelma.cljs
+++ b/src/cljs/harja/tiedot/urakka/suunnittelu/mhu_kustannussuunnitelma.cljs
@@ -3295,7 +3295,7 @@
                                          (get-in app [:domain :tavoitehintaiset-rahavaraukset])))]
       ;; Ei yritetä tallentaa, jos mitään ei ole annettu
       ;; Paitsi, jos poistetaan jo olemassa oleva summa
-      (if (or (and summa indeksisumma)
+      (if (or (and summa)
             (and (nil? summa) (not (nil? (:summa muokattava-rahavaraus)))))
         (tallenna-ja-odota-vastaus app
           {:palvelu :tallenna-tavoitehintainen-rahavaraus

--- a/src/cljs/harja/views/urakka/kulut/kululomake.cljs
+++ b/src/cljs/harja/views/urakka/kulut/kululomake.cljs
@@ -101,7 +101,9 @@
                                        (str/includes? (str/lower-case (:tehtavaryhma t)) "äkilliset")
                                        (str/includes? (str/lower-case (:tehtavaryhma t)) "hoidonjohtopalkkio")
                                        (str/includes? (str/lower-case (:tehtavaryhma t)) "erillishankinnat")
-                                       (str/includes? (str/lower-case (:tehtavaryhma t)) "hallintokorvaus")))]
+                                       (str/includes? (str/lower-case (:tehtavaryhma t)) "hallintokorvaus")
+                                       (str/includes? (str/lower-case (:tehtavaryhma t)) "t4") ; Digitalisaatiot ja innovaatiot kuuluu rahavarauksille
+                                       ))]
                             sisaltaako?))
                         tehtavaryhmat)]
     [:div.row

--- a/src/cljs/harja/views/urakka/kulut/kululomake.cljs
+++ b/src/cljs/harja/views/urakka/kulut/kululomake.cljs
@@ -92,19 +92,13 @@
 
 (defn- hankintakulu-kohdistus [e! lomake kohdistus tehtavaryhmat nro]
   (let [;; Hankintakululla ei saa olla kaikkia mahdollisia tehtäväryhmiä. Siivotaan väärät pois tässä
-        tehtavaryhmat (filter
-                        (fn [t]
-                          (let [sisaltaako?
-                                (not (or
-                                       (str/includes? (str/lower-case (:tehtavaryhma t)) "rahavaraus")
-                                       (str/includes? (str/lower-case (:tehtavaryhma t)) "vahinkojen")
-                                       (str/includes? (str/lower-case (:tehtavaryhma t)) "äkilliset")
-                                       (str/includes? (str/lower-case (:tehtavaryhma t)) "hoidonjohtopalkkio")
-                                       (str/includes? (str/lower-case (:tehtavaryhma t)) "erillishankinnat")
-                                       (str/includes? (str/lower-case (:tehtavaryhma t)) "hallintokorvaus")
-                                       (str/includes? (str/lower-case (:tehtavaryhma t)) "t4") ; Digitalisaatiot ja innovaatiot kuuluu rahavarauksille
-                                       ))]
-                            sisaltaako?))
+        kielletyt-tehtavaryhmat #{"rahavaraus" "vahinkojen" "äkilliset" "hoidonjohtopalkkio"
+                                  "erillishankinnat" "hallintokorvaus" "t4"}
+        tehtavaryhmat (remove (fn [tr]
+                                (some
+                                  (fn [kielletty-tr]
+                                    (str/includes? (str/lower-case (:tehtavaryhma tr)) kielletty-tr))
+                                  kielletyt-tehtavaryhmat))
                         tehtavaryhmat)]
     [:div.row
      [:div.col-xs-12.col-md-6

--- a/src/cljs/harja/views/urakka/suunnittelu/kustannussuunnitelma/tavoitehintaiset_rahavaraukset_osio.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/kustannussuunnitelma/tavoitehintaiset_rahavaraukset_osio.cljs
@@ -26,7 +26,7 @@
 
 (defn tallenna-tavoitehintainen-rahavaraus! [vuosi loppuvuodet? indeksit rivi rivi-id]
   (let [indeksikerroin-vuodelle (:indeksikerroin (first (filter #(= (:vuosi %) vuosi) indeksit)))]
-    (e! (t/->TallennaTavoitehintainenRahavaraus rivi-id (:summa rivi) (* indeksikerroin-vuodelle (:summa rivi)) vuosi loppuvuodet?))))
+    (e! (t/->TallennaTavoitehintainenRahavaraus rivi-id (:summa rivi) (when indeksikerroin-vuodelle (* indeksikerroin-vuodelle (:summa rivi))) vuosi loppuvuodet?))))
 
 ;; Tehdään tavanomainen taulukko rahavarausten näyttämiselle
 (defn tavoitehintaiset-rahavaraukset-taulukko [rivit vuosi loppuvuodet? vahvistettu? indeksit]

--- a/test/clj/harja/palvelin/palvelut/toimenpidekoodit_test.clj
+++ b/test/clj/harja/palvelin/palvelut/toimenpidekoodit_test.clj
@@ -34,7 +34,7 @@
   {1 6
    2 25
    3 50
-   4 388})
+   4 389})
 
 (defn- tason-lukumaarat-samat [palvelusta kannasta kovakoodattu taso]
   (= (count (get palvelusta taso)) kannasta (get kovakoodattu taso)))

--- a/tietokanta/testidata.sql
+++ b/tietokanta/testidata.sql
@@ -196,6 +196,9 @@ SELECT paivita_pohjavesialueet();
 -- Välikatselmusten tiedot
 \i testidata/kulut/valikatselmus.sql
 
+-- Kulujen muita tarpeita
+\i testidata/kulut/kulutarpeita.sql
+
 -- Tilaajan-konsultti organisaatio
 \i testidata/tilaajan-konsultit.sql
 

--- a/tietokanta/testidata/kulut/kulutarpeita.sql
+++ b/tietokanta/testidata/kulut/kulutarpeita.sql
@@ -1,0 +1,6 @@
+-- Lisätään tehtävä, jotta digitalisaatio tehtäväryhmä saadaan näkyviin, kun sitä tarvitaan toimenpiteen kautta
+-- Emo 612 = toimenpide.id ja viittaa Liikenneympäirstön hoitoon
+insert into tehtava (nimi, emo, luotu, muokattu, luoja, poistettu, yksikko, jarjestys, hinnoittelu, api_seuranta, suoritettavatehtava, piilota, api_tunnus, tehtavaryhma, "mhu-tehtava?", yksiloiva_tunniste, suunnitteluyksikko, voimassaolo_alkuvuosi, voimassaolo_loppuvuosi, kasin_lisattava_maara, "raportoi-tehtava?", materiaaliluokka_id, materiaalikoodi_id, aluetieto, nopeusrajoitus)
+values  ( 'Digitalisaation edistäminen ja innovaatioiden kehittäminen', 612, '2024-10-10 08:46:02.742654', null,
+          (SELECT id FROM kayttaja WHERE kayttajanimi = 'Integraatio'), false, 'euroa', 1475, '{yksikkohintainen}', null, null, null, null,
+         (SELECT id FROM tehtavaryhma WHERE nimi = 'Digitalisaatio ja innovaatiot (T4)'), true, null, 'euroa', 2018, 2018, true, false, null, null, false, 108);


### PR DESCRIPTION
Tässä on ensimmäinen osa löydetyistä rahavarausbugeista korjattuna. Korjatut bugit:

- Jos urakalla ei ole indeksiä/peruslukua vielä, niin rahavarausken tallentamisen jälkeen indeksikohtaan tallentuu 0,00. Pitäisi olla tyhjä.
- Hankintakululle voi valita tehtäväryhmän (T4), se kuuluu vain rahavarauksiin ja se pitää poistaa


Muut korjataan myöhemmin. Mutta näitä korjauksia ei kannata jättää korjaamatta sen vuoksi, että kaikkia ehditä korjaamaan kerralla. Lisäksi palastelu helpottaa katselmointia.
