### PR TITLE
 Korjaa kok. hint. töiden hakeminen tiemerkintäurakassa

### DIFF
--- a/src/cljc/harja/pvm.cljc
+++ b/src/cljc/harja/pvm.cljc
@@ -1104,7 +1104,7 @@ kello 00:00:00.000 ja loppu on kuukauden viimeinen päivä kello 23:59:59.999 ."
 
       (vec (concat [[alkupvm (vuoden-viim-pvm ensimmainen-vuosi)]]
                    (mapv (fn [vuosi]
-                           [(vuoden-eka-pvm vuosi) (vuoden-viim-pvm vuosi)])
+                           [(vuoden-eka-pvm vuosi) (paivan-lopussa (vuoden-viim-pvm vuosi))])
                          (range (inc ensimmainen-vuosi) viimeinen-vuosi))
                    [[(vuoden-eka-pvm viimeinen-vuosi) loppupvm]])))))
 

--- a/src/cljc/harja/pvm.cljc
+++ b/src/cljc/harja/pvm.cljc
@@ -1102,11 +1102,11 @@ kello 00:00:00.000 ja loppu on kuukauden viimeinen päivä kello 23:59:59.999 ."
     (if (= ensimmainen-vuosi viimeinen-vuosi)
       [[alkupvm loppupvm]]
 
-      (vec (concat [[alkupvm (vuoden-viim-pvm ensimmainen-vuosi)]]
+      (vec (concat [[alkupvm (paivan-lopussa (vuoden-viim-pvm ensimmainen-vuosi))]]
                    (mapv (fn [vuosi]
                            [(vuoden-eka-pvm vuosi) (paivan-lopussa (vuoden-viim-pvm vuosi))])
                          (range (inc ensimmainen-vuosi) viimeinen-vuosi))
-                   [[(vuoden-eka-pvm viimeinen-vuosi) loppupvm]])))))
+                   [[(vuoden-eka-pvm viimeinen-vuosi) (paivan-lopussa loppupvm)]])))))
 
 (def paivan-aikavali (juxt paivan-alussa paivan-lopussa))
 

--- a/test/clj/harja/palvelin/integraatiot/sampo/kasittely/kustannussuunnitelmat_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/sampo/kasittely/kustannussuunnitelmat_test.clj
@@ -10,12 +10,12 @@
 ;; Jos summa on 0 euroa, summaksi asetetaan 1 euro. Sampo-järjestelmän vaatimus.
 (deftest tarkista-kokonaishintaisten-vuosisummien-muodostus
   (let [db (:db jarjestelma)
-        odotettu [{:alkupvm "2014-01-01T00:00:00.0", :loppupvm "2014-12-31T00:00:00.0", :summa 10500M}
-                  {:alkupvm "2015-01-01T00:00:00.0", :loppupvm "2015-12-31T00:00:00.0", :summa 31510M}
-                  {:alkupvm "2016-01-01T00:00:00.0", :loppupvm "2016-12-31T00:00:00.0", :summa 1}
-                  {:alkupvm "2017-01-01T00:00:00.0", :loppupvm "2017-12-31T00:00:00.0", :summa 1}
-                  {:alkupvm "2018-01-01T00:00:00.0", :loppupvm "2018-12-31T00:00:00.0", :summa 1}
-                  {:alkupvm "2019-01-01T00:00:00.0", :loppupvm "2019-12-31T00:00:00.0", :summa 1}]
+        odotettu [{:alkupvm "2014-01-01T00:00:00.0", :loppupvm "2014-12-31T23:59:59.999", :summa 10500M}
+                  {:alkupvm "2015-01-01T00:00:00.0", :loppupvm "2015-12-31T23:59:59.999", :summa 31510M}
+                  {:alkupvm "2016-01-01T00:00:00.0", :loppupvm "2016-12-31T23:59:59.999", :summa 1}
+                  {:alkupvm "2017-01-01T00:00:00.0", :loppupvm "2017-12-31T23:59:59.999", :summa 1}
+                  {:alkupvm "2018-01-01T00:00:00.0", :loppupvm "2018-12-31T23:59:59.999", :summa 1}
+                  {:alkupvm "2019-01-01T00:00:00.0", :loppupvm "2019-12-31T23:59:59.999", :summa 1}]
         numero (ffirst (q "SELECT numero
                            FROM maksuera
                            WHERE nimi = 'Oulu Talvihoito TP ME 2014-2019' AND
@@ -29,22 +29,22 @@
 (deftest tarkista-muiden-maksuerien-vuosisummien-muodostus
   (let [db (:db jarjestelma)
         odotettu [{:alkupvm "2014-01-01T00:00:00.0"
-                   :loppupvm "2014-12-31T00:00:00.0"
+                   :loppupvm "2014-12-31T23:59:59.999"
                    :summa 1}
                   {:alkupvm "2015-01-01T00:00:00.0"
-                   :loppupvm "2015-12-31T00:00:00.0"
+                   :loppupvm "2015-12-31T23:59:59.999"
                    :summa 1}
                   {:alkupvm "2016-01-01T00:00:00.0"
-                   :loppupvm "2016-12-31T00:00:00.0"
+                   :loppupvm "2016-12-31T23:59:59.999"
                    :summa 1}
                   {:alkupvm "2017-01-01T00:00:00.0"
-                   :loppupvm "2017-12-31T00:00:00.0"
+                   :loppupvm "2017-12-31T23:59:59.999"
                    :summa 1}
                   {:alkupvm "2018-01-01T00:00:00.0"
-                   :loppupvm "2018-12-31T00:00:00.0"
+                   :loppupvm "2018-12-31T23:59:59.999"
                    :summa 1}
                   {:alkupvm "2019-01-01T00:00:00.0"
-                   :loppupvm "2019-12-31T00:00:00.0"
+                   :loppupvm "2019-12-31T23:59:59.999"
                    :summa 1}]
         numero (ffirst (q "SELECT numero
                            FROM maksuera


### PR DESCRIPTION
 Urakan vuodet palautti päällystysurakoissa keskimmäisten hoitokausien päättymispäivän kellon ajalla 00:00 kun hoidossa esim palautetaan pvm/paivan-lopussa. Aletaan tässäkin käyttää paivan-lopussa funktiota niin alkaa kok.hintaisten töiden hakeminenkin toimia.

    Muut käytöt varmistettu testaamalla ja koodia lukemalla, että urakan-vuodet funktion käyttäjät parsivat siitä erilaisin funktion vuositiedon, eikä niiden pitäisi häiriintyä muuttuneesta kellonajasta.