### PR TITLE
Harja-906_Paivamaarakentan_nappaimistokaytto

### DIFF
--- a/cypress/e2e/mhu_kustannuskirjaus.cy.js
+++ b/cypress/e2e/mhu_kustannuskirjaus.cy.js
@@ -46,9 +46,9 @@ let tallennaJaTarkistaKulu = (kuluTaiKulut) => {
 
     cy.contains('Kulujen kohdistus');
 
-    cy.get('.pvm-kentta > input').eq(0).click().wait(3000).type('{selectall}29.09.2021');
-    cy.get('.pvm-kentta > input').eq(1).click().wait(3000).type('{selectall}29.09.2021');
-    cy.get('.pvm-kentta > input').eq(1).should('have.value', "29.09.2021").type('{enter}');
+    cy.get('.pvm-kentta > .pvm-ikoni > input').eq(0).click().wait(3000).type('{selectall}29.09.2021');
+    cy.get('.pvm-kentta > .pvm-ikoni > input').eq(1).click().wait(3000).type('{selectall}29.09.2021');
+    cy.get('.pvm-kentta > .pvm-ikoni > input').eq(1).should('have.value', "29.09.2021").type('{enter}');
 
     if (Array.isArray(kuluTaiKulut)) {
         cy.get('table.grid tr.klikattava').eq(0).click();

--- a/cypress/e2e/paikkauskohteet.cy.js
+++ b/cypress/e2e/paikkauskohteet.cy.js
@@ -62,8 +62,8 @@ let avaaToteumat = () => {
     cy.get('.ajax-loader', {timeout: clickTimeout}).should('not.exist')
 
 
-    cy.get('label[for=filtteri-aikavali] + div .pvm-kentta > .input-default > input').first().focus().type("01.01.2021" ).clear().type("01.01.2021" );
-    cy.get('label[for=filtteri-aikavali] + div .pvm-kentta > .input-default > input').last().focus().type("31.12.2021").clear().type("31.12.2021" );
+    cy.get('label[for=filtteri-aikavali] + div .pvm-kentta > .pvm-ikoni > .input-default').first().focus().type("01.01.2021" ).clear().type("01.01.2021" );
+    cy.get('label[for=filtteri-aikavali] + div .pvm-kentta > .pvm-ikoni > .input-default').last().focus().type("31.12.2021").clear().type("31.12.2021" );
     cy.get('label').contains("Työmenetelmä").click(); // Klikataan vain ohi aukeavasta valikosta.
     cy.contains('.nappi-ensisijainen', 'Hae toteumia').click({force: true})
     cy.wait('@2021-paikkaukset', {timeout: clickTimeout})
@@ -115,8 +115,8 @@ describe('Paikkauskohteet latautuu oikein', function () {
         cy.get('label[for=losa] + span > input').type("420")
         cy.get('label[for=let] + span > input').type("5000")
         // Ajankohta
-        cy.get('label[for=alkupvm] + .pvm-kentta > .input-default').type("1.5.2021")
-        cy.get('label[for=loppupvm] + .pvm-kentta > .input-default').type("1.6.2021")
+        cy.get('label[for=alkupvm] + .pvm-kentta > .pvm-ikoni > .input-default').type("1.5.2021")
+        cy.get('label[for=loppupvm] + .pvm-kentta > .pvm-ikoni > .input-default').type("1.6.2021")
         //Suunnitellut määrät ja summa
         cy.get('label[for=suunniteltu-maara] + span > input').type("355")
         cy.get('label[for=yksikko] + div').valinnatValitse({valinta: 'jm'})
@@ -274,8 +274,8 @@ describe('Päällystysilmoitukset toimii', function () {
         cy.get('label[for=losa] + span > input').type("421")
         cy.get('label[for=let] + span > input').type("2000")
         // Ajankohta
-        cy.get('label[for=alkupvm] + .pvm-kentta > .input-default').type("1.8.2021")
-        cy.get('label[for=loppupvm] + .pvm-kentta > .input-default').type("1.9.2021")
+        cy.get('label[for=alkupvm] + .pvm-kentta > .pvm-ikoni > .input-default').type("1.8.2021")
+        cy.get('label[for=loppupvm] + .pvm-kentta > .pvm-ikoni > .input-default').type("1.9.2021")
         //Suunnitellut määrät ja summa
         cy.get('label[for=suunniteltu-maara] + span > input').type("1111")
         cy.get('label[for=yksikko] + div').valinnatValitse({valinta: 'jm'})

--- a/dev-resources/less/pages/ilmoitukset.less
+++ b/dev-resources/less/pages/ilmoitukset.less
@@ -112,6 +112,24 @@
       width: 96px;
     }
   }
+
+  .paivays {
+    label {
+      margin-top: 0.5rem;
+    }
+    margin-bottom: 3px;
+  }
+
+  .pvm-aika-kentta {
+    .inline-block {
+      .ikoni-input {
+        @media (max-width: extract(@taulukko-breakpointit, 1)) {
+          max-width: 120px;
+        }
+     }
+    }
+    width: 100%
+  }
 }
 
 .kuittauslista {

--- a/dev-resources/less/pages/ilmoitukset.less
+++ b/dev-resources/less/pages/ilmoitukset.less
@@ -119,17 +119,6 @@
     }
     margin-bottom: 3px;
   }
-
-  .pvm-aika-kentta {
-    .inline-block {
-      .ikoni-input {
-        @media (max-width: extract(@taulukko-breakpointit, 1)) {
-          max-width: 120px;
-        }
-     }
-    }
-    width: 100%
-  }
 }
 
 .kuittauslista {

--- a/dev-resources/less/pages/ilmoitukset.less
+++ b/dev-resources/less/pages/ilmoitukset.less
@@ -115,9 +115,9 @@
 
   .paivays {
     label {
-      margin-top: 0.5rem;
+      margin-top: @valistys-8;
     }
-    margin-bottom: 3px;
+    margin-bottom: @valistys-4;
   }
 }
 

--- a/dev-resources/less/pages/integraatioloki.less
+++ b/dev-resources/less/pages/integraatioloki.less
@@ -17,8 +17,8 @@
   .label-ja-aikavali {
     width: 420px;
     label {
-      margin: 16px 0 0 0;
-      line-height: 16px;
+      margin: @valistys-16 0 0 0;
+      line-height: inherit;
       font-weight: 600;
     }
     .pvm-aika-kentta {
@@ -28,11 +28,11 @@
 
     .pvm {
       width: 120px;
-      height: 31px;
+      height: @valistys-32;
     }
 
     .aika-input {
-      height: 31px;
+      height: @valistys-32;
     }
   }
 }

--- a/dev-resources/less/pages/integraatioloki.less
+++ b/dev-resources/less/pages/integraatioloki.less
@@ -19,28 +19,20 @@
     label {
       margin: 16px 0 0 0;
       line-height: 16px;
+      font-weight: 600;
     }
     .pvm-aika-kentta {
       display: inline-block;
       width: unset;
-      .ikoni-input {
-        padding: 0.375rem 8px;
-        height: auto;
-        input {
-          padding: 0 2px;
-          height: auto;
-          max-width: 80px;
-          top: 0;
-        }
-        .glyphicon {
-          padding: 0 8px;
-        }
-      }
-      .aika-input {
-        padding: 0.375rem 8px;
-        height: auto;
-        top: 0;
-      }
+    }
+
+    .pvm {
+      width: 120px;
+      height: 31px;
+    }
+
+    .aika-input {
+      height: 31px;
     }
   }
 }

