### PR TITLE
Poista vikaantuva tr-osien-tiedot validointi muukohde osiosta

### DIFF
--- a/src/cljs/harja/views/urakka/yllapitokohteet.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet.cljs
@@ -905,7 +905,8 @@
   (let [vuosi @u/valittu-urakan-vuosi
         ;; Kohteiden päällekkyys keskenään validoidaan taulukko tasolla, jotta rivin päivittämine oikeaksi korjaa
         ;; myös toisilla riveillä olevat validoinnit.
-        validoitu (yllapitokohteet-domain/validoi-muukohde paakohde rivi [] (get @paallystys-tiedot/tr-osien-tiedot (:tr-numero rivi)) vuosi)]
+        ;; 5.12.24: Poistettu tr-osien-tiedot validointi, koska tr-tietoa ei haettu muille kohteille ja mahdollisuus poimia väärä tieto pääkohteelta
+        validoitu (yllapitokohteet-domain/validoi-muukohde paakohde rivi [] nil vuosi)]
     (yllapitokohteet-domain/validoitu-kohde-tekstit (dissoc validoitu :muukohde-paallekkyys) false)))
 
 (defn muukohde-toisten-kanssa-paallekkain-validointi


### PR DESCRIPTION
Disabloi muukohteen-validointi osuudesta tr-osien-tiedot validointi.

Selvitetty että meillä ei nykyisellään haeta tarvittavia tr-osoite tietoja pääkohteen ulkopuolisille alikohteille. Validointi pystyi ennen tätä korjausta menemään pieleen jos urakassa jollakin toisella pääkohteella oli sama tr-numero kuin ulkopuolisella alikohteella.

Tämä korjaus päästää käyttäjän jatkamaan täyttöä ja tilanteen parantamiseen tehdään erillinen tiketti.