### PR TITLE
Sorttaa varusteet aikaleiman mukaisesti

### DIFF
--- a/dev-resources/less/grid.less
+++ b/dev-resources/less/grid.less
@@ -921,4 +921,8 @@ span.ajax-loader-pisteet {
     border-bottom: 5px solid rgba(0,0,0,0.0) !important;
   }
 }
-
+.sort-nuoli {
+  img {
+    transform: scale(0.6);
+  }
+}

--- a/dev-resources/less/pages/ilmoitukset.less
+++ b/dev-resources/less/pages/ilmoitukset.less
@@ -22,12 +22,6 @@
   margin-bottom: 1rem;
 }
 
-.ilmoitukset-sort {
-  img {
-    transform: scale(0.6);
-  }
-}
-
 .ilmoitukset {
   .boolean > .checkbox {
     padding-top: 0;

--- a/src/clj/harja/palvelin/integraatiot/velho/varusteet.clj
+++ b/src/clj/harja/palvelin/integraatiot/velho/varusteet.clj
@@ -585,7 +585,9 @@
                                                          :yhteinen-key2 [:ominaisuudet :toimenpiteen-kohde]
                                                          :etsittava-avain [:ominaisuudet :toimenpide]
                                                          :asetettava-avain :valimaiset-toimenpiteet})
-                varusteet (mapv (partial varuste-velhosta->harja db) varusteet-valimaisilla-toimenpiteilla)]
+                varusteet (sort-by :alkupvm
+                            #(compare %2 %1)
+                            (mapv (partial varuste-velhosta->harja db) varusteet-valimaisilla-toimenpiteilla))]
             {:urakka-id urakka-id :toteumat varusteet}))))))
 
 (defn hae-varusteen-historia [{:keys [integraatioloki db asetukset]}

--- a/src/cljs/harja/tiedot/urakka/urakka.cljs
+++ b/src/cljs/harja/tiedot/urakka/urakka.cljs
@@ -353,7 +353,7 @@
                                                                                          ::t/toteuma-tehtava-id nil
                                                                                          ::t/lisatieto          nil
                                                                                          ::t/maara              nil}]}}
-                             :velho-varusteet {:valinnat {:hoitokauden-alkuvuosi nil
+                             :velho-varusteet {:valinnat {:hoitokauden-alkuvuosi kuluva-alkuvuosi
                                                           :hoitovuoden-kuukausi nil
                                                           :kuntoluokat nil
                                                           :varustetyypit nil

--- a/src/cljs/harja/ui/grid/muokkaus.cljs
+++ b/src/cljs/harja/ui/grid/muokkaus.cljs
@@ -489,7 +489,7 @@
            [:span.kentan-yksikko yksikko])
          (when sarake-sort
            [napit/nappi "" (:fn sarake-sort)
-            {:luokka (y/luokat "muokkaus-grid-sort-nappi"
+            {:luokka (y/luokat "muokkaus-grid-sort-nappi sort-nuoli"
                        (:luokka sarake-sort))
              :ikoninappi? true
              :ikoni [ikonit/action-sort-descending]}])])

--- a/src/cljs/harja/ui/grid/perus.cljs
+++ b/src/cljs/harja/ui/grid/perus.cljs
@@ -561,7 +561,7 @@
                [otsikko-komp]
                (if-not sarake-sort
                  [:div otsikko]
-                 [:div.ilmoitukset-sort
+                 [:div.sort-nuoli
                   [:span.klikattava {:on-click (:fn sarake-sort)}
                    otsikko " " (sort-ikoni (:suunta sarake-sort)) " "]]))]) skeema)
         (when (or nayta-toimintosarake?

--- a/src/cljs/harja/views/urakka/toteumat/velho_varusteet.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/velho_varusteet.cljs
@@ -7,6 +7,7 @@
   Harjaan tallennettu varustetoimenpide sisältää Tievelhosta haetun kopion toimenpiteestä ja sen kohteesta rajatuilla tiedoilla.
   Tarkemmat tiedot löytyvät Tievelhosta."
   (:require [clojure.string :as str]
+            [harja.tiedot.urakka :as u]
             [reagent.core :refer [atom]]
             [tuck.core :as tuck]
             [harja.asiakas.kommunikaatio :as k]
@@ -56,9 +57,10 @@
 
 (defn suodatuslomake [_e! _app]
   (fn [e! {:keys [valinnat urakka kuntoluokat-nimikkeisto kohdeluokat-nimikkeisto varustetyyppihaku] :as app}]
-    (let [alkupvm (:alkupvm urakka)
-          vuosi (pvm/vuosi alkupvm)
-          hoitokaudet (into [] (range vuosi (+ 5 vuosi)))
+    (let [hoitokausien-alkuvuodet (into []
+                                    (range
+                                      (pvm/vuosi (:alkupvm urakka))
+                                      (pvm/vuosi (:loppupvm urakka))))
           hoitokauden-alkuvuosi (:hoitokauden-alkuvuosi valinnat)
           valittu-toimenpide (:toimenpide valinnat)
           hoitovuoden-kuukaudet [nil 10 11 12 1 2 3 4 5 6 7 8 9]
@@ -94,15 +96,11 @@
       [:div
        [debug app {:otsikko "TUCK STATE"}]
        [:div.row.filtterit-container {:style {:height "100px"}}
-        [yleiset/pudotusvalikko "Hoitovuosi"
-         {:wrap-luokka "col-md-2 filtteri label-ja-alasveto-grid"
-          :valinta hoitokauden-alkuvuosi
-          :vayla-tyyli? true
-          :data-cy "hoitokausi-valinta"
-          :valitse-fn #(e! (v/->ValitseHoitokausi %))
-          :format-fn #(str v/fin-hk-alkupvm % " \u2014 " v/fin-hk-loppupvm (inc %))
-          :klikattu-ulkopuolelle-params {:tarkista-komponentti? true}}
-         hoitokaudet]
+        [valinnat/urakan-hoitokausi-tuck
+         (:hoitokauden-alkuvuosi valinnat)
+         hoitokausien-alkuvuodet
+         #(e! (v/->ValitseHoitokausi %))
+         {:wrapper-luokka "col-md-2 filtteri label-ja-alasveto-grid"}]
         [yleiset/pudotusvalikko "Kuukausi"
          {:wrap-luokka "col-md-1 filtteri varusteet label-ja-alasveto-grid"
           :valinta (:hoitovuoden-kuukausi valinnat)
@@ -309,7 +307,9 @@
          (reset! nav/kartan-edellinen-koko @nav/kartan-koko)
          (nav/vaihda-kartan-koko! :M)
          (kartta-tasot/taso-paalle! :varusteet-ulkoiset)
-         (e! (v/->ValitseHoitokausi (pvm/vuosi (get-in app [:urakka :alkupvm]))))
+         (e! (v/->ValitseHoitokausi (if (u/urakka-kaynnissa? (:urakka app))
+                                      urakka-tila/kuluva-alkuvuosi
+                                      (pvm/vuosi (get-in app [:urakka :alkupvm])))))
          (e! (v/->HaeNimikkeisto))
          (reset! varusteet-kartalla/varuste-klikattu-fn
            (fn [varuste-kartalla]


### PR DESCRIPTION
Mukana myös pieni siistiminen grid.cljs:ään, jonne oli vuosien saatossa lipsahtanut näkymäspesifiä koodia.