### PR TITLE
Korjaa failaava testi asettamalla päättely testin tulokseen myös pvm/nyt avulla

### DIFF
--- a/test/clj/harja/palvelin/integraatiot/yha/kohteen_lahetyssanoma_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/yha/kohteen_lahetyssanoma_test.clj
@@ -463,7 +463,7 @@
       (is (= (xml/luetun-xmln-tagin-sisalto kohde :kohdetyotyyppi) ["paallystys"]))
       (is (= (xml/luetun-xmln-tagin-sisalto kohde :nimi) ["Testikohde 1"]))
 
-      (is (= (xml/luetun-xmln-tagin-sisalto kohde :takuupaivamaara) ["2024-12-12"]))
+      (is (= (xml/luetun-xmln-tagin-sisalto kohde :takuupaivamaara) [(tee-pvm-tulos)]))
       (is (= (xml/luetun-xmln-tagin-sisalto kohde :toteutunuthinta) ["4000.4"])))))
 
 


### PR DESCRIPTION
Korjaa failaava testi muodosta-pot-sanoma-kun-urakkasidonta-puuttuu asettamalla päättely testin tulokseen myös pvm/nyt avulla.