### PR TITLE
Käytetään \n linefeediä uuden kaista-aineiston sisäänluvussa

### DIFF
--- a/asetukset.edn
+++ b/asetukset.edn
@@ -103,6 +103,7 @@
                         :tieosoiteverkon-tuontikohde "./shp/Tieosoiteverkko/tieosoiteverkkoLine.shz"
 
                         :laajennetun-tieosoiteverkon-tiedot "../.harja/kaista-aineisto.csv"
+                        :paivita-kaista-aineisto true
 
                         :pohjavesialueen-shapefile "file://shp/Pohjavesialueet/pohjavesialueetLine.shp"
                         :pohjavesialueen-osoite "https://avoinapi.vaylapilvi.fi/vaylatiedot/wfs?request=GetFeature&service=WFS&version=1.1.0&typeName=tiestotiedot:pohjavesialueet&outputFormat=SHAPE-ZIP"

--- a/src/clj/harja/palvelin/ajastetut_tehtavat/geometriapaivitykset.clj
+++ b/src/clj/harja/palvelin/ajastetut_tehtavat/geometriapaivitykset.clj
@@ -119,8 +119,9 @@
 
 (def tee-laajennetun-tieverkon-paivitystehtava
   (fn [this asetukset]
-    (clojure.core.async/thread
-      (tieverkon-tuonti/vie-laajennettu-tieverkko-kantaan (:db this) (:laajennetun-tieosoiteverkon-tiedot asetukset))))
+    (when (:paivita-kaista asetukset)
+      (clojure.core.async/thread
+        (tieverkon-tuonti/vie-laajennettu-tieverkko-kantaan (:db this) (:laajennetun-tieosoiteverkon-tiedot asetukset)))))
   #_(maarittele-paivitystehtava
     "laajennettu-tieverkko"
     :laajennetun-tieosoiteverkon-osoite

--- a/src/clj/harja/palvelin/ajastetut_tehtavat/geometriapaivitykset.clj
+++ b/src/clj/harja/palvelin/ajastetut_tehtavat/geometriapaivitykset.clj
@@ -26,10 +26,7 @@
             [harja.palvelin.integraatiot.paikkatietojarjestelma.tuonnit.kanavasulut :as kanavasulut]
             [harja.kyselyt.geometriaaineistot :as geometria-aineistot]
             [harja.domain.geometriaaineistot :as ga]
-            [clojure.core.async :as async])
-  (:use [slingshot.slingshot :only [try+ throw+]])
-  (:import (java.net URI)
-           (java.sql Timestamp)))
+            [clojure.core.async :as async]))
 
 (def virhekasittely
   {:error-handler #(log/error "Käsittelemätön poikkeus ajastetussa tehtävässä:" %)})
@@ -120,7 +117,7 @@
 (def tee-laajennetun-tieverkon-paivitystehtava
   (fn [this asetukset]
     (when (:paivita-kaista asetukset)
-      (clojure.core.async/thread
+      (async/thread
         (tieverkon-tuonti/vie-laajennettu-tieverkko-kantaan (:db this) (:laajennetun-tieosoiteverkon-tiedot asetukset)))))
   #_(maarittele-paivitystehtava
     "laajennettu-tieverkko"

--- a/src/clj/harja/palvelin/asetukset.clj
+++ b/src/clj/harja/palvelin/asetukset.clj
@@ -99,6 +99,7 @@
                                            (s/optional-key :tieosoiteverkon-osoite) s/Str
                                            (s/optional-key :tieosoiteverkon-tuontikohde) s/Str
                                            (s/optional-key :laajennetun-tieosoiteverkon-tiedot) s/Str
+                                           (s/optional-key :paivita-kaista-aineisto) s/Bool
                                            (s/optional-key :pohjavesialueen-shapefile) s/Str
                                            (s/optional-key :pohjavesialueen-osoite) s/Str
                                            (s/optional-key :pohjavesialueen-tuontikohde) s/Str

--- a/src/clj/harja/palvelin/integraatiot/paikkatietojarjestelma/tuonnit/tieverkko.clj
+++ b/src/clj/harja/palvelin/integraatiot/paikkatietojarjestelma/tuonnit/tieverkko.clj
@@ -326,7 +326,7 @@
   "Tämän funktion voi poistaa sitten, kun oikea integraatio on saatu"
   [tiedosto-polku]
   (let [raakasisalto (slurp tiedosto-polku)
-        rivit (clj-str/split raakasisalto #"\r")
+        rivit (clj-str/split raakasisalto #"\n")
         muuta-rivi (fn [rivi f]
                      (map (fn [kentta]
                             (->> kentta


### PR DESCRIPTION
Uusi kaista-aineisto luetaan rajapinnasta ja tallennetaan unix linefeedillä tiedostoon.