### PR TITLE
HARJA-958 Paranna Urakoiden tilanteen kustannussuunnitelman seurantaa

### DIFF
--- a/src/clj/harja/kyselyt/kojelauta.sql
+++ b/src/clj/harja/kyselyt/kojelauta.sql
@@ -1,4 +1,4 @@
--- name: hae-urakat-kojelautaan
+-- name: hae-hoidon-urakat-kojelautaan
 SELECT u.id,
        u.nimi,
        u.hallintayksikko as ely_id,
@@ -13,6 +13,37 @@ SELECT u.id,
      (:hoitokauden_alkuvuosi BETWEEN
          EXTRACT (YEAR FROM u.alkupvm) AND
          EXTRACT (YEAR FROM u.loppupvm) - 1) AND
+     (:urakat_annettu IS NOT TRUE OR u.id IN (:urakka_idt)) AND
+     (:ely_id::INTEGER IS NULL OR u.hallintayksikko = :ely_id)
+ ORDER BY u.nimi;
+
+-- name: hae-paallystysurakat-kojelautaan
+SELECT u.id,
+       u.nimi,
+       u.hallintayksikko as ely_id,
+       :vuosi as hoitokauden_alkuvuosi,
+       (SELECT count(*) FROM yllapitokohde y
+                        WHERE y.urakka = u.id AND
+                              y.vuodet @> ARRAY[:vuosi]::INTEGER[] AND
+                          -- y.yhaid IS NOT NULL --> kohde on YHA:sta Harjaan haettu päällystyskohde
+                            (y.yhaid IS NOT NULL OR
+                                -- y.yhaid IS NULL AND paikkauskohde.pot? = TRUE --> kohde on Harjassa luotu paikkauskohde, jolle on merkitty että tehdään päällystysilmoitus (POT)
+                             (y.yhaid IS NULL AND EXISTS (SELECT id FROM paikkauskohde where "pot?" = true and "yllapitokohde-id" = y.id)))) as yllapitokohteiden_lkm
+  FROM urakka u
+           join organisaatio o ON u.hallintayksikko = o.id
+
+ WHERE
+     u.tyyppi = 'paallystys' AND
+     u.urakkanro IS NOT NULL AND -- testiurakat pois
+     -- oltava vähintään yksi ylläpitokohde jolle tehdään pot-lomake
+     (SELECT count(*) FROM yllapitokohde y
+       WHERE y.urakka = u.id AND
+           y.vuodet @> ARRAY[:vuosi]::INTEGER[] AND
+           (y.yhaid IS NOT NULL OR
+            (y.yhaid IS NULL AND EXISTS (SELECT id FROM paikkauskohde where "pot?" = true and "yllapitokohde-id" = y.id)))) > 0 AND
+     (:vuosi BETWEEN
+         EXTRACT (YEAR FROM u.alkupvm) AND
+         EXTRACT (YEAR FROM u.loppupvm)) AND
      (:urakat_annettu IS NOT TRUE OR u.id IN (:urakka_idt)) AND
      (:ely_id::INTEGER IS NULL OR u.hallintayksikko = :ely_id)
  ORDER BY u.nimi;

--- a/src/clj/harja/palvelin/palvelut/hallinta/kojelauta.clj
+++ b/src/clj/harja/palvelin/palvelut/hallinta/kojelauta.clj
@@ -19,18 +19,26 @@
                                         (budjettisuunnittelu/hae-urakan-indeksikertoimet db kayttaja {:urakka-id id}))))]
     (assoc rivi :indeksikerroin urakan-vuoden-indeksikerroin)))
 
