### PR TITLE
Harja-1340 Älä näytä käyttäjälle tilaa

### DIFF
--- a/src/cljs/harja/views/ilmoitukset/tieliikenneilmoitukset.cljs
+++ b/src/cljs/harja/views/ilmoitukset/tieliikenneilmoitukset.cljs
@@ -438,8 +438,12 @@
         {:otsikko "Tila" :nimi :tila :otsikkorivi-luokka "tila"
          :leveys ""
          :hae #(let [selite (tilan-selite (:tila %))]
-                 (if (:aiheutti-toimenpiteita %)
+                 (cond
+                   (= :ei-valitetty (:tila %))
+                   nil
+                   (:aiheutti-toimenpiteita %)
                    (str selite " (Toimenpitein)")
+                   :else
                    selite))}
         {:otsikko "Toimenpiteet aloitettu" :nimi :toimenpiteet-aloitettu
          :tyyppi :pvm :fmt pvm/pvm-aika


### PR DESCRIPTION
Jos tieliikenneilmoituksen vastaanottokuittauksen lähettäminen TLoikiin ei onnistu, kuittauksen tilaa ei näytetä Harja-käyttäjälle, vaan se näkyy tyhjänä.