### PR TITLE
Harja-1464 paallystysilmoitusten rc-prosenttimuutokset

### DIFF
--- a/src/clj/harja/kyselyt/paallystys.sql
+++ b/src/clj/harja/kyselyt/paallystys.sql
@@ -214,6 +214,7 @@ SELECT
     um.tyyppi as "murske-tyyppi",
     um.rakeisuus,
     um.iskunkestavyys,
+    pot2_alusta_rc_prosentti(pot2a.id) as "rc%",
     p2mt.*
   FROM pot2_alusta pot2a
   JOIN paallystysilmoitus pot ON pot.id = pot2a.pot2_id AND pot.poistettu IS FALSE

--- a/src/cljc/harja/domain/pot2.cljc
+++ b/src/cljc/harja/domain/pot2.cljc
@@ -17,14 +17,16 @@
 (def +masuunikuonan-sideainetyyppi-koodi+ 12)
 (def +kulutuskerros-toimenpide-karhinta+ 41)
 (def +rem-toimenpide+ 31)
+(def +rem-plus-toimenpide+ 32)
 (def +remo-toimenpide+ 33)
+(def +rem-tas-toimenpide+ 4)
 
 (def alusta-toimenpide-kaikki-lisaavaimet
   {:lisatty-paksuus {:nimi :lisatty-paksuus :otsikko "Lisätty paksuus" :yksikko "cm"
                      :validoi [[:rajattu-numero-tai-tyhja 1 500 "Arvon tulee olla välillä 1-500cm"]]
                      :tyyppi :positiivinen-numero :kokonaisluku? true
                      :validoi-kentta-fn (fn [numero] (v/validoi-numero numero 1 500 0))}
-   :massamenekki {:nimi :massamenekki :otsikko "Massa\u00ADmäärä" :yksikko "kg/m²"
+   :massamenekki {:nimi :massamenekki :otsikko "Massamenekki" :yksikko "kg/m²"
                   :tyyppi :positiivinen-numero :desimaalien-maara 1
                   :validoi-kentta-fn (fn [numero] (v/validoi-numero numero 0 1000000 1))}
    :murske {:nimi :murske :otsikko "Murske"

--- a/src/cljs/harja/tiedot/urakka/pot2/pot2_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/pot2/pot2_tiedot.cljs
@@ -62,9 +62,20 @@
 (defn onko-alustatoimenpide-verkko? [koodi]
   (= koodi 3))
 
+(defn asfalttirouheen-osuus-massassa [massa]
+  (->> massa
+    ::pot2-domain/runkoaineet
+    (filter #(= pot2-domain/+runkoainetyyppi-asfalttirouhe+ (:runkoaine/tyyppi %)))
+    first
+    :runkoaine/massaprosentti))
+
+(defn koko-toimenpiteen-rc-pros [massamenekki massa]
+  (when (and massamenekki (< massamenekki 100))
+    (fmt/desimaaliluku (+ (- 100 massamenekki) (* massamenekki (/ (asfalttirouheen-osuus-massassa massa) 100))) 0 false)))
+
 (defn toimenpiteen-tiedot
-  [{:keys [koodistot]} rivi]
-  (fn [{:keys [koodistot]} rivi]
+  [{:keys [koodistot]} rivi massat voi-muokata?]
+  (fn [{:keys [koodistot]} {:keys [massa rc% toimenpide massamenekki] :as rivi} massat]
     [:div.pot2-toimenpiteen-tiedot
      ;; Kaivetaan metatiedosta sopivat kentät. Tähän mahdollisimman geneerinen ratkaisu olisi hyvä
      (when (some? rivi)
@@ -88,10 +99,26 @@
                                                                   :sideaine :sideainepitoisuus :sideaine2
                                                                   :massamenekki :kokonaismassamaara} nimi))]
 
-                                   (str (when otsikko? (str otsikko ": ")) teksti)))]
-           (str/join "; " (->> (pot2-domain/alusta-toimenpidespesifit-metadata rivi)
-                               (filter kuuluu-kentalle?)
-                               (map muotoile-kentta))))))]))
+                                   (str (when otsikko? (str otsikko ": ")) teksti)))
+               toimenpide-tiedot (str/join "; " (->> (pot2-domain/alusta-toimenpidespesifit-metadata rivi)
+                                                  (filter kuuluu-kentalle?)
+                                                  (map muotoile-kentta)))
+               massan-tiedot (some #(when (= (:harja.domain.pot2/massa-id %) massa) %) massat)
+               rc-pros (koko-toimenpiteen-rc-pros massamenekki massan-tiedot)
+               asfalttirouheen-osuus (asfalttirouheen-osuus-massassa massan-tiedot)
+               alustakerros-rc-pros (cond
+                                      (and (some? rc%) (not voi-muokata?))
+                                      (str "; rc%: " rc%)
+
+                                      (and voi-muokata? (= pot2-domain/+rem-tas-toimenpide+ toimenpide) rc-pros)
+                                      (str "; rc%: " rc-pros)
+
+                                      (and voi-muokata? asfalttirouheen-osuus)
+                                      (str "; rc%: " asfalttirouheen-osuus)
+
+                                      :else
+                                      nil)]
+           (str toimenpide-tiedot alustakerros-rc-pros))))]))
 
 (defn merkitse-muokattu [app]
   (assoc-in app [:paallystysilmoitus-lomakedata :muokattu?] true))

