### PR TITLE
HARJA-1604-Korjaa-myos-varmistaminen-maaramitattavaksi

### DIFF
--- a/tietokanta/src/main/resources/db/migration/V1_1200__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1200__.sql
@@ -1,0 +1,6 @@
+-- Korjaa oikea tehtävä 'Liikenteen varmistaminen kelirikkokohteessa (materiaali)' määrämitattavaksi
+UPDATE tehtava
+SET "maaramitattava?"      = true,
+    muokattu               = current_timestamp,
+    muokkaaja              = (select id from kayttaja where kayttajanimi = 'Integraatio')
+WHERE nimi = 'Liikenteen varmistaminen kelirikkokohteessa (materiaali)';


### PR DESCRIPTION
Korjaa oikea tehtävä 'Liikenteen varmistaminen kelirikkokohteessa (materiaali)' määrämitattavaksi.

Aiemmassa migraatiossa tämä oli jäänyt päivittymättä koska oli valittu eri niminen tehtävä vahingossa.