### PR TITLE
Harja 1614 muut kulut toimenkuviin

### DIFF
--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
@@ -354,8 +354,7 @@
         muut-kulut-kuukaudet (vec (sort-by (juxt :vuosi :kuukausi) muut-kulut-kuukaudet))
 
         ;; Muut kulut -rivi simuloi toimenkuvariviä.
-        muu-kulu {:id 999
-                  :toimenkuva "Muut kulut"
+        muu-kulu {:toimenkuva "Muut kulut"
                   :nimike "Muut kulut"
                   :viimeisin-muokkaus (:viimeisin_muokkaus viimeisin-muokkaus)
                   :viimeisin-muokkaaja (:viimeisin_muokkaaja viimeisin-muokkaus)

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
@@ -103,9 +103,10 @@
                     :yhteensa (+ (apply + (map :alkukausi kiinteat)) (apply + (map :loppukausi kiinteat)))
                     :yhteensa-indeksikorjattu (+ (apply + (map :alkukausi-indeksikorjattu kiinteat)) (apply + (map :loppukausi-indeksikorjattu kiinteat)))
                     :pysyvat-muutokset "Ei muutoksia"
+                    :toimenpideinstanssi-id 999999999 ;; Joku iso luku, jolla saadaan yhteenvetorivi listan loppuun
                     :viimeisin-muokkaus (:viimeisin_muokkaus viimeisin-muokkaus)
                     :viimeisin-muokkaaja (:viimeisin_muokkaaja viimeisin-muokkaus)}
-        kiinteat (conj kiinteat yhteenveto)]
+        kiinteat (vec (sort-by :toimenpideinstanssi-id (conj kiinteat yhteenveto)))]
     kiinteat))
 
 (defn hae-rahavaraukset
@@ -337,8 +338,7 @@
                                  muut-kulut-kuukaudet)
                                (mapv (fn [kk]
                                        (let [vuosi (if (>= kk 10) hoitovuoden-alkuvuosi (inc hoitovuoden-alkuvuosi))]
-                                         {:id 999
-                                          :toimenkuva "Muut kulut"
+                                         {:toimenkuva "Muut kulut"
                                           :nimike "Muut kulut"
                                           :urakka-id urakka-id
                                           :kuukausi kk
@@ -389,11 +389,11 @@
         johto-ja-hallintokorvaukset (if (seq johto-ja-hallintokorvaukset)
                                       ;; Jos on tallennettu jo johto-ja-hallintokorvauksia, niin lisätään niihin kalenterikuukausi
                                       (mapv (fn [rivi]
-                                             (merge rivi
-                                               {:kalenterikuukausi (pvm/koko-kuukausi-ja-vuosi
-                                                                     (pvm/->pvm (str "01." (:kuukausi rivi) "." (:vuosi rivi))) true)
-                                                :viimeisin-muokkaus (:viimeisin_muokkaus viimeisin-muokkaus)
-                                                :viimeisin-muokkaaja (:viimeisin_muokkaaja viimeisin-muokkaus)}))
+                                              (merge rivi
+                                                {:kalenterikuukausi (pvm/koko-kuukausi-ja-vuosi
+                                                                      (pvm/->pvm (str "01." (:kuukausi rivi) "." (:vuosi rivi))) true)
+                                                 :viimeisin-muokkaus (:viimeisin_muokkaus viimeisin-muokkaus)
+                                                 :viimeisin-muokkaaja (:viimeisin_muokkaaja viimeisin-muokkaus)}))
                                         johto-ja-hallintokorvaukset)
                                       ;; Jos ei ole tallennettu hoidonjohtopalkkioita, niin luodaan nolla arvot
                                       (mapv (fn [kk]

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
@@ -361,16 +361,13 @@
                   :viimeisin-muokkaaja (:viimeisin_muokkaaja viimeisin-muokkaus)
                   :tuntipalkka nil
                   :tunnit nil ;; muilla kuluilla ei koskaan ole oikeasti tunteja.
-                  :yhteensa-kk (if (kust-domain/onko-tuntipalkka-samat? muut-kulut-kuukaudet) (:tuntipalkka (first muut-kulut-kuukaudet))
-                                 nil)
-                  :yhteensa-indeksikorjattu-kk (apply + (map (fn [rivi]
-                                                               (if (:tuntipalkka-indeksikorjattu rivi) (:tuntipalkka-indeksikorjattu rivi) 0))
-                                                          muut-kulut-kuukaudet))
+                  :yhteensa-kk (:yhteensa-kk (first muut-kulut-kuukaudet))
+                  :yhteensa-indeksikorjattu-kk (:yhteensa-indeksikorjattu-kk (first muut-kulut-kuukaudet))
                   :summa (apply + (map (fn [rivi]
-                                         (if (:tuntipalkka rivi) (:tuntipalkka rivi) 0))
+                                         (if (:yhteensa-kk rivi) (:yhteensa-kk rivi) 0))
                                     muut-kulut-kuukaudet))
                   :summa-indeksikorjattu (apply + (map (fn [rivi]
-                                                         (if (:tuntipalkka-indeksikorjattu rivi) (:tuntipalkka-indeksikorjattu rivi) 0))
+                                                         (if (:yhteensa-indeksikorjattu-kk rivi) (:yhteensa-indeksikorjattu-kk rivi) 0))
                                                     muut-kulut-kuukaudet))
                   :kuukaudet muut-kulut-kuukaudet}
 

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
@@ -1,5 +1,6 @@
 (ns harja.kyselyt.uusi-kustannussuunnitelma-kyselyt
-  (:require [harja.pvm :as pvm]
+  (:require [clojure.string :as str]
+            [harja.pvm :as pvm]
             [jeesql.core :refer [defqueries]]
             [harja.tyokalut.yleiset :refer [round2] :as yleiset]
             [harja.domain.mhu :as mhu]
@@ -190,6 +191,26 @@
       (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "harjoittelija")) [10 11 12 1 2 3 4 5 6 7 8 9]
       :else [10 11 12 1 2 3 4 5 6 7 8 9])))
 
+(defn paattele-toimenkuvan-jarjestys
+  "Pakotetaan toimenkuvat oikeaan järjestykseen kovakoodauksen avulla."
+  [toimenkuva-nimike]
+  (case (str/lower-case toimenkuva-nimike)
+    "valmistelukausi ennen urakka-ajan alkua" 0
+    "sopimusvastaava" 1
+    "vastuunalainen työnjohtaja" 2
+    "2. työnjohtaja" 3
+    "3. työnjohtaja" 4
+    "päätoiminen apulainen" 5
+    "päätoiminen apulainen (talvikausi)" 5
+    "päätoiminen apulainen (kesäkausi)" 6
+    "apulainen/työnjohtaja" 7
+    "apulainen/työnjohtaja (talvikausi)" 7
+    "apulainen/työnjohtaja (kesäkausi)" 8
+    "viherhoidosta vastaava henkilö" 9
+    "hankintavastaava" 10
+    "harjoittelija" 11
+    99)) ;; Muu toimenkuva, joka ei ole listassa
+
 (defn hae-johto-ja-hallintokorvaukset-2019-2024 [db urakka-id sopimus-id hoitovuoden-alkuvuosi urakan-alkuvuosi toimenkuvat-tarjouksesta]
   (let [viimeisin-muokkaus (first (hae-viimeisin-muokkaaja-jjh
                                     db {:urakka-id urakka-id
@@ -224,6 +245,11 @@
                                     (conj uudet-toimenkuvat uusi-toimenkuva toimenkuva)
                                     (conj uudet-toimenkuvat toimenkuva))))
                         [] toimenkuvat)
+                      toimenkuvat)
+
+        ;; Järjestetään toimenkuvat järkevään järjestykseen
+        toimenkuvat (map (fn [toimenkuva]
+                           (assoc toimenkuva :jarjestys (paattele-toimenkuvan-jarjestys (:nimike toimenkuva))))
                       toimenkuvat)
 
         ;; Haetaan raskaalla prosessilla toimenkuvakohtaisesti suunnitellut johto-ja-hallintokorvaukset
@@ -368,13 +394,12 @@
                   :summa-indeksikorjattu (apply + (map (fn [rivi]
                                                          (if (:yhteensa-indeksikorjattu-kk rivi) (:yhteensa-indeksikorjattu-kk rivi) 0))
                                                     muut-kulut-kuukaudet))
-                  :kuukaudet muut-kulut-kuukaudet}
+                  :kuukaudet muut-kulut-kuukaudet
+                  :jarjestys 99                             ;; Varmistetaan, että on viimeisenä ui:lla listassa
+                  }
 
         toimenkuvat (conj toimenkuvat muu-kulu)
-        ;; Lisää vielä järjestysnumero toimenkuville
-        toimenkuvat (vec (map-indexed (fn [i toimenkuva]
-                                        (assoc toimenkuva :jarjestys (inc i)))
-                           toimenkuvat))]
+        toimenkuvat (vec (sort-by :jarjestys toimenkuvat))]
     toimenkuvat))
 
 (defn hae-johto-ja-hallintokorvaukset [db urakka-id hoitovuoden-alkuvuosi toimenkuvat-tarjouksesta]

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
@@ -292,6 +292,7 @@
                                                                :viimeisin-muokkaus (:viimeisin_muokkaus viimeisin-muokkaus)
                                                                :viimeisin-muokkaaja (:viimeisin-muokkaaja viimeisin-muokkaus)}))))
                                                 [] toimenkuvan-kuukaudet)
