### PR TITLE
HARJA-1113 Poista väärä nimi käytöstä myös testiympäristössä

### DIFF
--- a/src/cljc/harja/domain/materiaali.cljc
+++ b/src/cljc/harja/domain/materiaali.cljc
@@ -5,7 +5,6 @@
   [materiaali-nimi]
   (case materiaali-nimi
     "Talvisuola, rakeinen NaCl" 1
-    "Talvisuola NaCl, rakeinen" 1.1
     "Talvisuolaliuos CaCl2" 2
     "Talvisuolaliuos NaCl" 3
     "Hiekoitushiekan suola" 4

--- a/tietokanta/src/main/resources/db/migration/V1_1152__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1152__.sql
@@ -1,0 +1,3 @@
+-- Oikea nimi on Talvisuola, rakeinen NaCl. Tuotannossa virheellistä versiota ei ole, mutta testiympäristössä on.
+DELETE FROM materiaalikoodi WHERE nimi = 'Talvisuola NaCl, rakeinen';
+


### PR DESCRIPTION
Poistetulle materiaalikoodille testiympäristössä tallennetut toteumat siirrettiin jo aiemmin oikealle materiaalikoodille (Talvisuola, rakeinen NaCl).