### PR TITLE
HARJA-1495 Korjaa ilmoituksen sähköpostiviestin formatointi 

### DIFF
--- a/src/clj/harja/palvelin/integraatiot/tloik/sahkoposti.clj
+++ b/src/clj/harja/palvelin/integraatiot/tloik/sahkoposti.clj
@@ -108,7 +108,7 @@ resursseja liitää sähköpostiin mukaan luotettavasti."
      ["Ilmoittaja" (apurit/nayta-henkilon-yhteystiedot (:ilmoittaja ilmoitus))]
      ["Lähettäjä" (apurit/nayta-henkilon-yhteystiedot (:lahettaja ilmoitus))]
      [(when (:lisatieto ilmoitus) "Kuvaus ")
-      (when (:lisatieto ilmoitus) (:lisatieto ilmoitus))]]))
+      (when (:lisatieto ilmoitus) (sanitoi (:lisatieto ilmoitus)))]]))
 
 (defn- aiheen-sisaltavat-yleiset-tiedot [db ilmoitus]
   (let [aiheet-ja-tarkenteet (palautevayla-kyselyt/hae-aiheet-ja-tarkenteet db)]
@@ -129,7 +129,7 @@ resursseja liitää sähköpostiin mukaan luotettavasti."
          (when (:selitteet ilmoitus) (apurit/parsi-selitteet (mapv keyword (:selitteet ilmoitus))))]
         ["Otsikko " (:otsikko ilmoitus)]
         ["Tierekisteriosoite" (tierekisteri/tierekisteriosoite-tekstina (:sijainti ilmoitus) {:teksti-tie? false})]
-        ["Kuvaus " (when (:lisatieto ilmoitus) (:lisatieto ilmoitus))]
+        ["Kuvaus " (when (:lisatieto ilmoitus) (sanitoi (:lisatieto ilmoitus)))]
         ["Aiheutti toimenpiteitä " (if (:aiheutti-toimenpiteita ilmoitus) "Kyllä" "Ei")]
         [(when (:toimenpiteet-aloitettu ilmoitus) "Toimenpiteet aloitettu ")
          (when (:toimenpiteet-aloitettu ilmoitus) (pvm/pvm-aika-sek (:toimenpiteet-aloitettu ilmoitus)))]])]))

--- a/src/clj/harja/palvelin/integraatiot/tloik/sahkoposti.clj
+++ b/src/clj/harja/palvelin/integraatiot/tloik/sahkoposti.clj
@@ -106,7 +106,9 @@ resursseja liitää sähköpostiin mukaan luotettavasti."
      ["Paikan kuvaus" (:paikankuvaus ilmoitus)]
      ["Selitteet" (apurit/parsi-selitteet (mapv keyword (:selitteet ilmoitus)))]
      ["Ilmoittaja" (apurit/nayta-henkilon-yhteystiedot (:ilmoittaja ilmoitus))]
-     ["Lähettäjä" (apurit/nayta-henkilon-yhteystiedot (:lahettaja ilmoitus))]]))
+     ["Lähettäjä" (apurit/nayta-henkilon-yhteystiedot (:lahettaja ilmoitus))]
+     [(when (:lisatieto ilmoitus) "Kuvaus ")
+      (when (:lisatieto ilmoitus) (:lisatieto ilmoitus))]]))
 
 (defn- aiheen-sisaltavat-yleiset-tiedot [db ilmoitus]
   (let [aiheet-ja-tarkenteet (palautevayla-kyselyt/hae-aiheet-ja-tarkenteet db)]

--- a/src/clj/harja/palvelin/integraatiot/tloik/sahkoposti.clj
+++ b/src/clj/harja/palvelin/integraatiot/tloik/sahkoposti.clj
@@ -141,7 +141,6 @@ resursseja liitää sähköpostiin mukaan luotettavasti."
         (aiheen-sisaltavat-yleiset-tiedot db ilmoitus))]
 
      [:div (parsi-kuvalinkit-sahkopostiin (:kuvat ilmoitus))]
-     [:blockquote (sanitoi (:lisatieto ilmoitus))]
      (when-let [sijainti (:sijainti ilmoitus)]
        (let [[lat lon] (geo/euref->wgs84 [(:x sijainti) (:y sijainti)])]
          [:a {:href (format open-google-map-url-template lat lon)


### PR DESCRIPTION
Poistettu turha blockquote, joka antaa kuvauksen tuplana sekä rikkoo sähköpostin formatoinnin.

Tiketiltä voi tarkastella miltä muutos näyttää.