+                                    kuukaudet (vec (sort-by (juxt :vuosi :kuukausi) kuukaudet))
                                     toimenkuva (assoc toimenkuva :kuukaudet kuukaudet
                                                  :kkv (count toimenkuvan-kuukaudet))
                                     summa (apply + (map
@@ -307,7 +308,7 @@
                                                  :viimeisin-muokkaaja (:viimeisin_muokkaaja viimeisin-muokkaus)
                                                  :tuntipalkka (:tuntipalkka (first kuukaudet))
                                                  :tunnit (if (kust-domain/onko-tunnit-samat? kuukaudet) (:tunnit (first kuukaudet))
-                                                           nil) ;; Aseta arvo buk, jos tunnit eivät ole samat kaikissa kuukausissa
+                                                           nil) ;; Aseta arvo nil, jos tunnit eivät ole samat kaikissa kuukausissa
                                                  :yhteensa-kk (* (or (:tuntipalkka (first kuukaudet)) 0) (or (:tunnit (first kuukaudet)) 0))
                                                  :yhteensa-indeksikorjattu-kk (* (or (:tuntipalkka-indeksikorjattu (first kuukaudet)) 0) (or (:tunnit (first kuukaudet)) 0))
                                                  :summa summa
@@ -315,10 +316,69 @@
                                 (conj kuvat toimenkuva)))
                       [] toimenkuvat)
 
+        ;; Muut kulut - kuten toimisto, ict yms on käyttöliittymässä lisätty toimenkuva -taulukkoon. Haetaan nekin
+        ;; Hoindonjohto toimenpide.koodi = 23151
+        hoidonjohto-tpi-id (:id (first (tpi-kyselyt/hae-urakan-toimenpideinstanssi-toimenpidekoodilla db
+                                         {:urakka urakka-id
+                                          :koodi "23151"})))
+        muut-kulut-kuukaudet (hae-muut-kulut-toimenkuviin-kuukausittain db {:sopimus-id sopimus-id
+                                                                            :vuosi hoitovuoden-alkuvuosi
+                                                                            :toimenpideinstanssi-id hoidonjohto-tpi-id})
+        ;; Jos muut-kulut-kuukaudet on nil, niin luodaan lista default arvoilla.
+        muut-kulut-kuukaudet (if (seq muut-kulut-kuukaudet)
+                               (map (fn [rivi]
+                                      (merge rivi
+                                        {:yhteensa-kk (if (:tuntipalkka rivi) (:tuntipalkka rivi) 0)
+                                         :yhteensa-indeksikorjattu-kk (if (:tuntipalkka-indeksikorjattu rivi) (:tuntipalkka-indeksikorjattu rivi) 0)
+                                         :kalenterikuukausi (pvm/koko-kuukausi-ja-vuosi
+                                                              (pvm/->pvm (str "01." (:kuukausi rivi) "." (:vuosi rivi))) true)
+                                         :viimeisin-muokkaus (:viimeisin_muokkaus viimeisin-muokkaus)
+                                         :viimeisin-muokkaaja (:viimeisin_muokkaaja viimeisin-muokkaus)}))
+                                 muut-kulut-kuukaudet)
+                               (mapv (fn [kk]
+                                       (let [vuosi (if (>= kk 10) hoitovuoden-alkuvuosi (inc hoitovuoden-alkuvuosi))]
+                                         {:id 999
+                                          :toimenkuva "Muut kulut"
+                                          :nimike "Muut kulut"
+                                          :urakka-id urakka-id
+                                          :kuukausi kk
+                                          :yhteensa-kk 0
+                                          :yhteensa-indeksikorjattu-kk nil
+                                          :vuosi vuosi
+                                          :tuntipalkka 0
+                                          :tuntipalkka-indeksikorjattu nil
+                                          :kalenterikuukausi (pvm/koko-kuukausi-ja-vuosi (pvm/->pvm (str "01." kk "." vuosi)) true)
+                                          :viimeisin-muokkaus (:viimeisin_muokkaus viimeisin-muokkaus)
+                                          :viimeisin-muokkaaja (:viimeisin_muokkaaja viimeisin-muokkaus)}))
+                                 [10 11 12 1 2 3 4 5 6 7 8 9]))
+        muut-kulut-kuukaudet (vec (sort-by (juxt :vuosi :kuukausi) muut-kulut-kuukaudet))
+
+        ;; Muut kulut -rivi simuloi toimenkuvariviä.
+        muu-kulu {:id 999
+                  :toimenkuva "Muut kulut"
+                  :nimike "Muut kulut"
+                  :viimeisin-muokkaus (:viimeisin_muokkaus viimeisin-muokkaus)
+                  :viimeisin-muokkaaja (:viimeisin_muokkaaja viimeisin-muokkaus)
+                  :tuntipalkka nil
+                  :tunnit nil ;; muilla kuluilla ei koskaan ole oikeasti tunteja.
+                  :yhteensa-kk (if (kust-domain/onko-tuntipalkka-samat? muut-kulut-kuukaudet) (:tuntipalkka (first muut-kulut-kuukaudet))
+                                 nil)
+                  :yhteensa-indeksikorjattu-kk (apply + (map (fn [rivi]
+                                                               (if (:tuntipalkka-indeksikorjattu rivi) (:tuntipalkka-indeksikorjattu rivi) 0))
+                                                          muut-kulut-kuukaudet))
+                  :summa (apply + (map (fn [rivi]
+                                         (if (:tuntipalkka rivi) (:tuntipalkka rivi) 0))
+                                    muut-kulut-kuukaudet))
+                  :summa-indeksikorjattu (apply + (map (fn [rivi]
+                                                         (if (:tuntipalkka-indeksikorjattu rivi) (:tuntipalkka-indeksikorjattu rivi) 0))
+                                                    muut-kulut-kuukaudet))
+                  :kuukaudet muut-kulut-kuukaudet}
+
+        toimenkuvat (conj toimenkuvat muu-kulu)
         ;; Lisää vielä järjestysnumero toimenkuville