--- a/src/cljs/harja/views/urakka/pot2/alusta.cljs
+++ b/src/cljs/harja/views/urakka/pot2/alusta.cljs
@@ -326,7 +326,7 @@
        {:otsikko "Toimenpiteen tie\u00ADdot" :nimi :toimenpiteen-tiedot :leveys (:tp-tiedot pot2-yhteiset/gridin-leveydet)
         :tyyppi :komponentti :muokattava? (constantly false)
         :komponentti (fn [rivi]
-                       [pot2-tiedot/toimenpiteen-tiedot {:koodistot materiaalikoodistot} rivi])}
+                       [pot2-tiedot/toimenpiteen-tiedot {:koodistot materiaalikoodistot} rivi massat voi-muokata?])}
        {:otsikko "" :nimi :alusta-toiminnot :tyyppi :reagent-komponentti :leveys (:toiminnot pot2-yhteiset/gridin-leveydet)
         :tasaa :keskita :komponentti-args [e! app kirjoitusoikeus? alustarivit-atom  :alusta voi-muokata? ohjauskahva]
         :komponentti pot2-yhteiset/rivin-toiminnot-sarake}]

--- a/src/cljs/harja/views/urakka/pot2/paallystekerros.cljs
+++ b/src/cljs/harja/views/urakka/pot2/paallystekerros.cljs
@@ -52,23 +52,20 @@
                                                      paallekkyydet}
                                                     (not alikohde?))))
 
