### PR TITLE
HARJA-1599 - Tilannekuva ei piirrä tehtävän toteumia kartalle

### DIFF
--- a/tietokanta/src/main/resources/db/migration/V1_1194__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1194__.sql
@@ -1,0 +1,6 @@
+-- Korjaa tilannekuvan toteumien näkyminen lisäämällä suoritettavatehtava tehtavalle
+UPDATE tehtava
+SET suoritettavatehtava = 'liik. opast. ja ohjausl. hoito seka reunapaalujen kun.pito',
+    muokattu            = current_timestamp,
+    muokkaaja           = (select id from kayttaja where kayttajanimi = 'Integraatio')
+WHERE nimi = 'Liikennemerkkien, opasteiden ja liikenteenohjauslaitteiden hoito sekä reunapaalujen kp';


### PR DESCRIPTION
Tilannekuvasta jäi näkymättä Liikennemerkkien, opasteiden ja liikenteenohjauslaitteiden hoito sekä reunapaalujen kp toteumat.

Korjaus lisää puuttuvan linkityksen migraatiolla.