### PR TITLE
HARJA-1153 Älä päättele hypyksi, jos ajorata vaihtuu mutta kaista on yhtenäinen

### DIFF
--- a/src/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys.clj
+++ b/src/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys.clj
@@ -243,27 +243,24 @@
     :leveys :pinta_ala :massamenekki :jarjestysnro :pot2p_id
     :velho-lahetyksen-aika :velho-lahetyksen-vastaus :velho-rivi-lahetyksen-tila :rc-prosentti})
 
-(defn- laske-kulutuskerroksen-hypyt
+(defn laske-kulutuskerroksen-hypyt
   "Laskee ja palauttaa kulutuskerroksessa hyppyjen määrän integerinä"
   [data i hypyt]
   (if (> (count data) (dec i))
     (let [rivi (get-in data [i])
           rivi-tie (:tr-numero rivi)
-          rivi-ajorata (:tr-ajorata rivi)
           rivi-aet (:tr-alkuetaisyys rivi)
           rivi-let (:tr-loppuetaisyys rivi)
           rivi-kaista (:tr-kaista rivi)
 
           seuraava-rivi (get-in data [(inc i)])
           seuraava-rivi-tie (:tr-numero seuraava-rivi)
-          seuraava-rivi-ajorata (:tr-ajorata seuraava-rivi)
           seuraava-rivi-aet (:tr-alkuetaisyys seuraava-rivi)
           seuraava-rivi-kaista (:tr-kaista seuraava-rivi)
 
           hyppy-olemassa? (if (and
                                 rivi-aet seuraava-rivi-aet
                                 (= rivi-tie seuraava-rivi-tie)
-                                (= rivi-ajorata seuraava-rivi-ajorata)
                                 (= rivi-kaista seuraava-rivi-kaista)
                                 (> seuraava-rivi-aet rivi-let))
                             true
@@ -280,29 +277,25 @@
    Laitetaan aluksi 50 metriä rajaksi, eli kaikki alle 50 metrin hypyt näytetään fronttiin
    Hyppy tulee tunnistaa kun mennään samalla ajoradalla, tiellä sekä samalla kaistalla. 
    Jos kaista tai tie vaihtuu, silloin tämä ei ole hyppy.
-   Ajorata = Rata jossa on yksi tai usea tie (ajoradalla voi olla esim. moottoritie jossa 2 tietä)
-   Tie = Tie jossa 2 kaistaa
-   Kaista = Tien kaista 
+   Tiellä voi olla yksi (0) tai kaksi ajorataa (1 ja 2)
+   Ajoradalla on vähintään yksi kaista
    Aet = Alkuetäisyys metreinä
    Let = Loppuetäisyys metreinä"
   [y data palautus maara]
   (when (> (count data) (dec y))
     (let [rivi (nth data y nil)
           rivi-tie (:tr-numero rivi)
-          rivi-ajorata (:tr-ajorata rivi)
           rivi-kaista (:tr-kaista rivi)
           rivi-aet (:tr-alkuetaisyys rivi)
           rivi-let (:tr-loppuetaisyys rivi)
 
           edellinen-rivi (nth data (dec y) nil)
           edellinen-rivi-tie (:tr-numero edellinen-rivi)
-          edellinen-rivi-ajorata (:tr-ajorata edellinen-rivi)
           edellinen-rivi-kaista (:tr-kaista edellinen-rivi)
           edellinen-rivi-let (:tr-loppuetaisyys edellinen-rivi)
 
           seuraava-rivi (nth data (inc y) nil)
           seuraava-rivi-tie (:tr-numero seuraava-rivi)
-          seuraava-rivi-ajorata (:tr-ajorata seuraava-rivi)
           seuraava-rivi-kaista (:tr-kaista seuraava-rivi)
           seuraava-rivi-aet (:tr-alkuetaisyys seuraava-rivi)
 
@@ -312,10 +305,8 @@
                    rivi-aet seuraava-rivi-aet
                    rivi-aet edellinen-rivi-let
                    (= rivi-tie seuraava-rivi-tie)
-                   (= rivi-ajorata seuraava-rivi-ajorata)
                    (= rivi-kaista seuraava-rivi-kaista)
                    (= rivi-tie edellinen-rivi-tie)
-                   (= rivi-ajorata edellinen-rivi-ajorata)
                    (= rivi-kaista edellinen-rivi-kaista)
                    (> seuraava-rivi-aet rivi-let)
                    (> rivi-aet edellinen-rivi-let))
@@ -327,7 +318,6 @@
                  (and
                    rivi-aet seuraava-rivi-aet
                    (= rivi-tie seuraava-rivi-tie)
-                   (= rivi-ajorata seuraava-rivi-ajorata)
                    (= rivi-kaista seuraava-rivi-kaista)
                    (> seuraava-rivi-aet rivi-let))
                  (merge rivi {:let-hyppy? true})
@@ -338,7 +328,6 @@
                  (and
                    rivi-aet edellinen-rivi-let
                    (= rivi-tie edellinen-rivi-tie)
-                   (= rivi-ajorata edellinen-rivi-ajorata)
                    (= rivi-kaista edellinen-rivi-kaista)
                    (> rivi-aet edellinen-rivi-let))
                  (merge rivi {:aet-hyppy? true})
@@ -371,13 +360,13 @@
                                                 {:kohdeosa-id (:id kohdeosa)}) pot2-paallystekerroksen-avaimet)]
                         rivi))
                     (:kohdeosat paallystysilmoitus))
-        
-        kohdeosat (vec (sort-by yllapitokohteet-domain/yllapitokohteen-jarjestys kohdeosat))
+        ;; järjestetään kaistoittain hyppyjen tunnistamiseksi
+        kohdeosat (vec (sort-by #(yllapitokohteet-domain/yllapitokohteen-jarjestys % true) kohdeosat))
         ;; Laske hypyt
         hyppyjen-maara (laske-kulutuskerroksen-hypyt kohdeosat 0 0)
         ;; Lisää avaimet riveille joissa hyppy 
         kohdeosat (tunnista-paallystys-hypyt 0 kohdeosat [] hyppyjen-maara)]
-    kohdeosat))
+    (vec (sort-by yllapitokohteet-domain/yllapitokohteen-jarjestys kohdeosat))))
 
 (defn pot2-alusta
   "Kasaa POT2-ilmoituksen tarvitsemaan muotoon alustakerroksen rivit"

--- a/src/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys.clj
+++ b/src/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys.clj
@@ -250,11 +250,13 @@
     (let [rivi (get-in data [i])
           rivi-tie (:tr-numero rivi)
           rivi-aet (:tr-alkuetaisyys rivi)
+          rivi-losa (:tr-loppuosa rivi)
           rivi-let (:tr-loppuetaisyys rivi)
           rivi-kaista (:tr-kaista rivi)
 
           seuraava-rivi (get-in data [(inc i)])
           seuraava-rivi-tie (:tr-numero seuraava-rivi)
+          seuraava-rivi-aosa (:tr-alkuosa seuraava-rivi)
           seuraava-rivi-aet (:tr-alkuetaisyys seuraava-rivi)
           seuraava-rivi-kaista (:tr-kaista seuraava-rivi)
 
@@ -262,7 +264,9 @@
                                 rivi-aet seuraava-rivi-aet
                                 (= rivi-tie seuraava-rivi-tie)
                                 (= rivi-kaista seuraava-rivi-kaista)
-                                (> seuraava-rivi-aet rivi-let))
+                                (= rivi-losa seuraava-rivi-aosa)
+                                ;; jos seur. rivin alku on 1-50 isompi, samalla tieosalla, kyseessä hyppy
+                                (< 0 (- seuraava-rivi-aet rivi-let) pot-domain/hypyn-kynnysarvo-metreina))
                             true
                             false)]
       (if hyppy-olemassa?
@@ -275,10 +279,10 @@
    Palauttaa vectorin kohdeosista joihin lisätty hyppyjen tiedot avaimiin
    Avaimet käsitellään frontissa paallystekerros.cljs missä ne passataan muokkaus.cljs korostusta varten
    Laitetaan aluksi 50 metriä rajaksi, eli kaikki alle 50 metrin hypyt näytetään fronttiin
-   Hyppy tulee tunnistaa kun mennään samalla ajoradalla, tiellä sekä samalla kaistalla. 
-   Jos kaista tai tie vaihtuu, silloin tämä ei ole hyppy.
-   Tiellä voi olla yksi (0) tai kaksi ajorataa (1 ja 2)
-   Ajoradalla on vähintään yksi kaista
+   Hyppy tulee tunnistaa kun mennään samalla tiellä, tienosalla ja kaistalla.
+   Jos tie, tienosa tai kaista vaihtuu, silloin tämä ei ole hyppy.
+   Tiellä voi olla yksi (0) tai kaksi ajorataa (1 ja 2), ja kaista voi jatkua yhtenäisenä vaikka ajoratojen lukumäärä muuttuu.
+   Ajoradalla on vähintään yksi kaista.
    Aet = Alkuetäisyys metreinä
    Let = Loppuetäisyys metreinä"
   [y data palautus maara]
@@ -286,17 +290,21 @@
     (let [rivi (nth data y nil)
           rivi-tie (:tr-numero rivi)
           rivi-kaista (:tr-kaista rivi)
+          rivi-aosa (:tr-alkuosa rivi)
           rivi-aet (:tr-alkuetaisyys rivi)
+          rivi-losa (:tr-loppuosa rivi)
           rivi-let (:tr-loppuetaisyys rivi)
 
           edellinen-rivi (nth data (dec y) nil)
           edellinen-rivi-tie (:tr-numero edellinen-rivi)
           edellinen-rivi-kaista (:tr-kaista edellinen-rivi)
+          edellinen-rivi-losa (:tr-loppuosa edellinen-rivi)
           edellinen-rivi-let (:tr-loppuetaisyys edellinen-rivi)
 
           seuraava-rivi (nth data (inc y) nil)
           seuraava-rivi-tie (:tr-numero seuraava-rivi)
           seuraava-rivi-kaista (:tr-kaista seuraava-rivi)
+          seuraava-rivi-aosa (:tr-alkuosa seuraava-rivi)
           seuraava-rivi-aet (:tr-alkuetaisyys seuraava-rivi)
 
           rivi (cond
@@ -308,8 +316,10 @@
                    (= rivi-kaista seuraava-rivi-kaista)
                    (= rivi-tie edellinen-rivi-tie)
                    (= rivi-kaista edellinen-rivi-kaista)
-                   (> seuraava-rivi-aet rivi-let)
-                   (> rivi-aet edellinen-rivi-let))
+                   (= seuraava-rivi-aosa rivi-losa)
+                   (< 0 (- seuraava-rivi-aet rivi-let) pot-domain/hypyn-kynnysarvo-metreina)
+                   (= edellinen-rivi-losa rivi-aosa)
+                   (< 0 (- rivi-aet edellinen-rivi-let) pot-domain/hypyn-kynnysarvo-metreina))
                  (merge rivi {:aet-hyppy? true :let-hyppy? true})
 
                  ;; Seuraava ja tämä rivi olemassa sekä molemmilla sama tie&ajorata&kaista
@@ -319,7 +329,8 @@
                    rivi-aet seuraava-rivi-aet
                    (= rivi-tie seuraava-rivi-tie)
                    (= rivi-kaista seuraava-rivi-kaista)
-                   (> seuraava-rivi-aet rivi-let))
+                   (= seuraava-rivi-aosa rivi-losa)
+                   (< 0 (- seuraava-rivi-aet rivi-let) pot-domain/hypyn-kynnysarvo-metreina))
                  (merge rivi {:let-hyppy? true})
 
                  ;; Tämä rivi ja edellinen rivi olemassa sekä molemmilla sama tie&ajorata&kaista