--- a/dev-resources/less/pages/integraatioloki.less
+++ b/dev-resources/less/pages/integraatioloki.less
@@ -13,11 +13,34 @@
   .label-ja-alasveto {
     width: 200px;
   }
-  .pvm-aika-kentta {
-    display: inline-block;
-    width: unset;
-    input.pvm {
-      max-width: 80px;
+
+  .label-ja-aikavali {
+    width: 420px;
+    label {
+      margin: 16px 0 0 0;
+      line-height: 16px;
+    }
+    .pvm-aika-kentta {
+      display: inline-block;
+      width: unset;
+      .ikoni-input {
+        padding: 0.375rem 8px;
+        height: auto;
+        input {
+          padding: 0 2px;
+          height: auto;
+          max-width: 80px;
+          top: 0;
+        }
+        .glyphicon {
+          padding: 0 8px;
+        }
+      }
+      .aika-input {
+        padding: 0.375rem 8px;
+        height: auto;
+        top: 0;
+      }
     }
   }
 }

--- a/dev-resources/less/pages/tienpidonluvat.less
+++ b/dev-resources/less/pages/tienpidonluvat.less
@@ -46,13 +46,9 @@
       text-align: left;
     }
 
-    .ikoni-input {
-      max-width: 200px;
-      width: 100%;
-    }
-
     input {
       width: 100%;
+      max-width: 200px;
     }
 
     @media (max-width: 768px) {

--- a/dev-resources/less/pages/tienpidonluvat.less
+++ b/dev-resources/less/pages/tienpidonluvat.less
@@ -42,7 +42,13 @@
   .label-ja-aikavali {
     .aikavali-valinnat {
       max-width: 420px;
+      width: fit-content;
       text-align: left;
+    }
+
+    .ikoni-input {
+      max-width: 200px;
+      width: 100%;
     }
 
     input {

--- a/dev-resources/less/pvm-valinta.less
+++ b/dev-resources/less/pvm-valinta.less
@@ -69,7 +69,7 @@
   color: @gray100;
 
   input {
-    padding: 8px;
+    padding: @valistys-8;
   }
 
   &.auki {

--- a/dev-resources/less/pvm-valinta.less
+++ b/dev-resources/less/pvm-valinta.less
@@ -59,7 +59,7 @@
 
 
 .kalenteri-kontti {
-  display: flex;
+  display: inline-block;
   flex-direction: column;
   width: 100%;
   position: relative;
@@ -67,6 +67,10 @@
   font-size: 14px;
   line-height:29px;
   color: @gray100;
+
+  input {
+    padding: 8px;
+  }
 
   &.auki {
     z-index: 2000;

--- a/dev-resources/less/vayla/inputs-and-selects.less
+++ b/dev-resources/less/vayla/inputs-and-selects.less
@@ -101,6 +101,7 @@ label {
     }
 
     &:focus, &.fokusoi {
+      outline: none;
       .outlinet-ja-borderit(@focus-color, 1px, .5px, -3px);
     }
 

--- a/dev-resources/less/yleiset.less
+++ b/dev-resources/less/yleiset.less
@@ -605,6 +605,23 @@ button > .ajax-loader {
   width: fit-content;
 }
 
+.pvm-ikoni {
+  position: relative;
+}
+
+.ikoni-osio {
+  color: @blue-dark;
+  width: 26px;
+  background-color: transparent;
+  border: none;
+  height: 100%;
+  position: absolute;
+  display: flex;
+  align-items: center;
+  top: 0;
+  right: 0;
+}
+
 .flex-lista {
     display:flex;
     flex-direction:column;

--- a/dev-resources/less/yleiset.less
+++ b/dev-resources/less/yleiset.less
@@ -596,11 +596,13 @@ button > .ajax-loader {
 .pvm-kentta .ikoni-input {
     min-width: 120px;
     max-width: 150px;
+    width: fit-content;
 }
 
 .pvm-aika-kentta .ikoni-input {
   min-width: 120px;
   max-width: 150px;
+  width: fit-content;
 }
 
 .flex-lista {

--- a/dev-resources/less/yleiset.less
+++ b/dev-resources/less/yleiset.less
@@ -598,6 +598,11 @@ button > .ajax-loader {
     max-width: 150px;
 }
 
+.pvm-aika-kentta .ikoni-input {
+  min-width: 120px;
+  max-width: 150px;
+}
+
 .flex-lista {
     display:flex;
     flex-direction:column;

--- a/src/cljs/harja/ui/kentat.cljs
+++ b/src/cljs/harja/ui/kentat.cljs
@@ -1062,7 +1062,8 @@
 
 ;; pvm-tyhjana ottaa vastaan pvm:n siitä kuukaudesta ja vuodesta, jonka sivu
 ;; halutaan näyttää ensin
-(defmethod tee-kentta :pvm [{:keys [pvm-tyhjana rivi on-focus lomake? pakota-suunta validointi on-datepicker-select vayla-tyyli?]} data]
+(defmethod tee-kentta :pvm [{:keys [pvm-tyhjana rivi on-focus lomake? pakota-suunta validointi
+                                    on-datepicker-select vayla-tyyli? elementin-nimi]} data]
 
   (let [;; pidetään kirjoituksen aikainen ei validi pvm tallessa
         p @data
@@ -1125,7 +1126,9 @@
                                 (pvm/->pvm nykyinen-teksti)
                                 nykyinen-pvm
                                 (pvm-tyhjana rivi))
-               elementin-id (str (gensym "pvm-input"))
+               elementin-id (if elementin-nimi
+                              elementin-nimi
+                              (str (gensym "pvm-input")))
                input-komponentti [:input {:class (yleiset/luokat (when-not (or kentan-tyylit vayla-tyyli?) "pvm")
                                                                  (cond
                                                                    kentan-tyylit (apply str kentan-tyylit)
@@ -1167,7 +1170,9 @@
               [pvm-valinta/pvm-valintakalenteri {:valitse #(when (validoi %)
                                                              (reset! auki false)
                                                              (muuta-data! %)
-                                                             (reset! teksti (pvm/pvm %)))
+                                                             (reset! teksti (pvm/pvm %))
+                                                             (when elementin-nimi
+                                                               (js/setTimeout (fn [] (some-> js/document (.getElementById elementin-id) .focus)) 200)))
                                                  :pvm naytettava-pvm
                                                  :pakota-suunta pakota-suunta
                                                  :valittava?-fn (when validoi?
@@ -1187,7 +1192,7 @@
 
 (defn- resetoi-jos-tyhja-tai-matchaa [t re atomi]
   (when (or (str/blank? t)
-            (re-matches re t))
+          (re-matches re t))
     (reset! atomi t)))
 
 (defn- aseta-aika! [aika-text aseta-fn!]
@@ -1202,7 +1207,7 @@
         (aseta-fn! (str (subs aika-text 0 1) ":" (subs aika-text 1)))))
 
     (when (or (str/blank? aika-text)
-              (re-matches +aika-regex+ aika-text))
+            (re-matches +aika-regex+ aika-text))
       (aseta-fn! aika-text))))
 
 (defmethod tee-kentta :pvm-aika [{:keys [pvm-tyhjana rivi focus on-focus on-blur lomake? pakota-suunta vayla-tyyli?]}

--- a/src/cljs/harja/ui/kentat.cljs
+++ b/src/cljs/harja/ui/kentat.cljs
@@ -1120,7 +1120,7 @@
                             ""))))
        :reagent-render
        (fn [{:keys [on-focus on-blur placeholder rivi validointi on-datepicker-select
-                    kentan-tyylit virhe? ikoni-sisaan? muokattu?]} data]
+                    kentan-tyylit virhe? muokattu?]} data]
          (let [nykyinen-pvm @data
                {vanha-data-arvo :data muokattu-tassa? :muokattu-tassa?} @vanha-data
                _ (when (and (not= nykyinen-pvm vanha-data-arvo)
@@ -1212,7 +1212,7 @@
               (re-matches +aika-regex+ aika-text))
       (aseta-fn! aika-text))))
 
-(defmethod tee-kentta :pvm-aika [{:keys [pvm-tyhjana rivi focus on-focus on-blur lomake? pakota-suunta]}
+(defmethod tee-kentta :pvm-aika [{:keys [pvm-tyhjana rivi focus on-focus on-blur lomake? pakota-suunta vayla-tyyli?]}
                                  data]
 
   (let [;; pidetään kirjoituksen aikainen ei validi pvm tallessa
@@ -1295,12 +1295,10 @@
                                nykyinen-pvm
                                (pvm-tyhjana rivi))
               elementin-id (str (gensym "pvm-aika-input"))
-              input-komponentti [:input.pvm {:class (when lomake? "form-control margin-bottom-4")
+              input-komponentti [:input.pvm {:class (cond
+                                                      vayla-tyyli? (str "input-default ")
+                                                      lomake? "form-control margin-bottom-4")
                                              :placeholder "pp.kk.vvvv"
-                                             :on-click #(do (.stopPropagation %)
-                                                          (.preventDefault %)
-                                                          (reset! auki true)
-                                                          %)
                                              :value nykyinen-pvm-teksti
                                              :on-focus #(when on-focus (on-focus))
                                              :on-change #(muuta-pvm! (-> % .-target .-value))
@@ -1313,7 +1311,10 @@
                                              :on-blur #(do (when on-blur (on-blur %)) (koske-pvm!) (aseta! false) %)
                                              :id elementin-id}]]
           [:span.pvm-aika-kentta
-           [:div.inline-block
+           [:div.inline-block {:on-click #(do (.stopPropagation %)
+                                            (.preventDefault %)
+                                            (reset! auki true)
+                                            %)}
             (tee-ikoni-komponentti input-komponentti @auki)
             (when @auki
               [pvm-valinta/pvm-valintakalenteri {:valitse #(do (reset! auki false)
@@ -1327,7 +1328,8 @@
                                                                      (reset! auki false))
                                                  :input-id elementin-id}])]
            [:div.inline-block
-            [:input.aika-input {:class (str (when lomake? "form-control")
+            [:input.aika-input {:class (str (when lomake? "form-control margin-bottom-4")
+                                            (when vayla-tyyli? "input-default")
                                             (when (and (not (re-matches +validi-aika-regex+
                                                                         nykyinen-aika-teksti))
                                                        (pvm/->pvm nykyinen-pvm-teksti))

--- a/src/cljs/harja/ui/kentat.cljs
+++ b/src/cljs/harja/ui/kentat.cljs
@@ -1060,15 +1060,6 @@
 (def key-code-tab 9)
 (def key-code-enter 13)
 
-
-(defn- tee-ikoni-komponentti
-  [[tagi optiot] auki]
-  (let [{:keys [class]} optiot
-        input-optiot (dissoc optiot :class)]
-    [:span {:class (str "ikoni-input " (when auki "fokusoi ") class)}
-     [tagi input-optiot]
-     (ikonit/calendar)]))
-
 ;; pvm-tyhjana ottaa vastaan pvm:n siitä kuukaudesta ja vuodesta, jonka sivu
 ;; halutaan näyttää ensin
 (defmethod tee-kentta :pvm [{:keys [pvm-tyhjana rivi on-focus lomake? pakota-suunta validointi on-datepicker-select vayla-tyyli?]} data]
@@ -1140,36 +1131,38 @@
                                                                    kentan-tyylit (apply str kentan-tyylit)
                                                                    vayla-tyyli? (str "input-" (if (and muokattu? virhe?) "error-" "") "default ")
                                                                    lomake? "form-control"))
-                         :placeholder (or placeholder "pp.kk.vvvv")
-                         :value nykyinen-teksti
-                         :on-focus #(when on-focus (on-focus))
-                         :on-click #(do (.stopPropagation %)
-                                      (.preventDefault %)
-                                      (reset! auki true)
-                                      %)
-                         :on-change #(muuta! data (-> % .-target .-value))
-                         ;; Suljetaan datepicker kun painetaan tab + shift tai esc. Enterillä datepickerin saa auki/kiinni.
-                         :on-key-down #(do
-                                         (when (or (dom/tab+shift-nappaimet? %) (dom/esc-nappain? %))
-                                           (teksti-paivamaaraksi! validoi data nykyinen-teksti)
-                                           (reset! auki false))
-                                         (when (dom/enter-nappain? %)
-                                           (teksti-paivamaaraksi! validoi data nykyinen-teksti)
-                                           (reset! auki (not @auki))))
-                         :on-blur #(let [arvo (.. % -target -value)
-                                         pvm (pvm/->pvm arvo)]
-                                     (when on-blur
-                                       (on-blur %))
-                                     (if (and pvm (not (validoi pvm)))
-                                       (do (muuta-data! nil)
-                                           (reset! teksti ""))
-                                       (teksti-paivamaaraksi! validoi data arvo)))
-                         :id elementin-id}]]
+                                  :placeholder (or placeholder "pp.kk.vvvv")
+                                  :value nykyinen-teksti
+                                  :on-focus #(when on-focus (on-focus))
+                                  :on-change #(muuta! data (-> % .-target .-value))
+                                  ;; Suljetaan datepicker kun painetaan tab + shift tai esc. Enterillä datepickerin saa auki/kiinni.
+                                  :on-key-down #(do
+                                                  (when (or (dom/tab+shift-nappaimet? %) (dom/esc-nappain? %))
+                                                      (teksti-paivamaaraksi! validoi data nykyinen-teksti)
+                                                      (reset! auki false))
+                                                  (when (dom/enter-nappain? %)
+                                                    (teksti-paivamaaraksi! validoi data nykyinen-teksti)
+                                                    (reset! auki (not @auki))))
+                                  :on-blur #(let [arvo (.. % -target -value)
+                                                  pvm (pvm/->pvm arvo)]
+                                            (when on-blur
+                                              (on-blur %))
+                                            (if (and pvm (not (validoi pvm)))
+                                              (do (muuta-data! nil)
+                                                (reset! teksti ""))
+                                              (teksti-paivamaaraksi! validoi data arvo)))
+                                  :aria-label "päiväys"
+                                  :id elementin-id}]]
            (swap! vanha-data assoc :data nykyinen-pvm :muokattu-tassa? false)
            [:span.pvm-kentta
-            {:on-click #(do (reset! auki true) nil)
+            {:on-click #(do (.stopPropagation %)
+                          (.preventDefault %)
+                          (reset! auki true) nil)
              :style {:display "inline-block"}}
-            (tee-ikoni-komponentti input-komponentti @auki)
+            [:div.pvm-ikoni input-komponentti
+             [:span.ikoni-osio
+              (ikonit/calendar)]]
+
             (when @auki
               [pvm-valinta/pvm-valintakalenteri {:valitse #(when (validoi %)
                                                              (reset! auki false)
@@ -1309,13 +1302,17 @@
                                                              (when (dom/enter-nappain? %)
                                                                (reset! auki (not @auki))))
                                              :on-blur #(do (when on-blur (on-blur %)) (koske-pvm!) (aseta! false) %)
+                                             :aria-label "päiväys"
                                              :id elementin-id}]]
           [:span.pvm-aika-kentta
            [:div.inline-block {:on-click #(do (.stopPropagation %)
                                             (.preventDefault %)
                                             (reset! auki true)
                                             %)}
-            (tee-ikoni-komponentti input-komponentti @auki)
+            [:div.pvm-ikoni input-komponentti
+             [:span.ikoni-osio
+              (ikonit/calendar)]]
+
             (when @auki
               [pvm-valinta/pvm-valintakalenteri {:valitse #(do (reset! auki false)
                                                                (muuta-pvm! (pvm/pvm %))
@@ -1335,6 +1332,7 @@
                                                        (pvm/->pvm nykyinen-pvm-teksti))
                                               " puuttuva-arvo"))
                                 :placeholder "tt:mm"
+                                :aria-label "kellonaika"
                                 :size 5 :max-length 5
                                 :value nykyinen-aika-teksti
                                 :on-change #(muuta-aika! (-> % .-target .-value))

--- a/src/cljs/harja/ui/kentat.cljs
+++ b/src/cljs/harja/ui/kentat.cljs
@@ -1142,7 +1142,11 @@
                                                                    lomake? "form-control"))
                          :placeholder (or placeholder "pp.kk.vvvv")
                          :value nykyinen-teksti
-                         :on-focus #(do (when on-focus (on-focus)) (reset! auki true) %)
+                         :on-focus #(when on-focus (on-focus))
+                         :on-click #(do (.stopPropagation %)
+                                      (.preventDefault %)
+                                      (reset! auki true)
+                                      %)
                          :on-change #(muuta! data (-> % .-target .-value))
                          ;; Suljetaan datepicker kun painetaan tab + shift tai esc. Enterillä datepickerin saa auki/kiinni.
                          :on-key-down #(do
@@ -1165,9 +1169,7 @@
            [:span.pvm-kentta
             {:on-click #(do (reset! auki true) nil)
              :style {:display "inline-block"}}
-            (if-not ikoni-sisaan?
-              input-komponentti
-              (tee-ikoni-komponentti input-komponentti @auki))
+            (tee-ikoni-komponentti input-komponentti @auki)
             (when @auki
               [pvm-valinta/pvm-valintakalenteri {:valitse #(when (validoi %)
                                                              (reset! auki false)
@@ -1292,26 +1294,27 @@
                                (pvm/->pvm nykyinen-pvm-teksti)
                                nykyinen-pvm
                                (pvm-tyhjana rivi))
-              elementin-id (str (gensym "pvm-aika-input"))]
+              elementin-id (str (gensym "pvm-aika-input"))
+              input-komponentti [:input.pvm {:class (when lomake? "form-control margin-bottom-4")
+                                             :placeholder "pp.kk.vvvv"
+                                             :on-click #(do (.stopPropagation %)
+                                                          (.preventDefault %)
+                                                          (reset! auki true)
+                                                          %)
+                                             :value nykyinen-pvm-teksti
+                                             :on-focus #(when on-focus (on-focus))
+                                             :on-change #(muuta-pvm! (-> % .-target .-value))
+                                             ;; Suljetaan datepicker kun painetaan tab + shift tai esc. Enterillä datepickerin saa auki/kiinni.
+                                             :on-key-down #(do
+                                                             (when (or (dom/tab+shift-nappaimet? %) (dom/esc-nappain? %))
+                                                               (reset! auki false))
+                                                             (when (dom/enter-nappain? %)
+                                                               (reset! auki (not @auki))))
+                                             :on-blur #(do (when on-blur (on-blur %)) (koske-pvm!) (aseta! false) %)
+                                             :id elementin-id}]]
           [:span.pvm-aika-kentta
            [:div.inline-block
-            [:input.pvm {:class (when lomake? "form-control margin-bottom-4")
-                         :placeholder "pp.kk.vvvv"
-                         :on-click #(do (.stopPropagation %)
-                                        (.preventDefault %)
-                                        (reset! auki true)
-                                        %)
-                         :value nykyinen-pvm-teksti
-                         :on-focus #(do (when on-focus (on-focus)) (reset! auki true) %)
-                         :on-change #(muuta-pvm! (-> % .-target .-value))
-                         ;; Suljetaan datepicker kun painetaan tab + shift tai esc. Enterillä datepickerin saa auki/kiinni.
-                         :on-key-down #(do
-                                         (when (or (dom/tab+shift-nappaimet? %) (dom/esc-nappain? %))
-                                           (reset! auki false))
-                                         (when (dom/enter-nappain? %)
-                                           (reset! auki (not @auki))))
-                         :on-blur #(do (when on-blur (on-blur %)) (koske-pvm!) (aseta! false) %)
-                         :id elementin-id}]
+            (tee-ikoni-komponentti input-komponentti @auki)
             (when @auki
               [pvm-valinta/pvm-valintakalenteri {:valitse #(do (reset! auki false)
                                                                (muuta-pvm! (pvm/pvm %))

--- a/src/cljs/harja/ui/pvm.cljs
+++ b/src/cljs/harja/ui/pvm.cljs
@@ -21,10 +21,10 @@
         etaisyys-oikeaan-reunaan (dom/elementin-etaisyys-viewportin-oikeaan-reunaan
                                    (.-parentNode (r/dom-node komponentti)))
         uusi-suunta (if (< etaisyys-alareunaan 250)
-                      (if (< etaisyys-oikeaan-reunaan 200)
+                      (if (< etaisyys-oikeaan-reunaan 100)
                         :ylos-vasen
                         :ylos-oikea)
-                      (if (< etaisyys-oikeaan-reunaan 200)
+                      (if (< etaisyys-oikeaan-reunaan 100)
                         :alas-vasen
                         :alas-oikea))]
     (reset! sijainti-atom uusi-suunta)))

--- a/src/cljs/harja/ui/pvm.cljs
+++ b/src/cljs/harja/ui/pvm.cljs
@@ -258,32 +258,34 @@
       (fn [{:keys [paivamaara valitse luokat valittava?-fn disabled sumeutus-fn placeholder]}]
         (let [kiinni #(reset! % false)
               elementin-id (str (gensym "pvm-pakollinen-input"))]
-          [:div.kalenteri-kontti
-           [:input {:disabled disabled
-                    :type :text
-                    :class (apply conj #{} (filter #(not (nil? %)) (conj luokat (when @auki? "auki"))))
-                    :value (cond
-                             (seq @suora-syotto-sisalto) @suora-syotto-sisalto
-                             (not (nil? paivamaara)) (pvm/pvm paivamaara)
-                             :else "")
-                    :placeholder placeholder
-                    :on-change #(reset! suora-syotto-sisalto (-> % .-target .-value))
-                    :on-click #(reset! auki? true)
-                    :on-focus    #(reset! auki? true)
-                    :on-key-down #(do
-                                    (when (or (dom/tab+shift-nappaimet? %) (dom/esc-nappain? %))
-                                      (kiinni auki?))
-                                    (when (dom/enter-nappain? %)
-                                      (reset! auki? (not @auki?))))
-                    :on-blur     (fn []
-                                   (when (not paivamaara) (kiinni auki?)) ; jos ei ole päivämäärää määritelty, niin valintoja ei voi tehdä. droppari jää auki, kunnes koontilaskun kuukausi klikataan. tällä estetään se tilanne.
-                                   (when sumeutus-fn (sumeutus-fn))
-                                   (when (seq @suora-syotto-sisalto)
-                                     (let [pvm-sisalto (pvm/->pvm @suora-syotto-sisalto)]
-                                       (when (valittava?-fn pvm-sisalto)
-                                         (valitse (pvm/->pvm @suora-syotto-sisalto))))
-                                     (reset! suora-syotto-sisalto "")))
-                    :id elementin-id}]
+          [:div.kalenteri-kontti {:on-click  #(reset! auki? true)}
+           [:div.pvm-ikoni
+            [:input {:disabled disabled
+                     :type :text
+                     :class (apply conj #{} (filter #(not (nil? %)) (conj luokat (when @auki? "auki"))))
+                     :value (cond
+                              (seq @suora-syotto-sisalto) @suora-syotto-sisalto
+                              (not (nil? paivamaara)) (pvm/pvm paivamaara)
+                              :else "")
+                     :placeholder placeholder
+                     :aria-label "päiväys"
+                     :on-change #(reset! suora-syotto-sisalto (-> % .-target .-value))
+                     :on-key-down #(do
+                                     (when (or (dom/tab+shift-nappaimet? %) (dom/esc-nappain? %))
+                                       (kiinni auki?))
+                                     (when (dom/enter-nappain? %)
+                                       (reset! auki? (not @auki?))))
+                     :on-blur     (fn []
+                                    (when (not paivamaara) (kiinni auki?)) ; jos ei ole päivämäärää määritelty, niin valintoja ei voi tehdä. droppari jää auki, kunnes koontilaskun kuukausi klikataan. tällä estetään se tilanne.
+                                    (when sumeutus-fn (sumeutus-fn))
+                                    (when (seq @suora-syotto-sisalto)
+                                      (let [pvm-sisalto (pvm/->pvm @suora-syotto-sisalto)]
+                                        (when (valittava?-fn pvm-sisalto)
+                                          (valitse (pvm/->pvm @suora-syotto-sisalto))))
+                                      (reset! suora-syotto-sisalto "")))
+                     :id elementin-id}]
+            [:span.ikoni-osio
+             (ikonit/calendar)]]
            (when @auki?
              [pvm-valintakalenteri {:valitse       #(do
                                                       (kiinni auki?)

--- a/src/cljs/harja/ui/pvm.cljs
+++ b/src/cljs/harja/ui/pvm.cljs
@@ -194,7 +194,7 @@
                                        (.preventDefault %)
 
                                        (cond
-                                         (and (dom/enter-nappain? %) valittava?)
+                                         (and (or (dom/enter-nappain? %) (dom/valilyonti? %)) valittava?)
                                          (do (valitse paiva) (sulje-kalenteri))
 
                                          (dom/esc-nappain? %)

--- a/src/cljs/harja/ui/pvm.cljs
+++ b/src/cljs/harja/ui/pvm.cljs
@@ -133,7 +133,7 @@
                                 (when (dom/enter-nappain? %)
                                   (.preventDefault %)
                                   (nayta-edellinen-kk))
-                                (when (dom/tab+shift-nappaimet? %)
+                                (when (or (dom/tab+shift-nappaimet? %) (dom/esc-nappain? %))
                                   (.preventDefault %)
                                   (sulje-kalenteri))
                                 nil)}
@@ -152,6 +152,9 @@
                                (when (dom/tab-nappain-ilman-shiftia? %)
                                  (.preventDefault %)
                                  (r/after-render (fn [] (some-> js/document (.getElementById (str "paiva_" fokus-paiva)) .focus))))
+                               (when (dom/esc-nappain? %)
+                                 (.preventDefault %)
+                                 (sulje-kalenteri))
                                nil)}
               (ikonit/livicon-chevron-right)]]
             [:tr {:class tyyli-otsikkorivi}
@@ -193,6 +196,9 @@
                                        (cond
                                          (and (dom/enter-nappain? %) valittava?)
                                          (do (valitse paiva) (sulje-kalenteri))
+
+                                         (dom/esc-nappain? %)
+                                         (sulje-kalenteri)
 
                                          (dom/tab+shift-nappaimet? %)
                                          (r/after-render (fn [] (some-> js/document (.getElementById "seuraava-kk") .focus)))
@@ -238,7 +244,7 @@
                                                            (some-> js/document (.getElementById (if pvm
                                                                                                   (str "paiva_" (t/day pvm))
                                                                                                   (str "paiva_1"))) .focus))))
-                                       (when (dom/tab-nappain-ilman-shiftia? %)
+                                       (when (or (dom/tab-nappain-ilman-shiftia? %) (dom/esc-nappain? %))
                                          (sulje-kalenteri))
                                        nil)}
                    "Tänään"]]]]])))))

