### PR TITLE
Viimeistele POT-tiedot kojelautaan PR

### DIFF
--- a/src/clj/harja/kyselyt/kojelauta.sql
+++ b/src/clj/harja/kyselyt/kojelauta.sql
@@ -58,11 +58,14 @@ SELECT u.id,
        COUNT(*) FILTER (WHERE y.lahetetty IS NOT NULL AND pot2.tila IN ('valmis', 'lukittu')
            AND y.lahetys_onnistunut IS TRUE) AS lahetetty_onnistuneesti,
        COUNT(*) FILTER (WHERE y.lahetetty IS NOT NULL AND pot2.tila IN ('valmis', 'lukittu')
+           AND y.lahetysvirhe IS NOT NULL
            AND y.lahetys_onnistunut IS FALSE) AS epaonnistuneet_lahetetyt,
        COUNT(*) FILTER (WHERE pot2.tila IN ('valmis', 'lukittu') AND y.lahetetty IS NULL) AS valmiit_ei_lahetetty,
        COUNT(*) FILTER (WHERE y.id IS NOT NULL AND NOT exists (select id from paallystysilmoitus WHERE paallystyskohde = y.id)) AS aloittamatta,
-       (SELECT array_agg(ROW(y.id::TEXT, y.kohdenumero::TEXT, y.tunnus::TEXT, y.nimi::TEXT)) FROM yllapitokohde y
-        WHERE y.lahetetty IS NOT NULL AND y.lahetysvirhe IS NOT NULL
+       (SELECT array_agg(ROW(y.id::TEXT, y.kohdenumero::TEXT, y.tunnus::TEXT, y.nimi::TEXT, REPLACE(REPLACE(y.lahetysvirhe, ',', ';'), '"', '')::TEXT)) FROM yllapitokohde y
+        WHERE y.lahetetty IS NOT NULL
+          AND y.lahetysvirhe IS NOT NULL
+          AND y.lahetys_onnistunut IS FALSE
           AND y.vuodet @> ARRAY[:vuosi]::INTEGER[] AND y.poistettu IS FALSE AND y.urakka = u.id) AS virheelliset_kohteet
 FROM urakka u
          JOIN organisaatio o ON u.hallintayksikko = o.id

--- a/src/clj/harja/palvelin/palvelut/urakkatilanne/kojelauta.clj
+++ b/src/clj/harja/palvelin/palvelut/urakkatilanne/kojelauta.clj
@@ -47,7 +47,12 @@
                            (update :virheelliset_kohteet
                              (fn [kohteet]
                                (mapv
-                                 #(konv/pgobject->map % :id :long :kohdenumero :string :tunnus :string :kohdenimi :string)
+                                 #(konv/pgobject->map %
+                                    :id :long
+                                    :kohdenumero :string
+                                    :tunnus :string
+                                    :kohdenimi :string
+                                    :lahetysvirhe :string)
                                  (konv/pgarray->vector kohteet))))))
                    (q/hae-paallystysurakat-kojelautaan db (set/rename-keys params {:hoitokauden_alkuvuosi :vuosi}))))]
     urakat))

--- a/src/cljs/harja/tiedot/urakkatilanne/kojelauta.cljs
+++ b/src/cljs/harja/tiedot/urakkatilanne/kojelauta.cljs
@@ -73,7 +73,7 @@
         epaonnistuneet-lkm (reduce + 0 (map :epaonnistuneet_lahetetyt urakat))
         epaonnistuneet-yhteenveto (when-not (empty? urakat) [:span.epaonnistuneet_lahetetyt
                                                              [yleiset/tietoja {:class "body-text"}
-                                                              "Epäonnistuneet: " (str epaonnistuneet-lkm " (" (fmt/prosentti-opt (math/osuus-prosentteina epaonnistuneet-lkm kohteiden-lukumaara) 0) ")")]])]
+                                                              "Epäonnis\u00ADtuneet: " (str epaonnistuneet-lkm " (" (fmt/prosentti-opt (math/osuus-prosentteina epaonnistuneet-lkm kohteiden-lukumaara) 0) ")")]])]
     epaonnistuneet-yhteenveto))
 
 (defn valmiit-ei-lahetetty-yhteenveto
@@ -93,15 +93,6 @@
                                                           [yleiset/tietoja {:class "body-text"}
                                                            "Aloittamatta: " (str aloittamatta-lkm " (" (fmt/prosentti-opt (math/osuus-prosentteina aloittamatta-lkm kohteiden-lukumaara) 0) ")")]])]
     aloittamatta-yhteenveto))
