### PR TITLE
HARJA-1023 Älä piirrä karttacontrollia DOMiin jos näkymässä ei käytetä karttaa

### DIFF
--- a/src/cljs/harja/views/main.cljs
+++ b/src/cljs/harja/views/main.cljs
@@ -243,7 +243,12 @@
                                      ;; Estetään asioiden vuotaminen ulos kartalta kun kartta on avattu
                                      :overflow (if @nav/kartta-nakyvissa?
                                                  "hidden"
-                                                 "visible")}}
+                                                 "visible")
+                                     ;; Jos näkymässä ei ole karttaa, älä piirrä containeria ollenkaan DOMiin
+                                     ;; Sotkee muuten näppäin navigointia (TAB) muissa näkymissä 
+                                     :display (if (and
+                                                    (= @nav/kartan-koko :hidden)
+                                                    (not @nav/kartta-nakyvissa?)) "none" "block")}}
       [kartta/kartta]]]))
 
 (defn varoita-jos-vanha-ie []


### PR DESCRIPTION
Korjaa näppäimistökäyttöä.


> 2.4.7 Näkyvä kohdistus (AA), 4.1.1  Jäsentäminen (A)
> - Hallinta-sivulla kohdistus häviää näkyvistä, kun käyttäjä siirtyy eteenpäin viimeiseltä kohdistettavalta komponentilt