### PR TITLE
Poista role presentation valilehdista tiketin mukaisesti

### DIFF
--- a/src/cljs/harja/ui/bootstrap.cljs
+++ b/src/cljs/harja/ui/bootstrap.cljs
@@ -45,8 +45,7 @@ The following keys are supported in the configuration:
             [:ul.nav {:class style-class}
              (for [[title keyword] tabs]
                ^{:key title}
-               [:li {:role  "presentation"
-                     :class (when (= keyword active-tab-keyword)
+               [:li {:class (when (= keyword active-tab-keyword)
                               "active")}
                 [:a.klikattava (merge
                                  {:tabIndex "0"


### PR DESCRIPTION
Poistettu bootstrapin peruja oleva role="presentation" tabeista. 

Tämä olisi hyödyllinen vain tablist komponentilla ja meillä ei ole sitä rakennetta.