### PR TITLE
HARJA-1054 Lisää uusi päätason välilehti Urakoiden tilanne

### DIFF
--- a/cypress/e2e/nakymien_avaus.cy.js
+++ b/cypress/e2e/nakymien_avaus.cy.js
@@ -47,7 +47,7 @@ describe('Päänäkymien avaamiset', function () {
 
     it("Urakoiden tilanne välilehti toimii", function () {
         cy.contains('ul#sivut a span', 'Urakoiden tilanne').click({force: true})
-        cy.contains('label', "Urakkatyyppi", { timeout: 10000 }).should('be.visible');
+        cy.contains('h1', "Urakoiden tilanne", { timeout: 10000 }).should('be.visible');
         cy.contains('Hupsista').should('not.exist')
     })
 

--- a/cypress/e2e/nakymien_avaus.cy.js
+++ b/cypress/e2e/nakymien_avaus.cy.js
@@ -45,6 +45,12 @@ describe('Päänäkymien avaamiset', function () {
         cy.contains('Hupsista').should('not.exist')
     })
 
+    it("Urakoiden tilanne välilehti toimii", function () {
+        cy.contains('ul#sivut a span', 'Urakoiden tilanne').click({force: true})
+        cy.contains('label', "Urakkatyyppi", { timeout: 10000 }).should('be.visible');
+        cy.contains('Hupsista').should('not.exist')
+    })
+
     it("Info -sivu toimii", function () {
         cy.contains('ul li a span', 'INFO').click({ force: true });
         cy.contains('Hupsista').should('not.exist')

--- a/src/clj/harja/palvelin/main.clj
+++ b/src/clj/harja/palvelin/main.clj
@@ -77,7 +77,7 @@
     [harja.palvelin.palvelut.hallinta.lupaukset-palvelu :as lupaukset-hallinta]
     [harja.palvelin.palvelut.hallinta.rahavaraukset :as rahavaraukset-hallinta]
     [harja.palvelin.palvelut.hallinta.urakkahenkilot :as urakkahenkilot-hallinta]
-    [harja.palvelin.palvelut.hallinta.kojelauta :as kojelauta-hallinta]
+    [harja.palvelin.palvelut.urakkatilanne.kojelauta :as kojelauta-hallinta]
     [harja.palvelin.palvelut.selainvirhe :as selainvirhe]
     [harja.palvelin.palvelut.lupaus.lupaus-palvelu :as lupaus-palvelu]
     [harja.palvelin.palvelut.valitavoitteet :as valitavoitteet]
@@ -829,7 +829,7 @@
         (urakkahenkilot-hallinta/->UrakkaHenkilotHallinta)
         [:http-palvelin :db :excel-vienti])
 
-      :kojelauta-hallinta
+      :urakkatilanne
       (component/using
         (kojelauta-hallinta/->KojelautaHallinta)
         [:http-palvelin :db]))))