-        toimenkuvat (map-indexed (fn [i toimenkuva]
-                                  (assoc toimenkuva :jarjestys (inc i)))
-                                toimenkuvat)]
+        toimenkuvat (vec (map-indexed (fn [i toimenkuva]
+                                        (assoc toimenkuva :jarjestys (inc i)))
+                           toimenkuvat))]
     toimenkuvat))
 
 (defn hae-johto-ja-hallintokorvaukset [db urakka-id hoitovuoden-alkuvuosi toimenkuvat-tarjouksesta]
@@ -331,7 +391,7 @@
 
         johto-ja-hallintokorvaukset (if (seq johto-ja-hallintokorvaukset)
                                       ;; Jos on tallennettu jo johto-ja-hallintokorvauksia, niin lisätään niihin kalenterikuukausi
-                                      (map (fn [rivi]
+                                      (mapv (fn [rivi]
                                              (merge rivi
                                                {:kalenterikuukausi (pvm/koko-kuukausi-ja-vuosi
                                                                      (pvm/->pvm (str "01." (:kuukausi rivi) "." (:vuosi rivi))) true)
@@ -533,6 +593,41 @@
                          :tehtavaryhma-id (:id tehtavaryhma)
                          :luoja (:id kayttaja)}))]))]))
 
+(defn tallenna-kuukausittaiset-muut-kulut [db kuukaudet urakan-indeksit urakan-tiedot kayttaja sopimus-id toimenpideinstanssi-id]
+  (let [tehtava (hae-tehtava-tunnisteella db {:tunniste "8376d9c4-3daf-4815-973d-cd95ca3bb388"})
+        tehtava-id (:id (first tehtava))] ;; Muut kulut tehtävä
+    (doseq [{:keys [vuosi kuukausi yhteensa-kk summa] :as rivi} (sort-by (juxt :vuosi :kuukausi) kuukaudet)]
+      (let [;; Haetaan muut-kulut kuukaudelle
+            db-kuukausi (first (hae-muut-kulut-kuukaudelle db {:sopimus-id sopimus-id
+                                                               :toimenpideinstanssi-id toimenpideinstanssi-id
+                                                               :vuosi vuosi
+                                                               :kuukausi kuukausi}))
+            t (if-not db-kuukausi
+                (lisaa-kuukauden-muu-kulu<! db
+                  {:summa yhteensa-kk
+                   :summa_indeksikorjattu (when yhteensa-kk
+                                            (indeksi-kyselyt/indeksikorjaa
+                                              (indeksi-kyselyt/indeksikerroin urakan-indeksit
+                                                (pvm/paivamaara->mhu-hoitovuosi-nro
+                                                  (:alkupvm urakan-tiedot) (pvm/luo-pvm-dec-kk vuosi kuukausi 1)))
+                                              yhteensa-kk))
+                   :vuosi vuosi
+                   :kuukausi kuukausi
+                   :toimenpideinstanssi-id toimenpideinstanssi-id
+                   :tehtava-id tehtava-id
+                   :sopimus-id sopimus-id
+                   :luoja (:id kayttaja)})
+                (paivita-kuukauden-muu-kulu<! db
+                  {:id (:id db-kuukausi)
+                   :summa yhteensa-kk
+                   :summa_indeksikorjattu (when yhteensa-kk
+                                            (indeksi-kyselyt/indeksikorjaa
+                                              (indeksi-kyselyt/indeksikerroin urakan-indeksit
+                                                (pvm/paivamaara->mhu-hoitovuosi-nro
+                                                  (:alkupvm urakan-tiedot) (pvm/luo-pvm-dec-kk vuosi kuukausi 1)))
+                                              yhteensa-kk))
+                   :muokkaaja (:id kayttaja)}))]))))
+
 (defn tallenna-kuukausittaiset-toimenkuvat [db kuukaudet urakan-indeksit urakan-tiedot kayttaja urakka-id toimenkuva-id]
   (let [urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))]
     (doseq [{:keys [vuosi kuukausi tunnit tuntipalkka] :as rivi} (sort-by (juxt :vuosi :kuukausi) kuukaudet)]
@@ -600,7 +695,13 @@
 
 (defn tallenna-johto-ja-hallintokorvaukset
   [db kayttaja urakka-id johto-ja-hallintokorvaukset]
-  (let [urakan-tiedot (first (urakat-q/hae-urakka db {:id urakka-id}))
+  (let [;; Johto-ja hallintakorvausten mukana tulee -19 - 24 alkavilla urakoilla myös "Muut kulut" rivi
+        ;; Poistetaan se tarvittaessa listasta ja tallennetaan erikseen
+        vain-jjh (filter (fn [rivi] (not= "Muut kulut" (:toimenkuva rivi))) johto-ja-hallintokorvaukset)
+        muut-kulut (first (filter (fn [rivi] (= "Muut kulut" (:toimenkuva rivi))) johto-ja-hallintokorvaukset))
+
+        sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
+        urakan-tiedot (first (urakat-q/hae-urakka db {:id urakka-id}))
         urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
         urakan-indeksit (indeksi-kyselyt/hae-urakan-indeksikertoimet db urakka-id)
 
@@ -610,7 +711,7 @@
                                          :koodi (mhu/toimenpide-avain->toimenpide :mhu-johto)})))
 
         ; Tallenna kuukausittaiset summat
-        _ (doseq [toimenkuva johto-ja-hallintokorvaukset]
+        _ (doseq [toimenkuva vain-jjh]
             (let [;; rivi voi sisältää joko kuukausisumman kaikille toimenkuville (silloin id 1) tai
                   ;; toimenkuvan, jolla on kuukausittaiset arvot, tunnit ja tuntipalkat.
                   kuukaudet (when (<= urakan-alkuvuosi 2024)
@@ -626,6 +727,11 @@
                   _ (if (<= urakan-alkuvuosi 2024)
                       (tallenna-kuukausittaiset-toimenkuvat db kuukaudet urakan-indeksit urakan-tiedot kayttaja urakka-id toimenkuva-id)
                       (tallenna-vuosittaiset-toimenkuvat db toimenkuva urakan-indeksit urakan-tiedot kayttaja urakka-id toimenkuva-id))]))
+
+        ;; Tallennetaan mahdolliset muut kulut
+        _ (when muut-kulut
+            (tallenna-kuukausittaiset-muut-kulut db (:kuukaudet muut-kulut) urakan-indeksit urakan-tiedot kayttaja sopimus-id toimenpideinstanssi-id))
+
         _ (ka-q/merkitse-kustannussuunnitelmat-likaisiksi! db {:toimenpideinstanssi toimenpideinstanssi-id})
         _ (kiint-kyselyt/merkitse-maksuerat-likaisiksi-hoidonjohdossa! db {:toimenpideinstanssi toimenpideinstanssi-id})]))
 

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
@@ -159,34 +159,34 @@
 (defn paattele-toimenkuvan-kuukaudet [urakan-alkuvuosi toimenkuva]
   (let [toimenkuva-nimi (:toimenkuva toimenkuva)
         toimenkuva-nimike (:nimike toimenkuva)]
-   (cond
-     (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimi "sopimusvastaava")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimi "vastuunalainen työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimike "Päätoiminen apulainen (talvikausi)")) [5 6 7 8 9]
-     (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimike "Päätoiminen apulainen (kesäkausi)")) [10 11 12 1 2 3 4]
-     (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimike "Apulainen/työnjohtaja (talvikausi)")) [5 6 7 8 9]
-     (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimike "Apulainen/työnjohtaja (kesäkausi)")) [10 11 12 1 2 3 4]
-     (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimi "viherhoidosta vastaava henkilö")) [4 5 6 7 8]
-     (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimi "hankintavastaava")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimi "harjoittelija")) [5 6 7 8]
+    (cond
+      (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimi "sopimusvastaava")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimi "vastuunalainen työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimike "Päätoiminen apulainen (talvikausi)")) [5 6 7 8 9]
+      (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimike "Päätoiminen apulainen (kesäkausi)")) [10 11 12 1 2 3 4]
+      (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimike "Apulainen/työnjohtaja (talvikausi)")) [5 6 7 8 9]
+      (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimike "Apulainen/työnjohtaja (kesäkausi)")) [10 11 12 1 2 3 4]
+      (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimi "viherhoidosta vastaava henkilö")) [4 5 6 7 8]
+      (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimi "hankintavastaava")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimi "harjoittelija")) [5 6 7 8]
 