@@ -329,7 +340,8 @@
                    rivi-aet edellinen-rivi-let
                    (= rivi-tie edellinen-rivi-tie)
                    (= rivi-kaista edellinen-rivi-kaista)
-                   (> rivi-aet edellinen-rivi-let))
+                   (= edellinen-rivi-losa rivi-aosa)
+                   (< 0 (- rivi-aet edellinen-rivi-let) pot-domain/hypyn-kynnysarvo-metreina))
                  (merge rivi {:aet-hyppy? true})
 
                  ;; Ei hyppyjä

--- a/src/cljc/harja/domain/paallystysilmoitus.cljc
+++ b/src/cljc/harja/domain/paallystysilmoitus.cljc
@@ -358,3 +358,7 @@
 
 ;; POT2 lomaketta aletaan käyttää kesällä 2021 ja siitä eteenpäin.
 (def pot2-vuodesta-eteenpain 2021)
+
+;; jos kaista ei ole yhtenäinen ja tyhjä väli on 0 < hyppy < kynnysarvo, merkataan se hypyksi
+;; konsepti liittyy päällystysilmoitukseen missä on tarve visualisoida hypyt
+(def hypyn-kynnysarvo-metreina 50)

--- a/src/cljc/harja/domain/yllapitokohde.cljc
+++ b/src/cljc/harja/domain/yllapitokohde.cljc
@@ -90,10 +90,10 @@ yllapitoluokkanimi->numero
    (if niputa-kaistat?
      ((juxt #(kohdenumero-str->kohdenumero-vec (:kohdenumero %))
         :tie :tr-numero :tienumero
+        :kaista :tr-kaista
         :aosa :tr-alkuosa :aet
         :tr-alkuetaisyys :ajr
-        :tr-ajorata :ajorata
-        :kaista :tr-kaista) kohde)
+        :tr-ajorata :ajorata) kohde)
 
      ((juxt #(kohdenumero-str->kohdenumero-vec (:kohdenumero %))
         :tie :tr-numero :tienumero

--- a/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
+++ b/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
@@ -944,7 +944,7 @@
                              (assoc-in [:paallystekerros 1 :tr-alkuosa] 1)
                              (assoc-in [:paallystekerros 1 :tr-loppuosa] 1)
                              (assoc-in [:paallystekerros 1 :tr-loppuetaisyys] 3827)
-                             (assoc-in [:paallystekerros 1 :tr-alkuetaisyys] (+ aet 100))
+                             (assoc-in [:paallystekerros 1 :tr-alkuetaisyys] (+ aet (- pot-domain/hypyn-kynnysarvo-metreina 1)))
                              (assoc-in [:paallystekerros 1 :tr-numero] 20)
                              (assoc-in [:paallystekerros 1 :tr-kaista] 12)
                              (assoc-in [:paallystekerros 1 :tr-ajorata] 1))
@@ -1877,17 +1877,41 @@
            (paallystys/lisaa-paallystysilmoitukseen-kohdeosien-idt paallystysilmoitus kohdeosat))
         "Kohdeosille on lisätty id:t oikein, kun ajorataa ja kaistaa ei ole")))
 