--- a/src/cljs/harja/ui/valinnat.cljs
+++ b/src/cljs/harja/ui/valinnat.cljs
@@ -166,6 +166,7 @@
          tyyppi (if (= :pvm-aika (:tyyppi asetukset))
                   :pvm-aika
                   :pvm)
+         elementin-nimi (:elementin-nimi asetukset)
          uusi-aikavali (fn [paa uusi-arvo]
                          {:pre [(contains? #{:alku :loppu} paa)]}
                          (let [uusi-arvo (if (= tyyppi :pvm-aika)
@@ -225,13 +226,15 @@
            [tee-kentta {:tyyppi tyyppi
                         :pakota-suunta aloitusaika-pakota-suunta
                         :validointi validointi
-                        :vayla-tyyli? vayla-tyyli?}
+                        :vayla-tyyli? vayla-tyyli?
+                        :elementin-nimi (when elementin-nimi (str elementin-nimi "-alku"))}
             aikavalin-alku]
            [:div.pvm-valiviiva-wrap [:span.pvm-valiviiva " \u2014 "]]
            [tee-kentta {:tyyppi tyyppi
                         :pakota-suunta paattymisaika-pakota-suunta
                         :validointi validointi
-                        :vayla-tyyli? vayla-tyyli?}
+                        :vayla-tyyli? vayla-tyyli?
+                        :elementin-nimi (when elementin-nimi (str elementin-nimi "-loppu"))}
             aikavalin-loppu]]])))))
 
 (defn numerovali
@@ -344,8 +347,10 @@
      [hoitokauden-kuukausi hoitokauden-kuukaudet valittu-kuukausi-atom valitse-kuukausi-fn (:otsikko kuukausi)])
    (when-let [{:keys [urakan-toimenpideinstassit-atom valittu-toimenpideinstanssi-atom valitse-toimenpide-fn]} toimenpide]
      [urakan-toimenpide urakan-toimenpideinstassit-atom valittu-toimenpideinstanssi-atom valitse-toimenpide-fn])