-     (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "valmistelukausi ennen urakka-ajan alkua")) [8] ;; Tämä pitäisi olla ennen sopimuskautta. Mutta laitetaan sinne yksi kuukausi
-     (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "vastuunalainen työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "päätoiminen apulainen")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "apulainen/työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "viherhoidosta vastaava henkilö")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "hankintavastaava")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "harjoittelija")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "valmistelukausi ennen urakka-ajan alkua")) [8] ;; Tämä pitäisi olla ennen sopimuskautta. Mutta laitetaan sinne yksi kuukausi
+      (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "vastuunalainen työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "päätoiminen apulainen")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "apulainen/työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "viherhoidosta vastaava henkilö")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "hankintavastaava")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "harjoittelija")) [10 11 12 1 2 3 4 5 6 7 8 9]
 
-     (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "valmistelukausi ennen urakka-ajan alkua")) [8] ;; Tämäkin pitäisi olla ennen sopimuskautta. Mutta laitetaan sinne yksi kuukausi
-     (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "vastuunalainen työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "2. työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "3. työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "viherhoidosta vastaava henkilö")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "harjoittelija")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     :else [10 11 12 1 2 3 4 5 6 7 8 9])))
+      (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "valmistelukausi ennen urakka-ajan alkua")) [8] ;; Tämäkin pitäisi olla ennen sopimuskautta. Mutta laitetaan sinne yksi kuukausi
+      (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "vastuunalainen työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "2. työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "3. työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "viherhoidosta vastaava henkilö")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "harjoittelija")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      :else [10 11 12 1 2 3 4 5 6 7 8 9])))
 
-(defn hae-johto-ja-hallintokorvaukset-2019-2024 [db urakka-id hoitovuoden-alkuvuosi urakan-alkuvuosi toimenkuvat-tarjouksesta]
+(defn hae-johto-ja-hallintokorvaukset-2019-2024 [db urakka-id sopimus-id hoitovuoden-alkuvuosi urakan-alkuvuosi toimenkuvat-tarjouksesta]
   (let [viimeisin-muokkaus (first (hae-viimeisin-muokkaaja-jjh
                                     db {:urakka-id urakka-id
                                         :vuosi hoitovuoden-alkuvuosi}))

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
@@ -31,6 +31,9 @@
   hae-johto-ja-hallintokorvaukset-2019-mhu
   hae-kuukauden-johto-ja-hallintokorvaus hae-toimenkuvan-kuukauden-johto-ja-hallintokorvaus
   hae-urakan-toimenkuvat hae-toimenkuvan-johto-ja-hallintokorvaukset-kuukausittain
+  hae-muut-kulut-toimenkuviin-kuukausittain hae-muut-kulut-kuukaudelle
+  lisaa-kuukauden-muu-kulu<! paivita-kuukauden-muu-kulu<!
+  hae-tehtava-tunnisteella
   paivita-kuukauden-johto-ja-hallintokorvaus<!
   lisaa-kuukauden-johto-ja-hallintokorvaus<! hae-viimeisin-muokkaaja-jjh
   vahvista-tai-kumoa-indeksikorjaukset-kiinteahintaisille-toille!

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.sql
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.sql
@@ -367,13 +367,14 @@ WITH urakka_toimenkuvat AS (SELECT nimike
                                          ELSE ARRAY ['valmistelukausi ennen urakka-ajan alkua','vastuunalainen työnjohtaja','2. työnjohtaja', '3. työnjohtaja', 'viherhoidosta vastaava henkilö', 'harjoittelija']
                                          END
                                  ) AS nimike)
-SELECT id, toimenkuva
+SELECT id, toimenkuva, toimenkuva as nimike
 FROM johto_ja_hallintokorvaus_toimenkuva jht
 WHERE jht."urakka-id" = :urakka-id
 AND jht.toimenkuva is not null
 UNION
 SELECT (select MIN(id) from johto_ja_hallintokorvaus_toimenkuva where toimenkuva = ut.nimike) AS id,
-       nimike                                                                                 AS toimenkuva
+       nimike                                                                                 AS toimenkuva,
+       nimike
 from urakka_toimenkuvat ut
 ORDER BY ID;
 

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.sql
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.sql
@@ -394,3 +394,55 @@ WHERE jh."urakka-id" = :urakka-id
     OR (jh.vuosi = :vuosi + 1 AND jh.kuukausi >= 1 AND jh.kuukausi <= 9))
 AND jh."toimenkuva-id" = :toimenkuva-id
 AND jh.kuukausi IN (:sallitut-kuukaudet);
+
+-- name: hae-muut-kulut-toimenkuviin-kuukausittain
+-- Muut kulut on vanhoille -24 ja ennen alkaneille urakoille. Muudemmat -25 ja myöhemmin alkaneet eivät enää käytä tätä.
+SELECT kt.id,
+       kt.kuukausi,
+       kt.vuosi,
+       1 as tunnit,
+       kt.summa as "tuntipalkka",
+       kt.summa_indeksikorjattu as "tuntipalkka-indeksikorjattu",
+       'Muut kulut' as toimenkuva,
+       'Muut kulut' as nimike
+  FROM kustannusarvioitu_tyo kt
+       JOIN tehtava t ON kt.tehtava = t.id AND t.yksiloiva_tunniste = '8376d9c4-3daf-4815-973d-cd95ca3bb388' -- Muut kulut
+ WHERE kt.sopimus = :sopimus-id
+   AND ((kt.vuosi = :vuosi AND kt.kuukausi IN (10, 11, 12))
+       OR (kt.vuosi = :vuosi + 1 AND kt.kuukausi >= 1 AND kt.kuukausi <= 9))
+   AND kt.toimenpideinstanssi = :toimenpideinstanssi-id;
+
+-- name: hae-muut-kulut-kuukaudelle
+SELECT kt.id,
+       kt.kuukausi,
+       kt.vuosi,
+       kt.summa,
+       kt.summa_indeksikorjattu
+  FROM kustannusarvioitu_tyo kt
+       JOIN tehtava t ON kt.tehtava = t.id AND t.yksiloiva_tunniste = '8376d9c4-3daf-4815-973d-cd95ca3bb388' -- Muut kulut
+ WHERE kt.sopimus = :sopimus-id
+   AND kt.vuosi = :vuosi
+   AND kt.kuukausi = :kuukausi
+   AND toimenpideinstanssi = :toimenpideinstanssi-id;
+
+-- name: lisaa-kuukauden-muu-kulu<!
+INSERT INTO kustannusarvioitu_tyo (kuukausi, vuosi, summa, summa_indeksikorjattu,
+                                   toimenpideinstanssi, tehtava, sopimus, tyyppi, osio, luoja, luotu)
+VALUES (:kuukausi, :vuosi, :summa, :summa_indeksikorjattu,
+        :toimenpideinstanssi-id,  :tehtava-id, :sopimus-id,
+        'laskutettava-tyo', 'johto-ja-hallintokorvaus', :luoja, NOW());
+
+-- name: paivita-kuukauden-muu-kulu<!
+UPDATE kustannusarvioitu_tyo
+   SET summa                 = :summa,
+       summa_indeksikorjattu = :summa_indeksikorjattu,
+       muokkaaja             = :muokkaaja,
+       muokattu              = NOW()
+ WHERE id = :id;
+
+-- name: hae-tehtava-tunnisteella
+SELECT id, nimi, yksikko, suunnitteluyksikko, tehtavaryhma, luoja, luotu, muokkaaja, muokattu
+  FROM tehtava
+ WHERE yksiloiva_tunniste = :tunniste::UUID
+   AND piilota IS NOT TRUE
+   AND poistettu IS NOT TRUE;

--- a/src/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_palvelu.clj
@@ -93,7 +93,7 @@
           johto-ja-hallintokorvaukset
           (cond
             (and (>= urakan-alkuvuosi 2019) (<= urakan-alkuvuosi 2024))
-            (suunnitelma-q/hae-johto-ja-hallintokorvaukset-2019-2024 db urakka-id hoitovuoden-alkuvuosi urakan-alkuvuosi toimenkuvat-tarjouksesta)
+            (suunnitelma-q/hae-johto-ja-hallintokorvaukset-2019-2024 db urakka-id sopimus-id hoitovuoden-alkuvuosi urakan-alkuvuosi toimenkuvat-tarjouksesta)
             (>= urakan-alkuvuosi 2025)
             (suunnitelma-q/hae-johto-ja-hallintokorvaukset db urakka-id hoitovuoden-alkuvuosi toimenkuvat-tarjouksesta)
             :else (suunnitelma-q/hae-johto-ja-hallintokorvaukset db urakka-id hoitovuoden-alkuvuosi toimenkuvat-tarjouksesta))

--- a/src/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_palvelu.clj
@@ -38,7 +38,7 @@
 
 (defn hae-kustannussuunnitelman-tiedot [db kayttaja {:keys [urakka-id hoitovuoden-alkuvuosi] :as tiedot}]
   (oikeudet/vaadi-lukuoikeus oikeudet/urakat-suunnittelu-kustannussuunnittelu kayttaja urakka-id)
-  (log/info "hae-kustannussuunnitelman-tiedot :: tiedot: " tiedot)
+  (log/debug "hae-kustannussuunnitelman-tiedot :: tiedot: " tiedot)
   (jdbc/with-db-transaction [db db]
     (let [;; Urakan sopimus id
           sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
@@ -141,7 +141,7 @@
 
 (defn tallenna-kilpailutettavat-hankinnat [db kayttaja {:keys [urakka-id hoitovuoden-alkuvuosi] :as tiedot}]
   (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-suunnittelu-kustannussuunnittelu kayttaja urakka-id)
-  (log/info "tallenna-kilpailutettavat-hankinnat :: tiedot: " tiedot)
+  (log/debug "tallenna-kilpailutettavat-hankinnat :: tiedot: " tiedot)
   (jdbc/with-db-transaction [db db]
     (suunnitelma-q/tallenna-kilpailutettavat-hankinnat db kayttaja urakka-id hoitovuoden-alkuvuosi (:toimenpiteet tiedot))
     (suunnitelma-q/paivita-tavoite-ja-kattohinta db kayttaja urakka-id hoitovuoden-alkuvuosi)
@@ -149,7 +149,7 @@
 
 (defn tallenna-erillishankinnat [db kayttaja {:keys [urakka-id hoitovuoden-alkuvuosi] :as tiedot}]
   (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-suunnittelu-kustannussuunnittelu kayttaja urakka-id)
-  (log/info "tallenna-erillishankinnat :: tiedot: " tiedot)
+  (log/debug "tallenna-erillishankinnat :: tiedot: " tiedot)
   (jdbc/with-db-transaction [db db]
     (suunnitelma-q/tallenna-erillishankinnat db kayttaja urakka-id (:erillishankinnat tiedot))
     (suunnitelma-q/paivita-tavoite-ja-kattohinta db kayttaja urakka-id hoitovuoden-alkuvuosi)
@@ -157,7 +157,7 @@
 
 (defn tallenna-tallenna-johto-ja-hallintokorvaukset [db kayttaja {:keys [urakka-id hoitovuoden-alkuvuosi] :as tiedot}]
   (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-suunnittelu-kustannussuunnittelu kayttaja urakka-id)
-  (log/info "tallenna-johto-ja-hallintokorvaukset :: tiedot: " tiedot)
+  (log/debug "tallenna-johto-ja-hallintokorvaukset :: tiedot: " tiedot)
   (jdbc/with-db-transaction [db db]
     (let [urakan-tiedot (first (urakat-q/hae-urakan-tiedot db urakka-id))
           urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
@@ -173,7 +173,7 @@
 
 (defn tallenna-hoidonjohtopalkkiot [db kayttaja {:keys [urakka-id hoitovuoden-alkuvuosi] :as tiedot}]
   (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-suunnittelu-kustannussuunnittelu kayttaja urakka-id)
-  (log/info "tallenna-hoidonjohtopalkkiot :: tiedot: " tiedot)
+  (log/debug "tallenna-hoidonjohtopalkkiot :: tiedot: " tiedot)
   (jdbc/with-db-transaction [db db]
     (suunnitelma-q/tallenna-hoidonjohtopalkkiot db kayttaja urakka-id (:hoidonjohtopalkkiot tiedot))
     (suunnitelma-q/paivita-tavoite-ja-kattohinta db kayttaja urakka-id hoitovuoden-alkuvuosi)

--- a/src/cljc/harja/domain/suunnittelu/uusi_kustannussuunnitelma_domain.cljc
+++ b/src/cljc/harja/domain/suunnittelu/uusi_kustannussuunnitelma_domain.cljc
@@ -10,15 +10,6 @@
       (= 1 (count distinct-values)) ;; Vain yksi distinct arvo tarkoittaa, että kaikki arvot olivat samat
       )))
 
-(defn onko-tuntipalkka-samat?
-  "Tarkistaa, onko :tuntipalkka arvo sama, jokaisena kuukautena."
-  [kuukaudet]
-  (let [tunnit-values (map :tuntipalkka kuukaudet)
-        distinct-values (distinct (remove nil? tunnit-values))]
-    (or (empty? distinct-values)      ;; Arvot eivät olleet samat
-      (= 1 (count distinct-values)) ;; Vain yksi distinct arvo tarkoittaa, että kaikki arvot olivat samat
-      )))
-
 (s/def ::hoitovuoden_alkuvuosi #(and (int? %) (pos? %) (> % 2000)))
 (s/def ::urakka-id #(and (int? %) (pos? %) (>= % 1) (< % 99999)))
 (s/def ::alkukausi #(or (nil? %) (and (number? %) (>= % 0))))

--- a/src/cljc/harja/domain/suunnittelu/uusi_kustannussuunnitelma_domain.cljc
+++ b/src/cljc/harja/domain/suunnittelu/uusi_kustannussuunnitelma_domain.cljc
@@ -10,6 +10,15 @@
       (= 1 (count distinct-values)) ;; Vain yksi distinct arvo tarkoittaa, että kaikki arvot olivat samat
       )))
 
+(defn onko-tuntipalkka-samat?
+  "Tarkistaa, onko :tuntipalkka arvo sama, jokaisena kuukautena."
+  [kuukaudet]
+  (let [tunnit-values (map :tuntipalkka kuukaudet)
+        distinct-values (distinct (remove nil? tunnit-values))]
+    (or (empty? distinct-values)      ;; Arvot eivät olleet samat
+      (= 1 (count distinct-values)) ;; Vain yksi distinct arvo tarkoittaa, että kaikki arvot olivat samat
+      )))
+
 (s/def ::hoitovuoden_alkuvuosi #(and (int? %) (pos? %) (> % 2000)))
 (s/def ::urakka-id #(and (int? %) (pos? %) (>= % 1) (< % 99999)))
 (s/def ::alkukausi #(or (nil? %) (and (number? %) (>= % 0))))

--- a/src/cljc/harja/domain/suunnittelu/uusi_kustannussuunnitelma_domain.cljc
+++ b/src/cljc/harja/domain/suunnittelu/uusi_kustannussuunnitelma_domain.cljc
@@ -84,8 +84,7 @@
                       :opt-un [::tuntipalkka-indeksikorjattu])))
 
 (s/def ::johto-ja-hallintokorvaukset-2019 (s/coll-of
-                                            (s/keys :req-un [::id
-                                                             ::toimenkuva
+                                            (s/keys :req-un [::toimenkuva
                                                              ::kuukaudet (s/coll-of ::jjh-2019)])))
 
 (s/def ::kilpailutettavat-hankinnat (s/keys :req-un [::toimenpiteet ::urakka-id]))

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_johto_ja_hallintokorvaus.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_johto_ja_hallintokorvaus.cljs
@@ -398,6 +398,7 @@
     [:div [grid/muokkaus-grid
            {:otsikko ""
             :id "toimenkuvat-taulukko-2022"
+            :jarjesta :jarjestys
             :luokat ["poista-bottom-margin"]
             :voi-lisata? false
             :voi-kumota? false

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_johto_ja_hallintokorvaus.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_johto_ja_hallintokorvaus.cljs
@@ -78,6 +78,75 @@
       [:div.col-xs-3.oikealle [:strong (fmt/euro-opt true yht)]]
       [:div.col-xs-3.oikealle [:strong (fmt/euro-opt yht-indeksikorjattu)]]]]))
 
+(defn muut-kulut-vetolaatikko
+  "Muut kulut ei ole toimenkuva, joten joudumme renderöimään sen vetolaatikon eritavalla"
+  [e! vetolaatikon-muokkaus kuukaudet vahvistettu?]
+  (let [voi-muokata? (and (not vahvistettu?) vetolaatikon-muokkaus)
+        muokkaus-kuukaudet (into {} (mapv (fn [kuukausi]
+                                            {(:kalenterikuukausi kuukausi) kuukausi})
+                                      kuukaudet))
+        kuukaudet-atom (r/atom muokkaus-kuukaudet)]
+    [:div
+     [kentat/tee-kentta {:tyyppi :checkbox
+                         :teksti "Suunnittele kuukausittain"
+                         :disabled? vahvistettu?
+                         :valitse! #(e! (kust-tiedot/->ToggleVetolaatikonMuokkaus (-> % .-target .-checked)))}
+      vetolaatikon-muokkaus]
+     [:div.vetolaatikko-border {:style {:border-left "4px solid lightblue" :padding-left "18px"}}
+      [grid/muokkaus-grid
+       {:id (str "kuukausitaulukko-muut-kulut")
+        :voi-poistaa? (constantly false)
+        :voi-lisata? false
+        :piilota-toiminnot? true
+        :muokkauspaneeli? false
+        :jarjesta (juxt :vuosi :kuukausi)
+        :voi-muokata? (not vahvistettu?)
+        :on-rivi-blur (fn [kuukausi-rivi]
+                        (let [muut-kulut-toimenkuva (first (filter
+                                                  #(= "Muut kulut" (:toimenkuva %))
+                                                  @yhteiset/grid-johto-ja-hallintokorvaukset-atom))
+                              toimenkuvat-ilman-muutettavaa (remove
+                                                              #(= "Muut kulut" (:toimenkuva %))
+                                                              @yhteiset/grid-johto-ja-hallintokorvaukset-atom)
+                              valittu-kuukausi (first (filter
+                                                        (fn [kuukausi]
+                                                          (and (= (:kuukausi kuukausi-rivi) (:kuukausi kuukausi))
+                                                            (= (:vuosi kuukausi-rivi) (:vuosi kuukausi))))
+                                                        (:kuukaudet muut-kulut-toimenkuva)))
+                              kuukaudet-ilman-valittua (remove
+                                                         (fn [kuukausi]
+                                                           (and (= (:kuukausi kuukausi-rivi) (:kuukausi kuukausi))
+                                                             (= (:vuosi kuukausi-rivi) (:vuosi kuukausi))))
+                                                         (:kuukaudet muut-kulut-toimenkuva))
+
+                              valittu-kuukausi (assoc valittu-kuukausi :yhteensa-kk (:yhteensa-kk kuukausi-rivi))
+                              uudet-kuukaudet (sort-by :vuosi :kuukausi (conj kuukaudet-ilman-valittua valittu-kuukausi))
+
+
+                              ;; Lasketaan suunniteltu määrä uusiksi.
+                              kuukaudet (map (fn [rivi]
+                                               (assoc rivi :yhteensa-kk (if (:yhteensa-kk rivi) (:yhteensa-kk rivi) 0)))
+                                          uudet-kuukaudet)
+                              suunniteltu-yht (apply + (map #(if (:yhteensa-kk %) (:yhteensa-kk %) 0) kuukaudet))
+                              muut-kulut (assoc muut-kulut-toimenkuva
+                                           :tunnit nil
+                                           :tuntipalkka nil
+                                           :kuukaudet (sort-by (juxt :vuosi :kuukausi) kuukaudet)
+                                           :summa suunniteltu-yht
+                                           :summa-indeksikorjattu nil) ;; indeksikorjaus lasketaan bäckendissä
+                              _ (reset! yhteiset/tallenna-painettu false)
+                              uudet-toimenkuvat (sort-by :id (conj toimenkuvat-ilman-muutettavaa muut-kulut))
+                              _ (reset! yhteiset/grid-johto-ja-hallintokorvaukset-atom uudet-toimenkuvat)
+                              _ (e! (kust-tiedot/->PaivitaJohtoJaHallintokorvaukset uudet-toimenkuvat))]))
+        :voi-kumota? false}
+       [{:otsikko "Kalenterikuukausi" :nimi :kalenterikuukausi :tyyppi :string :leveys "40%"
+         :muokattava? (constantly false) :otsikkorivi-luokka "korkea"}
+        {:otsikko "Yhteensa (€)" :nimi :yhteensa-kk :leveys "20%" :tyyppi :euro :tasaa :oikea
+         :fmt #(when % (fmt/euro-opt false %)) :muokattava? (constantly voi-muokata?) :otsikkorivi-luokka "korkea"}
+        {:otsikko "Indeksikorjattu (€)" :nimi :yhteensa-indeksikorjattu-kk :leveys "20%" :tyyppi :euro :tasaa :oikea
+         :fmt #(when % (fmt/euro-opt false %)) :muokattava? (constantly false) :otsikkorivi-luokka "korkea"}]
+       kuukaudet-atom]]]))
+
 (defn toimenkuvat-vetolaatikko-2019
   "Anna parametrina valittu toimenkuva sekä kaikki mahdolliset kuukaudet, joita voidaan muokata."
   [e! vetolaatikon-muokkaus toimenkuva-id kuukaudet vahvistettu?]
@@ -99,6 +168,7 @@
         :voi-lisata? false
         :piilota-toiminnot? true
         :muokkauspaneeli? false
+        :jarjesta (juxt :vuosi :kuukausi)
         :voi-muokata? (not vahvistettu?)
         :on-rivi-blur (fn [kuukausi-rivi]
                         (let [toimenkuva (first (filter
@@ -152,7 +222,17 @@
   (let [muokkaus-toimenkuvat (into {} (mapv (fn [toimenkuva]
                                               {(:nimike toimenkuva) toimenkuva})
                                         johto-ja-hallintokorvaukset))
-        toimenkuvat-atom (r/atom muokkaus-toimenkuvat)]
+        toimenkuvat-atom (r/atom muokkaus-toimenkuvat)
+
+        voiko-muokata? (fn [rivi voi-muokata? on-muu-kulu-kolumni?]
+                         (cond
+                           (and (= "Muut kulut" (:toimenkuva rivi)) voi-muokata? on-muu-kulu-kolumni?)
+                           true
+                           (and (= "Muut kulut" (:toimenkuva rivi)) (false? voi-muokata?))
+                           false
+                           (not= "Muut kulut" (:toimenkuva rivi))
+                           voi-muokata?
+                           :else false))]
     [grid/muokkaus-grid
      {:otsikko ""
       :id "toimenkuvat-taulukko"
@@ -164,16 +244,29 @@
                                                          #(= (:id rivi) (:id %))
                                                          @yhteiset/grid-johto-ja-hallintokorvaukset-atom))
                             muokattu-toimenkuva (assoc muokattu-toimenkuva
-                                                  :tunnit (if (= nil (:tunnit rivi)) 0 (:tunnit rivi)) ;; nil arvoa käytetään, jos tunnit eivät ole samat kaikissa kuukausissa
-                                                  :tuntipalkka (:tuntipalkka rivi))
+                                                  :tunnit (if (and (not= (:toimenkuva rivi) "Muut kulut") (= nil (:tunnit rivi))) 0 (:tunnit rivi)) ;; nil arvoa käytetään, jos tunnit eivät ole samat kaikissa kuukausissa
+                                                  :tuntipalkka (if (and (not= (:toimenkuva rivi) "Muut kulut") (= nil (:tuntipalkka rivi))) 0 (:tuntipalkka rivi))
+                                                  :summa (:summa rivi))
                             toimenkuvat-ilman-muutettavaa (remove
                                                             #(= (:id rivi) (:id %))
                                                             @yhteiset/grid-johto-ja-hallintokorvaukset-atom)
                             uudet-toimenkuvat (sort-by :id (conj toimenkuvat-ilman-muutettavaa muokattu-toimenkuva))
                             toimenkuvat (reduce (fn [uudet-toimenkuvat toimenkuva]
                                                   (let [;; Laske toimenkuvan kokonaissumma kuudaudelle
-                                                        summa (if (and (:tuntipalkka toimenkuva) (:tunnit toimenkuva)) (* (:tunnit toimenkuva) (:tuntipalkka toimenkuva)) 0)
+                                                        summa (cond
+                                                                ;; Toimenkuvat
+                                                                (and (:tuntipalkka toimenkuva) (:tunnit toimenkuva) (not= (:toimenkuva rivi) "Muut kulut"))
+                                                                (* (:tunnit toimenkuva) (:tuntipalkka toimenkuva))
+                                                                ;; Muut kulut
+                                                                (and (:summa toimenkuva) (= (:toimenkuva rivi) "Muut kulut"))
+                                                                (:summa toimenkuva)
+                                                                :else 0)
+
                                                         toimenkuva (assoc toimenkuva :summa summa)
+
+                                                        ;; Koskee vain Muut Kulut riviä.
+                                                        kk-summa (tyokalut/round2 2 (/ summa 12))
+                                                        viimeneinen-summa (- summa (tyokalut/round2 2 (* 11 kk-summa)))
 
                                                         ;; Laske toimenkuvan yhteensä summat kuukausista
                                                         kuukaudet (map-indexed (fn [indeksi rivi]
@@ -181,7 +274,9 @@
                                                                                    {:tuntipalkka (:tuntipalkka toimenkuva)
                                                                                     :tuntipalkka-indeksikorjattu nil ;; indeksikorjaus lasketaan bäckendissä
                                                                                     :tunnit (:tunnit toimenkuva)
-                                                                                    :yhteensa-kk (* (:tuntipalkka toimenkuva) (:tunnit toimenkuva))
+                                                                                    :yhteensa-kk (if (not= (:toimenkuva rivi) "Muut kulut")
+                                                                                                   (* (:tuntipalkka toimenkuva) (:tunnit toimenkuva))
+                                                                                                   (if (= indeksi 11) viimeneinen-summa kk-summa))
                                                                                     :yhteensa-indeksikorjattu-kk nil}))
                                                                     (:kuukaudet toimenkuva))
                                                         yht-kk (apply + (map :yhteensa-kk kuukaudet))
@@ -190,7 +285,7 @@
                                                                      :summa yht-kk)]
                                                     (conj uudet-toimenkuvat toimenkuva)))
                                           [] uudet-toimenkuvat)
-                            toimenkuvat (sort-by :id toimenkuvat)]
+                            toimenkuvat (sort-by :jarjesta toimenkuvat)]
 
                         (reset! yhteiset/tallenna-painettu false)
                         (reset! yhteiset/grid-johto-ja-hallintokorvaukset-atom toimenkuvat)
@@ -200,7 +295,10 @@
       :voi-muokata? true
       :voi-poistaa? (constantly false)
       :vetolaatikot (into {}
-                      (map (juxt :nimike (fn [rivi] [toimenkuvat-vetolaatikko-2019 e! (:vetolaatikon-muokkaus app) (:id rivi) (:kuukaudet rivi) vahvistettu?]))
+                      (map (juxt :nimike (fn [rivi]
+                                           (if (= "Muut kulut" (:nimike rivi))
+                                             [muut-kulut-vetolaatikko e! (:vetolaatikon-muokkaus app) (:kuukaudet rivi) vahvistettu?]
+                                             [toimenkuvat-vetolaatikko-2019 e! (:vetolaatikon-muokkaus app) (:id rivi) (:kuukaudet rivi) vahvistettu?])))
                         johto-ja-hallintokorvaukset))
 
       :vetolaatikko-optiot {:ei-paddingia true}
@@ -212,12 +310,12 @@
       {:otsikko "Tarjouksen määrä (€ / vuosi)" :nimi :tarjous-summa :leveys "20%" :tyyppi :positiivinen-numero :tasaa :oikea
        :fmt #(when % (fmt/euro-opt false %)) :muokattava? (constantly false) :otsikkorivi-luokka "korkea"}
       {:otsikko "Tunnit (h/kk)" :nimi :tunnit :leveys "15%" :tyyppi :positiivinen-numero :tasaa :oikea
-       :fmt #(when % (fmt/euro-opt false %)) :muokattava? (constantly voi-muokata?) :otsikkorivi-luokka "korkea"}
+       :fmt #(when % (fmt/euro-opt false %)) :muokattava? #(voiko-muokata? % voi-muokata? false) :otsikkorivi-luokka "korkea"}
       {:otsikko "Tuntipalkka (€/h)" :nimi :tuntipalkka :leveys "15%" :tyyppi :positiivinen-numero :tasaa :oikea
-       :fmt #(when % (fmt/euro-opt false %)) :muokattava? (constantly true) :otsikkorivi-luokka "korkea"}
+       :fmt #(when % (fmt/euro-opt false %)) :muokattava? #(voiko-muokata? % voi-muokata? false) :otsikkorivi-luokka "korkea"}
       {:otsikko "Yhteensä (€/vuosi)" :nimi :summa :leveys "20%" :tyyppi :euro :tasaa :oikea
        :fmt #(when % (fmt/euro-opt false %))
-       :muokattava? (constantly false)
+       :muokattava? #(voiko-muokata? % voi-muokata? true)
        :voi-muokata-rivia? (constantly true)
        :otsikkorivi-luokka "korkea"}
       {:otsikko "Kk/v" :nimi :kkv :leveys "10%" :tyyppi :euro :tasaa :oikea
@@ -324,7 +422,9 @@
                                                               kuukaudet (map-indexed (fn [indeksi rivi]
                                                                                        (merge rivi
                                                                                          {:tuntipalkka (if (= indeksi 11) viimeneinen-summa kk-summa)
-                                                                                          :tuntipalkka-indeksikorjattu nil}))
+                                                                                          :tuntipalkka-indeksikorjattu nil}
+                                                                                         (when (= "Muut kulut" (:toimenkuva toimenkuva))
+                                                                                           {:yhteensa-kk (if (= indeksi 11) viimeneinen-summa kk-summa)})))
                                                                           (:kuukaudet toimenkuva))
                                                               toimenkuva (assoc toimenkuva :kuukaudet kuukaudet)]
                                                           (conj uudet-toimenkuvat toimenkuva)))
@@ -373,7 +473,7 @@
                        (map #(:summa % 0) johto-ja-hallintokorvaukset)))
         yht-indeksikorjattu (apply + (if (<= urakan-alkuvuosi 2021)
                                        (map #(:yhteensa-indeksikorjattu-kk % 0) toimenpiteiden-kuukaudet)
-                                      (map #(:summa_indeksikorjattu % 0) johto-ja-hallintokorvaukset)))
+                                       (map #(:summa_indeksikorjattu % 0) johto-ja-hallintokorvaukset)))
         kirjaamatta (tyokalut/round2 2 (- tarjouksen-maara yht))
         kirjaamatta-luokka (if (= 0 kirjaamatta) "yhteensa" "yhteensa-punainen")
         kirjaamatta-rivi (cond (and (<= urakan-alkuvuosi 2021) (not vahvistettu?))

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_johto_ja_hallintokorvaus.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_johto_ja_hallintokorvaus.cljs
@@ -433,7 +433,6 @@
                               (reset! yhteiset/tallenna-painettu false)
                               (reset! yhteiset/grid-johto-ja-hallintokorvaukset-atom toimenkuvat)
                               (e! (kust-tiedot/->PaivitaJohtoJaHallintokorvaukset toimenkuvat))))
-            :jarjesta :id
             :piilota-toiminnot? true
             :voi-muokata? voi-muokata?
             :voi-poistaa? (constantly false)

--- a/test/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_test.clj
+++ b/test/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_test.clj
@@ -500,7 +500,6 @@
 
 (deftest vahvista-tavoite-ja-kattohinta-toimii
   (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
-        sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
         hoitovuoden-alkuvuosi 2024
 
         ;; Lisätään ensin kilpailutettavat hankinnat
@@ -546,6 +545,6 @@
     (is (= 3 (count (get-in vastaus [:kustannussuunnitelma :rahavaraukset]))))
     (is (= 7 (count (get-in vastaus [:kustannussuunnitelma :kilpailutettavat-hankinnat :toimenpiteet]))))
     (is (= 12 (count (get-in vastaus [:kustannussuunnitelma :erillishankinnat]))))
-    (is (= 9 (count (get-in vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset]))))
+    (is (= 10 (count (get-in vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset]))))
     (is (= 12 (count (:kuukaudet (first (get-in vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset]))))))
     (is (= 12 (count (get-in vastaus [:kustannussuunnitelma :hoidonjohtopalkkiot]))))))

--- a/test/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_test.clj
+++ b/test/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_test.clj
@@ -330,7 +330,10 @@
 
     ;; Ei ole erroreita
     (is (nil? (:error vastaus)))
-    (is (= (bigdec (round2 tietomallin-summa 2)) (bigdec (round2 vastaus-summa 2))))))
+    (is (= (bigdec (round2 tietomallin-summa 2)) (bigdec (round2 vastaus-summa 2))))
+    ;; Viimeinen rivi on "Muut kulut"
+    (is (= "Muut kulut" (:toimenkuva (last (get-in vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset])))))))
+
 
 (deftest muokkaa-johto-ja-hallintokorvaukset-2025-rajapinnasta-toimii
   (let [urakka-id (hae-urakan-id-nimella "Kittilän MHU 2025-2030")
@@ -367,7 +370,9 @@
         muokattu-vastaus-summa (apply +
                                  (map :summa (get-in muokattu-vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset])))]
 
-    (is (= (bigdec muokattu-summa) (bigdec muokattu-vastaus-summa)))))
+    (is (= (bigdec muokattu-summa) (bigdec muokattu-vastaus-summa)))
+    ;; Viimeinen rivi ei ole "Muut kulut" - -25 urakoilla ei ole muita kuluja
+    (is (not= "Muut kulut" (:toimenkuva (last (get-in vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset])))))))
 
 (deftest muokkaa-johto-ja-hallintokorvaukset-2019-rajapinnasta-toimii
   (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
@@ -405,7 +410,7 @@
                            (catch Exception e
                              (println "Tapahtui virhe:" (.getMessage e))
                              {:error (.getMessage e)}))
-        _ (println "(get-in muokattu-vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset]):" (get-in muokattu-vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset]))
+
         muokattu-vastaus-summa (apply +
                                  (map #(or (:yhteensa-kk %) 0)
                                    (flatten (map :kuukaudet (get-in muokattu-vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset])))))]
@@ -495,6 +500,7 @@
 
 (deftest vahvista-tavoite-ja-kattohinta-toimii
   (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
+        sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
         hoitovuoden-alkuvuosi 2024
 
         ;; Lisätään ensin kilpailutettavat hankinnat


### PR DESCRIPTION
19-24 urakoilla on uudessa kustannussuunnitelmassa toimenkuvien viimeisenä rivinä Muut kulut.
Muille kuluille käyttöliittymä on hieman erilainen, koska niillä ei luonnollisesti ole tuntihintaa tai tuntimäärää, vaan kuukausisumma.
Muut kulut tallentuu Johto ja hallinto toimenpideinstanssille sekä ICT ja toimistotarvike tehtävälle kustannusarvioitu_tyo tauluun.
Toimenkuvat tulevat siis johto_ja_hallintokorvaus-taulusta. Eli tässä on yhdistetty tietomalliltaan kaksi aivan täysin erilaista konseptia yhteen ja samaan käyttöliittymään, joten dataa on jouduttu hieman muklaamaan.