### PR TITLE
HARJA-1412 Tavoitehintaisuustieto analytiikalle

### DIFF
--- a/resources/api/schemas/analytiikka-mhu-toteutuneet-kustannukset-haku-response.schema.json
+++ b/resources/api/schemas/analytiikka-mhu-toteutuneet-kustannukset-haku-response.schema.json
@@ -88,6 +88,10 @@
                             "type": "string",
                             "description": "Kulukohdstukseen tyyppi. Tyypitys on uudistuksen kohteena 2024, sen takia string, ei enumia."
                           },
+                          "tavoitehintainen": {
+                            "type": "boolean",
+                            "description": "True, jos kulukohdistus lasketaan mukaan tavoitehintaan. False, jos kulukohdistus jätetään tavoitehintatarkastelun ulkopuolelle. Arvon tulisi olla aina true, jos kulukohdistuksen tyyppi on hankintakustannus tai rahavaraus. Arvon tulisi olla aina false, jos kulukohdistuksen tyyppi on lisatyo tai paatos. Muukulu-tyyppinen kulukohdistus voi liittyä tavoitehintaisiin kuluihin tai olla tavoitehintatarkastelun ulkopuolella."
+                          },
                           "lisatieto": {
                             "type": "string",
                             "description": "Kulukohdstukseen kirjattu lisätieto."

--- a/src/clj/harja/kyselyt/kulut.sql
+++ b/src/clj/harja/kyselyt/kulut.sql
@@ -318,6 +318,7 @@ SELECT k.id                        AS "kulu-id",
                                  kk.id, -- AS "kulukohdistus_kulukohdistus-id",
                                  kk.rivi, -- AS "kulukohdistus_rivinumero",
                                  kk.maksueratyyppi, -- AS "kulukohdistus_tyyppi",
+                                 kk.tavoitehintainen, -- AS "kulukohdistus_tavoitehintainen"
                                  kk.lisatyon_lisatieto, -- AS "kulukohdistus_lisatieto",
                                  kk.poistettu, -- AS "kulukohdistus_poistettu",
                                  kk.summa, -- AS "kulukohdistus_summa",

--- a/src/clj/harja/palvelin/integraatiot/api/analytiikka.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/analytiikka.clj
@@ -858,13 +858,14 @@
   {:f1 :kulukohdistus_kulukohdistus-id
    :f2 :kulukohdistus_rivinumero
    :f3 :kulukohdistus_tyyppi
-   :f4 :kulukohdistus_lisatieto
-   :f5 :kulukohdistus_poistettu
-   :f6 :kulukohdistus_summa
-   :f7 :kulukohdistus_kohdistus_toimenpide
-   :f8 :kulukohdistus_kohdistus_tehtavaryhma
-   :f9 :kulukohdistus_kohdistus_rahavaraus
-   :f10 :kulukohdistus_kohdistus_tehtava})
+   :f4 :kulukohdistus_tavoitehintainen
+   :f5 :kulukohdistus_lisatieto
+   :f6 :kulukohdistus_poistettu
+   :f7 :kulukohdistus_summa
+   :f8 :kulukohdistus_kohdistus_toimenpide
+   :f9 :kulukohdistus_kohdistus_tehtavaryhma
+   :f10 :kulukohdistus_kohdistus_rahavaraus
+   :f11 :kulukohdistus_kohdistus_tehtava})
 
 
 

--- a/test/clj/harja/palvelin/integraatiot/api/analytiikka_kustannukset_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/analytiikka_kustannukset_test.clj
@@ -107,6 +107,7 @@
     (is (= 2024 (get-in juuri-luotu-kulu-rajapinnasta [:kulu :kulun-ajankohta :koontilaskun-vuosi])))
     (is (= 8 (get-in juuri-luotu-kulu-rajapinnasta [:kulu :kulun-ajankohta :koontilaskun-kuukausi])))
     (is (= "2024-08-01T21:00:00Z" (get-in juuri-luotu-kulu-rajapinnasta [:kulu :kulun-ajankohta :laskun-paivamaara])))
+    (is (= true (get-in (first (get-in juuri-luotu-kulu-rajapinnasta [:kulu :kulukohdistukset])) [:kulukohdistus :tavoitehintainen])) "Tavoitehintaisuus ei palaudu oikein.")
     (is (= (count kulut-kannasta) (count (get-in encoodattu-body [:toteutuneet-kustannukset :kulut]))))))
 
 


### PR DESCRIPTION
Kulukohdistuksissa on tieto siitä, lasketaanko kulu tavoitehintaan kuuluviin vai ei. Palautetaan tieto analytiikalle toteutuneiden kustannusten mukana.