-(defn paallystekerros-rc-prosentti [rivi massat]
-  (let [rem-toimenpide? (#{pot2-domain/+rem-toimenpide+ pot2-domain/+remo-toimenpide+} (:toimenpide rivi))
-        karhinta-toimenpide? (= pot2-domain/+kulutuskerros-toimenpide-karhinta+ (:toimenpide rivi))
+(defn paallystekerros-rc-prosentti [{:keys [toimenpide massamenekki] :as rivi} massat]
+  (let [rem-toimenpide? (#{pot2-domain/+rem-toimenpide+ pot2-domain/+rem-plus-toimenpide+ pot2-domain/+remo-toimenpide+} toimenpide)
+        karhinta-toimenpide? (= pot2-domain/+kulutuskerros-toimenpide-karhinta+ toimenpide)
         massa (first (filter #(= (:materiaali rivi) (::pot2-domain/massa-id %)) massat))
-        asfalttirouheen-osuus (->> massa
-                                ::pot2-domain/runkoaineet
-                                (filter #(= pot2-domain/+runkoainetyyppi-asfalttirouhe+ (:runkoaine/tyyppi %)))
-                                first
-                                :runkoaine/massaprosentti)]
+        asfalttirouheen-osuus (pot2-tiedot/asfalttirouheen-osuus-massassa massa)
+        rc-pros (pot2-tiedot/koko-toimenpiteen-rc-pros massamenekki massa)]
     (cond
       ;; rem-toimenpiteissä rc%, eli asfalttirouheen osuus on se massa, mitä EI tuoda uutena vaan mnurskataan olemassa olevasta asfaltista.
       ;; Oletus on, että vanhan asfaltin ja uuden sekoitus on aina 100kg/m2.
       rem-toimenpide?
-      (- 100 (:massamenekki rivi))
+      rc-pros
 
       ;; Karhinnassa on RC% aina 100
-       karhinta-toimenpide?
+      karhinta-toimenpide?
       100
 
       :else

--- a/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
+++ b/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
@@ -843,6 +843,70 @@
         (is (= (:kokonaishinta-ilman-maaramuutoksia paallystysilmoitus-kannassa) 0M))
         (poista-paallystysilmoitus-paallystyskohtella paallystyskohde-id)))))
 
+(deftest tallenna-uusi-pot2-paallystysilmoitus-kantaan-ja-laske-rc-prosentti-rem-toimenpiteilla
+  (let [;; Ei saa olla POT ilmoitusta
+        paallystyskohde-id (hae-yllapitokohteen-id-nimella "Aloittamaton kohde mt20")]
+    (is (some? paallystyskohde-id))
+    (is (= 28 paallystyskohde-id))
+    (u (str "UPDATE yllapitokohdeosa SET toimenpide = 'Wut' WHERE yllapitokohde = 28"))
+    (log/debug "Tallennetaan päällystyskohteelle " paallystyskohde-id " uusi pot2 ilmoitus")
+    (let [paallystysilmoitus (-> pot2-testidata
+                               (assoc :paallystyskohde-id paallystyskohde-id)
+                               (assoc-in [:paallystekerros 0 :toimenpide] 31)
+                               (assoc-in [:paallystekerros 1 :toimenpide] 32)
+                               (assoc-in [:paallystekerros 0 :materiaali] 2)
+                               (assoc-in [:paallystekerros 1 :materiaali] 2)
+                               (assoc-in [:perustiedot :valmis-kasiteltavaksi] true))
+          maara-ennen-lisaysta (ffirst (q (str "SELECT count(*) FROM paallystysilmoitus;")))
+          [urakka-id sopimus-id] (tallenna-testipaallystysilmoitus
+                                   paallystysilmoitus
+                                   paallystysilmoitus-domain/pot2-vuodesta-eteenpain)
+          maara-lisayksen-jalkeen (ffirst (q (str "SELECT count(*) FROM paallystysilmoitus;")))
+          paallystysilmoitus-kannassa (kutsu-palvelua (:http-palvelin jarjestelma)
+                                        :urakan-paallystysilmoitus-paallystyskohteella
+                                        +kayttaja-jvh+ {:urakka-id urakka-id
+                                                        :sopimus-id sopimus-id
+                                                        :paallystyskohde-id paallystyskohde-id})]
+      (log/debug "Testitallennus valmis. POTTI kannassa: " (pr-str paallystysilmoitus-kannassa))
+      (is (not (nil? paallystysilmoitus-kannassa)))
+      (is (= (+ maara-ennen-lisaysta 1) maara-lisayksen-jalkeen) "Tallennuksen jälkeen päällystysilmoituksien määrä")
+      (is (= (:tila paallystysilmoitus-kannassa) :valmis))
+      (is (= 98.1M (get-in paallystysilmoitus-kannassa [:paallystekerros 0 :rc-prosentti])))
+      (is (= 98.1M (get-in paallystysilmoitus-kannassa [:paallystekerros 1 :rc-prosentti])))
+      (poista-paallystysilmoitus-paallystyskohtella paallystyskohde-id))))
+
+(deftest tallenna-uusi-pot2-paallystysilmoitus-kantaan-ja-laske-rc-prosentti-kar-ja-mp-toimenpiteilla
+  (let [;; Ei saa olla POT ilmoitusta
+        paallystyskohde-id (hae-yllapitokohteen-id-nimella "Aloittamaton kohde mt20")]
+    (is (some? paallystyskohde-id))
+    (is (= 28 paallystyskohde-id))
+    (u (str "UPDATE yllapitokohdeosa SET toimenpide = 'Wut' WHERE yllapitokohde = 28"))
+    (log/debug "Tallennetaan päällystyskohteelle " paallystyskohde-id " uusi pot2 ilmoitus")
+    (let [paallystysilmoitus (-> pot2-testidata
+                               (assoc :paallystyskohde-id paallystyskohde-id)
+                               (assoc-in [:paallystekerros 0 :toimenpide] 41)
+                               (assoc-in [:paallystekerros 1 :toimenpide] 21)
+                               (assoc-in [:paallystekerros 0 :materiaali] 2)
+                               (assoc-in [:paallystekerros 1 :materiaali] 2)
+                               (assoc-in [:perustiedot :valmis-kasiteltavaksi] true))
+          maara-ennen-lisaysta (ffirst (q (str "SELECT count(*) FROM paallystysilmoitus;")))
+          [urakka-id sopimus-id] (tallenna-testipaallystysilmoitus
+                                   paallystysilmoitus
+                                   paallystysilmoitus-domain/pot2-vuodesta-eteenpain)
+          maara-lisayksen-jalkeen (ffirst (q (str "SELECT count(*) FROM paallystysilmoitus;")))
+          paallystysilmoitus-kannassa (kutsu-palvelua (:http-palvelin jarjestelma)
+                                        :urakan-paallystysilmoitus-paallystyskohteella
+                                        +kayttaja-jvh+ {:urakka-id urakka-id
+                                                        :sopimus-id sopimus-id
+                                                        :paallystyskohde-id paallystyskohde-id})]
+      (log/debug "Testitallennus valmis. POTTI kannassa: " (pr-str paallystysilmoitus-kannassa))
+      (is (not (nil? paallystysilmoitus-kannassa)))
+      (is (= (+ maara-ennen-lisaysta 1) maara-lisayksen-jalkeen) "Tallennuksen jälkeen päällystysilmoituksien määrä")
+      (is (= (:tila paallystysilmoitus-kannassa) :valmis))
+      (is (= 100M (get-in paallystysilmoitus-kannassa [:paallystekerros 0 :rc-prosentti])))
+      (is (= 5.0M (get-in paallystysilmoitus-kannassa [:paallystekerros 1 :rc-prosentti])))
+      (poista-paallystysilmoitus-paallystyskohtella paallystyskohde-id))))
+
 (deftest tallenna-uusi-pot2-paallystysilmoitus-kantaan-vaikka-paallystyskerros-ei-validi
   (let [;; Ei saa olla POT ilmoitusta
         paallystyskohde-id (hae-yllapitokohteen-id-nimella "Aloittamaton kohde mt20")]
@@ -1246,6 +1310,27 @@
                                                   urakka-id sopimus-id paallystyskohde-id paallystysilmoitus)
         paallystekerrokset-jalkeen (:paallystekerros paallystysilmoitus-kannassa-jalkeen)]
     #_(poista-paallystysilmoitus-paallystyskohtella paallystyskohde-id)))
+
+(deftest tallenna-pot2-lisaa-alustarivi-ja-laske-rc-prosentti-tas-ja-rem-tas-toimenpiteilla
+  (let [paallystyskohde-id (hae-yllapitokohteen-id-nimella "Tärkeä kohde mt20")
+        paallystysilmoitus (-> pot2-alustatestien-ilmoitus
+                             (assoc :alusta pot2-alusta-esimerkki)
+                             (assoc-in [:alusta 0 :massa] 2)
+                             (assoc-in [:alusta 1 :massa] 2)
+                             (assoc-in [:alusta 1 :massamenekki] 10)
+                             (assoc-in [:alusta 0 :toimenpide] 32)
+                             (assoc-in [:alusta 1 :toimenpide] 4))
+        [urakka-id sopimus-id] (tallenna-testipaallystysilmoitus
+                                 paallystysilmoitus
+                                 paallystysilmoitus-domain/pot2-vuodesta-eteenpain)
+        paallystysilmoitus-kannassa (kutsu-palvelua (:http-palvelin jarjestelma)
+                                      :urakan-paallystysilmoitus-paallystyskohteella
+                                      +kayttaja-jvh+ {:urakka-id urakka-id
+                                                      :sopimus-id sopimus-id
+                                                      :paallystyskohde-id paallystyskohde-id})]
+    (is (= 5.0M (get-in paallystysilmoitus-kannassa [:alusta 0 :rc%])))
+    (is (= 90.5M (get-in paallystysilmoitus-kannassa [:alusta 1 :rc%])))
+    (poista-paallystysilmoitus-paallystyskohtella paallystyskohde-id)))
 
 (deftest ei-saa-tallenna-pot2-paallystysilmoitus-jos-alustarivi-on-tiella-joka-ei-loydy-kulutuskerroksesta
   (let [paallystyskohde-id (hae-yllapitokohteen-id-nimella "Tärkeä kohde mt20")
@@ -1935,4 +2020,3 @@
 (deftest hyppya-ei-ole-koska-tienosa-vaihtuu
   (let [hyppyjen-lkm (paallystys/laske-kulutuskerroksen-hypyt testidata-hypyton-tienosa-vaihtuu 0 0)]
     (is (= 0 hyppyjen-lkm) "ei hyppyä")))
-

--- a/tietokanta/src/main/resources/db/migration/V1_1185__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1185__.sql
@@ -1,0 +1,118 @@
+CREATE OR REPLACE FUNCTION pot2_rc_prosentti(paallystekerros_id INT)
+    RETURNS NUMERIC AS
+$$
+DECLARE
+    paallystekerros         pot2_paallystekerros;
+    toimenpide              TEXT;
+    asfalttirouhe_koodi     INTEGER;
+    asfalttirouhe_runkoaine pot2_mk_massan_runkoaine;
+BEGIN
+    SELECT * FROM pot2_paallystekerros WHERE id = paallystekerros_id LIMIT 1 INTO paallystekerros;
+    SELECT lyhenne FROM pot2_mk_paallystekerros_toimenpide WHERE koodi = paallystekerros.toimenpide INTO toimenpide;
+    SELECT koodi FROM pot2_mk_runkoainetyyppi WHERE nimi = 'Asfalttirouhe' INTO asfalttirouhe_koodi;
+    SELECT * FROM pot2_mk_massan_runkoaine WHERE pot2_massa_id = paallystekerros.materiaali
+                                         AND tyyppi = asfalttirouhe_koodi INTO asfalttirouhe_runkoaine;
+
+    -- REM-toimenpiteissä sekoitetaan nykyistä massaa uuteen kiviainekseen, ja lähtökohtaisesti niiden
+    -- yhteenlaskettu summa on aina 100kg/m2. Tällöin vanhan murskatun asfaltin osuus on RC-prosentti.
+    -- Mikäli näiden toimenpiteiden runkoaineessakin on mukana asfalttirouhetta, pitää laskea koko toimenpiteen
+    -- rc-prosentti ja sitä varten on käytössä uudistettu kaava.
+    IF toimenpide IN ('REM', 'REM+','REMO') THEN
+        IF paallystekerros.massamenekki < 100 THEN
+            IF asfalttirouhe_runkoaine.massaprosentti IS DISTINCT FROM NULL THEN
+                RETURN (100 - paallystekerros.massamenekki) + paallystekerros.massamenekki * (asfalttirouhe_runkoaine.massaprosentti / 100);
+            ELSE
+                RETURN 100 - paallystekerros.massamenekki;
+            END IF;
+        ELSE
+            -- Jos REM-toimenpiteen massamenekki on yli 100, ei voida laskea RC-prosenttia oikein.
+            -- Tämän pitäisi aina olla viite siitä, että kirjauksessa on tapahtunut virhe.
+            RETURN NULL;
+        END IF;
+    ELSE
+        IF toimenpide IN ('KAR') THEN
+            RETURN 100;
+        END IF;
+    END IF;
+
+    IF asfalttirouhe_runkoaine.massaprosentti IS DISTINCT FROM NULL THEN
+        RETURN asfalttirouhe_runkoaine.massaprosentti;
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION pot2_alusta_rc_prosentti(alusta_id INT)
+    RETURNS NUMERIC AS
+$$
+DECLARE
+    alusta                  pot2_alusta;
+    toimenpide              TEXT;
+    asfalttirouhe_koodi     INTEGER;
+    asfalttirouhe_runkoaine pot2_mk_massan_runkoaine;
+BEGIN
+    SELECT * FROM pot2_alusta WHERE id = alusta_id LIMIT 1 INTO alusta;
+    SELECT lyhenne FROM pot2_mk_alusta_toimenpide WHERE koodi = alusta.toimenpide INTO toimenpide;
+    SELECT koodi FROM pot2_mk_runkoainetyyppi WHERE nimi = 'Asfalttirouhe' INTO asfalttirouhe_koodi;
+    SELECT * FROM pot2_mk_massan_runkoaine WHERE pot2_massa_id = alusta.massa
+                                         AND tyyppi = asfalttirouhe_koodi INTO asfalttirouhe_runkoaine;
+
+    -- REM-toimenpiteissä sekoitetaan nykyistä massaa uuteen kiviainekseen, ja lähtökohtaisesti niiden
+    -- yhteenlaskettu summa on aina 100kg/m2. Tällöin vanhan murskatun asfaltin osuus on RC-prosentti.
+    -- Mikäli näiden toimenpiteiden runkoaineessakin on mukana asfalttirouhetta, pitää laskea koko toimenpiteen
+    -- rc-prosentti ja sitä varten on käytössä uudistettu kaava. Jos alustan toimenpiteenä on REM-TAS, palautetaan
+    -- koko toimenpiteen rc-prosentti.
+    IF toimenpide IN ('REM-TAS') THEN
+        IF alusta.massamenekki < 100 THEN
+            IF asfalttirouhe_runkoaine.massaprosentti IS DISTINCT FROM NULL THEN
+                RETURN (100 - alusta.massamenekki) + alusta.massamenekki * (asfalttirouhe_runkoaine.massaprosentti / 100);
+            END IF;
+        END IF;
+    ELSE
+        IF asfalttirouhe_runkoaine.massaprosentti IS DISTINCT FROM NULL THEN
+            RETURN asfalttirouhe_runkoaine.massaprosentti;
+        END IF;
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+
+DROP VIEW IF EXISTS pot2_massan_tiedot;
+
+CREATE OR REPLACE VIEW pot2_massan_tiedot AS
+SELECT um.id,
+       um.nimen_tarkenne as "nimen-tarkenne",
+       um.tyyppi as "paallystetyyppi",
+       um.max_raekoko as "max-raekoko",
+       um.kuulamyllyluokka,
+       um.litteyslukuluokka,
+       (SELECT array_to_string(array_agg(asfrouhe.tyyppi), ', ')
+        FROM pot2_mk_massan_runkoaine asfrouhe
+        WHERE asfrouhe.pot2_massa_id = um.id) as "runkoaine-koodit",
+       mr.esiintyma,
+       mr.kuulamyllyarvo as "km-arvo",
+       mr.litteysluku as "muotoarvo",
+       mla.tyyppi as "lisaaine-koodi",
+       (SELECT array_to_string(array_agg(p2ml.nimi||': '||ml.pitoisuus||'%'), ', ')
+        FROM pot2_mk_massan_lisaaine ml
+                 JOIN pot2_mk_lisaainetyyppi p2ml on ml.tyyppi = p2ml.koodi
+        WHERE ml.pot2_massa_id = um.id) as "lisaaineet",
+       ms.pitoisuus,
+       ms.tyyppi as "sideainetyyppi"
+FROM pot2_mk_urakan_massa um
+         LEFT JOIN pot2_mk_massan_runkoaine mr ON mr.id = (SELECT p2mmr.id
+                                                           FROM pot2_mk_massan_runkoaine p2mmr
+                                                           WHERE p2mmr.pot2_massa_id = um.id
+                                                           ORDER BY p2mmr.massaprosentti DESC LIMIT 1)
+    LEFT JOIN pot2_mk_massan_lisaaine mla ON mla.id = (SELECT p2mma.id
+    FROM pot2_mk_massan_lisaaine p2mma
+    WHERE p2mma.pot2_massa_id = um.id
+    ORDER BY p2mma.pitoisuus DESC LIMIT 1)
+    LEFT JOIN pot2_mk_massan_sideaine ms ON ms.id = (SELECT p2mms.id
+    FROM pot2_mk_massan_sideaine p2mms
+    WHERE p2mms.pot2_massa_id = um.id AND p2mms."lopputuote?" IS TRUE
+    LIMIT 1);


### PR DESCRIPTION
Tässä haarassa on toteutettu nämä molemmat tiketit: HARJA-1464 ja HARJA-1509
Päällystyskerroksen rc-prosentin formatointi on muutettu kokonaisluvuksi, koska aiemminkin se on näkynyt kokonaislukuna muilla kuin REM-toimenpiteillä.
Muutettu alustalomakkeen otsikko "Massamäärä kg/m²" tähän: "Massamenekki kg/m²", kuten sovittiin Ylläpidon suunnittelupalaverissa.