### PR TITLE
Pikakorjaus pot-lomakkeen kaatumiselle

### DIFF
--- a/src/cljs/harja/views/urakka/pot2/alusta.cljs
+++ b/src/cljs/harja/views/urakka/pot2/alusta.cljs
@@ -28,6 +28,8 @@
                    [harja.atom :refer [reaction<!]]))
 
 
+(def maksimimaara-validoitaville-riveille 50)
+
 (defn alustan-validointi [rivi taulukko]
   (let [{:keys [tr-osien-tiedot]} (:paallystysilmoitus-lomakedata @paallystys/tila)
         alikohteet (vals @pot2-tiedot/kohdeosat-atom)
@@ -200,7 +202,8 @@
                        (let [{:keys [tr-ajorata]} rivi]
                          (e! (paallystys/->HaeKaistat
                                (select-keys rivi tr/paaluvali-avaimet)
-                               tr-ajorata))))]
+                               tr-ajorata))))
+        rivien-maara (count @alustarivit-atom)]
     [:div.alusta
      (when alustalomake
        [alustalomake-nakyma e! {:alustalomake alustalomake
@@ -230,7 +233,9 @@
        #_#_:on-rivi-blur on-rivi-blur
        ;; Varoitetaan validointivirheistä, mutta ei estetä tallentamista.
        ;; Backendin puolella suoritetaan validointi, kun lomake merkitetään tarkastettavaksi ja tallennetaan.
-       :rivi-varoitus (:rivi validointi)
+       ;; Validointia rajoitettu maksimimaara-validoitaville-riveille huonon suorituskyvyn vuoksi. 
+       :rivi-varoitus (when (<= rivien-maara maksimimaara-validoitaville-riveille)
+                        (:rivi validointi))
        :taulukko-varoitus (:taulukko validointi)
        :tyhja (if (nil? @alustarivit-atom)
                 [ajax-loader "Haetaan alustarivejä..."]

--- a/src/cljs/harja/views/urakka/pot2/paallystekerros.cljs
+++ b/src/cljs/harja/views/urakka/pot2/paallystekerros.cljs
@@ -20,6 +20,7 @@
    [harja.fmt :as fmt]
    [harja.domain.paikkaus :as paikkaus]))
 
+(def maksimimaara-validoitaville-riveille 50)
 
 (defn validoi-paallystekerros
   [rivi taulukko]
@@ -110,7 +111,8 @@
                                   (second data))]
                         (+ acc pituus)))
                     0
-                    @kohdeosat-atom)]
+                    @kohdeosat-atom)
+        rivien-maara (count @kohdeosat-atom)]
     [:div
      [grid/muokkaus-grid
       {:otsikko "Kulutuskerros" :tunniste :kohdeosa-id :rivinumerot? true
@@ -180,7 +182,9 @@
        :virheet-ylos? false
        ;; Varoitetaan validointivirheistä, mutta ei estetä tallentamista.
        ;; Backendin puolella suoritetaan validointi, kun lomake merkitetään tarkastettavaksi ja tallennetaan.
-       :rivi-varoitus (:rivi validointi)
+       ;; Validointia rajoitettu maksimimaara-validoitaville-riveille huonon suorituskyvyn vuoksi. 
+       :rivi-varoitus (when (<= rivien-maara maksimimaara-validoitaville-riveille)
+                        (:rivi validointi))
        :taulukko-varoitus (:taulukko validointi)
        :tyhja (if (nil? @kohdeosat-atom)
                 [ajax-loader "Haetaan kohdeosia..."]


### PR DESCRIPTION
Jarnon kanssa käytiin läpi että mikäli pot-lomakkeella on suuri määrä kohteita mikä aiheuttaa mm. rivejä kopioidessa Harjan kaatumisen voisi rajoittaa vaan että validointi tapahtuu vain pienemmällä määrällä kohteita. 

Kohteet validoidaan yhä serverillä joten validointeja ei kuitenkaan kokonaan poisteta tässä pullarissa.