### PR TITLE
Ilmoitusten testityokalu

### DIFF
--- a/src/clj/harja/palvelin/palvelut/debug.clj
+++ b/src/clj/harja/palvelin/palvelut/debug.clj
@@ -189,7 +189,7 @@
 (defn hae-ilmoitus [db ilmoitusid]
   (let [id (:id (first (tieliikenneilmoitukset-q/hae-id-ilmoitus-idlla db ilmoitusid)))
         _ (when-not id
-            (log/error (format "Ilmoitusta %s ei löytynyt tietokannasta." ilmoitusid))
+            (log/error (format "[Testi] Ilmoitusta %s ei löytynyt tietokannasta." ilmoitusid))
             (throw (Exception. "Ilmoitusta ei löytynyt ilmoitus-id:llä")))
         ilmoitus (first
                    (konversio/sarakkeet-vektoriin
@@ -205,17 +205,17 @@
     ilmoitus))
 
 (defn- laheta-paivystaja-ilmoitus-sahkopostilla [db api-sahkoposti vastaanottajan-email {id :ilmoitusid :as ilmoitus}]
-  (log/info (format "Lähetetään ilmoitus (id: %s) sähköpostilla" id))
+  (log/info (format "[Testi] Lähetetään ilmoitus (id: %s) sähköpostilla" id))
 
   (let [lahettaja "harja-ala-vastaa@vayla.fi" #_(sahkoposti/vastausosoite api-sahkoposti)
         [otsikko viesti] (tloik-sahkoposti/otsikko-ja-viesti db lahettaja ilmoitus)
         vastaus (sahkoposti/laheta-viesti! api-sahkoposti lahettaja vastaanottajan-email (str "TESTI: " otsikko) viesti {"X-Correlation-ID" id})]
     (when (not= "Message processed" vastaus)
-      (log/error (format "Ilmoituksen %s lähettämisessä sähköpostilla tapahtui virhe, vastaus integraatiolta %s" id vastaus))
+      (log/error (format "[Testi] Ilmoituksen %s lähettämisessä sähköpostilla tapahtui virhe, vastaus integraatiolta %s" id vastaus))
       (throw (Exception. "Sähköpostin lähetys epäonnistui")))))
 
 (defn- laheta-paivystaja-ilmoitus-sms [db sms {id :ilmoitusid :as ilmoitus} puhelinnumero]
-  (log/info (format "Lähetetään ilmoitus (id: %s) tekstiviestillä" id))
+  (log/info (format "[Testi] Lähetetään ilmoitus (id: %s) tekstiviestillä" id))
 
   (let [viestinumero (rand-int 100000) ; Satunnainen viestinumero
         aiheet-ja-tarkenteet (when (get-in ilmoitus [:luokittelu :aihe])
@@ -224,7 +224,7 @@
         vastaus (sms/laheta sms puhelinnumero viesti (:ilmoitusid ilmoitus) {})]
 
     (when (or (not vastaus) (not (str/includes? (:sisalto vastaus) "OK")))
-      (log/error (format "Ilmoituksen %s lähettämisessä tekstiviestillä tapahtui virhe, vastaus integraatiolta: %s" id vastaus))
+      (log/error (format "[Testi] Ilmoituksen %s lähettämisessä tekstiviestillä tapahtui virhe, vastaus integraatiolta: %s" id vastaus))
       (throw (Exception. "Tekstiviestin lähetys epäonnistui")))))
 
 (defn- laheta-paivystajan-ilmoitus
@@ -233,14 +233,14 @@
   (try
     (when (and (string/blank? sahkoposti) (string/blank? puhelinnumero))
       (do
-        (log/error (format "Päivystajan ilmoitusta %s ei voida lähettää ilman sähköpostiosoitetta tai puhelinnumeroa." ilmoitus-id))
+        (log/error (format "[Testi] Päivystajan ilmoitusta %s ei voida lähettää ilman sähköpostiosoitetta tai puhelinnumeroa." ilmoitus-id))
         (throw (Exception. "Päivystajan ilmoitusta ei voida lähettää ilman sähköpostiosoitetta tai puhelinnumeroa."))))
 
     (let [email-sensuroitu (when (string? sahkoposti)
                              (str/replace sahkoposti #"(?<=^.)[^@]*|(?<=@.).*(?=\.[^.]+$)" "***"))
           puh-sensuroitu (when (string? puhelinnumero)
                            (str/replace puhelinnumero #"\d(?=\d{4})" "*"))
-          _ (log/info "Lähetetään päivystajan ilmoitus, ilmoitus-id: " ilmoitus-id
+          _ (log/info "[Testi] Lähetetään päivystajan ilmoitus, ilmoitus-id: " ilmoitus-id
               " sähköposti: " email-sensuroitu
               " puhelinnumero: " puh-sensuroitu)
 
@@ -257,7 +257,7 @@
               :ilmoitus-id ilmoitus-id}})
 
     (catch Exception e
-      (log/error (format "Päivystäjän ilmoituksen lähettämisessä tapahtui poikkeus: %s" e))
+      (log/error (format "[Testi] Päivystäjän ilmoituksen lähettämisessä tapahtui poikkeus: %s" e))
       {:status 500
        :error "Virhe"
        :body {:virhe "Päivystäjän ilmoituksen lähettäminen epäonnistui"

--- a/src/clj/harja/palvelin/palvelut/debug.clj
+++ b/src/clj/harja/palvelin/palvelut/debug.clj
@@ -1,10 +1,12 @@
 (ns harja.palvelin.palvelut.debug
   "Erinäisiä vain JVH:lle tarkoitettuja palveluita, joilla voi selvitellä
   eri tilanteita, esim. TR-osiossa."
-  (:require [harja.domain.oikeudet :as oikeudet]
+  (:require [clojure.string :as string]
+            [harja.domain.oikeudet :as oikeudet]
             [harja.domain.roolit :as roolit]
             [com.stuartsierra.component :as component]
             [harja.kyselyt.konversio :as konversio]
+            [harja.kyselyt.palautevayla :as palautevayla-kyselyt]
             [harja.palvelin.komponentit.http-palvelin :as http]
             [harja.kyselyt.debug :as q]
 
@@ -17,6 +19,7 @@
             [harja.palvelin.palvelut.ilmoitukset :as ilmoitukset]
             [harja.kyselyt.tieliikenneilmoitukset :as tieliikenneilmoitukset-q]
             [harja.palvelin.integraatiot.tloik.sahkoposti :as tloik-sahkoposti]
+            [harja.palvelin.integraatiot.tloik.tekstiviesti :as tloik-tekstivietsi]
             [harja.palvelin.palvelut.tierekisteri-haku :as tierekisteri-haku]
             [taoensso.timbre :as log]
             [harja.palvelin.integraatiot.api.tyokalut.sijainnit :as sijainnit]
@@ -202,31 +205,64 @@
     ilmoitus))
 
 (defn- laheta-paivystaja-ilmoitus-sahkopostilla [db api-sahkoposti vastaanottajan-email {id :ilmoitusid :as ilmoitus}]
-  (let [lahettaja "no-reply@harjatesti.fi" #_(sahkoposti/vastausosoite api-sahkoposti)
-        [otsikko viesti] (tloik-sahkoposti/otsikko-ja-viesti db lahettaja ilmoitus)]
-    (try
-      (sahkoposti/laheta-viesti! api-sahkoposti lahettaja vastaanottajan-email (str "TESTI: " otsikko) viesti {"X-Correlation-ID" id})
-      (catch Exception e
-        (log/error (format "Ilmoituksen %s lähettämisessä sähköpostilla tapahtui poikkeus." (:ilmoitusid ilmoitus)) e))))
-  (log/warn (format "Ilmoitusta %s ei voida lähettää sähköpostilla ilman sähköpostiosoitetta." (:ilmoitusid ilmoitus))))
+  (log/info (format "Lähetetään ilmoitus (id: %s) sähköpostilla" id))
 
-(defn- laheta-paivystaja-ilmoitus-sms []
-  (log/info "TODO: Toteuta SMS-lähetys päivystajan ilmoitukselle, jos puhelinnumero on annettu."))
+  (let [lahettaja "no-reply@harjatesti.fi" #_(sahkoposti/vastausosoite api-sahkoposti)
+        [otsikko viesti] (tloik-sahkoposti/otsikko-ja-viesti db lahettaja ilmoitus)
+        vastaus (sahkoposti/laheta-viesti! api-sahkoposti lahettaja vastaanottajan-email (str "TESTI: " otsikko) viesti {"X-Correlation-ID" id})]
+    (when (not= "Message processed" vastaus)
+      (log/error (format "Ilmoituksen %s lähettämisessä sähköpostilla tapahtui virhe, vastaus integraatiolta %s" id vastaus))
+      (throw (Exception. "Sähköpostin lähetys epäonnistui")))))
+
+(defn- laheta-paivystaja-ilmoitus-sms [db sms {id :ilmoitusid :as ilmoitus} puhelinnumero]
+  (log/info (format "Lähetetään ilmoitus (id: %s) tekstiviestillä" id))
+
+  (let [viestinumero (rand-int 100000) ; Satunnainen viestinumero
+        aiheet-ja-tarkenteet (when (get-in ilmoitus [:luokittelu :aihe])
+                               (palautevayla-kyselyt/hae-aiheet-ja-tarkenteet db))
+        viesti (tloik-tekstivietsi/ilmoitus-tekstiviesti ilmoitus viestinumero aiheet-ja-tarkenteet)
+        vastaus (sms/laheta sms puhelinnumero viesti (:ilmoitusid ilmoitus) {})]
+
+    (when (or (not vastaus) (not (str/includes? (:sisalto vastaus) "OK")))
+      (log/error (format "Ilmoituksen %s lähettämisessä tekstiviestillä tapahtui virhe, vastaus integraatiolta: %s" id vastaus))
+      (throw (Exception. "Tekstiviestin lähetys epäonnistui")))))
 
 (defn- laheta-paivystajan-ilmoitus
   ""
   [db api-sahkoposti sms {:keys [ilmoitus-id sahkoposti puhelinnumero] :as ilmoitus-tiedot}]
-  (let [email-sensuroitu (when (string? sahkoposti)
-                           (str/replace sahkoposti #"(?<=^.)[^@]*|(?<=@.).*(?=\.[^.]+$)" "***"))
-        puh-sensuroitu (when (string? puhelinnumero)
-                         (str/replace puhelinnumero #"\d(?=\d{4})" "*"))
-        _ (println "Lähetetään päivystajan ilmoitus, ilmoitus-id: " ilmoitus-id
-            " sähköposti: " email-sensuroitu
-            " puhelinnumero: " puh-sensuroitu)
+  (try
+    (when (and (string/blank? sahkoposti) (string/blank? puhelinnumero))
+      (do
+        (log/error (format "Päivystajan ilmoitusta %s ei voida lähettää ilman sähköpostiosoitetta tai puhelinnumeroa." ilmoitus-id))
+        (throw (Exception. "Päivystajan ilmoitusta ei voida lähettää ilman sähköpostiosoitetta tai puhelinnumeroa."))))
 
-        ilmoitus (hae-ilmoitus db ilmoitus-id)]
+    (let [email-sensuroitu (when (string? sahkoposti)
+                             (str/replace sahkoposti #"(?<=^.)[^@]*|(?<=@.).*(?=\.[^.]+$)" "***"))
+          puh-sensuroitu (when (string? puhelinnumero)
+                           (str/replace puhelinnumero #"\d(?=\d{4})" "*"))
+          _ (println "Lähetetään päivystajan ilmoitus, ilmoitus-id: " ilmoitus-id
+              " sähköposti: " email-sensuroitu
+              " puhelinnumero: " puh-sensuroitu)
 
-    (laheta-paivystaja-ilmoitus-sahkopostilla db api-sahkoposti sahkoposti ilmoitus)))
+          ilmoitus (hae-ilmoitus db ilmoitus-id)]
+
+      (when-not (string/blank? sahkoposti)
+        (laheta-paivystaja-ilmoitus-sahkopostilla db api-sahkoposti sahkoposti ilmoitus))
+
+      (when-not (string/blank? puhelinnumero)
+        (laheta-paivystaja-ilmoitus-sms db sms ilmoitus puhelinnumero))
+
+      {:status 200
+       :body {:viesti "Päivystäjän ilmoitus lähetetty"
+              :ilmoitus-id ilmoitus-id}})
+
+    (catch Exception e
+      (log/error (format "Päivystäjän ilmoituksen lähettämisessä tapahtui poikkeus: %s" e))
+      {:status 500
+       :error "Virhe"
+       :body {:virhe "Päivystäjän ilmoituksen lähettäminen epäonnistui"
+              :viesti (.getMessage e)
+              :ilmoitus-id ilmoitus-id}})))
 
 ;; --- Päivystäjän ilmoituksen testaus -- Päättyy ---
 

--- a/src/clj/harja/palvelin/palvelut/debug.clj
+++ b/src/clj/harja/palvelin/palvelut/debug.clj
@@ -240,7 +240,7 @@
                              (str/replace sahkoposti #"(?<=^.)[^@]*|(?<=@.).*(?=\.[^.]+$)" "***"))
           puh-sensuroitu (when (string? puhelinnumero)
                            (str/replace puhelinnumero #"\d(?=\d{4})" "*"))
-          _ (println "Lähetetään päivystajan ilmoitus, ilmoitus-id: " ilmoitus-id
+          _ (log/info "Lähetetään päivystajan ilmoitus, ilmoitus-id: " ilmoitus-id
               " sähköposti: " email-sensuroitu
               " puhelinnumero: " puh-sensuroitu)
 

--- a/src/clj/harja/palvelin/palvelut/debug.clj
+++ b/src/clj/harja/palvelin/palvelut/debug.clj
@@ -4,6 +4,7 @@
   (:require [harja.domain.oikeudet :as oikeudet]
             [harja.domain.roolit :as roolit]
             [com.stuartsierra.component :as component]
+            [harja.kyselyt.konversio :as konversio]
             [harja.palvelin.komponentit.http-palvelin :as http]
             [harja.kyselyt.debug :as q]
 
@@ -13,6 +14,9 @@
             [harja.kyselyt.toimenpidekoodit :as toimenpidekoodit-kyselyt]
             [cheshire.core :as cheshire]
             [harja.palvelin.integraatiot.api.reittitoteuma :as reittitoteuma]
+            [harja.palvelin.palvelut.ilmoitukset :as ilmoitukset]
+            [harja.kyselyt.tieliikenneilmoitukset :as tieliikenneilmoitukset-q]
+            [harja.palvelin.integraatiot.tloik.sahkoposti :as tloik-sahkoposti]
             [harja.palvelin.palvelut.tierekisteri-haku :as tierekisteri-haku]
             [taoensso.timbre :as log]
             [harja.palvelin.integraatiot.api.tyokalut.sijainnit :as sijainnit]
@@ -176,16 +180,55 @@
               :viesti vastaus}})
     vastaus))
 
+
+;; --- Päivystäjän ilmoituksen testaus -- Alkaa ---
+
+(defn hae-ilmoitus [db ilmoitusid]
+  (let [id (:id (first (tieliikenneilmoitukset-q/hae-id-ilmoitus-idlla db ilmoitusid)))
+        _ (when-not id
+            (log/error (format "Ilmoitusta %s ei löytynyt tietokannasta." ilmoitusid))
+            (throw (Exception. "Ilmoitusta ei löytynyt ilmoitus-id:llä")))
+        ilmoitus (first
+                   (konversio/sarakkeet-vektoriin
+                     (into [] ilmoitukset/ilmoitus-xf
+                       (tieliikenneilmoitukset-q/hae-ilmoitus db {:id id}))
+                     {:kuittaus :kuittaukset}))
+        ;; Normaalisti käsitellään ns. raaka" T-Loikista tullut ilmoitus, joka on hiukan eri muodossa kuin kantaan tallennettu
+        ;; Tässä muokataan kannasta haetun ilmoituksen tietoja niin, että ne ovat samassa muodossa kuin T-Loikista tuleva ilmoitus
+        ilmoitus (assoc ilmoitus
+                   :sijainti {:x (get-in ilmoitus [:sijainti :coordinates 0])
+                              :y (get-in ilmoitus [:sijainti :coordinates 1])}
+                   :luokittelu {:aihe (:aihe ilmoitus) :tarkenne (:tarkenne ilmoitus)})]
+    ilmoitus))
+
+(defn- laheta-paivystaja-ilmoitus-sahkopostilla [db api-sahkoposti vastaanottajan-email {id :ilmoitusid :as ilmoitus}]
+  (let [lahettaja "no-reply@harjatesti.fi" #_(sahkoposti/vastausosoite api-sahkoposti)
+        [otsikko viesti] (tloik-sahkoposti/otsikko-ja-viesti db lahettaja ilmoitus)]
+    (try
+      (sahkoposti/laheta-viesti! api-sahkoposti lahettaja vastaanottajan-email (str "TESTI: " otsikko) viesti {"X-Correlation-ID" id})
+      (catch Exception e
+        (log/error (format "Ilmoituksen %s lähettämisessä sähköpostilla tapahtui poikkeus." (:ilmoitusid ilmoitus)) e))))
+  (log/warn (format "Ilmoitusta %s ei voida lähettää sähköpostilla ilman sähköpostiosoitetta." (:ilmoitusid ilmoitus))))
+
+(defn- laheta-paivystaja-ilmoitus-sms []
+  (log/info "TODO: Toteuta SMS-lähetys päivystajan ilmoitukselle, jos puhelinnumero on annettu."))
+
 (defn- laheta-paivystajan-ilmoitus
   ""
-  [sms api-sahkoposti {:keys [ilmoitus-id sahkoposti puhelinnumero] :as ilmoitus-tiedot}]
+  [db api-sahkoposti sms {:keys [ilmoitus-id sahkoposti puhelinnumero] :as ilmoitus-tiedot}]
   (let [email-sensuroitu (when (string? sahkoposti)
                            (str/replace sahkoposti #"(?<=^.)[^@]*|(?<=@.).*(?=\.[^.]+$)" "***"))
         puh-sensuroitu (when (string? puhelinnumero)
-                         (str/replace puhelinnumero #"\d(?=\d{4})" "*"))]
-    (println "Lähetetään päivystajan ilmoitus, ilmoitus-id: " ilmoitus-id
-      " sähköposti: " email-sensuroitu
-      " puhelinnumero: " puh-sensuroitu)))
+                         (str/replace puhelinnumero #"\d(?=\d{4})" "*"))
+        _ (println "Lähetetään päivystajan ilmoitus, ilmoitus-id: " ilmoitus-id
+            " sähköposti: " email-sensuroitu
+            " puhelinnumero: " puh-sensuroitu)
+
+        ilmoitus (hae-ilmoitus db ilmoitus-id)]
+
+    (laheta-paivystaja-ilmoitus-sahkopostilla db api-sahkoposti sahkoposti ilmoitus)))
+
+;; --- Päivystäjän ilmoituksen testaus -- Päättyy ---
 
 (defn hae-tieturvalliusuus-geometriat
   "Kokeillaan hakea kaikki tieturvallisuusgeometriat. Jos haluat lokaalisti ajaa geometriat kantaan, päivitä polku, josta niitä
@@ -287,7 +330,7 @@
       :debug-laheta-tekstiviesti
       (vaadi-jvh! (partial #'laheta-sms sms))
       :debug-laheta-paivystajan-ilmoitus
-      (vaadi-jvh! (partial #'laheta-paivystajan-ilmoitus api-sahkoposti sms))
+      (vaadi-jvh! (partial #'laheta-paivystajan-ilmoitus db api-sahkoposti sms))
       :debug-hae-tieturvalliusuus-geometriat
       (vaadi-jvh! (partial #'hae-tieturvalliusuus-geometriat db))
       :debug-hae-yllapitokohteen-geometriat

--- a/src/clj/harja/palvelin/palvelut/debug.clj
+++ b/src/clj/harja/palvelin/palvelut/debug.clj
@@ -176,6 +176,17 @@
               :viesti vastaus}})
     vastaus))
 
+(defn- laheta-paivystajan-ilmoitus
+  ""
+  [sms api-sahkoposti {:keys [ilmoitus-id sahkoposti puhelinnumero] :as ilmoitus-tiedot}]
+  (let [email-sensuroitu (when (string? sahkoposti)
+                           (str/replace sahkoposti #"(?<=^.)[^@]*|(?<=@.).*(?=\.[^.]+$)" "***"))
+        puh-sensuroitu (when (string? puhelinnumero)
+                         (str/replace puhelinnumero #"\d(?=\d{4})" "*"))]
+    (println "Lähetetään päivystajan ilmoitus, ilmoitus-id: " ilmoitus-id
+      " sähköposti: " email-sensuroitu
+      " puhelinnumero: " puh-sensuroitu)))
+
 (defn hae-tieturvalliusuus-geometriat
   "Kokeillaan hakea kaikki tieturvallisuusgeometriat. Jos haluat lokaalisti ajaa geometriat kantaan, päivitä polku, josta niitä
   tallennetaan. Lokaalisti tieturvallisuusgeometrioita ei välttämättä ole ajettu kantaan."
@@ -275,6 +286,8 @@
       (vaadi-jvh! (partial #'laheta-emailapi api-sahkoposti))
       :debug-laheta-tekstiviesti
       (vaadi-jvh! (partial #'laheta-sms sms))
+      :debug-laheta-paivystajan-ilmoitus
+      (vaadi-jvh! (partial #'laheta-paivystajan-ilmoitus api-sahkoposti sms))
       :debug-hae-tieturvalliusuus-geometriat
       (vaadi-jvh! (partial #'hae-tieturvalliusuus-geometriat db))
       :debug-hae-yllapitokohteen-geometriat

--- a/src/clj/harja/palvelin/palvelut/debug.clj
+++ b/src/clj/harja/palvelin/palvelut/debug.clj
@@ -19,7 +19,7 @@
             [harja.palvelin.palvelut.ilmoitukset :as ilmoitukset]
             [harja.kyselyt.tieliikenneilmoitukset :as tieliikenneilmoitukset-q]
             [harja.palvelin.integraatiot.tloik.sahkoposti :as tloik-sahkoposti]
-            [harja.palvelin.integraatiot.tloik.tekstiviesti :as tloik-tekstivietsi]
+            [harja.palvelin.integraatiot.tloik.tekstiviesti :as tloik-tekstiviesti]
             [harja.palvelin.palvelut.tierekisteri-haku :as tierekisteri-haku]
             [taoensso.timbre :as log]
             [harja.palvelin.integraatiot.api.tyokalut.sijainnit :as sijainnit]
@@ -220,7 +220,7 @@
   (let [viestinumero (rand-int 100000) ; Satunnainen viestinumero
         aiheet-ja-tarkenteet (when (get-in ilmoitus [:luokittelu :aihe])
                                (palautevayla-kyselyt/hae-aiheet-ja-tarkenteet db))
-        viesti (tloik-tekstivietsi/ilmoitus-tekstiviesti ilmoitus viestinumero aiheet-ja-tarkenteet)
+        viesti (tloik-tekstiviesti/ilmoitus-tekstiviesti ilmoitus viestinumero aiheet-ja-tarkenteet)
         vastaus (sms/laheta sms puhelinnumero viesti (:ilmoitusid ilmoitus) {})]
 
     (when (or (not vastaus) (not (str/includes? (:sisalto vastaus) "OK")))

--- a/src/clj/harja/palvelin/palvelut/debug.clj
+++ b/src/clj/harja/palvelin/palvelut/debug.clj
@@ -207,7 +207,7 @@
 (defn- laheta-paivystaja-ilmoitus-sahkopostilla [db api-sahkoposti vastaanottajan-email {id :ilmoitusid :as ilmoitus}]
   (log/info (format "Lähetetään ilmoitus (id: %s) sähköpostilla" id))
 
-  (let [lahettaja "no-reply@harjatesti.fi" #_(sahkoposti/vastausosoite api-sahkoposti)
+  (let [lahettaja "harja-ala-vastaa@vayla.fi" #_(sahkoposti/vastausosoite api-sahkoposti)
         [otsikko viesti] (tloik-sahkoposti/otsikko-ja-viesti db lahettaja ilmoitus)
         vastaus (sahkoposti/laheta-viesti! api-sahkoposti lahettaja vastaanottajan-email (str "TESTI: " otsikko) viesti {"X-Correlation-ID" id})]
     (when (not= "Message processed" vastaus)

--- a/src/cljs/harja/tiedot/hallinta/viestitestaus_tiedot.cljs
+++ b/src/cljs/harja/tiedot/hallinta/viestitestaus_tiedot.cljs
@@ -33,7 +33,12 @@
                           :lahetys-kaynnissa? false}
                :tekstiviesti {:puhelinnumero "<vastaanottajan puhelinnumero>"
                               :viesti "<anna viesti>"
-                              :lahetys-kaynnissa? false}})
+                              :lahetys-kaynnissa? false}
+               :ilmoitus-tiedot {:puhelinnumero nil
+                                 :sahkoposti nil
+                                 :ilmoitus-id nil
+                                 :lahetys-kaynnissa? false}})
+
 (def tila (atom alkutila))
 (def nakymassa? (atom false))
 
@@ -54,6 +59,12 @@
 (defrecord LahetaSMS [tekstiviesti])
 (defrecord LahetysSMSOnnistui [vastaus])
 (defrecord LahetysSMSEpaonnistui [vastaus])
+
+;; Päivystäjän ilmoituksen lähetys
+(defrecord MuokkaaPaivystajanIlmoitus [ilmoitus-tiedot])
+(defrecord LahetaPaivystajanIlmoitus [ilmoitus-tiedot])
+(defrecord LahetaPaivystajanIlmoitusOnnistui [vastaus])
+(defrecord LahetaPaivystajanIlmoitusEpaonnistui [vastaus])
 
 (extend-protocol tuck/Event
 
@@ -168,5 +179,35 @@
   (process-event [{vastaus :vastaus} app]
     (do
       (viesti/nayta-toast! "Lähetys epäonnistui" :varoitus viesti/viestin-nayttoaika-pitka)
+      (js/console.error "Virhe: " (pr-str vastaus))
+      (assoc app :lahetys-kaynnissa? false)))
+
+
+  MuokkaaPaivystajanIlmoitus
+  (process-event [{ilmoitus-tiedot :ilmoitus-tiedot} app]
+    (assoc app :ilmoitus-tiedot ilmoitus-tiedot))
+
+  LahetaPaivystajanIlmoitus
+  (process-event [{ilmoitus-tiedot :ilmoitus-tiedot} app]
+    (let [data (select-keys ilmoitus-tiedot [:puhelinnumero :sahkoposti :ilmoitus-id])]
+      (js/console.log "Lähetetään ilmoitus paivystajälle: " (pr-str data))
+
+      (tuck-apurit/post! :debug-laheta-paivystajan-ilmoitus data
+        {:onnistui ->LahetaPaivystajanIlmoitusOnnistui
+         :epaonnistui ->LahetaPaivystajanIlmoitusEpaonnistui})
+      (js/console.log "Lähetys matkalla!")
+      (assoc app :lahetys-kaynnissa? true)))
+
+  LahetaPaivystajanIlmoitusOnnistui
+  (process-event [{vastaus :vastaus} app]
+    (do
+      (viesti/nayta-toast! "Päivystäjän ilmoitus lähetetty" :onnistui)
+      (js/console.log "Vastaus: " (pr-str vastaus))
+      (assoc app :lahetys-kaynnissa? false)))
+
+  LahetaPaivystajanIlmoitusEpaonnistui
+  (process-event [{vastaus :vastaus} app]
+    (do
+      (viesti/nayta-toast! "Päivystäjän ilmoituksen lähetys epäonnistui" :varoitus viesti/viestin-nayttoaika-pitka)
       (js/console.error "Virhe: " (pr-str vastaus))
       (assoc app :lahetys-kaynnissa? false))))

--- a/src/cljs/harja/ui/kentat.cljs
+++ b/src/cljs/harja/ui/kentat.cljs
@@ -517,7 +517,7 @@
 (defmethod nayta-arvo :big [{:keys [desimaalien-maara]} data]
   [:span (some-> @data (big/fmt desimaalien-maara))])
 
-(defmethod tee-kentta :email [{:keys [on-focus on-blur lomake? disabled?] :as kentta} data]
+(defmethod tee-kentta :email [{:keys [on-focus on-blur lomake? placeholder disabled?] :as kentta} data]
   [:input {:class (cond-> nil
                           lomake? (str "form-control ")
                           disabled? (str "disabled"))
@@ -526,6 +526,7 @@
            :disabled disabled?
            :on-focus on-focus
            :on-blur on-blur
+           :placeholder placeholder
            :on-change #(reset! data (-> % .-target .-value))}])
 
 

--- a/src/cljs/harja/views/hallinta/viestitestaus_nakyma.cljs
+++ b/src/cljs/harja/views/hallinta/viestitestaus_nakyma.cljs
@@ -149,7 +149,7 @@
 
      [:h2 "Testaa päivystäjän ilmoitusta (tieliikenneilmoitukset)"]
      [:p "Tämä lähettää päivystäjälle tarkoitetun ilmoitusviestin, kuten tapahtuisi uuden tieliikenneilmoituksen saapuessa."]
-     [:p "Viesti lähetetään sähköpostiin ja lisäksi tekstiviestinä, jos puhelinnumero on annettu."]
+     [:p "Viesti lähetetään sähköpostina ja/tai tekstiviestinä, riippuen siitä, mitkä yhteystiedot on annettu."]
      [:p "Tällä voi testata viestintää ilman T-Loik-integraatiota. Tieliikenneilmoituksen tiedot haetaan Harjan tietokannasta ID:llä."]
      [lomake/lomake
       {:ei-borderia? true
@@ -160,22 +160,24 @@
                       #(e! (tiedot/->LahetaPaivystajanIlmoitus t))
                       {:disabled disable-laheta-paivystajan-ilmoitus? :paksu? true}]])
        :muokkaa! #(e! (tiedot/->MuokkaaPaivystajanIlmoitus %))}
-      [{:nimi :sahkoposti
-        :otsikko "Sähköposti"
-        :tyyppi :email
-        :placeholder "Vastaanottajan sähköposti"
-        :pakollinen? true}
-       {:nimi :puhelinnumero
-        :otsikko "Puhelinnumero"
-        :tyyppi :puhelin
-        :placeholder "Vastaanottajan puhelinnumero"
-        :pakollinen? false}
-       {:nimi :ilmoitus-id
-        :otsikko "Tieliikenneilmoituksen ID (ilmoitus-id)"
-        :placeholder "Tieliikenneilmoituksen ID"
-        :tyyppi :positiivinen-numero
-        :kokonaisluku? true
-        :pakollinen? true}]
+      [(lomake/rivi
+         {:nimi :ilmoitus-id
+          :otsikko "Tieliikenneilmoituksen ID (ilmoitus-id)"
+          :placeholder "Tieliikenneilmoituksen ID (katso Ilmoitukset-näkymästä)"
+          :tyyppi :positiivinen-numero
+          :kokonaisluku? true
+          :pakollinen? true})
+       (lomake/rivi
+         {:nimi :sahkoposti
+          :otsikko "Sähköposti"
+          :tyyppi :email
+          :placeholder "Vastaanottajan sähköposti"
+          :pakollinen? false}
+         {:nimi :puhelinnumero
+          :otsikko "Puhelinnumero"
+          :tyyppi :puhelin
+          :placeholder "Vastaanottajan puhelinnumero"
+          :pakollinen? false})]
       ilmoitus-tiedot]]))
 
 (defn viestitestaus []

--- a/src/cljs/harja/views/hallinta/viestitestaus_nakyma.cljs
+++ b/src/cljs/harja/views/hallinta/viestitestaus_nakyma.cljs
@@ -6,7 +6,7 @@
             [harja.ui.napit :as napit]
             [harja.tiedot.hallinta.viestitestaus-tiedot :as tiedot]))
 
-(defn viestitestaus* [e! {:keys [email emailapi tekstiviesti] :as app}]
+(defn viestitestaus* [e! {:keys [email emailapi tekstiviesti ilmoitus-tiedot] :as app}]
   (let [disable-laheta? (if (or (nil? (:palvelin email))
                               (nil? (:tunnus email))
                               (nil? (:salasana email))
@@ -28,7 +28,10 @@
                                   (nil? (:puhelinnumero tekstiviesti))
                                   (nil? (:viesti tekstiviesti)))
                               true
-                              false)]
+                              false)
+        disable-laheta-paivystajan-ilmoitus? (or
+                                               (and (nil? (:puhelinnumero ilmoitus-tiedot)) (nil? (:sahkoposti ilmoitus-tiedot)))
+                                               (nil? (:ilmoitus-id ilmoitus-tiedot)))]
     [:div
      [:h1 "Sähköpostin ja tekstiviestin lähetyksen testaustoiminnot"]
      [:p "Voit testata täällä eri ympäristöissä sähköpostin ja tekstiviestin lähettämistä."]
@@ -122,6 +125,8 @@
         :tyyppi :string
         :pakollinen? true}]
       emailapi]
+
+
      [:h2 "Lähetä tekstiviesti SMS-integraation kautta."]
      [lomake/lomake
       {:ei-borderia? true
@@ -141,7 +146,36 @@
         :tyyppi :string
         :pakollinen? true}]
       tekstiviesti]
-     ]))
+
+     [:h2 "Testaa päivystäjän ilmoitusta (tieliikenneilmoitukset)"]
+     [:p "Tämä lähettää päivystäjälle tarkoitetun ilmoitusviestin, kuten tapahtuisi uuden tieliikenneilmoituksen saapuessa."]
+     [:p "Viesti lähetetään sähköpostiin ja lisäksi tekstiviestinä, jos puhelinnumero on annettu."]
+     [:p "Tällä voi testata viestintää ilman T-Loik-integraatiota. Tieliikenneilmoituksen tiedot haetaan Harjan tietokannasta ID:llä."]
+     [lomake/lomake
+      {:ei-borderia? true
+       :tarkkaile-ulkopuolisia-muutoksia? true
+       :footer-fn (fn [t]
+                    [:div
+                     [napit/tallenna "Lähetä päivystäjän ilmoitus"
+                      #(e! (tiedot/->LahetaPaivystajanIlmoitus t))
+                      {:disabled disable-laheta-paivystajan-ilmoitus? :paksu? true}]])
+       :muokkaa! #(e! (tiedot/->MuokkaaPaivystajanIlmoitus %))}
+      [{:nimi :sahkoposti
+        :otsikko "Sähköposti"
+        :tyyppi :email
+        :placeholder "Vastaanottajan sähköposti"
+        :pakollinen? true}
+       {:nimi :puhelinnumero
+        :otsikko "Puhelinnumero"
+        :tyyppi :puhelin
+        :placeholder "Vastaanottajan puhelinnumero"
+        :pakollinen? false}
+       {:nimi :ilmoitus-id
+        :otsikko "Tieliikenneilmoituksen ID (key)"
+        :placeholder "Tieliikenneilmoituksen ID"
+        :tyyppi :string
+        :pakollinen? true}]
+      ilmoitus-tiedot]]))
 
 (defn viestitestaus []
   [tuck tiedot/tila viestitestaus*])

--- a/src/cljs/harja/views/hallinta/viestitestaus_nakyma.cljs
+++ b/src/cljs/harja/views/hallinta/viestitestaus_nakyma.cljs
@@ -171,9 +171,10 @@
         :placeholder "Vastaanottajan puhelinnumero"
         :pakollinen? false}
        {:nimi :ilmoitus-id
-        :otsikko "Tieliikenneilmoituksen ID (key)"
+        :otsikko "Tieliikenneilmoituksen ID (ilmoitus-id)"
         :placeholder "Tieliikenneilmoituksen ID"
-        :tyyppi :string
+        :tyyppi :positiivinen-numero
+        :kokonaisluku? true
         :pakollinen? true}]
       ilmoitus-tiedot]]))
 


### PR DESCRIPTION
Mahdollista tieliikenneilmoitusten päivystäjäviestien (email, sms) templaattien testaaminen ilman T-Loik integraatiota.