### PR TITLE
Ota tuck-remoting pois käytöstä

### DIFF
--- a/cypress/e2e/ilmoitukset.cy.js
+++ b/cypress/e2e/ilmoitukset.cy.js
@@ -97,7 +97,9 @@ describe('Ilmoitus-näkymä (Tieliikenne)', function () {
         cy.contains('.ilmoitukset', 'Uusia ilmoituksia haetaan', {timeout: timeout})
     })
 
-    it("Ilmoitusten ws-yhteys aktivoituu", function () {
+    // FIXME: Tämä  testi ei toimi, koska ilmoitusten ws-yhteys on otettu pois testikäytöstä
+    //        Poista tämä testi, jos ws-yhteys poistetaan kokonaan koodipesästä
+    it.skip("Ilmoitusten ws-yhteys aktivoituu", function () {
         cy.get('[data-cy=ilmoitukset-grid] .ajax-loader', { timeout: timeout }).should('not.exist')
         cy.contains('Aktivoi kokeellinen ilmoitusten reaaliaikahaku').click()
         cy.contains('.ilmoitukset', 'Uusien ilmoitusten reaaliaikahaku aktiivinen')

--- a/src/clj/harja/palvelin/main.clj
+++ b/src/clj/harja/palvelin/main.clj
@@ -235,12 +235,13 @@
                        (http-palvelin/luo-http-palvelin http-palvelin
                          kehitysmoodi)
                        [:todennus :metriikka :db])
-      :tuck-remoting (component/using
+      ;; FIXME: Tuck-remoting otettu toistaiseksi pois testikäytöstä kokonaan, koska se ei toimi kunnolla
+      #_#_:tuck-remoting (component/using
                        (tuck-remoting/luo-tuck-remoting (:sahke-headerit asetukset))
                        [:http-palvelin :db])
 
       ;; Tuck-remoting palvelu ilmoitusten välittämiseen WebSocketin yli
-      :ilmoitukset-ws-palvelu (component/using
+      #_#_:ilmoitukset-ws-palvelu (component/using
                                 (ilmoitukset-ws/luo-ilmoitukset-ws)
                                 [:tuck-remoting :db])
 

--- a/src/cljs/harja/views/ilmoitukset/tieliikenneilmoitukset.cljs
+++ b/src/cljs/harja/views/ilmoitukset/tieliikenneilmoitukset.cljs
@@ -331,8 +331,10 @@
       ;; FIXME: Tämä on väliaikainen toiminto WS-kuuntelijan testikäyttöä varten.
       ;;        Käyttäjä voi aktivoida/deaktivoida WS-kuuntelun.
       ;;        Asetus tallennnetaan localstorageen, jolloin valittu asetus on aktiivinen myös refreshin jälkeen.
+      ;; 2024-11-28: Kokeellinen ilmoitusten reaaliaikahaku otettu pois käytöstä, koska se ei toimi kunnolla
+      ;;             Jatketaan testikäyttöä myöhemmin, jos koemme sen tarpeelliseksi tai päätetään ominaisuuden poistosta.
 
-      [:div.margin-top-16
+      #_[:div.margin-top-16
        [kentat/tee-kentta {:tyyppi :checkbox
                            :teksti "Aktivoi kokeellinen ilmoitusten reaaliaikahaku (testikäyttö)"}
         tiedot/ws-kuuntelija-ominaisuus?]]
@@ -487,7 +489,7 @@
                                           (e! (ilmoitukset-ws/->AloitaKuuntelu uudet-valinnat)))))))
 
     ;; FIXME: Tämä on väliaikainen ominaisuus WS-kuuntelijan testikäyttöä varten.
