### PR TITLE
HARJA-999 - Estä kartan koko-kontrollien jääminen kartan selitteiden alle

### DIFF
--- a/dev-resources/less/kartta.less
+++ b/dev-resources/less/kartta.less
@@ -57,6 +57,7 @@
 .kartan-koko-kontrollit {
   position: absolute;
   width: 100%;
+  z-index: 902; // Jotta kartan kontrollit eivät jää kartan selitteiden alle
   button:nth-of-type(2) {
     margin-left: 20px;
   }


### PR DESCRIPTION
Hoidetaan asia yksinkertaisesti z-indexiä sopivasti säätämällä.
Jos oikeasti halutaan tukea karttaa todella kapealla näytöllä, täytyy se suunnitella mielestäni kokonaan uusiksi mobiilikäyttöliittymälle.