### PR TITLE
Harja-1008 Tekstin korostusten kontrasti

### DIFF
--- a/dev-resources/less/pages/ilmoitukset.less
+++ b/dev-resources/less/pages/ilmoitukset.less
@@ -217,7 +217,7 @@
 }
 
 .selite-virkaapu {
-  color: @pinkki-kevyt;
+  color: @punainen4;
   font-weight: bold;
 }
 


### PR DESCRIPTION
Piti laittaa tähän väriksi @punainen4 eli #dd0000, koska tiketillä olleen korjausehdotuksen eli @red-default #DE3618 kontrasti ei riittänytkään.