-(defn hae-urakat-kojelautaan [db kayttaja {:keys [hoitokauden-alkuvuosi urakka-idt ely-id] :as hakuehdot}]
+(defn hae-urakat-kojelautaan [db kayttaja {:keys [urakkatyyppi hoitokauden-alkuvuosi urakka-idt ely-id] :as hakuehdot}]
   (oikeudet/vaadi-lukuoikeus oikeudet/hallinta-jarjestelmaasetukset kayttaja)
-  (let [urakat (into []
-                 (mapv
-                   (comp
-                     (fn [ks-tilat]
-                       (update ks-tilat :ks_tila konv/jsonb->clojuremap))
-                     #(liita-indeksikertoimet db kayttaja %))
-                   (q/hae-urakat-kojelautaan db {:hoitokauden_alkuvuosi hoitokauden-alkuvuosi
-                                                 :urakat_annettu (boolean (seq urakka-idt))
-                                                 :urakka_idt urakka-idt
-                                                 :ely_id ely-id})))]
+  (let [urakat (cond
+                 (= urakkatyyppi :hoito)                    ;; tässä kohti hoito = MHU, vanhoja alueurakoita ei tueta
+                 (into []
+                   (mapv
+                     (comp
+                       (fn [ks-tilat]
+                         (update ks-tilat :ks_tila konv/jsonb->clojuremap))
+                       #(liita-indeksikertoimet db kayttaja %))
+                     (q/hae-hoidon-urakat-kojelautaan db {:hoitokauden_alkuvuosi hoitokauden-alkuvuosi
+                                                          :urakat_annettu (boolean (seq urakka-idt))
+                                                          :urakka_idt urakka-idt
+                                                          :ely_id ely-id})))
+
+                 (= urakkatyyppi :paallystys)
+                 (q/hae-paallystysurakat-kojelautaan db {:vuosi hoitokauden-alkuvuosi
+                                                         :urakat_annettu (boolean (seq urakka-idt))
+                                                         :urakka_idt urakka-idt
+                                                         :ely_id ely-id}))]
     urakat))
 
 (defrecord KojelautaHallinta []

--- a/src/clj/harja/palvelin/palvelut/hallinta/kojelauta.clj
+++ b/src/clj/harja/palvelin/palvelut/hallinta/kojelauta.clj
@@ -3,18 +3,34 @@
             [harja.domain.oikeudet :as oikeudet]
             [harja.kyselyt.konversio :as konv]
             [harja.palvelin.komponentit.http-palvelin :refer [julkaise-palvelu poista-palvelut]]
-            [harja.kyselyt.kojelauta :as q]))
+            [harja.kyselyt.kojelauta :as q]
+            [harja.palvelin.palvelut.budjettisuunnittelu :as budjettisuunnittelu]))
 
+(defn- liita-indeksikertoimet
+  "Liitetään urakka- ja hoitovuosikohtaiseen riviin ko. vuoden indeksikerroin, jos saatavilla.
+
+  Tätä tietoa voidaan hyödyntää kojelautanäkymässä päättelemään, onko kustannussuunnitelmien vahvistaminen pahasti myöhässä,
+  vai esimerkiksi indeksitietojen puuttumisen vuoksi ei vielä edes mahdollista."
+  [db kayttaja {:keys [hoitokauden_alkuvuosi id] :as rivi}]
+  (let [urakan-vuoden-indeksikerroin (:indeksikerroin
+                                    (first
+                                      (filter
+                                        #(= hoitokauden_alkuvuosi (:vuosi %))
+                                        (budjettisuunnittelu/hae-urakan-indeksikertoimet db kayttaja {:urakka-id id}))))]
+    (assoc rivi :indeksikerroin urakan-vuoden-indeksikerroin)))
 
 (defn hae-urakat-kojelautaan [db kayttaja {:keys [hoitokauden-alkuvuosi urakka-idt ely-id] :as hakuehdot}]
   (oikeudet/vaadi-lukuoikeus oikeudet/hallinta-jarjestelmaasetukset kayttaja)
-  (let [urakat (mapv
-                 (fn [ks-tilat]
-                   (update ks-tilat :ks_tila konv/jsonb->clojuremap))
-                 (q/hae-urakat-kojelautaan db {:hoitokauden_alkuvuosi hoitokauden-alkuvuosi
-                                               :urakat_annettu (boolean (seq urakka-idt))
-                                               :urakka_idt urakka-idt
-                                               :ely_id ely-id}))]
+  (let [urakat (into []
+                 (mapv
+                   (comp
+                     (fn [ks-tilat]
+                       (update ks-tilat :ks_tila konv/jsonb->clojuremap))
+                     #(liita-indeksikertoimet db kayttaja %))
+                   (q/hae-urakat-kojelautaan db {:hoitokauden_alkuvuosi hoitokauden-alkuvuosi
+                                                 :urakat_annettu (boolean (seq urakka-idt))
+                                                 :urakka_idt urakka-idt
+                                                 :ely_id ely-id})))]
     urakat))
 
 (defrecord KojelautaHallinta []

--- a/src/cljs/harja/tiedot/hallinta/kojelauta.cljs
+++ b/src/cljs/harja/tiedot/hallinta/kojelauta.cljs
@@ -23,7 +23,8 @@
             (vec (sort-by :nimi itemit)))))))
 
 (def tila (atom {:urakat []
-                 :valinnat {:ely nil
+                 :valinnat {:urakkatyyppi {:nimi "Hoito" :arvo :hoito}
+                            :ely nil
                             :urakat nil
                             :urakkavuosi (pvm/vuosi (first (pvm/paivamaaran-hoitokausi (pvm/nyt))))}}))
 
@@ -42,9 +43,9 @@
                                            urakat))
         ks-tilojen-yhteenveto (when-not (empty? urakat)
                                 (clj-str/join ", "
-                                  [(str "Aloittamatta: " (fmt/prosentti-opt (* 100 (/ urakat-joissa-ks-aloittamatta kaikkien-urakoiden-lkm))))
-                                   (str "kesken: " (fmt/prosentti-opt (* 100 (/ urakat-joissa-ks-aloitettu kaikkien-urakoiden-lkm))))
-                                   (str "valmiina: " (fmt/prosentti-opt (* 100 (/ urakat-joissa-ks-valmiina kaikkien-urakoiden-lkm))))]))]
+                                  [(str "Aloittamatta: " urakat-joissa-ks-aloittamatta " (" (fmt/prosentti-opt (* 100 (/ urakat-joissa-ks-aloittamatta kaikkien-urakoiden-lkm))) ")")
+                                   (str "kesken: " urakat-joissa-ks-aloitettu " (" (fmt/prosentti-opt (* 100 (/ urakat-joissa-ks-aloitettu kaikkien-urakoiden-lkm)))")")
+                                   (str "valmiina: " urakat-joissa-ks-valmiina " (" (fmt/prosentti-opt (* 100 (/ urakat-joissa-ks-valmiina kaikkien-urakoiden-lkm)))")")]))]
     ks-tilojen-yhteenveto))
 
 (defrecord AsetaSuodatin [avain valinta])