-   (when-let [{:keys [valittu-aikavali-atom]} aikavali-optiot]
-     [aikavali valittu-aikavali-atom])])
+   (when-let [{:keys [valittu-aikavali-atom elementin-nimi]} aikavali-optiot]
+     (if elementin-nimi
+       [aikavali valittu-aikavali-atom {:elementin-nimi elementin-nimi}]
+       [aikavali valittu-aikavali-atom]))])
 
 (defn vuosi
   ([ensimmainen-vuosi viimeinen-vuosi valittu-vuosi-atom]

--- a/src/cljs/harja/ui/valinnat.cljs
+++ b/src/cljs/harja/ui/valinnat.cljs
@@ -209,8 +209,7 @@
                             (remove-watch valittu-aikavali-atom :aikavali-komponentin-kuuntelija)))
        (fn [_ {:keys [nayta-otsikko? aikavalin-rajoitus luokka
                       aloitusaika-pakota-suunta paattymisaika-pakota-suunta
-                      lomake? otsikko for-teksti validointi vayla-tyyli?
-                      ikoni-sisaan?]}]
+                      lomake? otsikko for-teksti validointi vayla-tyyli?]}]
          (when-not (= aikavalin-rajoitus (:aikavalin-rajoitus @asetukset-atom))
            (swap! asetukset-atom assoc :aikavalin-rajoitus aikavalin-rajoitus))
          [:span {:class (cond
@@ -226,14 +225,12 @@
            [tee-kentta {:tyyppi tyyppi
                         :pakota-suunta aloitusaika-pakota-suunta
                         :validointi validointi
-                        :ikoni-sisaan? ikoni-sisaan?
                         :vayla-tyyli? vayla-tyyli?}
             aikavalin-alku]
            [:div.pvm-valiviiva-wrap [:span.pvm-valiviiva " \u2014 "]]
            [tee-kentta {:tyyppi tyyppi
                         :pakota-suunta paattymisaika-pakota-suunta
                         :validointi validointi
-                        :ikoni-sisaan? ikoni-sisaan?
                         :vayla-tyyli? vayla-tyyli?}
             aikavalin-loppu]]])))))
 
