### PR TITLE
Korjaa kust.suunn. tilan päättelyä dashboardiin

### DIFF
--- a/test/clj/harja/palvelin/palvelut/hallinta/kojelauta_test.clj
+++ b/test/clj/harja/palvelin/palvelut/hallinta/kojelauta_test.clj
@@ -147,7 +147,27 @@
                                        vastaus))]
     (is (str/includes? vastaus "Iin MHU") "Iin MHU")
     (is (= 1 (get-in vahvistettu-2024-rivi [:ks_tila :vahvistettuja])) "yksi vahvistettu")
-    (is (= 5 (get-in vahvistettu-2024-rivi [:ks_tila :aloittamattomia])) "5 aloittamatta")
-    (is (= 0 (get-in vahvistettu-2024-rivi [:ks_tila :vahvistamattomia])) "yksi vahvistamatta")
+    (is (= 5 (get-in vahvistettu-2024-rivi [:ks_tila :aloittamattomia])) "4 aloittamatta")
+    (is (= 1 (get-in vahvistettu-2024-rivi [:ks_tila :vahvistamattomia])) "1 kesken") ;; tavoitehinta on kesken, jos jotain on kirjattu
+    (is (= "aloitettu" (get-in vahvistettu-2024-rivi [:ks_tila :suunnitelman_tila])) "tila")
+    (is (= 1 (count vastaus)) "Urakoiden lukumäärä")))
+
+
+
+(deftest iin-mhu-kojelautaan-yksikin-osio-aloitettu-niin-myos-tavoite-ja-kattohinta-aloitettu
+  (let [iin-mhu-urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
+        kayttaja (:id +kayttaja-jvh+)
+        _ (i (format "INSERT INTO suunnittelu_kustannussuunnitelman_tila (urakka, osio, hoitovuosi, vahvistettu, luoja)
+        VALUES (%s, 'hankintakustannukset', 5, false, %s);" iin-mhu-urakka-id kayttaja))
+        vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
+                  :hae-urakat-kojelautaan +kayttaja-jvh+ {:hoitokauden-alkuvuosi 2025
+                                                          :urakka-idt [iin-mhu-urakka-id]
+                                                          :ely-id nil})
+        vahvistettu-2024-rivi (first (filter #(= 2025 (:hoitokauden_alkuvuosi %))
+                                       vastaus))]
+    (is (str/includes? vastaus "Iin MHU") "Iin MHU")
+    (is (= 0 (get-in vahvistettu-2024-rivi [:ks_tila :vahvistettuja])) "0 vahvistettu")
+    (is (= 4 (get-in vahvistettu-2024-rivi [:ks_tila :aloittamattomia])) "4 aloittamatta")
+    (is (= 2 (get-in vahvistettu-2024-rivi [:ks_tila :vahvistamattomia])) "kaksi vahvistamatta")
     (is (= "aloitettu" (get-in vahvistettu-2024-rivi [:ks_tila :suunnitelman_tila])) "tila")
     (is (= 1 (count vastaus)) "Urakoiden lukumäärä")))

--- a/test/clj/harja/palvelin/palvelut/hallinta/kojelauta_test.clj
+++ b/test/clj/harja/palvelin/palvelut/hallinta/kojelauta_test.clj
@@ -147,7 +147,7 @@
                                        vastaus))]
     (is (str/includes? vastaus "Iin MHU") "Iin MHU")
     (is (= 1 (get-in vahvistettu-2024-rivi [:ks_tila :vahvistettuja])) "yksi vahvistettu")
-    (is (= 5 (get-in vahvistettu-2024-rivi [:ks_tila :aloittamattomia])) "4 aloittamatta")
+    (is (= 4 (get-in vahvistettu-2024-rivi [:ks_tila :aloittamattomia])) "4 aloittamatta")
     (is (= 1 (get-in vahvistettu-2024-rivi [:ks_tila :vahvistamattomia])) "1 kesken") ;; tavoitehinta on kesken, jos jotain on kirjattu
     (is (= "aloitettu" (get-in vahvistettu-2024-rivi [:ks_tila :suunnitelman_tila])) "tila")
     (is (= 1 (count vastaus)) "Urakoiden lukumäärä")))

--- a/tietokanta/src/main/resources/db/migration/R__Kojelauta.sql
+++ b/tietokanta/src/main/resources/db/migration/R__Kojelauta.sql
@@ -8,28 +8,28 @@ DECLARE
     vahvistettuja INTEGER;
     suunnitelman_tila TEXT;
     kaikkien_osioiden_lkm_per_hoitokausi INTEGER;
-    tavoite_ja_kattohinta_kesken BOOLEAN;
+    jokin_osio_aloitettu BOOLEAN;
 
 BEGIN
-    -- jos kaikki ao. osioit on vahvistettu, on ko. hoitokauden osalta kustannussuunnitelma vahvistettu
+    -- jos kaikki osiot on vahvistettu, on ko. hoitokauden osalta kustannussuunnitelma vahvistettu
     kaikkien_osioiden_lkm_per_hoitokausi := 6;
     SELECT COALESCE(count(*), 0) INTO vahvistettuja
                                  FROM suunnittelu_kustannussuunnitelman_tila
                                 WHERE hoitovuosi = _hoitovuosi AND urakka = _urakka AND vahvistettu IS TRUE
-                                  AND osio NOT IN ('tilaajan-rahavaraukset', 'tavoite-ja-kattohinta');
+                                  AND osio NOT IN ('tilaajan-rahavaraukset');
     SELECT COALESCE(count(*), 0) INTO vahvistamattomia
                                  FROM suunnittelu_kustannussuunnitelman_tila
                                 WHERE hoitovuosi = _hoitovuosi AND urakka = _urakka AND vahvistettu IS FALSE
-                                  AND osio NOT IN ('tilaajan-rahavaraukset');
+                                  AND osio NOT IN ('tilaajan-rahavaraukset', 'tavoite-ja-kattohinta');
 
-    -- Jos mikä tahansa osio on edes aloitettu, tavoite- ja kattohintaosio on täten aina aloitettu
+
     SELECT exists(SELECT id from suunnittelu_kustannussuunnitelman_tila WHERE urakka = _urakka and hoitovuosi = _hoitovuosi)
-      INTO tavoite_ja_kattohinta_kesken;
+      INTO jokin_osio_aloitettu;
 
     -- Harja ei erikseen kirjaa jos tavoite- ja kattohinta on "aloitettu", koska minkä tahansa osion aloittaminen
     -- aloittaa myös tavoite- ja kattohinnan. Tässä lisätään se tarvittaessa aloitetuksi yksinkertaisella tarkistuksella.
     -- Poikkeus: jos kaikki osiot on vahvistettu, ei lisätä tavoite- ja kattohintaosiota keskeneräiseksi
-    IF (tavoite_ja_kattohinta_kesken IS TRUE AND vahvistettuja != kaikkien_osioiden_lkm_per_hoitokausi)
+    IF (jokin_osio_aloitettu IS TRUE AND vahvistettuja != kaikkien_osioiden_lkm_per_hoitokausi)
     THEN vahvistamattomia := vahvistamattomia + 1;
     END IF;
 


### PR DESCRIPTION
Huomioi, että jos mitä tahansa kust. suunn. osiota on täytetty, myös tavoite- ja kattohinta on "aloitettu". Sitä ei erikseen siis merkitä aloitetuksi.