@@ -60,7 +61,8 @@
   HaeUrakat
   (process-event [_ app]
     (tuck-apurit/post! :hae-urakat-kojelautaan
-      {:hoitokauden-alkuvuosi (get-in app [:valinnat :urakkavuosi])
+      {:urakkatyyppi (or (get-in app [:valinnat :urakkatyyppi :arvo]) :hoito)
+       :hoitokauden-alkuvuosi (get-in app [:valinnat :urakkavuosi])
        :urakka-idt (map :id (get-in app [:valinnat :urakat]))
        :ely-id (get-in app [:valinnat :ely :id])}
       {:onnistui ->HaeUrakatOnnistui

--- a/src/cljs/harja/views/hallinta/kojelauta.cljs
+++ b/src/cljs/harja/views/hallinta/kojelauta.cljs
@@ -1,6 +1,7 @@
 (ns harja.views.hallinta.kojelauta
   (:require [harja.pvm :as pvm]
             [harja.tiedot.hallintayksikot :as hal]
+            [harja.tiedot.navigaatio :as nav]
             [harja.tiedot.urakka.siirtymat :as siirtymat]
             [harja.ui.grid :as grid]
             [harja.ui.kentat :as kentat]
@@ -19,49 +20,64 @@
     (+ hoitokausia-eteenpain (pvm/vuosi pvm-nyt))))
 
 (defn suodattimet [e! {:keys [valinnat urakkahaku] :as app}]
-  [:<>
+  [:div
    [yleiset/pudotusvalikko
-    "ELY"
+    "Urakkatyyppi"
     {:valitse-fn #(do
-                    (e! (tiedot/->AsetaSuodatin :ely %))
+                    (e! (tiedot/->AsetaSuodatin :urakkatyyppi %))
                     (e! (tiedot/->HaeUrakat)))
-     :valinta (:ely valinnat)
-     :format-fn #(or (hal/elynumero-ja-nimi %) "Kaikki")
+     :valinta (:urakkatyyppi valinnat)
+     :format-fn :nimi
      :vayla-tyyli? true}
-    (into [nil] (map #(select-keys % [:id :nimi :elynumero])
-                  @hal/vaylamuodon-hallintayksikot))]
-   [yleiset/pudotusvalikko
-    "Hoitokauden alkuvuosi"
-    {:valitse-fn  #(do
+    (filter (fn [ut]
+              (#{:hoito :paallystys} (:arvo ut)))
+      nav/+urakkatyypit+)]
+   [:div
+    [yleiset/pudotusvalikko
+     "ELY"
+     {:valitse-fn #(do
+                     (e! (tiedot/->AsetaSuodatin :ely %))
+                     (e! (tiedot/->HaeUrakat)))
+      :valinta (:ely valinnat)
+      :format-fn #(or (hal/elynumero-ja-nimi %) "Kaikki")
+      :vayla-tyyli? true}
+     (into [nil] (map #(select-keys % [:id :nimi :elynumero])
+                   @hal/vaylamuodon-hallintayksikot))]
+    [yleiset/pudotusvalikko
+     (if (= :paallystys (get-in valinnat [:urakkatyyppi :arvo]))
+       "Vuosi"
+       "Hoitokauden alkuvuosi")
+     {:valitse-fn #(do
                      (e! (tiedot/->AsetaSuodatin :urakkavuosi %))
                      (e! (tiedot/->HaeUrakat)))
-     :valinta (:urakkavuosi valinnat)
-     :vayla-tyyli? true}
-    (mahdolliset-hoitokauden-alkuvuodet (pvm/nyt))]
+      :valinta (:urakkavuosi valinnat)
+      :vayla-tyyli? true}
+     (mahdolliset-hoitokauden-alkuvuodet (pvm/nyt))]
 
-   [:div.label-ja-alasveto
-    [:label.alasvedon-otsikko-vayla {:for "urakkahaku"} "Hae urakkaa"]
-    [kentat/tee-kentta
-     {:tyyppi :haku
-      :input-id "urakkahaku"
-      :nayta :nimi :fmt :nimi
-      :hae-kun-yli-n-merkkia 0
-      :vayla-tyyli? true
-      :lahde urakkahaku
-      :monivalinta? true
-      :tarkkaile-ulkopuolisia-muutoksia? true
-      :hakuikoni? true
-      :placeholder "Käytä suurennuslasia tai anna urakan nimi"
-      :monivalinta-teksti #(case (count %)
-                             0 ""
-                             1 (:nimi (first %))
-                             (str (count %) " urakkaa valittu"))}
-     (r/wrap (:urakat valinnat) #(e! (tiedot/->AsetaSuodatin :urakat %)))]]])
+    [:div.label-ja-alasveto
+     [:label.alasvedon-otsikko-vayla {:for "urakkahaku"} "Hae urakkaa"]
+     [kentat/tee-kentta
+      {:tyyppi :haku
+       :input-id "urakkahaku"
+       :nayta :nimi :fmt :nimi
+       :hae-kun-yli-n-merkkia 0
+       :vayla-tyyli? true
+       :lahde urakkahaku
+       :monivalinta? true
+       :tarkkaile-ulkopuolisia-muutoksia? true
+       :hakuikoni? true
+       :placeholder "Käytä suurennuslasia tai anna urakan nimi"
+       :monivalinta-teksti #(case (count %)
+                              0 ""
+                              1 (:nimi (first %))
+                              (str (count %) " urakkaa valittu"))}
+      (r/wrap (:urakat valinnat) #(e! (tiedot/->AsetaSuodatin :urakat %)))]]]])
 
 
 (defn kustannussuunitelman-tila-sarake
   [rivi]
-  (let [{:keys [vahvistamattomia vahvistettuja suunnitelman_tila]} (:ks_tila rivi)]
+  (let [indeksi-saatavilla? (boolean (:indeksikerroin rivi))
+        {:keys [aloittamattomia vahvistamattomia vahvistettuja suunnitelman_tila]} (:ks_tila rivi)]
     [yleiset/wrap-if true
      [yleiset/tooltip {} :% "Siirry kustannussuunnitelmaan"]
      [:a.klikattava {:on-click #(siirtymat/kustannusten-seurantaan-valitussa-urakassa (:ely_id rivi) (:id rivi))}
@@ -70,13 +86,52 @@
         (yleiset/tila-indikaattori "hylatty" {:fmt-fn (constantly "Aloittamatta")})
 
         (= "aloitettu" suunnitelman_tila)
-        (yleiset/tila-indikaattori "kesken" {:fmt-fn #(str "Kesken: " vahvistamattomia
-                                                        ", vahvistettuja: " vahvistettuja)})
+        (yleiset/tila-indikaattori (if indeksi-saatavilla?
+                                     "hylatty"
+                                     "kesken")
+          {:fmt-fn #(str
+                      (when indeksi-saatavilla? "Indeksi saatavilla. ")
+                      "Aloittamatta: " aloittamattomia
+                      ", kesken: " vahvistamattomia
+                      ", vahvistettuja: " vahvistettuja)})
 
         (= "vahvistettu" suunnitelman_tila)
         (yleiset/tila-indikaattori "valmis" {:fmt-fn (constantly "Valmis")}))]]))
 
-(defn listaus [e! {:keys [valinnat urakat haku-kaynnissa?] :as app}]
+(defn taulukko-paallystysurakat [e!  {:keys [urakat haku-kaynnissa?]}]
+  [:div "Tänne päällystysurakoiden taulukko samaan tyyliin kuin alla hoitourakoille..."])
+
+(defn taulukko-hoitourakat [e! {:keys [urakat haku-kaynnissa?]}]
+  [grid/grid
+   {:otsikko (str "")
+    :tyhja (if haku-kaynnissa?
+             [ajax-loader "Ladataan tietoja"]
+             "Ei tietoja, tarkistathan valitut suodattimet.")
+    :rivi-jalkeen-fn (fn [urakat]
+                       (let [ks-tilojen-yhteenveto (tiedot/ks-tilojen-yhteenveto urakat)]
+                         (when-not (empty? urakat)
+                           [{:teksti "Yhteensä" :luokka "lihavoitu"}
+                            {:teksti (str (count urakat) " kpl urakoita") :luokka "lihavoitu"}
+                            {:teksti ks-tilojen-yhteenveto :luokka "lihavoitu"}])))}
+   [{:otsikko "Urakka"
+     :tyyppi :string
+     :nimi :nimi
+     :leveys 5
+     :muokattava? (constantly false)}
+    {:otsikko "Hoito\u00ADvuosi"
+     :muokattava? (constantly false)
+     :nimi :hoitokauden_alkuvuosi :leveys 3
+     :tyyppi :string :fmt #(pvm/hoitokausi-str-alkuvuodesta %)}
+    {:otsikko "Kustannus\u00ADsuunnitelma"
+     :muokattava? (constantly false)
+     :nimi :ks_tila :leveys 15
+     :tyyppi :komponentti
+     :komponentti (fn [rivi] [kustannussuunitelman-tila-sarake rivi])}]
+   urakat])
+
+(defn listaus
+  "Listauskomponentti, joka toimii pohjana eri urakkatyypeille, ja hoitaa urakkatyypeille yhteisen suodattamisen elyn, vuoden sekä valitun urakan perusteella."
+  [e! {:keys [valinnat urakat haku-kaynnissa?] :as app}]
   (let [valitut-urakat (:urakat valinnat)
         valittu-ely (get-in valinnat [:ely :id])
         valittu-hk-alkuvuosi (:urakkavuosi valinnat)
@@ -94,32 +149,11 @@
                  (filter #((into #{} (map :id valitut-urakat)) (:id %)) urakat))]
     [:div
      ;; [debug/debug urakat]
-     [grid/grid
-      {:otsikko (str "")
-       :tyhja (if haku-kaynnissa?
-                [ajax-loader "Ladataan tietoja"]
-                "Ei tietoja, tarkistathan valitut suodattimet.")
-       :rivi-jalkeen-fn (fn [urakat]
-                          (let [ks-tilojen-yhteenveto (tiedot/ks-tilojen-yhteenveto urakat)]
-                            (when-not (empty? urakat)
-                              [{:teksti "Yhteensä" :luokka "lihavoitu"}
-                               {:teksti (str (count urakat) " kpl urakoita") :luokka "lihavoitu"}
-                               {:teksti ks-tilojen-yhteenveto :luokka "lihavoitu"}])))}
-      [{:otsikko "Urakka"
-        :tyyppi :string
-        :nimi :nimi
-        :leveys 5
-        :muokattava? (constantly false)}
-       {:otsikko "Hoito\u00ADvuosi"
-        :muokattava? (constantly false)
-        :nimi :hoitokauden_alkuvuosi :leveys 3
-        :tyyppi :string :fmt #(pvm/hoitokausi-str-alkuvuodesta %)}
-       {:otsikko "Kustannus\u00ADsuunnitelma"
-        :muokattava? (constantly false)
-        :nimi :ks_tila :leveys 15
-        :tyyppi :komponentti
-        :komponentti (fn [rivi] [kustannussuunitelman-tila-sarake rivi])}]
-      urakat]]))
+     (if (= :paallystys (get-in app [:valinnat :urakkatyyppi :arvo]))
+       [taulukko-paallystysurakat e! {:urakat urakat
+                                      :haku-kaynnissa? haku-kaynnissa?}]
+       [taulukko-hoitourakat e! {:urakat urakat
+                                 :haku-kaynnissa? haku-kaynnissa?}])]))
 
 
 (defn kojelauta* [e! app]

--- a/test/clj/harja/palvelin/palvelut/hallinta/kojelauta_test.clj
+++ b/test/clj/harja/palvelin/palvelut/hallinta/kojelauta_test.clj
@@ -27,7 +27,8 @@
 
 (deftest kaikki-mhut-kojelautaan-hk-alkuvuosi-2024
   (let [vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
-                  :hae-urakat-kojelautaan +kayttaja-jvh+ {:hoitokauden-alkuvuosi 2024
+                  :hae-urakat-kojelautaan +kayttaja-jvh+ {:urakkatyyppi :hoito
+                                                          :hoitokauden-alkuvuosi 2024
                                                           :urakka-idt nil
                                                           :ely-id nil})]
     (is (every? #(integer? (:id %)) vastaus))
@@ -57,7 +58,8 @@
 
 (deftest kaikki-mhut-kojelautaan-hk-alkuvuosi-2005-ei-palauta-yhtaan
   (let [vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
-                  :hae-urakat-kojelautaan +kayttaja-jvh+ {:hoitokauden-alkuvuosi 2005
+                  :hae-urakat-kojelautaan +kayttaja-jvh+ {:urakkatyyppi :hoito
+                                                          :hoitokauden-alkuvuosi 2005
                                                           :urakka-idt nil
                                                           :ely-id nil})]
 
@@ -66,7 +68,8 @@
 (deftest kaikki-pop-elyn-mhut-kojelautaan-hk-alkuvuosi-2024
   (let [pop-ely-id @pohjois-pohjanmaan-hallintayksikon-id
         vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
-                  :hae-urakat-kojelautaan +kayttaja-jvh+ {:hoitokauden-alkuvuosi 2024
+                  :hae-urakat-kojelautaan +kayttaja-jvh+ {:urakkatyyppi :hoito
+                                                          :hoitokauden-alkuvuosi 2024
                                                           :urakka-idt nil
                                                           :ely-id pop-ely-id})]
     (is (str/includes? vastaus "Iin MHU") "Iin MHU")
@@ -79,7 +82,8 @@
 (deftest vain-iin-mhu-kojelautaan-hk-alkuvuosi-2024
   (let [iin-mhu-urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
         vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
-                  :hae-urakat-kojelautaan +kayttaja-jvh+ {:hoitokauden-alkuvuosi 2024
+                  :hae-urakat-kojelautaan +kayttaja-jvh+ {:urakkatyyppi :hoito
+                                                          :hoitokauden-alkuvuosi 2024
                                                           :urakka-idt [iin-mhu-urakka-id]
                                                           :ely-id nil})]
     (is (= (:indeksikerroin (first vastaus)) 1.298) "Indeksikerroin palautuu oikein")
@@ -89,7 +93,8 @@
 (deftest oulun-mhu-kojelautaan-aloittamatta
   (let [urakka-id (hae-urakan-id-nimella "Oulun MHU 2019-2024")
         vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
-                  :hae-urakat-kojelautaan +kayttaja-jvh+ {:hoitokauden-alkuvuosi 2022
+                  :hae-urakat-kojelautaan +kayttaja-jvh+ {:urakkatyyppi :hoito
+                                                          :hoitokauden-alkuvuosi 2022
                                                           :urakka-idt [urakka-id]
                                                           :ely-id nil})
         rivi (first (filter #(= 2022 (:hoitokauden_alkuvuosi %))
@@ -115,7 +120,8 @@
         _ (i (format "INSERT INTO suunnittelu_kustannussuunnitelman_tila (urakka, osio, hoitovuosi, vahvistettu, luoja)
         VALUES (%s, 'tavoitehintaiset-rahavaraukset', 2, true, %s);" urakka-id kayttaja))
         vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
-                  :hae-urakat-kojelautaan +kayttaja-jvh+ {:hoitokauden-alkuvuosi 2024
+                  :hae-urakat-kojelautaan +kayttaja-jvh+ {:urakkatyyppi :hoito
+                                                          :hoitokauden-alkuvuosi 2024
                                                           :urakka-idt [urakka-id]
                                                           :ely-id nil})
         rivi (first (filter #(= 2024 (:hoitokauden_alkuvuosi %))
@@ -143,7 +149,8 @@
         _ (i (format "INSERT INTO suunnittelu_kustannussuunnitelman_tila (urakka, osio, hoitovuosi, vahvistettu, luoja)
         VALUES (%s, 'hankintakustannukset', 5, false, %s);" iin-mhu-urakka-id kayttaja))
         vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
-                  :hae-urakat-kojelautaan +kayttaja-jvh+ {:hoitokauden-alkuvuosi 2024
+                  :hae-urakat-kojelautaan +kayttaja-jvh+ {:urakkatyyppi :hoito
+                                                          :hoitokauden-alkuvuosi 2024
                                                           :urakka-idt [iin-mhu-urakka-id]
                                                           :ely-id nil})
         vahvistettu-2024-rivi (first (filter #(= 2024 (:hoitokauden_alkuvuosi %))
@@ -161,7 +168,8 @@
         _ (i (format "INSERT INTO suunnittelu_kustannussuunnitelman_tila (urakka, osio, hoitovuosi, vahvistettu, luoja)
         VALUES (%s, 'hankintakustannukset', 5, false, %s);" iin-mhu-urakka-id kayttaja))
         vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
-                  :hae-urakat-kojelautaan +kayttaja-jvh+ {:hoitokauden-alkuvuosi 2025
+                  :hae-urakat-kojelautaan +kayttaja-jvh+ {:urakkatyyppi :hoito
+                                                          :hoitokauden-alkuvuosi 2025
                                                           :urakka-idt [iin-mhu-urakka-id]
                                                           :ely-id nil})
         vahvistettu-2024-rivi (first (filter #(= 2025 (:hoitokauden_alkuvuosi %))

--- a/test/clj/harja/palvelin/palvelut/hallinta/kojelauta_test.clj
+++ b/test/clj/harja/palvelin/palvelut/hallinta/kojelauta_test.clj
@@ -82,6 +82,7 @@
                   :hae-urakat-kojelautaan +kayttaja-jvh+ {:hoitokauden-alkuvuosi 2024
                                                           :urakka-idt [iin-mhu-urakka-id]
                                                           :ely-id nil})]
+    (is (= (:indeksikerroin (first vastaus)) 1.298) "Indeksikerroin palautuu oikein")
     (is (str/includes? vastaus "Iin MHU") "Iin MHU")
     (is (= 1 (count vastaus)) "Urakoiden lukumäärä")))
 
@@ -94,6 +95,7 @@
         rivi (first (filter #(= 2022 (:hoitokauden_alkuvuosi %))
                                        vastaus))]
     (is (str/includes? vastaus "Oulun MHU") "Oulun MHU")
+    (is (= (:indeksikerroin rivi) 1.352) "Indeksikerroin palautuu oikein")
     (is (= "aloittamatta" (get-in rivi [:ks_tila :suunnitelman_tila])) "tila")
     (is (= 1 (count vastaus)) "Urakoiden lukumäärä")))
 
@@ -119,6 +121,7 @@
         rivi (first (filter #(= 2024 (:hoitokauden_alkuvuosi %))
                       vastaus))]
     (is (str/includes? vastaus "Raahen MHU") "Raahen MHU")
+    (is (= (:indeksikerroin rivi) 1.118) "Indeksikerroin palautuu oikein")
     (is (= 6 (get-in rivi [:ks_tila :vahvistettuja])) "6 vahvistettua")
     (is (= 0 (get-in rivi [:ks_tila :aloittamattomia])) "0 aloittamatta")
     (is (= 0 (get-in rivi [:ks_tila :vahvistamattomia])) "0 vahvistamatta")


### PR DESCRIPTION
HARJA-958 Paranna Urakoiden tilanteen kustannussuunnitelman seurantaa

    -Paranna Urakoiden tilanteen kustannussuunnitelman seurantaa asiakaspalautteen pohjata
    -Luo pohjat valita urakkatyyppi, ja hakea valitun vuoden ne urakat, joilla on sellaisia ylläpitokohteita, joilta odotetaan päällystysilmoitusta.