@@ -411,12 +408,12 @@
          alkuaikakentta {:nimi (or (:alkuaika kenttien-nimet) :alkuaika)
                          :otsikko "Alku"
                          ::lomake/col-luokka (when aikavalivalitsin-flex?
-                                               "lomakepalsta-flex-puolikas")
+                                               "lomakepalsta-flex-kokonainen paivays")
                          :tyyppi (if vain-pvm :pvm :pvm-aika)
                          :validoi [[:ei-tyhja "Anna alkuaika"]]}
          loppuaikakentta {:nimi (or (:loppuaika kenttien-nimet) :loppuaika)
                           ::lomake/col-luokka (when aikavalivalitsin-flex?
-                                                "lomakepalsta-flex-puolikas")
+                                                "lomakepalsta-flex-kokonainen paivays")
                           :otsikko "Loppu"
                           :tyyppi (if vain-pvm :pvm :pvm-aika)
                           :validoi [[:ei-tyhja "Anna loppuaika"]

--- a/src/cljs/harja/views/hallinta/integraatioloki.cljs
+++ b/src/cljs/harja/views/hallinta/integraatioloki.cljs
@@ -219,7 +219,7 @@
             (vec (concat [nil] (sort (:integraatiot @tiedot/valittu-jarjestelma))))]])
 
 