-
-(defn virheelliset-yhteenveto
-  [urakat]
-  (let [kohteiden-lukumaara (reduce + 0 (map :yllapitokohteiden_lkm urakat))
-        virheelliset-lkm (count (filter not-empty (map :virheelliset_kohteet urakat)))
-        virheelliset-yhteenveto (when-not (empty? urakat) [:span.virheelliset
-                                                          [yleiset/tietoja {:class "body-text"}
-                                                           "Virheelliset: " (str virheelliset-lkm " (" (fmt/prosentti-opt (math/osuus-prosentteina virheelliset-lkm kohteiden-lukumaara) 0) ")")]])]
-    virheelliset-yhteenveto))
 
 (defn poikkeusten-yhteenveto
   [urakat]

--- a/src/cljs/harja/views/urakkatilanne/kojelauta.cljs
+++ b/src/cljs/harja/views/urakkatilanne/kojelauta.cljs
@@ -195,16 +195,18 @@
 
 (defn virheelliset-tila-sarake
   [rivi]
-  (if (empty? (:virheelliset_kohteet rivi))
-    (str "0")
+  (for [kohde (:virheelliset_kohteet rivi)]
+    ^{:key (:id kohde)}
     [yleiset/wrap-if true
-     [yleiset/tooltip {} :% "Siirry kohteeseen"]
-     (for [kohde (:virheelliset_kohteet rivi)]
-       ^{:key (:id kohde)}
-       [yleiset/linkki (pot-yhteinen/paallystyskohteen-fmt kohde)
-        #(siirtymat/avaa-paallystysilmoitus! {:paallystyskohde-id (:id kohde)
-                                              :kohteen-urakka-id (:id rivi)})
-        {:block? true}])]))
+     [yleiset/tooltip {} :%
+      [:div
+       [:p "Siirry päällystys\u00ADilmoitukseen."]
+       (when (:lahetysvirhe kohde)
+         [:p "Virhe: " (:lahetysvirhe kohde)])]]
+     [yleiset/linkki (pot-yhteinen/paallystyskohteen-fmt kohde)
+      #(siirtymat/avaa-paallystysilmoitus! {:paallystyskohde-id (:id kohde)
+                                            :kohteen-urakka-id (:id rivi)})
+      {:block? true}]]))
 
 (defn taulukko-paallystysurakat [e! {:keys [urakat haku-kaynnissa?]}]
   [grid/grid
@@ -219,18 +221,17 @@
                              lahetetty (tiedot/lahetetyt-yhteenveto urakat)
                              valmiit-ei-lahetetty (tiedot/valmiit-ei-lahetetty-yhteenveto urakat)
                              epaonnistuneet-lahetetty (tiedot/epaonnistuneet-lahetetyt-yhteenveto urakat)
-                             aloittamatta (tiedot/aloittamatta-yhteenveto urakat)
-                             virheelliset (tiedot/virheelliset-yhteenveto urakat)]
+                             aloittamatta (tiedot/aloittamatta-yhteenveto urakat)]
                          (when-not (empty? urakat)
                            [{:teksti "Yhteensä" :luokka "lihavoitu"}
-                            {:teksti (str (count urakat) " kpl urakoita") :luokka "lihavoitu"}
+                            {:teksti (str (count urakat) " urak\u00ADkaa") :luokka "lihavoitu"}
                             {:teksti yhteenveto :luokka "lihavoitu"}
+                            {:teksti aloittamatta :luokka "lihavoitu"}
+                            {:teksti valmiit-ei-lahetetty :luokka "lihavoitu"}
                             {:teksti valmiit-kohteet :luokka "lihavoitu"}
                             {:teksti lahetetty :luokka "lihavoitu"}
-                            {:teksti valmiit-ei-lahetetty :luokka "lihavoitu"}
                             {:teksti epaonnistuneet-lahetetty :luokka "lihavoitu"}
-                            {:teksti aloittamatta :luokka "lihavoitu"}
-                            {:teksti virheelliset :luokka "lihavoitu"}])))}
+                            {:teksti ""}])))}
    [{:otsikko "Urakka"
      :tyyppi :string
      :nimi :nimi
@@ -246,6 +247,16 @@
      :nimi :yllapitokohteiden_lkm :leveys 4
      :tyyppi :positiivinen-numero :kokonaisluku? true
      :tasaa :oikea}
+    {:otsikko "Aloittamatta"
+     :muokattava? (constantly false)
+     :nimi :aloittamatta :leveys 6
+     :tyyppi :positiivinen-numero :kokonaisluku? true
+     :tasaa :oikea}
+    {:otsikko "Valmiit, ei vielä lähetetty"
+     :muokattava? (constantly false)
+     :nimi :valmiit_ei_lahetetty :leveys 6
+     :tyyppi :positiivinen-numero :kokonaisluku? true
+     :tasaa :oikea}
     {:otsikko "Valmis/hyväksytty"
      :muokattava? (constantly false)
      :nimi :valmis_hyvaksytty :leveys 6
@@ -256,22 +267,12 @@
      :nimi :lahetetty_onnistuneesti :leveys 6
      :tyyppi :positiivinen-numero :kokonaisluku? true
      :tasaa :oikea}
-    {:otsikko "Valmiit, ei vielä lähetetty"
-     :muokattava? (constantly false)
-     :nimi :valmiit_ei_lahetetty :leveys 6
-     :tyyppi :positiivinen-numero :kokonaisluku? true
-     :tasaa :oikea}
-    {:otsikko "Epäonnistuneet YHA-lähetykset"
+    {:otsikko "Epäonnistu\u00ADneet YHA-lähetykset"
      :muokattava? (constantly false)
      :nimi :epaonnistuneet_lahetetyt :leveys 6
      :tyyppi :positiivinen-numero :kokonaisluku? true
      :tasaa :oikea}
-    {:otsikko "Aloittamatta"
-     :muokattava? (constantly false)
-     :nimi :aloittamatta :leveys 6
-     :tyyppi :positiivinen-numero :kokonaisluku? true
-     :tasaa :oikea}
-    {:otsikko "Lähetys\u00ADvirheet"
+    {:otsikko "Kohteet, joissa lähetys\u00ADvirhe"
      :muokattava? (constantly false)
      :nimi :virheelliset_kohteet :leveys 6
      :tyyppi :komponentti

--- a/test/clj/harja/palvelin/palvelut/urakkatilanne/kojelauta_test.clj
+++ b/test/clj/harja/palvelin/palvelut/urakkatilanne/kojelauta_test.clj
@@ -340,20 +340,34 @@
                                                                                 :urakka-idt [urakka-id]
                                                                                 :ely-idt #{}}))
 
-        _ (u (format "UPDATE yllapitokohde SET lahetetty = NOW(), lahetysvirhe = 'paha virhe' WHERE id = %s;" kohde-id))
+        _ (u (format "UPDATE yllapitokohde SET lahetetty = NOW(), lahetysvirhe = 'paha virhe', lahetys_onnistunut = FALSE WHERE id = %s;" kohde-id))
         vastaus-lahetys-epaonnistuu (first
+                                      (kutsu-palvelua (:http-palvelin jarjestelma)
+                                        :hae-urakat-kojelautaan +kayttaja-jvh+ {:urakkatyyppi :paallystys
+                                                                                :hoitokauden-alkuvuosi 2022
+                                                                                :urakka-idt [urakka-id]
+                                                                                :ely-idt #{}}))
+        kohteen-odotettu-virhe {:kohdenimi    "Tärkeä kohde mt20 2022"
+                                :kohdenumero  "L42"
+                                :lahetysvirhe "paha virhe"
+                                :tunnus       "B"}
+        ;; merkataan vielä lähetys onnistuneeksi ja assertataan niiden määrä
+        _ (u (format "UPDATE yllapitokohde SET lahetetty = NOW(), lahetysvirhe = null, lahetys_onnistunut = TRUE WHERE id = %s;" kohde-id))
+        vastaus-lahetys-onnistuu (first
                                       (kutsu-palvelua (:http-palvelin jarjestelma)
                                         :hae-urakat-kojelautaan +kayttaja-jvh+ {:urakkatyyppi :paallystys
                                                                                 :hoitokauden-alkuvuosi 2022
                                                                                 :urakka-idt [urakka-id]
                                                                                 :ely-idt #{}}))]
     (is (= urakka-id (get-in vastaus-aloitettu [:id])) "Urakka")
-    (is (= 1 (get-in vastaus-aloittamatta [:aloittamatta])) "Urakka")
-    (is (= 1 (get-in vastaus-aloitettu [:yllapitokohteiden_lkm])) "Urakka")
-    (is (= 1 (get-in vastaus-lahetys-epaonnistuu [:epaonnistuneet_lahetetyt])) "Urakka")
-    (is (= 1 (get-in vastaus-valmis-ei-lahetetty [:valmiit_ei_lahetetty])) "Urakka")
-    (is (= 1 (get-in vastaus-aloitettu [:valmis_hyvaksytty])) "Urakka")
-    (is (= 1 (get-in vastaus-valmis-ei-lahetetty [:valmis_hyvaksytty])) "Urakka")
-    (is (= 1 (get-in vastaus-lahetys-epaonnistuu [:valmis_hyvaksytty])) "Urakka")))
+    (is (= 1 (get-in vastaus-aloittamatta [:aloittamatta])) "Kohteita aloittamatta")
+    (is (= 1 (get-in vastaus-aloitettu [:yllapitokohteiden_lkm])) "ylläpitokohteiden lkm")
+    (is (= 1 (get-in vastaus-lahetys-epaonnistuu [:epaonnistuneet_lahetetyt])) "epäonnistuneet lähetykset")
+    (is (= 1 (get-in vastaus-lahetys-onnistuu [:lahetetty_onnistuneesti])) "lahetetty_onnistuneesti")
+    (is (= 1 (get-in vastaus-valmis-ei-lahetetty [:valmiit_ei_lahetetty])) "valmis ei lähetetty")
+    (is (= 1 (get-in vastaus-aloitettu [:valmis_hyvaksytty])) "valmis hyväksytty")
+    (is (= kohteen-odotettu-virhe
+          ;; kohteen id voi muuttua kun testidata elää, dissocataan id sen vuoksi niin testi on robustimpi
+          (dissoc (first (get-in vastaus-lahetys-epaonnistuu [:virheelliset_kohteet])) :id)) "Kohteen virhetiedot")))
 
 


### PR DESCRIPTION
-Hae frontille asti kohteen lähetysvirhe ja näytä se hoverissa
-escapoi pgobject parsinnalle vaikeat merkit , ja " jotta saadaan kaikenlaiset lähetysvirheet UI:lle asti. Muutoin pgobject parseri sekoaa kenttien määrässä. Ei ole tämän vuoksi tarkoituksen mukaista muokata parseria. 
-Lisää testistä puuttuneet assertit