-{:kohdeosa-id 36683, :tr-kaista 11, :leveys 4.30M, :kokonaismassamaara 1441.2M, :velho-lahetyksen-aika nil, :tr-ajorata 0, :pinta_ala 14362M, :tr-loppuosa 215, :jarjestysnro 1,
- :velho-lahetyksen-vastaus nil, :tr-alkuosa 214, :massamenekki 100.3M, :tr-loppuetaisyys 1270,
- :nimi nil, :rc-prosentti nil, :materiaali 7273, :velho-rivi-lahetyksen-tila "ei-lahetetty", :tr-alkuetaisyys 918, :piennar false, :tr-numero 3, :toimenpide 12, :pot2p_id 24963}
-
+;; huom. hyppyjä tarkasteltaessa on välttämätöntä järjestää rivit kaistoittain
+;; ao. testidatassa se on tehty käsin, palvelu tekee tämän toki itsestään
+;; alla testataan vain funktiota joten tehdään sortti sitä ennen käsin
 (def testidata-hypyton-mutta-ajorata-vaihtuu
   [{:kohdeosa-id 36683, :tr-numero 3, :tr-ajorata 0, :tr-kaista 11, :tr-alkuosa 214, :tr-alkuetaisyys 918, :tr-loppuosa 215, :tr-loppuetaisyys 1270}
-   {:kohdeosa-id 36686, :tr-numero 3, :tr-ajorata 0, :tr-kaista 21, :tr-alkuosa 214, :tr-alkuetaisyys 918, :tr-loppuosa 215, :tr-loppuetaisyys 1270}
    {:kohdeosa-id 36684, :tr-numero 3, :tr-ajorata 1, :tr-kaista 11, :tr-alkuosa 215, :tr-alkuetaisyys 1270, :tr-loppuosa 215, :tr-loppuetaisyys 3083}
-   {:kohdeosa-id 36687, :tr-numero 3, :tr-ajorata 2, :tr-kaista 21, :tr-alkuosa 215, :tr-alkuetaisyys 1270, :tr-loppuosa 215, :tr-loppuetaisyys 3083}
    {:kohdeosa-id 36685, :tr-numero 3, :tr-ajorata 0, :tr-kaista 11, :tr-alkuosa 215, :tr-alkuetaisyys 3083, :tr-loppuosa 215, :tr-loppuetaisyys 7735}
+   {:kohdeosa-id 36686, :tr-numero 3, :tr-ajorata 0, :tr-kaista 21, :tr-alkuosa 214, :tr-alkuetaisyys 918, :tr-loppuosa 215, :tr-loppuetaisyys 1270}
+   {:kohdeosa-id 36687, :tr-numero 3, :tr-ajorata 2, :tr-kaista 21, :tr-alkuosa 215, :tr-alkuetaisyys 1270, :tr-loppuosa 215, :tr-loppuetaisyys 3083}
    {:kohdeosa-id 36688, :tr-numero 3, :tr-ajorata 0, :tr-kaista 21, :tr-alkuosa 215, :tr-alkuetaisyys 3083, :tr-loppuosa 215, :tr-loppuetaisyys 7735}])
