### PR TITLE
Älä laske valittu kk rahavarauksia kahdesti

### DIFF
--- a/tietokanta/src/main/resources/db/migration/R__Laskutusyhteenveto_mhu.sql
+++ b/tietokanta/src/main/resources/db/migration/R__Laskutusyhteenveto_mhu.sql
@@ -1198,16 +1198,18 @@ BEGIN
             hj_hoitovuoden_paattaminen_kattohinnan_ylitys_laskutetaan := hj_hoitovuoden_paattaminen_rivi.hj_hoitovuoden_paattaminen_kattohinnan_ylitys_laskutetaan;
 
         END IF;
+
         -- Kustannusten kokonaissummat
         kaikki_laskutettu := 0.0;
         kaikki_laskutetaan := 0.0;
+
         kaikki_laskutettu := sakot_laskutettu + bonukset_laskutettu +
                               hankinnat_laskutettu + lisatyot_laskutettu + johto_ja_hallinto_laskutettu + 
                               hj_palkkio_laskutettu + hj_erillishankinnat_laskutettu + hj_hoitovuoden_paattaminen_tavoitepalkkio_laskutettu +
                               hj_hoitovuoden_paattaminen_tavoitehinnan_ylitys_laskutettu + hj_hoitovuoden_paattaminen_kattohinnan_ylitys_laskutettu + 
                               kaikki_rahavaraukset_hoitokausi_yht;
 
-        kaikki_laskutetaan := sakot_laskutetaan + bonukset_laskutetaan + kaikki_rahavaraukset_val_yht +
+        kaikki_laskutetaan := sakot_laskutetaan + bonukset_laskutetaan +
                               hankinnat_laskutetaan + lisatyot_laskutetaan + johto_ja_hallinto_laskutetaan + 
                               hj_palkkio_laskutetaan + hj_erillishankinnat_laskutetaan + hj_hoitovuoden_paattaminen_tavoitepalkkio_laskutetaan +
                               hj_hoitovuoden_paattaminen_tavoitehinnan_ylitys_laskutetaan + hj_hoitovuoden_paattaminen_kattohinnan_ylitys_laskutetaan + 


### PR DESCRIPTION
Valittu kk rahavaraukset lasketaan kahdesti:
![image](https://github.com/user-attachments/assets/55290567-a681-4aa4-89cb-791c764a26d5)

Tämän takia:
![image](https://github.com/user-attachments/assets/d1736412-dc58-4580-bb98-72f5e9662209)


Tässä korjaus.