### PR TITLE
HARJA-1298 - Korjaile fargate restarttia, jotta se ottaa aimmin asetetun desired

### DIFF
--- a/.github/actions/restart-fargate-tasks/action.yml
+++ b/.github/actions/restart-fargate-tasks/action.yml
@@ -14,13 +14,22 @@ runs:
       env:
         CLUSTER_NAME: ${{ inputs.cluster }}
         SERVICE_NAME: ${{ inputs.service }}
-        DESIRED_COUNT: "1"
+        DESIRED_COUNT_DEFAULT: "1"
 
       # Komennon 'update-service' stdout ohjataan /dev/nulliin, koska se voi tulostaa sensitiivisiä tietoja
       run: |
         echo "Getting available service: ${SERVICE_NAME}"
         AVAILABLE_SERVICE=$(aws ecs list-services --cluster "${CLUSTER_NAME}" --region eu-west-1 --query "serviceArns[?contains(@, \`${SERVICE_NAME}\`) == \`true\`] | [0]" --output text)
         
+        CURRENT_DESIRED_COUNT=$(aws ecs describe-services --cluster "${CLUSTER_NAME}" --services "${AVAILABLE_SERVICE}" --region eu-west-1 --query "services[0].desiredCount" --output text)
+
+        # If desired count is already 0, set it to default value. Otherwise, keep the current desired count.
+        if [[ "${CURRENT_DESIRED_COUNT}" == "0" ]]; then
+          DESIRED_COUNT="${DESIRED_COUNT_DEFAULT}"
+        else
+          DESIRED_COUNT="${CURRENT_DESIRED_COUNT}"
+        fi
+
         echo "Restarting tasks..."
         aws ecs update-service --force-new-deployment \
         --cluster "${CLUSTER_NAME}" --service $AVAILABLE_SERVICE \

--- a/.github/actions/start-fargate-tasks/action.yml
+++ b/.github/actions/start-fargate-tasks/action.yml
@@ -1,5 +1,5 @@
 name: 'Start Harja Fargate tasks'
-description: 'Käynnnistää uudelleen Harja servicen käynnissä olevat Fargate taskit (OIDC autentikaatio vaadittu)'
+description: 'Käynnistää sammutetut Harja servicen Fargate taskit (OIDC autentikaatio vaadittu)'
 
 inputs:
   cluster:


### PR DESCRIPTION
Korjaile fargate restarttia, jotta se ottaa aimmin asetetun desired countin huomioon.

Tässä otetaan huomioon eri ympäristöjen tarpeet erillisen restart-toiminnon näkökulmasta:
* Jos dev tai stg ympäristö on sammutettu ja ajetaan restart workflow -> Nostetaan desired count 0 arvosta 1:seen
   * Tehdään siis oletus, että ympäristön ollessa sammutettuna, tällä restart toiminnolla halutaan se käynnistää uudelleen.
* Jos ympäristö on jo ajossa ja  esim.  ALB asettanut jonkin desired count arvon aiemmin -> restartin yhteydessä kunnioitaan tätä arvoa. Eli, esimerkiksi. jos taskeja on skaalattu 4:ään, niin restart pitää huolen siitä että desired count pysyy samana.