+
+(def testidata-hypyllinen-ja-ajorata-vaihtuu
+  [{:kohdeosa-id 36683, :tr-numero 3, :tr-ajorata 0, :tr-kaista 11, :tr-alkuosa 214, :tr-alkuetaisyys 918, :tr-loppuosa 215, :tr-loppuetaisyys 1270}
+   {:kohdeosa-id 36684, :tr-numero 3, :tr-ajorata 1, :tr-kaista 11, :tr-alkuosa 215, :tr-alkuetaisyys 1272, :tr-loppuosa 215, :tr-loppuetaisyys 3083}
+   {:kohdeosa-id 36685, :tr-numero 3, :tr-ajorata 0, :tr-kaista 11, :tr-alkuosa 215, :tr-alkuetaisyys 3083, :tr-loppuosa 215, :tr-loppuetaisyys 7735}
+   {:kohdeosa-id 36686, :tr-numero 3, :tr-ajorata 0, :tr-kaista 21, :tr-alkuosa 214, :tr-alkuetaisyys 918, :tr-loppuosa 215, :tr-loppuetaisyys 1270}
+   {:kohdeosa-id 36687, :tr-numero 3, :tr-ajorata 2, :tr-kaista 21, :tr-alkuosa 215, :tr-alkuetaisyys 1272, :tr-loppuosa 215, :tr-loppuetaisyys 3083}
+   {:kohdeosa-id 36688, :tr-numero 3, :tr-ajorata 0, :tr-kaista 21, :tr-alkuosa 215, :tr-alkuetaisyys 3083, :tr-loppuosa 215, :tr-loppuetaisyys 7735}])
+
+(def testidata-hypyllinen-ja-alle-kynnysarvon
+  [{:kohdeosa-id 36683, :tr-numero 3, :tr-ajorata 0, :tr-kaista 11, :tr-alkuosa 214, :tr-alkuetaisyys 918, :tr-loppuosa 215, :tr-loppuetaisyys 1270}
+   {:kohdeosa-id 36684, :tr-numero 3, :tr-ajorata 1, :tr-kaista 11, :tr-alkuosa 215, :tr-alkuetaisyys (+ (- pot-domain/hypyn-kynnysarvo-metreina 1) 1270), :tr-loppuosa 215, :tr-loppuetaisyys 3083}
+   {:kohdeosa-id 36685, :tr-numero 3, :tr-ajorata 0, :tr-kaista 11, :tr-alkuosa 215, :tr-alkuetaisyys 3083, :tr-loppuosa 215, :tr-loppuetaisyys 7735}])
+
+(def testidata-hypyllinen-mutta-yli-kynnysarvon-joten-ei-huomioida
+  [{:kohdeosa-id 36683, :tr-numero 3, :tr-ajorata 0, :tr-kaista 11, :tr-alkuosa 214, :tr-alkuetaisyys 918, :tr-loppuosa 215, :tr-loppuetaisyys 1270}
+   {:kohdeosa-id 36684, :tr-numero 3, :tr-ajorata 1, :tr-kaista 11, :tr-alkuosa 215, :tr-alkuetaisyys (+ pot-domain/hypyn-kynnysarvo-metreina 1272), :tr-loppuosa 215, :tr-loppuetaisyys 3083}
+   {:kohdeosa-id 36685, :tr-numero 3, :tr-ajorata 0, :tr-kaista 11, :tr-alkuosa 215, :tr-alkuetaisyys 3083, :tr-loppuosa 215, :tr-loppuetaisyys 7735}])
+
+(def testidata-hypyton-tienosa-vaihtuu
+  [{:kohdeosa-id 36683, :tr-numero 3, :tr-ajorata 0, :tr-kaista 11, :tr-alkuosa 214, :tr-alkuetaisyys 918, :tr-loppuosa 215, :tr-loppuetaisyys 1270}
+   {:kohdeosa-id 36686, :tr-numero 3, :tr-ajorata 0, :tr-kaista 21, :tr-alkuosa 214, :tr-alkuetaisyys 918, :tr-loppuosa 215, :tr-loppuetaisyys 1270}
+   ;; tässä keinotekoisesti muutetaan tien osaa hyvin paljon, tämä ei ole hyppy vaan selkeästi toisistaan erillään olevat alikohteet
+   {:kohdeosa-id 36684, :tr-numero 3, :tr-ajorata 0, :tr-kaista 11, :tr-alkuosa 218, :tr-alkuetaisyys 1272, :tr-loppuosa 215, :tr-loppuetaisyys 3083}
+   {:kohdeosa-id 36685, :tr-numero 3, :tr-ajorata 0, :tr-kaista 21, :tr-alkuosa 218, :tr-alkuetaisyys 1272, :tr-loppuosa 215, :tr-loppuetaisyys 3083}])
 
 ;; joskus tiestöllä ajorata voi muuttua esim 0 --> 1, ja kaista pysyy samana, esim 11, ja taas palataan takaisin ajoradalle 0.
 ;; tällaisessa tilanteessa jos päällyste on kaistalle jatkuva, ei tule raportoida hyppyä. Tehdään erillinen testi tälle, koska
