### PR TITLE
Korjaa etsi-seuraava-input funktiota että poistaminen onnistuu

### DIFF
--- a/src/cljs/harja/ui/grid/perus.cljs
+++ b/src/cljs/harja/ui/grid/perus.cljs
@@ -130,19 +130,26 @@
             [:td {:class (y/luokat "ei-muokattava" tasaus-luokka (grid-yleiset/tiivis-tyyli skeema esta-tiivis-grid?))}
              ((or fmt str) (hae rivi))])))})))
 
-;; Luo funktio etsimään seuraavan input elementin
 (defn etsi-seuraava-input
-  "Fokusoitu-rivi parametri odottaa saavansa fokusoituneen rivin, jonka kautta etsitään seuraava input-elementti.
-  Suunta parametri odottaa saavansa arvot :eteen tai :taakse."
-  [fokusoitu-rivi suunta]
-  (let [edellinen-rivi (.-previousElementSibling (.-parentElement (.-parentElement fokusoitu-rivi)))
-        seuraava-rivi (.-nextElementSibling (.-parentElement (.-parentElement fokusoitu-rivi)))
-        rivi (if (= suunta :taakse) edellinen-rivi seuraava-rivi)
-        ;; Valitaan rivin ensimmäinen tai toinen td, riippuen siitä, että onko ensimmäisessä jokin input-elementti.
-        input (when rivi (or
-                           (-> (.getElementsByTagName rivi "td") (aget 0) (.querySelector "input, button, select, checkbox"))
-                           (-> (.getElementsByTagName rivi "td") (aget 1) (.querySelector "input, button, select, checkbox"))))]
-    input))
+  "Etsii seuraavan input-elementin annetun rivin suunnassa (:eteen tai :taakse).
+   Palauttaa ensimmäisen löytyvän input/button/select/checkbox-elementin seuraavalta riviltä.
+   Ohittaa rivit, joissa ei ole syötettäviä kenttiä (esim. vetolaatikot)."
+  [fokusoitu suunta]
+  (when-let [nykyinen-tr (loop [el fokusoitu]
+                           (cond
+                             (nil? el) nil
+                             (= "TR" (.-tagName el)) el
+                             :else (recur (.-parentElement el))))]
+    (loop [tr (case suunta
+                :taakse (.-previousElementSibling nykyinen-tr)
+                :eteen (.-nextElementSibling nykyinen-tr))]
+      (when (and tr (= "TR" (.-tagName tr)))
+        (let [inputs (.querySelectorAll tr "input, button, select, [type=checkbox]")]
+          (if (pos? (.-length inputs))
+            (aget inputs 0)
+            (recur (case suunta
+                     :taakse (.-previousElementSibling tr)
+                     :eteen (.-nextElementSibling tr)))))))))
 
 (defn- muokkausrivi [{:keys [ohjaus id muokkaa! luokka rivin-virheet rivin-varoitukset rivin-huomautukset voi-poistaa? esta-poistaminen?
                    esta-poistaminen-tooltip piilota-toiminnot? tallennus-kaynnissa?


### PR DESCRIPTION
Palautteen mukaan poistaminen ei onnistunut kohteille. 

Tässä taustalla oli että etsi-seuraava-input funktioon tuli tyhjiä arvoja ja harja räsähti.

Vetolaatikot tekevät domiin tyhjiä tr rivejä josta ongelmat johtuivat. Pullarissa muokattu etsi-seuraava-input funktiota selviytymään tällaisista riveistä ja luuppaamaan riveihin jossa kohteita löytyy.