--- a/src/clj/harja/palvelin/palvelut/urakkatilanne/kojelauta.clj
+++ b/src/clj/harja/palvelin/palvelut/urakkatilanne/kojelauta.clj
@@ -1,4 +1,4 @@
-(ns harja.palvelin.palvelut.hallinta.kojelauta
+(ns harja.palvelin.palvelut.urakkatilanne.kojelauta
   (:require [com.stuartsierra.component :as component]
             [harja.domain.oikeudet :as oikeudet]
             [harja.kyselyt.konversio :as konv]
@@ -23,7 +23,7 @@
   (update rivi avain konv/pgarray->vector))
 
 (defn hae-urakat-kojelautaan [db kayttaja {:keys [urakkatyyppi hoitokauden-alkuvuosi urakka-idt ely-id] :as hakuehdot}]
-  (oikeudet/vaadi-lukuoikeus oikeudet/hallinta-jarjestelmaasetukset kayttaja)
+  (oikeudet/vaadi-lukuoikeus oikeudet/urakkatilanne kayttaja)
   (let [urakat (cond
                  (= urakkatyyppi :hoito)                    ;; tässä kohti hoito = MHU, vanhoja alueurakoita ei tueta
                  (into []

--- a/src/cljs/harja/tiedot/navigaatio.cljs
+++ b/src/cljs/harja/tiedot/navigaatio.cljs
@@ -45,6 +45,7 @@
                                           (not= @valittu-sivu :tilannekuva)
                                           (not= @valittu-sivu :info)
                                           (not= @valittu-sivu :tienpidon-luvat)
+                                          (not= @valittu-sivu :urakoiden-tilanne)
                                           (not= @valittu-sivu :about)
                                           (not= @valittu-sivu :hallinta))))
 

--- a/src/cljs/harja/tiedot/urakkatilanne/kojelauta.cljs
+++ b/src/cljs/harja/tiedot/urakkatilanne/kojelauta.cljs
@@ -1,4 +1,4 @@
-(ns harja.tiedot.hallinta.kojelauta
+(ns harja.tiedot.urakkatilanne.kojelauta
   (:require [clojure.string :as clj-str]
             [harja.fmt :as fmt]
             [harja.pvm :as pvm]

--- a/src/cljs/harja/views/hallinta.cljs
+++ b/src/cljs/harja/views/hallinta.cljs
@@ -19,7 +19,6 @@
             [harja.views.hallinta.toteumatyokalu-nakyma :as toteumatyokalu-nakyma]
             [harja.views.hallinta.tyomaapaivakirjatyokalu-nakyma :as paivakirjatyokalu-nakyma]
             [harja.views.hallinta.koulutusvideot :as koulutusvideot]
-            [harja.views.hallinta.kojelauta :as kojelauta]
             [harja.views.hallinta.palauteluokitukset :as pl]
             [harja.views.hallinta.viestitestaus-nakyma :as viestinakyma]
             [harja.views.hallinta.urakkatiedot.tehtava-nakyma :as tehtava-nakyma]
@@ -120,12 +119,6 @@
    ^{:key "seuranta"}
    [bs/tabs {:style :tabs :classes "tabs-taso2"
              :active (nav/valittu-valilehti-atom :hallinta-seuranta)}
-
-    "Urakoiden tilanne"
-    :urakoiden-tilanne
-    (when (oikeudet/hallinta)
-      ^{:key "urakoiden-tilanne"}
-      [kojelauta/kojelauta])
 
     "Integraatiotilanne"
     :integraatiotilanne

--- a/src/cljs/harja/views/main.cljs
+++ b/src/cljs/harja/views/main.cljs
@@ -221,8 +221,8 @@
           :info [info/info]
           :ilmoitukset [ilmoitukset/ilmoitukset]
           :tienpidon-luvat [tieluvat/tieluvat]
-          :urakoiden-tilanne [kojelauta/kojelauta]
-          :hallinta [hallinta/hallinta]
+          :urakoiden-tilanne (when (oikeudet/urakkatilanne) [kojelauta/kojelauta])
+          :hallinta (when (oikeudet/hallinta) [hallinta/hallinta])
           :tilannekuva [tilannekuva/tilannekuva]
           :about [about/about]
           :tr [tierekisteri/tierekisteri]

--- a/src/cljs/harja/views/main.cljs
+++ b/src/cljs/harja/views/main.cljs
@@ -19,6 +19,7 @@
 
             [harja.views.urakat :as urakat]
             [harja.views.info :as info]
+            [harja.views.urakkatilanne.kojelauta :as kojelauta]
             [harja.views.raportit :as raportit]
             [harja.views.tilannekuva.tilannekuva :as tilannekuva]
             [harja.views.ilmoitukset.tieliikenneilmoitukset :as ilmoitukset]
@@ -112,6 +113,10 @@
                (istunto/ominaisuus-kaytossa? :tienpidon-luvat))
       [:li {:role "presentation" :class (when (= s :tienpidon-luvat) "active")}
        [linkki "Tienpidon luvat" #(nav/vaihda-sivu! :tienpidon-luvat)]])
+
+    (when (oikeudet/urakkatilanne)
+      [:li {:role "presentation" :class (when (= s :urakoiden-tilanne) "active")}
+       [linkki "Urakoiden tilanne" #(nav/vaihda-sivu! :urakoiden-tilanne)]])
 
     (when (oikeudet/hallinta)
       [:li {:role "presentation" :class (when (= s :hallinta) "active")}
@@ -216,6 +221,7 @@
           :info [info/info]
           :ilmoitukset [ilmoitukset/ilmoitukset]
           :tienpidon-luvat [tieluvat/tieluvat]
+          :urakoiden-tilanne [kojelauta/kojelauta]
           :hallinta [hallinta/hallinta]
           :tilannekuva [tilannekuva/tilannekuva]
           :about [about/about]

--- a/src/cljs/harja/views/urakkatilanne/kojelauta.cljs
+++ b/src/cljs/harja/views/urakkatilanne/kojelauta.cljs
@@ -1,9 +1,9 @@
-(ns harja.views.hallinta.kojelauta
+(ns harja.views.urakkatilanne.kojelauta
   (:require [harja.pvm :as pvm]
             [harja.tiedot.hallintayksikot :as hal]
             [harja.domain.kulut.kustannusten-seuranta :as kustannusten-seuranta-tiedot]
             [harja.tiedot.navigaatio :as nav]
-            [harja.tiedot.urakka :as u]
+            [harja.tiedot.palaute :as palaute-tiedot]
             [harja.tiedot.urakka.siirtymat :as siirtymat]
             [harja.ui.grid :as grid]
             [harja.ui.kentat :as kentat]
@@ -12,7 +12,7 @@
             [harja.ui.yleiset :refer [ajax-loader] :as yleiset]
             [harja.ui.debug :as debug]
             [harja.ui.komponentti :as komp]
-            [harja.tiedot.hallinta.kojelauta :as tiedot])
+            [harja.tiedot.urakkatilanne.kojelauta :as tiedot])
   (:require-macros [harja.tyokalut.ui :refer [for*]]))
 
 (def hoitokausia-taaksepain 4)
@@ -259,12 +259,22 @@
                                  :haku-kaynnissa? haku-kaynnissa?}])]))
 
 
+;; Näytetään uuden ominaisuuden vihjetekstiä jonkin aikaa, että käyttäjät oppivat mistä asiassa on kyse
+(def vihjeteksti-uudesta-ominaisuudesta
+  [:p "Tämä on uusi osio, jonka tarkoituksena on parantaa tiedon läpinäkyvyyttä Harjan sisällä.
+       Tässä vaiheessa osio näkyy vain pääkäyttäjille sekä ELY:jen pääkäyttäjille ja urakanvalvojille.
+       Myöhemmin laajennamme mahdollisesti tiedon näkyvyyttä myös urakoitsijoille heidän omien urakoidensa osalta. Jos löydät tiedoista virheitä tai sinulla
+       on muita toiveita tämän osion kehittämiseksi, voit "
+   [:a {:href (palaute-tiedot/mailto-kehitystiimi)} "laittaa meille viestiä osoitteeseen harjapalaute@solita.fi"]])
+
 (defn kojelauta* [e! app]
   (komp/luo
     (komp/sisaan #(e! (tiedot/->HaeUrakat)))
     (fn [e! app]
       [:div.kojelauta-hallinta
        [:h1 "Urakoiden tilanne"]
+       (when (< (pvm/nyt) (pvm/->pvm "7.12.2024"))
+         [yleiset/vihje vihjeteksti-uudesta-ominaisuudesta])
        [suodattimet e! app]
        ;; [debug/debug app]
        [listaus e! app]])))

--- a/test/clj/harja/palvelin/main_test.clj
+++ b/test/clj/harja/palvelin/main_test.clj
@@ -164,7 +164,7 @@
     :rahavaraukset-hallinta
     :urakkahenkilot-hallinta
     :lupaukset-hallinta
-    :kojelauta-hallinta})
+    :urakkatilanne})
 
 (def ei-statusta
   #{:metriikka
@@ -244,7 +244,7 @@
     :rahavaraukset-hallinta
     :urakkahenkilot-hallinta
     :lupaukset-hallinta
-    :kojelauta-hallinta})
+    :urakkatilanne})
 
 (def hidas-ok-status #{:itmf})
 

--- a/test/clj/harja/palvelin/palvelut/urakkatilanne/kojelauta_kustiskorjaus_test.clj
+++ b/test/clj/harja/palvelin/palvelut/urakkatilanne/kojelauta_kustiskorjaus_test.clj
@@ -1,6 +1,6 @@
-(ns harja.palvelin.palvelut.hallinta.kojelauta-kustiskorjaus-test
+(ns harja.palvelin.palvelut.urakkatilanne.kojelauta-kustiskorjaus-test
   (:require [clojure.test :refer :all]
-            [harja.palvelin.palvelut.hallinta.kojelauta :as kojelauta]
+            [harja.palvelin.palvelut.urakkatilanne.kojelauta :as kojelauta]
             [com.stuartsierra.component :as component]
             [harja.palvelin.komponentit.tietokanta :as tietokanta]
             [harja
@@ -14,7 +14,7 @@
         (component/system-map
           :db (tietokanta/luo-tietokanta testitietokanta)
           :http-palvelin (testi-http-palvelin)
-          :kojelauta-hallinta (component/using
+          :urakkatilanne (component/using
                                 (kojelauta/->KojelautaHallinta)
                                 [:db :http-palvelin])))))
   (testit)

--- a/test/clj/harja/palvelin/palvelut/urakkatilanne/kojelauta_test.clj
+++ b/test/clj/harja/palvelin/palvelut/urakkatilanne/kojelauta_test.clj
@@ -73,7 +73,16 @@
                            {:urakkatyyppi :hoito
                             :hoitokauden-alkuvuosi 2020
                             :urakka-idt #{@kemin-alueurakan-2019-2023-id}
-                            :ely-id nil})) "Ei oikeutta, poikkeus heitetään"))
+                            :ely-id nil})) "Ei oikeutta, poikkeus heitetään")
+
+;; myöskään urakoitsijan pääkäyttäjälle ei palauteta tietoa
+(is (thrown? Exception (kutsu-palvelua (:http-palvelin jarjestelma)
+                         :hae-urakat-kojelautaan
+                         kemin-alueurakan-2019-2023-paakayttaja
+                         {:urakkatyyppi :hoito
+                          :hoitokauden-alkuvuosi 2020
+                          :urakka-idt #{@kemin-alueurakan-2019-2023-id}
+                          :ely-id nil})) "Ei oikeutta, poikkeus heitetään"))
 
 (deftest kaikki-mhut-kojelautaan-hk-alkuvuosi-2005-ei-palauta-yhtaan
   (let [vastaus (kutsu-palvelua (:http-palvelin jarjestelma)

--- a/test/clj/harja/palvelin/palvelut/urakkatilanne/kojelauta_test.clj
+++ b/test/clj/harja/palvelin/palvelut/urakkatilanne/kojelauta_test.clj
@@ -1,7 +1,7 @@
-(ns harja.palvelin.palvelut.hallinta.kojelauta-test
+(ns harja.palvelin.palvelut.urakkatilanne.kojelauta-test
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
-            [harja.palvelin.palvelut.hallinta.kojelauta :as kojelauta]
+            [harja.palvelin.palvelut.urakkatilanne.kojelauta :as kojelauta]
             [com.stuartsierra.component :as component]
             [harja.palvelin.komponentit.tietokanta :as tietokanta]
             [harja
@@ -15,7 +15,7 @@
         (component/system-map
           :db (tietokanta/luo-tietokanta testitietokanta)
           :http-palvelin (testi-http-palvelin)
-          :kojelauta-hallinta (component/using
+          :urakkatilanne (component/using
                                 (kojelauta/->KojelautaHallinta)
                                 [:db :http-palvelin])))))
   (testit)
@@ -39,22 +39,41 @@
     (is (= 10 (count vastaus)) "Urakoiden lukumäärä")))
 
 (deftest kaikki-mhut-kojelautaan-hk-alkuvuosi-2024-vajaa-kayttooikeus-throwaa
-  ;; Kojelauta tässä vaiheessa vain pääkäyttäjälle, urakanvalvojalle ei näytetä
-  (is (thrown? Exception (kutsu-palvelua (:http-palvelin jarjestelma)
-                           :hae-urakat-kojelautaan
-                           +kayttaja-tero+
-                           {:hoitokauden-alkuvuosi 2024
-                            :urakka-idt nil
-                            :ely-id nil})) "Ei oikeutta poikkeus heitetään")
+  ;; Urakanvalvojan pitää nähdä
+  (let [vastaus-urakanvalvojalle (kutsu-palvelua (:http-palvelin jarjestelma)
+                                   :hae-urakat-kojelautaan
+                                   +kayttaja-tero+
+                                   {:urakkatyyppi :hoito
+                                    :hoitokauden-alkuvuosi 2024
+                                    :urakka-idt nil
+                                    :ely-id nil})
+        vastaus-ely-paakayttajalle (kutsu-palvelua (:http-palvelin jarjestelma)
+                                     :hae-urakat-kojelautaan
+                                     (ely-paakayttaja)
+                                     {:urakkatyyppi :hoito
+                                      :hoitokauden-alkuvuosi 2024
+                                      :urakka-idt nil
+                                      :ely-id nil})]
+    (is (= 10 (count vastaus-urakanvalvojalle)) "Urakanvalvoja näkee")
+    (is (= 10 (count vastaus-ely-paakayttajalle)) "ELY:n Pääkäyttäjä näkee"))
 
-  ;; Kojelauta tässä vaiheessa vain pääkäyttäjälle, urakoitsijalle ei näytetä
+  ;; Urakoitsijalle ei tässä vaiheessa näytetä (myöh. suunnitelma avata oman urakan osalta)
   (is (thrown? Exception (kutsu-palvelua (:http-palvelin jarjestelma)
                            :hae-urakat-kojelautaan
                            +kayttaja-urakan-vastuuhenkilo+
-                           {:hoitokauden-alkuvuosi 2015
+                           {:urakkatyyppi :hoito
+                            :hoitokauden-alkuvuosi 2015
                             :urakka-idt nil
-                            :ely-id nil})) "Ei oikeutta poikkeus heitetään")
-  )
+                            :ely-id nil})) "Ei oikeutta, poikkeus heitetään")
+
+  ;; Urakoitsijan Laadunvalvojakaan ei ainakaan vielä saa nähdä asioita
+  (is (thrown? Exception (kutsu-palvelua (:http-palvelin jarjestelma)
+                           :hae-urakat-kojelautaan
+                           kemin-alueurakan-2019-2023-laadunvalvoja
+                           {:urakkatyyppi :hoito
+                            :hoitokauden-alkuvuosi 2020
+                            :urakka-idt #{@kemin-alueurakan-2019-2023-id}
+                            :ely-id nil})) "Ei oikeutta, poikkeus heitetään"))
 
 (deftest kaikki-mhut-kojelautaan-hk-alkuvuosi-2005-ei-palauta-yhtaan
   (let [vastaus (kutsu-palvelua (:http-palvelin jarjestelma)

--- a/test/clj/harja/testi.clj
+++ b/test/clj/harja/testi.clj
@@ -1332,6 +1332,14 @@
 
 (use-fixtures :once urakkatieto-fixture)
 
+(defn ely-paakayttaja []
+  {:sahkoposti "elypk@example.org", :kayttajanimi "ely-pk-urakanvalvoja",
+   :roolit #{"ELY_Paakayttaja"}, :id 4178,
+   :organisaatio {:id 10, :nimi "Pohjois-Pohjanmaa", :tyyppi "hallintayksikko"},
+   :organisaatioroolit {}
+   :organisaation-urakat #{@oulun-alueurakan-2005-2010-id}
+   :urakkaroolit {}})
+
 (defn oulun-2005-urakan-tilaajan-urakanvalvoja []
   {:sahkoposti "ely@example.org", :kayttajanimi "ely-oulun-urakanvalvoja",
    :roolit #{"ELY_Urakanvalvoja"}, :id 417,
@@ -1382,7 +1390,7 @@
    :roolit #{"Laadunvalvoja"}, :id 18, :etunimi "Keppi",
    :organisaatio {:id @kemin-aluerakennus-id, :nimi "Kemin Aluerakennus Oy", :tyyppi "urakoitsija"},
    :organisaation-urakat #{@kemin-alueurakan-2019-2023-id}
-   :organisaatioroolit {} #_{@kemin-aluerakennus-id #{"laadunvalvoja"}}
+   :organisaatioroolit {}
    :urakkaroolit {@kemin-alueurakan-2019-2023-id #{"Laadunvalvoja"}}})
 
 (defn kemin-alueurakan-2019-2023-urakan-tilaajan-urakanvalvoja []


### PR DESCRIPTION
Tuodaan dashboard näkyviin valituille käyttäjäryhmille eli ELY Pääkäyttäjä, ELY Urakanvalvoja, Tilaanan Urakanvalvoja ja Jarjestelmavastaava. Tähän liittyneet tarvittavat muutokset on jo viety Roolit-exceliin.