@@ -1895,3 +1919,20 @@
 (deftest ajaradan-muutos-ei-tarkoita-hyppya-test
   (let [hyppyjen-lkm (paallystys/laske-kulutuskerroksen-hypyt testidata-hypyton-mutta-ajorata-vaihtuu 0 0)]
     (is (= 0 hyppyjen-lkm) "Ei hyppyjä")))
+
+(deftest hyppy-loytyy
+  (let [hyppyjen-lkm (paallystys/laske-kulutuskerroksen-hypyt testidata-hypyllinen-ja-ajorata-vaihtuu 0 0)]
+    (is (= 2 hyppyjen-lkm) "2 hyppyä")))
+
+(deftest hyppy-on-ja-alle-kynnysarvon
+  (let [hyppyjen-lkm (paallystys/laske-kulutuskerroksen-hypyt testidata-hypyllinen-ja-alle-kynnysarvon 0 0)]
+    (is (= 1 hyppyjen-lkm) "Hyppy")))
+
+(deftest hyppya-ei-ole-koska-etaisyys-yli-kynnysarvon
+  (let [hyppyjen-lkm (paallystys/laske-kulutuskerroksen-hypyt testidata-hypyllinen-mutta-yli-kynnysarvon-joten-ei-huomioida 0 0)]
+    (is (= 0 hyppyjen-lkm) "ei hyppyä")))
+
+(deftest hyppya-ei-ole-koska-tienosa-vaihtuu
+  (let [hyppyjen-lkm (paallystys/laske-kulutuskerroksen-hypyt testidata-hypyton-tienosa-vaihtuu 0 0)]
+    (is (= 0 hyppyjen-lkm) "ei hyppyä")))
+