-    (komp/watcher tiedot/ws-kuuntelija-ominaisuus?
+    #_(komp/watcher tiedot/ws-kuuntelija-ominaisuus?
       (fn [_ _ uusi-tila]
         (if (true? uusi-tila)
           (e! (ilmoitukset-ws/->AloitaYhteysJaKuuntelu valinnat))
@@ -518,7 +520,7 @@
                          ;; jotka toimivat suodattimina WebSocketin kautta vastaanotettaville ilmoituksille
                          ;; FIXME: Tämä on väliaikainen ehtolause WS-kuuntelijan testikäyttöä varten.
                          ;;        Otetaan tämä ehtolause pois käytöstä, jos WS-kuuntelu koetaan testeissä vakaaksi.
-                         (when @tiedot/ws-kuuntelija-ominaisuus?
+                         #_(when @tiedot/ws-kuuntelija-ominaisuus?
                            (e! (ilmoitukset-ws/->AloitaYhteysJaKuuntelu valinnat))))
                       #(do
                          (kartta-tiedot/kasittele-infopaneelin-linkit! nil)
@@ -527,7 +529,7 @@
                          ;; Katkaise WS-yhteys ja lopeta samalla uusien ilmoitusten kuuntelu WebSocketin kautta
                          ;; FIXME: Tämä on väliaikainen ehtolause WS-kuuntelijan testikäyttöä varten.
                          ;;        Otetaan tämä ehtolause pois käytöstä, jos WS-kuuntelu koetaan testeissä vakaaksi.
-                         (when @tiedot/ws-kuuntelija-ominaisuus?
+                         #_(when @tiedot/ws-kuuntelija-ominaisuus?
                            (e! (ilmoitukset-ws/->KatkaiseYhteys)))))
     (fn [e! {:keys [valittu-ilmoitus aiheet-ja-tarkenteet] :as ilmoitukset}]
       [:span

--- a/test/clj/harja/palvelin/main_test.clj
+++ b/test/clj/harja/palvelin/main_test.clj
@@ -98,7 +98,7 @@
     :muut-tyot :kulut :toteumat :yllapitototeumat :paallystys :maaramuutokset
     :yllapitokohteet :muokkauslukko :yhteyshenkilot :toimenpidekoodit :pohjavesialueet
     :materiaalit :selainvirhe :valitavoitteet :siltatarkastukset :lampotilat :maksuerat
-    :liitteet :laadunseuranta :tarkastukset :ilmoitukset :tietyoilmoitukset :tuck-remoting :ilmoitukset-ws-palvelu
+    :liitteet :laadunseuranta :tarkastukset :ilmoitukset :tietyoilmoitukset #_:tuck-remoting #_:ilmoitukset-ws-palvelu
     :turvallisuuspoikkeamat :integraatioloki-palvelu :raportit :digiroad :yha :yha-velho :varustetoteuma-ulkoiset :tr-haku
     :geometriapaivitykset :api-yhteysvarmistus :tilannekuva
     :tienakyma :karttakuvat :debug :api-jarjestelmatunnukset :geometria-aineistot
@@ -181,7 +181,7 @@
     :muut-tyot :kulut :toteumat :yllapitototeumat :paallystys :maaramuutokset
     :yllapitokohteet :muokkauslukko :yhteyshenkilot :toimenpidekoodit :pohjavesialueet
     :materiaalit :selainvirhe :valitavoitteet :siltatarkastukset :lampotilat :maksuerat
-    :liitteet :laadunseuranta :tarkastukset :ilmoitukset :tietyoilmoitukset :tuck-remoting :ilmoitukset-ws-palvelu
+    :liitteet :laadunseuranta :tarkastukset :ilmoitukset :tietyoilmoitukset #_:tuck-remoting #_:ilmoitukset-ws-palvelu
     :turvallisuuspoikkeamat :integraatioloki-palvelu :raportit :digiroad :yha :yha-velho :varustetoteuma-ulkoiset :tr-haku
     :geometriapaivitykset :api-yhteysvarmistus :tilannekuva
     :tienakyma :karttakuvat :debug :api-jarjestelmatunnukset :geometria-aineistot


### PR DESCRIPTION
Otetaan testikäytössä ollut ilmoitusten ws-yhteys pois käytöstä, koska sitä ei ole saatu toimimaan luotettavasti.
-> Lopetetaan testikäyttö toistaiseksi.
Palataan asiaan myöhemmin, jos koetaan tarpeelliseksi jälleen edistää ws-yhteyden kautta vastaanotettavia ilmoituksia.