-        [valinnat/aikavali tiedot/valittu-aikavali {:tyyppi :pvm-aika}]
+        [valinnat/aikavali tiedot/valittu-aikavali {:tyyppi :pvm-aika :vayla-tyyli? true}]
         [lomake/lomake
          {:otsikko "Vapaaehtoiset tarkemmat hakuehdot"
           :muokkaa! #(reset! tiedot/hakuehdot %)}

--- a/src/cljs/harja/views/ilmoitukset/tieliikenneilmoitukset.cljs
+++ b/src/cljs/harja/views/ilmoitukset/tieliikenneilmoitukset.cljs
@@ -141,7 +141,6 @@
         false
         {:rivi-luokka "grid-column-end-span-2"
          :aikavalivalitsin-flex? true
-         :palstoja 2
          :vayla-tyyli? true})
       (valinnat/aikavalivalitsin "Toimenpiteet aloitettu"
         tiedot/toimenpiteiden-aikavalit

--- a/src/cljs/harja/views/kanavat/urakka/toimenpiteet/kokonaishintaiset.cljs
+++ b/src/cljs/harja/views/kanavat/urakka/toimenpiteet/kokonaishintaiset.cljs
@@ -22,13 +22,13 @@
   (:require-macros
     [harja.makrot :refer [defc]]))
 
-(defn hakuehdot [e! {:keys [huoltokohteet] :as app} kohteet]
+(defn hakuehdot [e! {:keys [huoltokohteet] :as app} kohteet elementin-nimi]
   (let [urakka-map (get-in app [:valinnat :urakka])]
     [valinnat/urakkavalinnat {:urakka urakka-map}
      ^{:key "valinnat"}
      [:div.kanava-suodattimet
       [:div.ryhma
-       [urakka-valinnat/urakan-sopimus-ja-hoitokausi-ja-aikavali-ja-toimenpide urakka-map]]
+       [urakka-valinnat/urakan-sopimus-ja-hoitokausi-ja-aikavali-ja-toimenpide urakka-map elementin-nimi]]
 
       [:div.ryhma
        [valinnat/kanava-kohde
@@ -97,7 +97,7 @@
         (if avattu-toimenpide
           [kokonaishintainen-toimenpidelomake e! app]
           [:div
-           [hakuehdot e! app kohteet]
+           [hakuehdot e! app kohteet "kokonaishintaiset-aikavali"]
            [kokonaishintaiset-toimenpiteet-taulukko e! app]])]]
       [ajax-loader "Ladataan..."])))
 

--- a/src/cljs/harja/views/tilannekuva/tilannekuva.cljs
+++ b/src/cljs/harja/views/tilannekuva/tilannekuva.cljs
@@ -63,6 +63,7 @@
 (defn historiankuvan-aikavalinnat []
   [:div#tk-historiakuvan-aikavalit
    [ui-valinnat/aikavali tiedot/historiakuvan-aikavali {:nayta-otsikko? false
+                                                        :vayla-tyyli? true
                                                         :aikavalin-rajoitus [12 :kuukausi]
                                                         :aloitusaika-pakota-suunta :alas-oikea
                                                         :paattymisaika-pakota-suunta :alas-vasen}]])

--- a/src/cljs/harja/views/urakka/kulut/kulut.cljs
+++ b/src/cljs/harja/views/urakka/kulut/kulut.cljs
@@ -288,6 +288,7 @@
                 [:div.aikavali-valinnat
                  [kentat/tee-kentta {:tyyppi :pvm
                                      :vayla-tyyli? true
+                                     :elementin-nimi "kulut-aikavali-alku"
                                      :on-datepicker-select #(do
                                                               (e! (tiedot/->AsetaHakuAlkuPvm %))
                                                               (when (and % @haun-loppupvm-atom)
@@ -299,6 +300,7 @@
                  [:div.pvm-valiviiva-wrap [:span.pvm-valiviiva " \u2014 "]]
                  [kentat/tee-kentta {:tyyppi :pvm
                                      :vayla-tyyli? true
+                                     :elementin-nimi "kulut-aikavali-loppu"
                                      :on-datepicker-select (fn [loppupvm]
                                                              (do
                                                                (e! (tiedot/->AsetaHakuLoppuPvm loppupvm))
@@ -319,4 +321,3 @@
 (defn kohdistetut-kulut
   []
   [tuck/tuck tila/laskutus-kohdistetut-kulut kohdistetut*])
-

--- a/src/cljs/harja/views/urakka/laadunseuranta/laatupoikkeamat.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/laatupoikkeamat.cljs
@@ -75,7 +75,8 @@
                (e! (laatupoikkeamat/->PaivitaAikavali arvo (:listaus-tyyppi app) urakka-id))))))
        {:otsikko "Aikaväli"
         :luokka #{"label-ja-aikavali " "ei-tiukkaa-leveytta "}
-        :vayla-tyyli? true}]
+        :vayla-tyyli? true
+        :elementin-nimi "laatupoikkeamat-aikavali"}]
 
       ^{:key "urakkatoiminnot"}
       [valinnat/urakkatoiminnot {:urakka urakka-id}

--- a/src/cljs/harja/views/urakka/laadunseuranta/laatupoikkeamat.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/laatupoikkeamat.cljs
@@ -75,7 +75,6 @@
                (e! (laatupoikkeamat/->PaivitaAikavali arvo (:listaus-tyyppi app) urakka-id))))))
        {:otsikko "Aikaväli"
         :luokka #{"label-ja-aikavali " "ei-tiukkaa-leveytta "}
-        :ikoni-sisaan? true
         :vayla-tyyli? true}]
 
       ^{:key "urakkatoiminnot"}