--- a/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
+++ b/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
@@ -1876,3 +1876,22 @@
                                           :tr-numero 20}]}}
            (paallystys/lisaa-paallystysilmoitukseen-kohdeosien-idt paallystysilmoitus kohdeosat))
         "Kohdeosille on lisätty id:t oikein, kun ajorataa ja kaistaa ei ole")))
+
+{:kohdeosa-id 36683, :tr-kaista 11, :leveys 4.30M, :kokonaismassamaara 1441.2M, :velho-lahetyksen-aika nil, :tr-ajorata 0, :pinta_ala 14362M, :tr-loppuosa 215, :jarjestysnro 1,
+ :velho-lahetyksen-vastaus nil, :tr-alkuosa 214, :massamenekki 100.3M, :tr-loppuetaisyys 1270,
+ :nimi nil, :rc-prosentti nil, :materiaali 7273, :velho-rivi-lahetyksen-tila "ei-lahetetty", :tr-alkuetaisyys 918, :piennar false, :tr-numero 3, :toimenpide 12, :pot2p_id 24963}
+
+(def testidata-hypyton-mutta-ajorata-vaihtuu
+  [{:kohdeosa-id 36683, :tr-numero 3, :tr-ajorata 0, :tr-kaista 11, :tr-alkuosa 214, :tr-alkuetaisyys 918, :tr-loppuosa 215, :tr-loppuetaisyys 1270}
+   {:kohdeosa-id 36686, :tr-numero 3, :tr-ajorata 0, :tr-kaista 21, :tr-alkuosa 214, :tr-alkuetaisyys 918, :tr-loppuosa 215, :tr-loppuetaisyys 1270}
+   {:kohdeosa-id 36684, :tr-numero 3, :tr-ajorata 1, :tr-kaista 11, :tr-alkuosa 215, :tr-alkuetaisyys 1270, :tr-loppuosa 215, :tr-loppuetaisyys 3083}
+   {:kohdeosa-id 36687, :tr-numero 3, :tr-ajorata 2, :tr-kaista 21, :tr-alkuosa 215, :tr-alkuetaisyys 1270, :tr-loppuosa 215, :tr-loppuetaisyys 3083}
+   {:kohdeosa-id 36685, :tr-numero 3, :tr-ajorata 0, :tr-kaista 11, :tr-alkuosa 215, :tr-alkuetaisyys 3083, :tr-loppuosa 215, :tr-loppuetaisyys 7735}
+   {:kohdeosa-id 36688, :tr-numero 3, :tr-ajorata 0, :tr-kaista 21, :tr-alkuosa 215, :tr-alkuetaisyys 3083, :tr-loppuosa 215, :tr-loppuetaisyys 7735}])
+
+;; joskus tiestöllä ajorata voi muuttua esim 0 --> 1, ja kaista pysyy samana, esim 11, ja taas palataan takaisin ajoradalle 0.
+;; tällaisessa tilanteessa jos päällyste on kaistalle jatkuva, ei tule raportoida hyppyä. Tehdään erillinen testi tälle, koska
+;; toimintaa jouduttiin tältä osin korjaamaan HARJA-1153 myötä
+(deftest ajaradan-muutos-ei-tarkoita-hyppya-test
+  (let [hyppyjen-lkm (paallystys/laske-kulutuskerroksen-hypyt testidata-hypyton-mutta-ajorata-vaihtuu 0 0)]
+    (is (= 0 hyppyjen-lkm) "Ei hyppyjä")))


### PR DESCRIPTION
HARJA-1153 Ylläpitokohteelle näytettiin virheellisesti hyppyä jos välissä on esim. ohituskaista ja ajoratatieto hetkeksi muuttuu, vaikka kaista on yhtenäisesti päällystetty