### PR TITLE
Poista trivy cache workaround

### DIFF
--- a/.github/actions/scan-docker-image/action.yml
+++ b/.github/actions/scan-docker-image/action.yml
@@ -30,86 +30,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # https://octokit.github.io/rest.js/v21/#packages-get-package-version-for-organization
-    # Versions: https://github.com/aquasecurity/trivy-db/pkgs/container/trivy-db/versions?filters%5Bversion_type%5D=tagged
-    - id: trivy-db-hash
-      name: Check Trivy DB SHA
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const targetVersionTag = '2'
-          const packageName = 'trivy-db'
-          
-          const { data } = await github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg({
-            package_type: 'container',
-            org: 'aquasecurity',
-            package_name: packageName,
-            per_page: 10,
-          });
-          
-          if (data.length === 0) {
-            core.warning(`No versions found for package "${packageName}". Skipping cache step.`);
-            return;
-          }
-          
-          // Filter out the latest version from the response
-          const versions = data.filter((v) => v.metadata.container.tags.includes(targetVersionTag));
-          console.log(JSON.stringify(versions));
-          
-          if (versions.length === 0) {
-            core.warning(`No version tag "${targetVersionTag}" for package "${packageName}" found. Skipping cache step.`);
-            return;
-          }
-          
-          const targetVersion = versions[0];
-          console.log(`Package version sha256:${targetVersion.name.replace('sha256:', '')}`);
-          
-          core.setOutput('sha', targetVersion.name.replace('sha256:', ''));
-
-        # https://octokit.github.io/rest.js/v21/#packages-get-package-version-for-organization
-    # Versions: https://github.com/aquasecurity/trivy-java-db/pkgs/container/trivy-java-db/versions?filters%5Bversion_type%5D=taggedd
-    - id: trivy-java-db-hash
-      name: Check Trivy Java DB SHA
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const targetVersionTag = '1'
-          const packageName = 'trivy-java-db'
-          
-          const { data } = await github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg({
-            package_type: 'container',
-            org: 'aquasecurity',
-            package_name: packageName,
-            per_page: 10,
-          });
-          
-          if (data.length === 0) {
-            core.warning(`No versions found for package "${packageName}". Skipping cache step.`);
-            return;
-          }
-          
-          // Filter out the latest version from the response
-          const versions = data.filter((v) => v.metadata.container.tags.includes(targetVersionTag));
-          console.log(JSON.stringify(versions));
-          
-          if (versions.length === 0) {
-            core.warning(`No version tag "${targetVersionTag}" for package "${packageName}" found. Skipping cache step.`);
-            return;
-          }
-          
-          const targetVersion = versions[0];
-          console.log(`Package version sha256:${targetVersion.name.replace('sha256:', '')}`);
-          
-          core.setOutput('sha', targetVersion.name.replace('sha256:', ''));
-
-    - name: Cache Trivy DBs
-      id: cache-trivy
-      uses: actions/cache@v4
-      if: ${{ steps.trivy-db-hash.outputs.sha != '' || steps.trivy-java-db-hash.outputs.sha != '' }}
-      with:
-        path: .trivy
-        key: ${{ runner.os }}-trivy-${{ steps.trivy-db-hash.outputs.sha }}-${{ steps.trivy-java-db-hash.outputs.sha }}
-
     # Note: Currently, the trivy action must be run multiple times to achieve different goals
     # Run a full scan and show results
     - name: Run Trivy vulnerability scanner (Full scan, all vuln-types, all severities, no job failure)
@@ -128,7 +48,6 @@ runs:
         vuln-type: 'os,library'
         severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
         trivyignores: ${{ inputs.trivyignores }}
-        cache-dir: .trivy
 
     - name: Publish Trivy Output to Summary
       run: |
@@ -162,7 +81,6 @@ runs:
         vuln-type: 'os,library'
         severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
         trivyignores: ${{ inputs.trivyignores }}
-        cache-dir: .trivy
 
     # Update the SARIF report artifact locations with the user provided Dockerfile path
     # This is a workaround for the issue where the Dockerfile path is not included in the SARIF report, to allow for better vulnerability tracking
@@ -217,9 +135,3 @@ runs:
         vuln-type: ${{ env.VULN_TYPES }}
         severity: ${{ env.SEVERITIES }}
         trivyignores: ${{ inputs.trivyignores }}
-        cache-dir: .trivy
-
-    - name: Fix Trivy cache dir permissions
-      if: ${{ steps.cache-trivy.outputs.cache-hit != 'true' }}
-      run: sudo chown -R $USER:$GROUP .trivy
-      shell: bash


### PR DESCRIPTION
* Päivitetyn trivy-actionin myötä (v0.26.0) omaa cache ratkaisua ei tarvitse enää tehdä. Se on sisäänrakennettu trivy-actioniin