--- a/src/cljs/harja/views/urakka/pot_yhteinen.cljs
+++ b/src/cljs/harja/views/urakka/pot_yhteinen.cljs
@@ -365,10 +365,10 @@
                ::lomake/col-luokka "col-xs-12 col-sm-6 col-md-6 col-lg-6"})
             {:otsikko "Työ aloitettu" :tyyppi :pvm :nimi :aloituspvm
              :label-ja-kentta-samalle-riville? true
-             :ikoni-sisaan? true :vayla-tyyli? true :pakollinen? true
+             :vayla-tyyli? true :pakollinen? true
              ::lomake/col-luokka "col-xs-12"}
             {:otsikko "Kohde valmistunut" :tyyppi :pvm :nimi :valmispvm-kohde :pakollinen? true
-             :label-ja-kentta-samalle-riville? true :ikoni-sisaan? true :vayla-tyyli? true
+             :label-ja-kentta-samalle-riville? true :vayla-tyyli? true
              :validoi [[:pvm-kentan-jalkeen :aloituspvm "Valmistumisen pitää olla työn alkamisen jälkeen"]]
              ::lomake/col-luokka "col-xs-12"}
             (if paikkauskohteet?

--- a/src/cljs/harja/views/urakka/tyomaapaivakirja/paivakirja.cljs
+++ b/src/cljs/harja/views/urakka/tyomaapaivakirja/paivakirja.cljs
@@ -65,7 +65,6 @@
         {:otsikko "Aikaväli"
          :for-teksti "filtteri-aikavali"
          :luokka #{"label-ja-aikavali " "ei-tiukkaa-leveytta "}
-         :ikoni-sisaan? true
          :vayla-tyyli? true
          :aikavalin-rajoitus [6 :kuukausi]}]
 

--- a/src/cljs/harja/views/urakka/valinnat.cljs
+++ b/src/cljs/harja/views/urakka/valinnat.cljs
@@ -253,9 +253,9 @@ valintaoptiot {:sopimus {:valittu-sopimusnumero-atom u/valittu-sopimusnumero
   (fn [ur]
     (valinnat/urakan-valinnat ur (select-keys valintaoptiot [:hoitokausi :aikavali-optiot]))))
 
-(defn urakan-sopimus-ja-hoitokausi-ja-aikavali-ja-toimenpide [ur]
-  (fn [ur]
-    (valinnat/urakan-valinnat ur (select-keys valintaoptiot [:sopimus :hoitokausi :aikavali-optiot :toimenpide]))))
+(defn urakan-sopimus-ja-hoitokausi-ja-aikavali-ja-toimenpide [ur elementin-nimi]
+  (fn [ur elementin-nimi]
+    (valinnat/urakan-valinnat ur (assoc-in (select-keys valintaoptiot [:sopimus :hoitokausi :aikavali-optiot :toimenpide]) [:aikavali-optiot :elementin-nimi] elementin-nimi))))
 
 (defn urakan-sopimus-ja-hoitokausi-ja-aikavali
   ([ur] (urakan-sopimus-ja-hoitokausi-ja-aikavali ur {}))
@@ -266,6 +266,3 @@ valintaoptiot {:sopimus {:valittu-sopimusnumero-atom u/valittu-sopimusnumero
        (merge-with merge
                    (select-keys valintaoptiot [:sopimus :hoitokausi :aikavali-optiot])
                    optiot)))))
-
-
-

--- a/src/cljs/harja/views/urakka/yleiset.cljs
+++ b/src/cljs/harja/views/urakka/yleiset.cljs
@@ -154,7 +154,7 @@
         [:span.takuuaika.inline
          (if (oikeudet/voi-kirjoittaa? oikeudet/urakat-yleiset (:id ur))
            [:span
-            [tee-kentta {:tyyppi :pvm :placeholder "Ei asetettu"}
+            [tee-kentta {:tyyppi :pvm :placeholder "Ei asetettu" :elementin-nimi "takuuaika"}
              (r/wrap (get-in ur [:takuu :loppupvm])
                      #(do (reset! tallennus-kaynnissa (:id ur))
                           (nav/paivita-urakan-tiedot! (:id ur) assoc-in [:takuu :loppupvm] %)

--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohdelomake.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohdelomake.cljs
@@ -311,7 +311,6 @@
        (when voi-muokata?
          {:otsikko "Arv. aloitus"
           :tyyppi :pvm
-          :ikoni-sisaan? true
           :nimi :alkupvm
           :pakollinen? true
           :vayla-tyyli? true
@@ -321,7 +320,6 @@
          {:otsikko "Arv. lopetus"
           :tyyppi :pvm
           :nimi :loppupvm
-          :ikoni-sisaan? true
           :pakollinen? true
           :vayla-tyyli? true
           :pvm-tyhjana #(:alkupvm %)
@@ -519,7 +517,6 @@
          (lomake/rivi
            {:otsikko "Työ alkoi"
             :tyyppi :pvm
-            :ikoni-sisaan? true
             :nimi :pot-tyo-alkoi
             :vayla-tyyli? true
             :virhe? (validointi/nayta-virhe? [:pot-tyo-alkoi] lomake)
@@ -528,7 +525,6 @@
             :pakollinen? true}
            {:otsikko "Työ päättyi"
             :tyyppi :pvm
-            :ikoni-sisaan? true
             :nimi :pot-tyo-paattyi
             :vayla-tyyli? true
             :virhe? (validointi/nayta-virhe? [:pot-tyo-paattyi] lomake)
@@ -543,7 +539,6 @@
            {:otsikko "Valmistumispvm"
             :tyyppi :pvm
             :nimi :pot-valmistumispvm
-            :ikoni-sisaan? true
             :vayla-tyyli? true
             :virhe? (validointi/nayta-virhe? [:pot-valmistumispvm] lomake)
             :virheteksti (validointi/nayta-virhe-teksti [:pot-valmistumispvm] lomake)

--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_yhteinen.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_yhteinen.cljs
@@ -68,7 +68,6 @@
        [valinnat/aikavali aikavali-atom {:otsikko aikavali-otsikko
                                          :for-teksti "filtteri-aikavali"
                                          :luokka #{"label-ja-aikavali " "ei-tiukkaa-leveytta "}
-                                         :ikoni-sisaan? true
                                          :vayla-tyyli? true}]
        [:span {:style {:width "500px"}}
         [:label.alasvedon-otsikko-vayla "Työmenetelmä"]

--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/reikapaikkaukset_apurit.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/reikapaikkaukset_apurit.cljs
@@ -55,7 +55,6 @@
      {:otsikko "Päivämäärä"
       :for-teksti "filtteri-aikavali"
       :luokka #{"label-ja-aikavali " "ei-tiukkaa-leveytta reikapaikkaus-pvm "}
-      :ikoni-sisaan? true
       :vayla-tyyli? true
       :aikavalin-rajoitus [6 :kuukausi]}]]
 
@@ -100,7 +99,6 @@
         :komponentti (fn []
                        [:span {:data-cy "reikapaikkaus-muokkaa-pvm"}
                         [kentat/tee-kentta {:tyyppi :pvm
-                                            :ikoni-sisaan? true
                                             :vayla-tyyli? true}
                          (r/wrap
                            alkuaika


### PR DESCRIPTION
Muutettu kalenterin aukeaminen näppäimistökäytössä niin että se aukeaa vasta painamalla enteriä. Kalenteri-ikoni on muutettu olemaan oletuksena input-kentässä ja siitä johtuen on muutettu asetteluja. Korjattu kalenterin sulkeminen esc-näppäimellä.