### PR TITLE
Harja 1525 uuden kustiksen vahvistus

### DIFF
--- a/src/clj/harja/kyselyt/budjettisuunnittelu.clj
+++ b/src/clj/harja/kyselyt/budjettisuunnittelu.clj
@@ -9,7 +9,7 @@
 (declare lisaa-suunnitelmalle-tila hae-budjettitavoite hae-valikatselmus-siirrot-ed-vuodelta
   onko-kustannussuunnitelma-vahvistettu hae-suunnitelman-tilat paivita-kiinteahintaiset-tyot-indeksille!
   paivita-kustannusarvioidut-tyot-indeksille! paivita-johto-ja-hallintokorvaus-indeksille!
-  paivita-urakka-tavoite-indeksille!)
+  paivita-urakka-tavoite-indeksille! tallenna-budjettitavoite<! paivita-budjettitavoite<!)
 
 (defn redusoi-suunnitelutilat
   [tilat tila]

--- a/src/clj/harja/kyselyt/kustannusarvioidut_tyot.clj
+++ b/src/clj/harja/kyselyt/kustannusarvioidut_tyot.clj
@@ -5,5 +5,5 @@
   {:positional? false})
 
 (declare merkitse-maksuerat-likaisiksi! hae-rahavarauskustannus
-  hae-tavoitehinnan-ulkopuolisen-rahavarauksen-toimenpideinstanssi paivita-rahavaraus<! lisaa-rahavaraus<!
+  hae-tavoitehinnan-ulkopuolisen-rahavarauksen-toimenpideinstanssi
   merkitse-kustannussuunnitelmat-likaisiksi!)

--- a/src/clj/harja/kyselyt/kustannusarvioidut_tyot.sql
+++ b/src/clj/harja/kyselyt/kustannusarvioidut_tyot.sql
@@ -83,16 +83,3 @@ SELECT 'Tavoitehinnan ulkopuoliset rahavaraukset' AS nimi, -- Tämä on johto ja
                               (kt.vuosi = y.year + 1 AND kt.kuukausi <= 9))
  GROUP BY kt.indeksikorjaus_vahvistettu, hoitokauden_alkuvuosi
  ORDER BY hoitokauden_alkuvuosi;
-
--- name: paivita-rahavaraus<!
-UPDATE kustannusarvioitu_tyo
-   SET summa = :summa,
-       muokattu = NOW(),
-       muokkaaja = :muokkaaja
- WHERE id = :id;
-
--- name: lisaa-rahavaraus<!
-INSERT INTO kustannusarvioitu_tyo (vuosi, kuukausi, summa, sopimus,
-                                   toimenpideinstanssi, tehtava, rahavaraus_id, tyyppi, osio, luoja, luotu)
-VALUES (:vuosi, :kuukausi, :summa, :sopimus_id, :toimenpideinstanssi_id, :tehtava_id, :rahavaraus_id, 'laskutettava-tyo', 'tilaajan-rahavaraukset',
-        :luoja, NOW());

--- a/src/clj/harja/kyselyt/tehtavamaarat.clj
+++ b/src/clj/harja/kyselyt/tehtavamaarat.clj
@@ -10,6 +10,8 @@
 (defqueries "harja/kyselyt/tehtavamaarat.sql"
   {:positional? true})
 
+(declare hae-sopimuksen-tehtavamaarat-urakalle)
+
 (defn hae-sopimuksen-tila
   [db {:keys [urakka-id sopimus-id]}]
   (fetch db ::tehtavamaarat/sopimuksen-tehtavamaarat-tallennettu

--- a/src/clj/harja/kyselyt/urakat.clj
+++ b/src/clj/harja/kyselyt/urakat.clj
@@ -7,10 +7,7 @@
 (declare urakan-paasopimus-id hae-urakka hae-urakan-tiedot hae-urakan-tyyppi hae-urakan-sopimukset
   hae-urakan-sampo-id hae-yksittainen-urakka hae-urakan-ely hae-urakan-parametrit aseta-tai-paivita-urakkaparametrit
   hae-urakat-tyypilla-ja-hallintayksikolla urakan-hallintayksikko hae-id-sampoidlla aseta-urakan-toimenkuvat
-  hae-urakan-alkuvuosi onko-olemassa onko-urakalla-tehtavaa)
+  hae-urakan-alkuvuosi onko-olemassa onko-urakalla-tehtavaa hae-urakka-sijainnilla)
 
 (defn onko-olemassa? [db id]
   (:exists (first (onko-olemassa db id))))
-
-(defn onko-urakalla-tehtavaa? [db urakka-id tehtava-id]
-  (:exists (first (onko-urakalla-tehtavaa db urakka-id tehtava-id))))

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
@@ -445,9 +445,11 @@
                     :luoja (:id kayttaja)}))]
     tiedot))
 
-(defn tallenna-hankintojen-kuukausittainen-summa [db kk-jakso alkujakso? viimeinen-summa summa hoitovuoden-alkuvuosi sopimus-id
+(defn tallenna-hankintojen-kuukausittainen-summa [db urakka-id kk-jakso alkujakso? viimeinen-summa summa hoitovuoden-alkuvuosi sopimus-id
                                                   toimenpideinstanssi-id kayttaja-id]
-  (let [_ (doseq [kk kk-jakso]
+  (let [urakan-tiedot (first (urakat-q/hae-urakka db {:id urakka-id}))
+        urakan-indeksit (indeksi-kyselyt/hae-urakan-indeksikertoimet db urakka-id)
+        _ (doseq [kk kk-jakso]
             (let [summa (cond
                           (and alkujakso? (= kk 12)) viimeinen-summa
                           (and (not alkujakso?) (= kk 9)) viimeinen-summa
@@ -463,7 +465,12 @@
                          :vuosi hoitovuoden-alkuvuosi
                          :kuukausi kk
                          :summa summa
-                         :summa_indeksikorjattu nil
+                         :summa_indeksikorjattu (when summa
+                                                  (indeksi-kyselyt/indeksikorjaa
+                                                    (indeksi-kyselyt/indeksikerroin urakan-indeksit
+                                                      (pvm/paivamaara->mhu-hoitovuosi-nro
+                                                        (:alkupvm urakan-tiedot) (pvm/luo-pvm-dec-kk hoitovuoden-alkuvuosi kk 1)))
+                                                    summa))
                          :toimenpideinstanssi-id toimenpideinstanssi-id
                          :tehtavaryhma nil
                          :tehtava nil
@@ -475,7 +482,12 @@
                          :vuosi hoitovuoden-alkuvuosi
                          :kuukausi kk
                          :summa summa
-                         :summa_indeksikorjattu nil
+                         :summa_indeksikorjattu (when summa
+                                                  (indeksi-kyselyt/indeksikorjaa
+                                                    (indeksi-kyselyt/indeksikerroin urakan-indeksit
+                                                      (pvm/paivamaara->mhu-hoitovuosi-nro
+                                                        (:alkupvm urakan-tiedot) (pvm/luo-pvm-dec-kk hoitovuoden-alkuvuosi kk 1)))
+                                                    summa))
                          :tehtavaryhma nil
                          :tehtava nil
                          :luoja kayttaja-id}))]))]))
@@ -494,15 +506,17 @@
                   loppukausi-kuukausisumma (yleiset/round2 2 (with-precision 4 (/ loppukausi 9)))
                   loppukausi-viimeinen-kuukausi (- loppukausi (* 8 loppukausi-kuukausisumma))
                   ;; Tallenna alkujakso
-                  _ (tallenna-hankintojen-kuukausittainen-summa db (range 10 13) true alkukausi-viimeinen-kuukausi alkukausi-kuukausisumma
+                  _ (tallenna-hankintojen-kuukausittainen-summa db urakka-id (range 10 13) true alkukausi-viimeinen-kuukausi alkukausi-kuukausisumma
                       hoitovuoden-alkuvuosi sopimus-id toimenpideinstanssi-id (:id kayttaja))
                   ;; Tallenna loppujakso
-                  _ (tallenna-hankintojen-kuukausittainen-summa db (range 1 10) false loppukausi-viimeinen-kuukausi loppukausi-kuukausisumma
+                  _ (tallenna-hankintojen-kuukausittainen-summa db urakka-id (range 1 10) false loppukausi-viimeinen-kuukausi loppukausi-kuukausisumma
                       (inc hoitovuoden-alkuvuosi) sopimus-id toimenpideinstanssi-id (:id kayttaja))]))]))
 
 (defn tallenna-erillishankinnat
   [db kayttaja urakka-id erillishankinnat]
-  (let [sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
+  (let [urakan-indeksit (indeksi-kyselyt/hae-urakan-indeksikertoimet db urakka-id)
+        urakan-tiedot (first (urakat-q/hae-urakka db {:id urakka-id}))
+        sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
         ;; Hae hoidonjohto toimenpideinstannssi
         ;; Hoindonjohto toimenpide.koodi = 23151
         hoidonjohto-tpi-id (:id (first (tpi-kyselyt/hae-urakan-toimenpideinstanssi-toimenpidekoodilla db
@@ -517,7 +531,12 @@
                       (paivita-kuukauden-erillishankinta<! db
                         {:id (:id dbrivi)
                          :summa (:summa rivi)
-                         :summa_indeksikorjattu nil
+                         :summa_indeksikorjattu (when (:summa rivi)
+                                                  (indeksi-kyselyt/indeksikorjaa
+                                                    (indeksi-kyselyt/indeksikerroin urakan-indeksit
+                                                      (pvm/paivamaara->mhu-hoitovuosi-nro
+                                                        (:alkupvm urakan-tiedot) (pvm/luo-pvm-dec-kk (:vuosi rivi) (:kuukausi rivi) 1)))
+                                                    (:summa rivi)))
                          :muokkaaja (:id kayttaja)})
                       ;; Lisää uusi
                       (tallenna-kuukauden-erillishankinta<! db
@@ -526,7 +545,12 @@
                          :vuosi (:vuosi rivi)
                          :kuukausi (:kuukausi rivi)
                          :summa (:summa rivi)
-                         :summa_indeksikorjattu nil
+                         :summa_indeksikorjattu (when (:summa rivi)
+                                                  (indeksi-kyselyt/indeksikorjaa
+                                                    (indeksi-kyselyt/indeksikerroin urakan-indeksit
+                                                      (pvm/paivamaara->mhu-hoitovuosi-nro
+                                                        (:alkupvm urakan-tiedot) (pvm/luo-pvm-dec-kk (:vuosi rivi) (:kuukausi rivi) 1)))
+                                                    (:summa rivi)))
                          :tehtavaryhma-id (:id tehtavaryhma)
                          :luoja (:id kayttaja)}))]))]))
 
@@ -610,15 +634,12 @@
         _ (doseq [toimenkuva johto-ja-hallintokorvaukset]
             (let [;; rivi voi sisältää joko kuukausisumman kaikille toimenkuville (silloin id 1) tai
                   ;; toimenkuvan, jolla on kuukausittaiset arvot, tunnit ja tuntipalkat.
-                  kuukaudet (when (<= urakan-alkuvuosi 2024)
-                              (:kuukaudet toimenkuva))
+                  kuukaudet (when (<= urakan-alkuvuosi 2024) (:kuukaudet toimenkuva))
 
                   ;; Toimenkuva on tietokannassa pakollinen.
                   ;; Asetetaan jokin toimenkuva myös 2025-> urakoille, koska oikeaa toimenkuvaa ei voida uudessa kustannusten suunnittelussa asettaa.
                   ;; Kuukausittaiset yhteenvetorivit eivät ole riippuvaisia toimenkuvasta, joten voidaan käyttää mitä tahansa.
-                  toimenkuva-id (if (>= urakan-alkuvuosi 2025)
-                                  1
-                                  (:id toimenkuva))
+                  toimenkuva-id (if (>= urakan-alkuvuosi 2025) 1 (:id toimenkuva))
 
                   _ (if (<= urakan-alkuvuosi 2024)
                       (tallenna-kuukausittaiset-toimenkuvat db kuukaudet urakan-indeksit urakan-tiedot kayttaja urakka-id toimenkuva-id)
@@ -628,7 +649,9 @@
 
 (defn tallenna-hoidonjohtopalkkiot
   [db kayttaja urakka-id hoidonjohtopalkkiot]
-  (let [sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
+  (let [urakan-tiedot (first (urakat-q/hae-urakka db {:id urakka-id}))
+        urakan-indeksit (indeksi-kyselyt/hae-urakan-indeksikertoimet db urakka-id)
+        sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
         ;; Hae hoidonjohto toimenpideinstannssi
         ;; Hoindonjohto toimenpide.koodi = 23151
         hoidonjohto-tpi-id (:id (first (tpi-kyselyt/hae-urakan-toimenpideinstanssi-toimenpidekoodilla db
@@ -642,7 +665,12 @@
                       (paivita-kuukauden-hoidonjohtopalkkio<! db
                         {:id (:id dbrivi)
                          :summa (:summa rivi)
-                         :summa_indeksikorjattu nil
+                         :summa_indeksikorjattu (when (:summa rivi)
+                                                  (indeksi-kyselyt/indeksikorjaa
+                                                    (indeksi-kyselyt/indeksikerroin urakan-indeksit
+                                                      (pvm/paivamaara->mhu-hoitovuosi-nro
+                                                        (:alkupvm urakan-tiedot) (pvm/luo-pvm-dec-kk (:vuosi rivi) (:kuukausi rivi) 1)))
+                                                    (:summa rivi)))
                          :muokkaaja (:id kayttaja)})
                       ;; Lisää uusi
                       (tallenna-kuukauden-hoidonjohtopalkkio<! db
@@ -651,35 +679,55 @@
                          :vuosi (:vuosi rivi)
                          :kuukausi (:kuukausi rivi)
                          :summa (:summa rivi)
-                         :summa_indeksikorjattu nil
+                         :summa_indeksikorjattu (when (:summa rivi)
+                                                  (indeksi-kyselyt/indeksikorjaa
+                                                    (indeksi-kyselyt/indeksikerroin urakan-indeksit
+                                                      (pvm/paivamaara->mhu-hoitovuosi-nro
+                                                        (:alkupvm urakan-tiedot) (pvm/luo-pvm-dec-kk (:vuosi rivi) (:kuukausi rivi) 1)))
+                                                    (:summa rivi)))
                          :tehtava-id (:id tehtava)
                          :luoja (:id kayttaja)}))]))]))
 
-(defn voidaanko-vahvistaa-tavoitehintaa?
+(defn puuttuvat-suunnitelmat
   "Jotta urakan tavoitehinta voidaan vahvistaa, Kustannusten Suunnittelussa pitää olla täydennettynä kaikki tiedot."
   [db urakka-id hoitovuoden-alkuvuosi]
-  (let [sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
-
+  (let [urakan-tiedot (first (urakat-q/hae-urakan-tiedot db urakka-id))
+        urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
+        sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
+        puuttuvat []
         ;; Kaikki kustannussuunnitelman summat vaikuttaa tavoitehintaan
         ;; Pysyvät muutokset lisätään mukaan joko vähentämään tai lisäämään tavoitehintaa
         kilpailutettavat-hankinnat (hae-kiinteat-kustannukset db sopimus-id urakka-id hoitovuoden-alkuvuosi)
-        hankinnat-ok? (and (boolean (seq kilpailutettavat-hankinnat))
-                        (some (fn [x] (not= (:yhteensa x) 0)) kilpailutettavat-hankinnat))
+        puuttuvat (if-not (and (boolean (seq kilpailutettavat-hankinnat))
+                            (some (fn [x] (not= (:yhteensa x) 0)) kilpailutettavat-hankinnat))
+                    (conj puuttuvat "Kilpailutettavat hankinnat") puuttuvat)
 
         erillishankinnat (hae-erillishankinnat db sopimus-id urakka-id hoitovuoden-alkuvuosi)
-        erillishankinnat-ok? (and (boolean (seq erillishankinnat))
-                               (some (fn [x] (not= (:summa x) 0)) erillishankinnat))
+        puuttuvat (if-not (and (boolean (seq erillishankinnat))
+                            (some (fn [x] (not= (:summa x) 0)) erillishankinnat))
+                    (conj puuttuvat "Erillishankinnat") puuttuvat)
 
         hoidonjohtopalkkiot (hae-hoidonjohtopalkkiot db sopimus-id urakka-id hoitovuoden-alkuvuosi)
-        hoidonjohtopalkkiot-ok? (and (boolean (seq hoidonjohtopalkkiot))
-                                  (some (fn [x] (not= (:summa x) 0)) hoidonjohtopalkkiot))
+        puuttuvat (if-not (and (boolean (seq hoidonjohtopalkkiot))
+                            (some (fn [x] (not= (:summa x) 0)) hoidonjohtopalkkiot))
+                    (conj puuttuvat "Hoidonjohtopalkkiot") puuttuvat)
 
-        johto-ja-hallintokorvaukset (hae-hoidonjohtopalkkiot db sopimus-id urakka-id hoitovuoden-alkuvuosi)
-        johto-ja-hallintokorvaukset-ok? (and (boolean (seq johto-ja-hallintokorvaukset))
-                                          (some (fn [x] (not= (:summa x) 0)) hoidonjohtopalkkiot))
-        voidaan-vahvistaa? (every? true? [hankinnat-ok? erillishankinnat-ok? hoidonjohtopalkkiot-ok?
-                                          johto-ja-hallintokorvaukset-ok?])]
-    voidaan-vahvistaa?))
+        johto-ja-hallintokorvaukset (cond
+                                      (and (>= urakan-alkuvuosi 2019) (<= urakan-alkuvuosi 2024))
+                                      (hae-johto-ja-hallintokorvaukset-2019-2024 db urakka-id hoitovuoden-alkuvuosi urakan-alkuvuosi nil)
+                                      (>= urakan-alkuvuosi 2025)
+                                      (hae-johto-ja-hallintokorvaukset db urakka-id hoitovuoden-alkuvuosi nil)
+                                      :else (hae-johto-ja-hallintokorvaukset db urakka-id hoitovuoden-alkuvuosi nil))
+
+        puuttuvat (if-not (and (boolean (seq johto-ja-hallintokorvaukset))
+                            (cond
+                              (and (>= urakan-alkuvuosi 2019) (<= urakan-alkuvuosi 2024))
+                              (some (fn [x] (not= (:yhteensa-kk x) 0M)) (flatten (map :kuukaudet johto-ja-hallintokorvaukset)))
+                              (>= urakan-alkuvuosi 2025)
+                              (some (fn [x] (not= (:yhteensa-kk x) 0)) johto-ja-hallintokorvaukset)
+                              :else (some (fn [x] (not= (:tuntipalkka x) 0)) johto-ja-hallintokorvaukset)))
+                    (conj puuttuvat "Johto-ja-hallintokorvaukset") puuttuvat)]
+    puuttuvat))
 
 (defn vahvista-tavoite-ja-kattohinta [db kayttaja urakka-id vahvista? hoitovuoden-alkuvuosi]
   (let [sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
@@ -159,32 +159,32 @@
 (defn paattele-toimenkuvan-kuukaudet [urakan-alkuvuosi toimenkuva]
   (let [toimenkuva-nimi (:toimenkuva toimenkuva)
         toimenkuva-nimike (:nimike toimenkuva)]
-   (cond
-     (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimi "sopimusvastaava")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimi "vastuunalainen työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimike "Päätoiminen apulainen (talvikausi)")) [5 6 7 8 9]
-     (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimike "Päätoiminen apulainen (kesäkausi)")) [10 11 12 1 2 3 4]
-     (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimike "Apulainen/työnjohtaja (talvikausi)")) [5 6 7 8 9]
-     (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimike "Apulainen/työnjohtaja (kesäkausi)")) [10 11 12 1 2 3 4]
-     (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimi "viherhoidosta vastaava henkilö")) [4 5 6 7 8]
-     (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimi "hankintavastaava")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimi "harjoittelija")) [5 6 7 8]
+    (cond
+      (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimi "sopimusvastaava")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimi "vastuunalainen työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimike "Päätoiminen apulainen (talvikausi)")) [5 6 7 8 9]
+      (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimike "Päätoiminen apulainen (kesäkausi)")) [10 11 12 1 2 3 4]
+      (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimike "Apulainen/työnjohtaja (talvikausi)")) [5 6 7 8 9]
+      (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimike "Apulainen/työnjohtaja (kesäkausi)")) [10 11 12 1 2 3 4]
+      (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimi "viherhoidosta vastaava henkilö")) [4 5 6 7 8]
+      (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimi "hankintavastaava")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (<= urakan-alkuvuosi 2021) (= toimenkuva-nimi "harjoittelija")) [5 6 7 8]
 
-     (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "valmistelukausi ennen urakka-ajan alkua")) [8] ;; Tämä pitäisi olla ennen sopimuskautta. Mutta laitetaan sinne yksi kuukausi
-     (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "vastuunalainen työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "päätoiminen apulainen")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "apulainen/työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "viherhoidosta vastaava henkilö")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "hankintavastaava")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "harjoittelija")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "valmistelukausi ennen urakka-ajan alkua")) [8] ;; Tämä pitäisi olla ennen sopimuskautta. Mutta laitetaan sinne yksi kuukausi
+      (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "vastuunalainen työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "päätoiminen apulainen")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "apulainen/työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "viherhoidosta vastaava henkilö")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "hankintavastaava")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (and (>= urakan-alkuvuosi 2022) (<= urakan-alkuvuosi 2024)) (= toimenkuva-nimi "harjoittelija")) [10 11 12 1 2 3 4 5 6 7 8 9]
 
-     (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "valmistelukausi ennen urakka-ajan alkua")) [8] ;; Tämäkin pitäisi olla ennen sopimuskautta. Mutta laitetaan sinne yksi kuukausi
-     (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "vastuunalainen työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "2. työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "3. työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "viherhoidosta vastaava henkilö")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "harjoittelija")) [10 11 12 1 2 3 4 5 6 7 8 9]
-     :else [10 11 12 1 2 3 4 5 6 7 8 9])))
+      (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "valmistelukausi ennen urakka-ajan alkua")) [8] ;; Tämäkin pitäisi olla ennen sopimuskautta. Mutta laitetaan sinne yksi kuukausi
+      (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "vastuunalainen työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "2. työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "3. työnjohtaja")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "viherhoidosta vastaava henkilö")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "harjoittelija")) [10 11 12 1 2 3 4 5 6 7 8 9]
+      :else [10 11 12 1 2 3 4 5 6 7 8 9])))
 
 (defn hae-johto-ja-hallintokorvaukset-2019-2024 [db urakka-id hoitovuoden-alkuvuosi urakan-alkuvuosi toimenkuvat-tarjouksesta]
   (let [viimeisin-muokkaus (first (hae-viimeisin-muokkaaja-jjh

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
@@ -44,6 +44,12 @@
   indeksikorjaukset-vahvistettu? paivita-tavoite-ja-kattohinta<!
   lisaa-tavoite-ja-kattohinta<! hae-urakan-hoitovuoden-tavoitetiedot)
 
+(defn- laske-indeksikorjattu-summa
+  "Indeksikorjattu summa lasketaan summasta ja urakan voimassaolevista indekseistä. Jos summaa ei ole annettu, palautetaan nil."
+  [summa urakan-indeksit hoitovuosi-nro]
+  (when summa
+    (indeksi-kyselyt/indeksikorjaa (indeksi-kyselyt/indeksikerroin urakan-indeksit hoitovuosi-nro) summa)))
+
 (defn hae-kiinteat-kustannukset [db sopimus-id urakka-id hoitovuoden-alkuvuosi]
   (let [;; Haetaan urakan toimenpiteet
         toimenpiteet (hae-urakan-toimenpiteet db {:urakkaid urakka-id})
@@ -532,11 +538,9 @@
                     :luoja (:id kayttaja)}))]
     tiedot))
 
-(defn tallenna-hankintojen-kuukausittainen-summa [db urakka-id kk-jakso alkujakso? viimeinen-summa summa hoitovuoden-alkuvuosi sopimus-id
-                                                  toimenpideinstanssi-id kayttaja-id]
-  (let [urakan-tiedot (first (urakat-q/hae-urakka db {:id urakka-id}))
-        urakan-indeksit (indeksi-kyselyt/hae-urakan-indeksikertoimet db urakka-id)
-        _ (doseq [kk kk-jakso]
+(defn tallenna-hankintojen-kuukausittainen-summa [db kk-jakso alkujakso? viimeinen-summa summa hoitovuoden-alkuvuosi sopimus-id
+                                                  toimenpideinstanssi-id kayttaja-id urakan-indeksit hoitovuosi-nro]
+  (let [_ (doseq [kk kk-jakso]
             (let [summa (cond
                           (and alkujakso? (= kk 12)) viimeinen-summa
                           (and (not alkujakso?) (= kk 9)) viimeinen-summa
@@ -552,12 +556,7 @@
                          :vuosi hoitovuoden-alkuvuosi
                          :kuukausi kk
                          :summa summa
-                         :summa_indeksikorjattu (when summa
-                                                  (indeksi-kyselyt/indeksikorjaa
-                                                    (indeksi-kyselyt/indeksikerroin urakan-indeksit
-                                                      (pvm/paivamaara->mhu-hoitovuosi-nro
-                                                        (:alkupvm urakan-tiedot) (pvm/luo-pvm-dec-kk hoitovuoden-alkuvuosi kk 1)))
-                                                    summa))
+                         :summa_indeksikorjattu (laske-indeksikorjattu-summa summa urakan-indeksit hoitovuosi-nro)
                          :toimenpideinstanssi-id toimenpideinstanssi-id
                          :tehtavaryhma nil
                          :tehtava nil
@@ -569,12 +568,7 @@
                          :vuosi hoitovuoden-alkuvuosi
                          :kuukausi kk
                          :summa summa
-                         :summa_indeksikorjattu (when summa
-                                                  (indeksi-kyselyt/indeksikorjaa
-                                                    (indeksi-kyselyt/indeksikerroin urakan-indeksit
-                                                      (pvm/paivamaara->mhu-hoitovuosi-nro
-                                                        (:alkupvm urakan-tiedot) (pvm/luo-pvm-dec-kk hoitovuoden-alkuvuosi kk 1)))
-                                                    summa))
+                         :summa_indeksikorjattu (laske-indeksikorjattu-summa summa urakan-indeksit hoitovuosi-nro)
                          :tehtavaryhma nil
                          :tehtava nil
                          :luoja kayttaja-id}))]))]))
@@ -583,6 +577,9 @@
   [db kayttaja urakka-id hoitovuoden-alkuvuosi kilpailutettavat-hankinnat]
   ;; Lisätään transktiot, jottei yhden epäonnistuminen päästä muita läpi
   (let [sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
+        urakan-tiedot (first (urakat-q/hae-urakka db {:id urakka-id}))
+        urakan-indeksit (indeksi-kyselyt/hae-urakan-indeksikertoimet db urakka-id)
+        hoitovuosi-nro (pvm/paivamaara->mhu-hoitovuosi-nro (:alkupvm urakan-tiedot) (pvm/->pvm (str "01.11." hoitovuoden-alkuvuosi)))
         ; Splittaa alkukauden summat kuukausittain
         _ (doseq [{:keys [alkukausi loppukausi toimenpideinstanssi-id]} kilpailutettavat-hankinnat]
             (let [alkukausi (bigdec alkukausi)
@@ -593,19 +590,20 @@
                   loppukausi-kuukausisumma (yleiset/round2 2 (with-precision 4 (/ loppukausi 9)))
                   loppukausi-viimeinen-kuukausi (- loppukausi (* 8 loppukausi-kuukausisumma))
                   ;; Tallenna alkujakso
-                  _ (tallenna-hankintojen-kuukausittainen-summa db urakka-id (range 10 13) true alkukausi-viimeinen-kuukausi alkukausi-kuukausisumma
-                      hoitovuoden-alkuvuosi sopimus-id toimenpideinstanssi-id (:id kayttaja))
+                  _ (tallenna-hankintojen-kuukausittainen-summa db (range 10 13) true alkukausi-viimeinen-kuukausi alkukausi-kuukausisumma
+                      hoitovuoden-alkuvuosi sopimus-id toimenpideinstanssi-id (:id kayttaja) urakan-indeksit hoitovuosi-nro)
                   ;; Tallenna loppujakso
-                  _ (tallenna-hankintojen-kuukausittainen-summa db urakka-id (range 1 10) false loppukausi-viimeinen-kuukausi loppukausi-kuukausisumma
-                      (inc hoitovuoden-alkuvuosi) sopimus-id toimenpideinstanssi-id (:id kayttaja))]))]))
+                  _ (tallenna-hankintojen-kuukausittainen-summa db (range 1 10) false loppukausi-viimeinen-kuukausi loppukausi-kuukausisumma
+                      (inc hoitovuoden-alkuvuosi) sopimus-id toimenpideinstanssi-id (:id kayttaja) urakan-indeksit hoitovuosi-nro)]))]))
 
 (defn tallenna-erillishankinnat
-  [db kayttaja urakka-id erillishankinnat]
+  [db kayttaja urakka-id erillishankinnat hoitovuoden-alkuvuosi]
   (let [urakan-indeksit (indeksi-kyselyt/hae-urakan-indeksikertoimet db urakka-id)
         urakan-tiedot (first (urakat-q/hae-urakka db {:id urakka-id}))
+        hoitovuosi-nro (pvm/paivamaara->mhu-hoitovuosi-nro (:alkupvm urakan-tiedot) (pvm/->pvm (str "01.11." hoitovuoden-alkuvuosi)))
         sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
         ;; Hae hoidonjohto toimenpideinstannssi
-        ;; Hoindonjohto toimenpide.koodi = 23151
+        ;; Hoidonjohto toimenpide.koodi = 23151
         hoidonjohto-tpi-id (:id (first (tpi-kyselyt/hae-urakan-toimenpideinstanssi-toimenpidekoodilla db
                                          {:urakka urakka-id
                                           :koodi "23151"})))
@@ -618,12 +616,7 @@
                       (paivita-kuukauden-erillishankinta<! db
                         {:id (:id dbrivi)
                          :summa (:summa rivi)
-                         :summa_indeksikorjattu (when (:summa rivi)
-                                                  (indeksi-kyselyt/indeksikorjaa
-                                                    (indeksi-kyselyt/indeksikerroin urakan-indeksit
-                                                      (pvm/paivamaara->mhu-hoitovuosi-nro
-                                                        (:alkupvm urakan-tiedot) (pvm/luo-pvm-dec-kk (:vuosi rivi) (:kuukausi rivi) 1)))
-                                                    (:summa rivi)))
+                         :summa_indeksikorjattu (laske-indeksikorjattu-summa (:summa rivi) urakan-indeksit hoitovuosi-nro)
                          :muokkaaja (:id kayttaja)})
                       ;; Lisää uusi
                       (tallenna-kuukauden-erillishankinta<! db
@@ -632,16 +625,12 @@
                          :vuosi (:vuosi rivi)
                          :kuukausi (:kuukausi rivi)
                          :summa (:summa rivi)
-                         :summa_indeksikorjattu (when (:summa rivi)
-                                                  (indeksi-kyselyt/indeksikorjaa
-                                                    (indeksi-kyselyt/indeksikerroin urakan-indeksit
-                                                      (pvm/paivamaara->mhu-hoitovuosi-nro
-                                                        (:alkupvm urakan-tiedot) (pvm/luo-pvm-dec-kk (:vuosi rivi) (:kuukausi rivi) 1)))
-                                                    (:summa rivi)))
+                         :summa_indeksikorjattu (laske-indeksikorjattu-summa (:summa rivi) urakan-indeksit hoitovuosi-nro)
                          :tehtavaryhma-id (:id tehtavaryhma)
                          :luoja (:id kayttaja)}))]))]))
 
-(defn tallenna-kuukausittaiset-muut-kulut [db kuukaudet urakan-indeksit urakan-tiedot kayttaja sopimus-id toimenpideinstanssi-id]
+(defn tallenna-kuukausittaiset-muut-kulut [db kuukaudet urakan-indeksit urakan-tiedot kayttaja sopimus-id
+                                           toimenpideinstanssi-id hoitovuosi-nro]
   (let [tehtava (hae-tehtava-tunnisteella db {:tunniste "8376d9c4-3daf-4815-973d-cd95ca3bb388"})
         tehtava-id (:id (first tehtava))] ;; Muut kulut tehtävä
     (doseq [{:keys [vuosi kuukausi yhteensa-kk summa] :as rivi} (sort-by (juxt :vuosi :kuukausi) kuukaudet)]
@@ -653,12 +642,7 @@
             t (if-not db-kuukausi
                 (lisaa-kuukauden-muu-kulu<! db
                   {:summa yhteensa-kk
-                   :summa_indeksikorjattu (when yhteensa-kk
-                                            (indeksi-kyselyt/indeksikorjaa
-                                              (indeksi-kyselyt/indeksikerroin urakan-indeksit
-                                                (pvm/paivamaara->mhu-hoitovuosi-nro
-                                                  (:alkupvm urakan-tiedot) (pvm/luo-pvm-dec-kk vuosi kuukausi 1)))
-                                              yhteensa-kk))
+                   :summa_indeksikorjattu (laske-indeksikorjattu-summa yhteensa-kk urakan-indeksit hoitovuosi-nro)
                    :vuosi vuosi
                    :kuukausi kuukausi
                    :toimenpideinstanssi-id toimenpideinstanssi-id
@@ -668,15 +652,11 @@
                 (paivita-kuukauden-muu-kulu<! db
                   {:id (:id db-kuukausi)
                    :summa yhteensa-kk
-                   :summa_indeksikorjattu (when yhteensa-kk
-                                            (indeksi-kyselyt/indeksikorjaa
-                                              (indeksi-kyselyt/indeksikerroin urakan-indeksit
-                                                (pvm/paivamaara->mhu-hoitovuosi-nro
-                                                  (:alkupvm urakan-tiedot) (pvm/luo-pvm-dec-kk vuosi kuukausi 1)))
-                                              yhteensa-kk))
+                   :summa_indeksikorjattu (laske-indeksikorjattu-summa yhteensa-kk urakan-indeksit hoitovuosi-nro)
                    :muokkaaja (:id kayttaja)}))]))))
 
-(defn tallenna-kuukausittaiset-toimenkuvat [db kuukaudet urakan-indeksit urakan-tiedot kayttaja urakka-id toimenkuva-id]
+(defn tallenna-kuukausittaiset-toimenkuvat [db kuukaudet urakan-indeksit urakan-tiedot kayttaja urakka-id
+                                            toimenkuva-id hoitovuosi-nro]
   (let [urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))]
     (doseq [{:keys [vuosi kuukausi tunnit tuntipalkka] :as rivi} (sort-by (juxt :vuosi :kuukausi) kuukaudet)]
       (let [;; Haetaan toimenkuvan kuukauden johto-ja-hallintokorvaus
@@ -696,26 +676,16 @@
                    :kuukausi kuukausi
                    :tunnit tunnit
                    :tuntipalkka tuntipalkka
-                   :tuntipalkka_indeksikorjattu (when tuntipalkka
-                                                  (indeksi-kyselyt/indeksikorjaa
-                                                    (indeksi-kyselyt/indeksikerroin urakan-indeksit
-                                                      (pvm/paivamaara->mhu-hoitovuosi-nro
-                                                        (:alkupvm urakan-tiedot) (pvm/luo-pvm-dec-kk vuosi kuukausi 1)))
-                                                    tuntipalkka))
+                   :tuntipalkka_indeksikorjattu (laske-indeksikorjattu-summa tuntipalkka urakan-indeksit hoitovuosi-nro)
                    :luoja (:id kayttaja)})
                 (paivita-kuukauden-johto-ja-hallintokorvaus<! db
                   {:id (:id db-kuukausi)
                    :tuntipalkka tuntipalkka
                    :tunnit tunnit
-                   :tuntipalkka_indeksikorjattu (when tuntipalkka
-                                                  (indeksi-kyselyt/indeksikorjaa
-                                                    (indeksi-kyselyt/indeksikerroin urakan-indeksit
-                                                      (pvm/paivamaara->mhu-hoitovuosi-nro
-                                                        (:alkupvm urakan-tiedot) (pvm/luo-pvm-dec-kk vuosi kuukausi 1)))
-                                                    tuntipalkka))
+                   :tuntipalkka_indeksikorjattu (laske-indeksikorjattu-summa tuntipalkka urakan-indeksit hoitovuosi-nro)
                    :muokkaaja (:id kayttaja)}))]))))
 
-(defn tallenna-vuosittaiset-toimenkuvat [db rivi urakan-indeksit urakan-tiedot kayttaja urakka-id toimenkuva-id]
+(defn tallenna-vuosittaiset-toimenkuvat [db rivi urakan-indeksit kayttaja urakka-id toimenkuva-id hoitovuosi-nro]
   (let [dbrivi (first (hae-kuukauden-johto-ja-hallintokorvaus db {:id (:id rivi)}))
         _ (if (:id dbrivi)
 
@@ -723,12 +693,7 @@
               {:id (:id dbrivi)
                :tuntipalkka (:summa rivi)
                :tunnit 1
-               :tuntipalkka_indeksikorjattu (when (:summa rivi)
-                                              (indeksi-kyselyt/indeksikorjaa
-                                                (indeksi-kyselyt/indeksikerroin urakan-indeksit
-                                                  (pvm/paivamaara->mhu-hoitovuosi-nro
-                                                    (:alkupvm urakan-tiedot) (pvm/luo-pvm-dec-kk (:vuosi rivi) (:kuukausi rivi) 1)))
-                                                (:summa rivi)))
+               :tuntipalkka_indeksikorjattu (laske-indeksikorjattu-summa (:summa rivi) urakan-indeksit hoitovuosi-nro)
                :muokkaaja (:id kayttaja)})
             ;; Lisää uusi
             (lisaa-kuukauden-johto-ja-hallintokorvaus<! db
@@ -738,11 +703,11 @@
                :kuukausi (:kuukausi rivi)
                :tunnit 1
                :tuntipalkka (:summa rivi)
-               :tuntipalkka_indeksikorjattu nil
+               :tuntipalkka_indeksikorjattu (laske-indeksikorjattu-summa (:summa rivi) urakan-indeksit hoitovuosi-nro)
                :luoja (:id kayttaja)}))]))
 
 (defn tallenna-johto-ja-hallintokorvaukset
-  [db kayttaja urakka-id johto-ja-hallintokorvaukset]
+  [db kayttaja urakka-id johto-ja-hallintokorvaukset hoitovuoden-alkuvuosi]
   (let [;; Johto-ja hallintakorvausten mukana tulee -19 - 24 alkavilla urakoilla myös "Muut kulut" rivi
         ;; Poistetaan se tarvittaessa listasta ja tallennetaan erikseen
         vain-jjh (filter (fn [rivi] (not= "Muut kulut" (:toimenkuva rivi))) johto-ja-hallintokorvaukset)
@@ -752,6 +717,7 @@
         urakan-tiedot (first (urakat-q/hae-urakka db {:id urakka-id}))
         urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
         urakan-indeksit (indeksi-kyselyt/hae-urakan-indeksikertoimet db urakka-id)
+        hoitovuosi-nro (pvm/paivamaara->mhu-hoitovuosi-nro (:alkupvm urakan-tiedot) (pvm/->pvm (str "01.11." hoitovuoden-alkuvuosi)))
 
         toimenpideinstanssi-id (:id (first
                                       (tpi-kyselyt/hae-urakan-toimenpideinstanssi-toimenpidekoodilla db
@@ -770,19 +736,23 @@
                   toimenkuva-id (if (>= urakan-alkuvuosi 2025) 1 (:id toimenkuva))
 
                   _ (if (<= urakan-alkuvuosi 2024)
-                      (tallenna-kuukausittaiset-toimenkuvat db kuukaudet urakan-indeksit urakan-tiedot kayttaja urakka-id toimenkuva-id)
-                      (tallenna-vuosittaiset-toimenkuvat db toimenkuva urakan-indeksit urakan-tiedot kayttaja urakka-id toimenkuva-id))]))
+                      (tallenna-kuukausittaiset-toimenkuvat db kuukaudet urakan-indeksit urakan-tiedot kayttaja
+                        urakka-id toimenkuva-id hoitovuosi-nro)
+                      (tallenna-vuosittaiset-toimenkuvat db toimenkuva urakan-indeksit kayttaja urakka-id
+                        toimenkuva-id hoitovuosi-nro))]))
 
         ;; Tallennetaan mahdolliset muut kulut
         _ (when muut-kulut
-            (tallenna-kuukausittaiset-muut-kulut db (:kuukaudet muut-kulut) urakan-indeksit urakan-tiedot kayttaja sopimus-id toimenpideinstanssi-id))
+            (tallenna-kuukausittaiset-muut-kulut db (:kuukaudet muut-kulut) urakan-indeksit urakan-tiedot kayttaja
+              sopimus-id toimenpideinstanssi-id hoitovuosi-nro))
 
         _ (ka-q/merkitse-kustannussuunnitelmat-likaisiksi! db {:toimenpideinstanssi toimenpideinstanssi-id})
         _ (kiint-kyselyt/merkitse-maksuerat-likaisiksi-hoidonjohdossa! db {:toimenpideinstanssi toimenpideinstanssi-id})]))
 
 (defn tallenna-hoidonjohtopalkkiot
-  [db kayttaja urakka-id hoidonjohtopalkkiot]
+  [db kayttaja urakka-id hoidonjohtopalkkiot hoitovuoden-alkuvuosi]
   (let [urakan-tiedot (first (urakat-q/hae-urakka db {:id urakka-id}))
+        hoitovuosi-nro (pvm/paivamaara->mhu-hoitovuosi-nro (:alkupvm urakan-tiedot) (pvm/->pvm (str "01.11." hoitovuoden-alkuvuosi)))
         urakan-indeksit (indeksi-kyselyt/hae-urakan-indeksikertoimet db urakka-id)
         sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
         ;; Hae hoidonjohto toimenpideinstannssi
@@ -798,12 +768,7 @@
                       (paivita-kuukauden-hoidonjohtopalkkio<! db
                         {:id (:id dbrivi)
                          :summa (:summa rivi)
-                         :summa_indeksikorjattu (when (:summa rivi)
-                                                  (indeksi-kyselyt/indeksikorjaa
-                                                    (indeksi-kyselyt/indeksikerroin urakan-indeksit
-                                                      (pvm/paivamaara->mhu-hoitovuosi-nro
-                                                        (:alkupvm urakan-tiedot) (pvm/luo-pvm-dec-kk (:vuosi rivi) (:kuukausi rivi) 1)))
-                                                    (:summa rivi)))
+                         :summa_indeksikorjattu (laske-indeksikorjattu-summa (:summa rivi) urakan-indeksit hoitovuosi-nro)
                          :muokkaaja (:id kayttaja)})
                       ;; Lisää uusi
                       (tallenna-kuukauden-hoidonjohtopalkkio<! db
@@ -812,12 +777,7 @@
                          :vuosi (:vuosi rivi)
                          :kuukausi (:kuukausi rivi)
                          :summa (:summa rivi)
-                         :summa_indeksikorjattu (when (:summa rivi)
-                                                  (indeksi-kyselyt/indeksikorjaa
-                                                    (indeksi-kyselyt/indeksikerroin urakan-indeksit
-                                                      (pvm/paivamaara->mhu-hoitovuosi-nro
-                                                        (:alkupvm urakan-tiedot) (pvm/luo-pvm-dec-kk (:vuosi rivi) (:kuukausi rivi) 1)))
-                                                    (:summa rivi)))
+                         :summa_indeksikorjattu (laske-indeksikorjattu-summa (:summa rivi) urakan-indeksit hoitovuosi-nro)
                          :tehtava-id (:id tehtava)
                          :luoja (:id kayttaja)}))]))]))
 
@@ -909,10 +869,7 @@
                                                        summa (if (and (>= kuukausimaara 9) (= @kk 9)) viimeinen-kuukausisumma kuukausisumma)]]
                                            ;; Rahavarauksesta ei voi muuttua, kuin summa
                                            (paivita-rahavaraus<! db {:summa summa
-                                                                     :summa_indeksikorjattu (when summa
-                                                                                              (indeksi-kyselyt/indeksikorjaa
-                                                                                                (indeksi-kyselyt/indeksikerroin urakan-indeksit hoitokausinumero)
-                                                                                                summa))
+                                                                     :summa_indeksikorjattu (laske-indeksikorjattu-summa summa urakan-indeksit hoitokausinumero)
                                                                      :muokattu (pvm/nyt)
                                                                      :muokkaaja (:id kayttaja)
                                                                      :id (:id r)})))
@@ -928,10 +885,7 @@
                                                                  :tehtava_id nil
                                                                  :rahavaraus_id rahavaraus-id
                                                                  :summa summa
-                                                                 :summa_indeksikorjattu (when summa
-                                                                                          (indeksi-kyselyt/indeksikorjaa
-                                                                                            (indeksi-kyselyt/indeksikerroin urakan-indeksit hoitokausinumero)
-                                                                                            summa))
+                                                                 :summa_indeksikorjattu (laske-indeksikorjattu-summa summa urakan-indeksit hoitokausinumero)
                                                                  :luoja (:id kayttaja)})))]
                     dbrahavaraus))
             rahavaraukset)

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
@@ -314,8 +314,8 @@
 
         ;; Lisää vielä järjestysnumero toimenkuville
         toimenkuvat (map-indexed (fn [i toimenkuva]
-                                  (assoc toimenkuva :jarjestys (inc i)))
-                                toimenkuvat)]
+                                   (assoc toimenkuva :jarjestys (inc i)))
+                      toimenkuvat)]
     toimenkuvat))
 
 (defn hae-johto-ja-hallintokorvaukset [db urakka-id hoitovuoden-alkuvuosi toimenkuvat-tarjouksesta]

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
@@ -402,7 +402,7 @@
         toimenkuvat (vec (sort-by :jarjestys toimenkuvat))]
     toimenkuvat))
 
-(defn hae-johto-ja-hallintokorvaukset [db urakka-id hoitovuoden-alkuvuosi toimenkuvat-tarjouksesta]
+(defn hae-johto-ja-hallintokorvaukset-2025 [db urakka-id hoitovuoden-alkuvuosi]
   (let [johto-ja-hallintokorvaukset (hae-johto-ja-hallintokorvaukset-kuukausittain db
                                       {:urakka-id urakka-id
                                        :vuosi hoitovuoden-alkuvuosi})
@@ -844,10 +844,10 @@
 
         johto-ja-hallintokorvaukset (cond
                                       (and (>= urakan-alkuvuosi 2019) (<= urakan-alkuvuosi 2024))
-                                      (hae-johto-ja-hallintokorvaukset-2019-2024 db urakka-id hoitovuoden-alkuvuosi urakan-alkuvuosi nil)
+                                      (hae-johto-ja-hallintokorvaukset-2019-2024 db urakka-id sopimus-id hoitovuoden-alkuvuosi urakan-alkuvuosi nil)
                                       (>= urakan-alkuvuosi 2025)
-                                      (hae-johto-ja-hallintokorvaukset db urakka-id hoitovuoden-alkuvuosi nil)
-                                      :else (hae-johto-ja-hallintokorvaukset db urakka-id hoitovuoden-alkuvuosi nil))
+                                      (hae-johto-ja-hallintokorvaukset-2025 db urakka-id hoitovuoden-alkuvuosi)
+                                      :else (hae-johto-ja-hallintokorvaukset-2025 db urakka-id hoitovuoden-alkuvuosi))
 
         puuttuvat (if-not (and (boolean (seq johto-ja-hallintokorvaukset))
                             (cond

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
@@ -402,7 +402,10 @@
         toimenkuvat (vec (sort-by :jarjestys toimenkuvat))]
     toimenkuvat))
 
-(defn hae-johto-ja-hallintokorvaukset-2025 [db urakka-id hoitovuoden-alkuvuosi]
+(defn hae-johto-ja-hallintokorvaukset-2025
+  "Käytetään haettaessa johto-ja-hallintokorvauksia 2025 ja myöhemmin alkaville urakoille.
+   -25 vuodesta eteenpäin toimenkuvat on kustannussuunnitelmassa könttäsummana kuukausittain. Ei yksittäisinä toimenkuvina."
+  [db urakka-id hoitovuoden-alkuvuosi]
   (let [johto-ja-hallintokorvaukset (hae-johto-ja-hallintokorvaukset-kuukausittain db
                                       {:urakka-id urakka-id
                                        :vuosi hoitovuoden-alkuvuosi})

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
@@ -25,7 +25,7 @@
   paivita-kuukauden-erillishankinta<! tallenna-kuukauden-erillishankinta<!
   hae-viimeisin-muokkaaja-erillishankinnoille
   hae-hoidonjohtopalkkiot-kuukausittain hae-kuukauden-hoidonjohtopalkkio hae-viimeisin-muokkaaja-hoidonjohtopalkkiolle
-  hae-rahavaraus-vuodelta
+  hae-rahavaraus-vuodelta paivita-rahavaraus<! lisaa-rahavaraus<!
   paivita-kuukauden-hoidonjohtopalkkio<! tallenna-kuukauden-hoidonjohtopalkkio<!
   hae-johto-ja-hallintokorvaukset-kuukausittain
   hae-johto-ja-hallintokorvaukset-2019-mhu
@@ -732,10 +732,13 @@
 (defn vahvista-tavoite-ja-kattohinta [db kayttaja urakka-id vahvista? hoitovuoden-alkuvuosi]
   (let [sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
         urakan-tiedot (first (urakat-q/hae-urakka db {:id urakka-id}))
+        urakan-indeksit (indeksi-kyselyt/hae-urakan-indeksikertoimet db urakka-id)
         hoitokausinumero (pvm/hoitokausivuosi->mhu-hoitovuosi-nro (:alkupvm urakan-tiedot) hoitovuoden-alkuvuosi)
         vahvistus-pvm (pvm/nyt)
         hoitokauden-alkupvm (pvm/->pvm (str "01.10." hoitovuoden-alkuvuosi))
         hoitokauden-loppupvm (pvm/->pvm (str "30.09." (inc hoitovuoden-alkuvuosi)))
+
+        ;; Vahvista kiinteähintaiset työt.
         _ (vahvista-tai-kumoa-indeksikorjaukset-kiinteahintaisille-toille! db
             {:urakka-id urakka-id
              :alkupvm hoitokauden-alkupvm
@@ -748,7 +751,6 @@
         ;; Hae ensin tarjouksen tiedot
         tarjous (tarjous-kyselyt/hae-tarjous db urakka-id)
         rahavaraukset (filter #(= "tavoitehintaiset-rahavaraukset" (:osio %)) (:tarjous tarjous))
-
         _ (mapv (fn [rahavaraus]
                   (let [rahavaraus-id (:rahavaraus-id rahavaraus)
                         vuosittainen-summa (:summa (first (filter #(= hoitovuoden-alkuvuosi (:vuosi %)) (:hoitovuosittaiset-arvot rahavaraus))))
@@ -770,23 +772,34 @@
                                                  :let [_ (swap! kk inc)
                                                        kuukausimaara (count kt-rahavaraus-kuukaudet)
                                                        kuukausisumma (when-not (nil? vuosittainen-summa) (round2 2 (/ vuosittainen-summa kuukausimaara))) ;; Tallenna nil kantaan, jos nil arvo on syötetty
-                                                       viimeinen-kuukausisumma (when-not (nil? vuosittainen-summa) (round2 2 (- vuosittainen-summa (* (dec kuukausimaara) kuukausisumma))))]]
+                                                       viimeinen-kuukausisumma (when-not (nil? vuosittainen-summa) (round2 2 (- vuosittainen-summa (* (dec kuukausimaara) kuukausisumma))))
+                                                       summa (if (and (>= kuukausimaara 9) (= @kk 9)) viimeinen-kuukausisumma kuukausisumma)]]
                                            ;; Rahavarauksesta ei voi muuttua, kuin summa
-                                           (ka-q/paivita-rahavaraus<! db {:summa (if (and (>= kuukausimaara 9) (= @kk 9)) viimeinen-kuukausisumma kuukausisumma)
-                                                                          :muokattu (pvm/nyt)
-                                                                          :muokkaaja (:id kayttaja)
-                                                                          :id (:id r)})))
+                                           (paivita-rahavaraus<! db {:summa summa
+                                                                     :summa_indeksikorjattu (when summa
+                                                                                              (indeksi-kyselyt/indeksikorjaa
+                                                                                                (indeksi-kyselyt/indeksikerroin urakan-indeksit hoitokausinumero)
+                                                                                                summa))
+                                                                     :muokattu (pvm/nyt)
+                                                                     :muokkaaja (:id kayttaja)
+                                                                     :id (:id r)})))
                                        (doseq [kk (range 1 13)
                                                :let [kuukausisumma (when-not (nil? vuosittainen-summa) (round2 2 (/ vuosittainen-summa 12)))
-                                                     viimeinen-kuukausisumma (when-not (nil? vuosittainen-summa) (round2 2 (- vuosittainen-summa (* 11 kuukausisumma))))]]
-                                         (ka-q/lisaa-rahavaraus<! db {:vuosi (if (< kk 10) (inc hoitovuoden-alkuvuosi) hoitovuoden-alkuvuosi)
-                                                                      :kuukausi kk
-                                                                      :sopimus_id sopimus-id
-                                                                      :toimenpideinstanssi_id ensimmainen-toimenpideinstanssi-id
-                                                                      :tehtava_id nil
-                                                                      :rahavaraus_id rahavaraus-id
-                                                                      :summa (if (= kk 9) viimeinen-kuukausisumma kuukausisumma)
-                                                                      :luoja (:id kayttaja)})))]
+                                                     viimeinen-kuukausisumma (when-not (nil? vuosittainen-summa) (round2 2 (- vuosittainen-summa (* 11 kuukausisumma))))
+                                                     vuosi (if (< kk 10) (inc hoitovuoden-alkuvuosi) hoitovuoden-alkuvuosi)
+                                                     summa (if (= kk 9) viimeinen-kuukausisumma kuukausisumma)]]
+                                         (lisaa-rahavaraus<! db {:vuosi vuosi
+                                                                 :kuukausi kk
+                                                                 :sopimus_id sopimus-id
+                                                                 :toimenpideinstanssi_id ensimmainen-toimenpideinstanssi-id
+                                                                 :tehtava_id nil
+                                                                 :rahavaraus_id rahavaraus-id
+                                                                 :summa summa
+                                                                 :summa_indeksikorjattu (when summa
+                                                                                          (indeksi-kyselyt/indeksikorjaa
+                                                                                            (indeksi-kyselyt/indeksikerroin urakan-indeksit hoitokausinumero)
+                                                                                            summa))
+                                                                 :luoja (:id kayttaja)})))]
                     dbrahavaraus))
             rahavaraukset)
 

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.sql
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.sql
@@ -291,47 +291,61 @@ WHERE sopimus = :sopimus-id
    OR (vuosi = :vuosi + 1 AND kuukausi >= 1 AND kuukausi <= 9))
 GROUP BY r.id;
 
+-- name: paivita-rahavaraus<!
+UPDATE kustannusarvioitu_tyo
+SET summa = :summa,
+    summa_indeksikorjattu = :summa_indeksikorjattu,
+    muokattu = NOW(),
+    muokkaaja = :muokkaaja
+WHERE id = :id;
+
+-- name: lisaa-rahavaraus<!
+INSERT INTO kustannusarvioitu_tyo (vuosi, kuukausi, summa, summa_indeksikorjattu, sopimus,
+                                   toimenpideinstanssi, tehtava, rahavaraus_id, tyyppi, osio, luoja, luotu)
+VALUES (:vuosi, :kuukausi, :summa, :summa_indeksikorjattu, :sopimus_id, :toimenpideinstanssi_id,
+        :tehtava_id, :rahavaraus_id, 'laskutettava-tyo', 'tilaajan-rahavaraukset',
+        :luoja, NOW());
+
 --name: vahvista-tai-kumoa-indeksikorjaukset-kiinteahintaisille-toille!
 UPDATE kiinteahintainen_tyo kt
 SET indeksikorjaus_vahvistettu = CASE WHEN :vahvista?::BOOLEAN = TRUE THEN :vahvistus-pvm::TIMESTAMP ELSE NULL END,
     vahvistaja                 = CASE WHEN :vahvista?::BOOLEAN = TRUE THEN :vahvistaja ELSE NULL END,
-    summa_indeksikorjattu = CASE WHEN :vahvista?::BOOLEAN = TRUE THEN indeksikorjaa(kt.summa::NUMERIC, kt.vuosi::INTEGER, kt.kuukausi::INTEGER, :urakka-id::INTEGER) ELSE NULL END
+    summa_indeksikorjattu = CASE WHEN :vahvista?::BOOLEAN = TRUE THEN indeksikorjaa(kt.summa::NUMERIC, kt.vuosi::INTEGER, kt.kuukausi::INTEGER, :urakka-id::INTEGER) ELSE kt.summa_indeksikorjattu END
 FROM toimenpideinstanssi tpi
+     JOIN toimenpide t ON tpi.toimenpide = t.id
 WHERE kt.toimenpideinstanssi = tpi.id
   AND tpi.urakka = :urakka-id
   AND (CONCAT(kt.vuosi, '-', kt.kuukausi, '-01')::DATE BETWEEN :alkupvm::DATE AND :loppupvm::DATE)
-  AND kt.versio = 0;
+  AND true = onko_mhu_hankintatoimenpide(t.koodi);
 
 --name: vahvista-tai-kumoa-indeksikorjaukset-kustannusarvioiduille-toille!
+-- Vahvistaa käytännössä rahavaraukset, hoidonjohtopalkkiot ja erillishankinnat
 UPDATE kustannusarvioitu_tyo kt
 SET indeksikorjaus_vahvistettu = CASE WHEN :vahvista?::BOOLEAN = TRUE THEN :vahvistus-pvm::TIMESTAMP ELSE NULL END,
     vahvistaja                 = CASE WHEN :vahvista?::BOOLEAN = TRUE THEN :vahvistaja ELSE NULL END,
-    summa_indeksikorjattu = CASE WHEN :vahvista?::BOOLEAN = TRUE THEN indeksikorjaa(kt.summa::NUMERIC, kt.vuosi::INTEGER, kt.kuukausi::INTEGER, :urakka-id::INTEGER) ELSE NULL END
+    summa_indeksikorjattu = CASE WHEN :vahvista?::BOOLEAN = TRUE THEN indeksikorjaa(kt.summa::NUMERIC, kt.vuosi::INTEGER, kt.kuukausi::INTEGER, :urakka-id::INTEGER) ELSE kt.summa_indeksikorjattu END
 FROM toimenpideinstanssi tpi
 WHERE kt.toimenpideinstanssi = tpi.id
   AND tpi.urakka = :urakka-id
-  AND (CONCAT(kt.vuosi, '-', kt.kuukausi, '-01')::DATE BETWEEN :alkupvm::DATE AND :loppupvm::DATE)
-  AND kt.versio = 0;
+  AND (CONCAT(kt.vuosi, '-', kt.kuukausi, '-01')::DATE BETWEEN :alkupvm::DATE AND :loppupvm::DATE);
 
 --name: vahvista-tai-kumoa-indeksikorjaukset-jh-korvauksille!
 UPDATE johto_ja_hallintokorvaus jh
 SET indeksikorjaus_vahvistettu = CASE WHEN :vahvista?::BOOLEAN = TRUE THEN :vahvistus-pvm::TIMESTAMP END,
     vahvistaja                 = CASE WHEN :vahvista?::BOOLEAN = TRUE THEN :vahvistaja END,
-    tuntipalkka_indeksikorjattu = CASE WHEN :vahvista?::BOOLEAN = TRUE THEN indeksikorjaa(jh.tuntipalkka::NUMERIC, jh.vuosi::INTEGER, jh.kuukausi::INTEGER, :urakka-id::INTEGER) ELSE NULL END
+    tuntipalkka_indeksikorjattu = CASE WHEN :vahvista?::BOOLEAN = TRUE THEN indeksikorjaa(jh.tuntipalkka::NUMERIC, jh.vuosi::INTEGER, jh.kuukausi::INTEGER, :urakka-id::INTEGER) ELSE jh.tuntipalkka_indeksikorjattu END
 WHERE jh."urakka-id" = :urakka-id
-  AND (CONCAT(jh.vuosi, '-', jh.kuukausi, '-01')::DATE BETWEEN :alkupvm::DATE AND :loppupvm::DATE)
-  AND jh.versio = 0;
+  AND (CONCAT(jh.vuosi, '-', jh.kuukausi, '-01')::DATE BETWEEN :alkupvm::DATE AND :loppupvm::DATE);
 
 --name: vahvista-tai-kumoa-indeksikorjaukset-urakan-tavoitteille!
 UPDATE urakka_tavoite ut
 SET indeksikorjaus_vahvistettu = CASE WHEN :vahvista?::BOOLEAN = TRUE THEN :vahvistus-pvm::TIMESTAMP END,
     vahvistaja                 = CASE WHEN :vahvista?::BOOLEAN = TRUE THEN :vahvistaja END,
-    tavoitehinta_indeksikorjattu = CASE WHEN :vahvista?::BOOLEAN = TRUE THEN indeksikorjaa(ut.tavoitehinta::NUMERIC, :vuosi::INTEGER, :urakka-id::INTEGER, :urakka-id::INTEGER) ELSE NULL END,
-    kattohinta_indeksikorjattu = CASE WHEN :vahvista?::BOOLEAN = TRUE THEN indeksikorjaa(ut.kattohinta::NUMERIC, :vuosi::INTEGER, :urakka-id::INTEGER, :urakka-id::INTEGER) ELSE NULL END
+    tavoitehinta_indeksikorjattu = CASE WHEN :vahvista?::BOOLEAN = TRUE THEN indeksikorjaa(ut.tavoitehinta::NUMERIC, :vuosi::INTEGER, :urakka-id::INTEGER, :urakka-id::INTEGER) ELSE ut.tavoitehinta_indeksikorjattu END,
+    kattohinta_indeksikorjattu = CASE WHEN :vahvista?::BOOLEAN = TRUE THEN indeksikorjaa(ut.kattohinta::NUMERIC, :vuosi::INTEGER, :urakka-id::INTEGER, :urakka-id::INTEGER) ELSE ut.kattohinta_indeksikorjattu END
 WHERE ut.urakka = :urakka-id
   -- hoitokausi ei ole hoitovuosi e.g. 2020, vaan hoitovuoden järjestysnumero e.g. 1
-  AND ut.hoitokausi = :hoitovuosi-nro
-  AND ut.versio = 0;
+  AND ut.hoitokausi = :hoitovuosi-nro;
 
 -- name: paivita-tavoite-ja-kattohinta<!
 UPDATE urakka_tavoite
@@ -353,7 +367,6 @@ FROM kiinteahintainen_tyo kt
 WHERE tpi.urakka = :urakka-id
   AND (CONCAT(kt.vuosi, '-', kt.kuukausi, '-01')::DATE BETWEEN :alkupvm::DATE AND :loppupvm::DATE)
   AND kt.indeksikorjaus_vahvistettu IS NOT NULL
-  AND kt.versio = 0
 
 UNION ALL
 SELECT COUNT(*) > 0 AS "arvioidut-vahvistettu?"
@@ -362,7 +375,13 @@ FROM kustannusarvioitu_tyo kt
 WHERE tpi.urakka = :urakka-id
   AND (CONCAT(kt.vuosi, '-', kt.kuukausi, '-01')::DATE BETWEEN :alkupvm::DATE AND :loppupvm::DATE)
   AND kt.indeksikorjaus_vahvistettu IS NOT NULL
-  AND kt.versio = 0;
+
+UNION ALL
+SELECT COUNT(*) > 0 AS "arvioidut-vahvistettu?"
+FROM johto_ja_hallintokorvaus jjh
+WHERE jjh."urakka-id" = :urakka-id
+  AND (CONCAT(jjh.vuosi, '-', jjh.kuukausi, '-01')::DATE BETWEEN :alkupvm::DATE AND :loppupvm::DATE)
+  AND jjh.indeksikorjaus_vahvistettu IS NOT NULL;
 
 -- name: hae-urakan-hoitovuoden-tavoitetiedot
 SELECT id, tavoitehinta, tavoitehinta_indeksikorjattu, kattohinta, kattohinta_indeksikorjattu, tarjous_tavoitehinta

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.sql
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.sql
@@ -22,15 +22,19 @@ WHERE sopimus = :sopimus-id
   AND toimenpideinstanssi = :toimenpideinstanssi-id;
 
 -- name: hae-viimeisin-muokkaaja-kiinteahintaiselle-kustannukselle
-SELECT GREATEST(kt.muokattu, kt.luotu) AS viimeisin_muokkaus, CONCAT(k.etunimi, ' ', k.sukunimi) AS viimeisin_muokkaaja
+SELECT GREATEST(kt.muokattu, kt.luotu) AS viimeisin_muokkaus,
+       CASE WHEN kr.rooli = 'jarjestelmavastuuhenkilo' THEN 'Järjestelmävastaava'
+            ELSE CONCAT(k.etunimi, ' ', k.sukunimi)
+       END AS viimeisin_muokkaaja
   FROM kiinteahintainen_tyo kt
        LEFT JOIN kayttaja k ON COALESCE(kt.muokkaaja, kt.luoja) = k.id
+       LEFT JOIN kayttaja_rooli kr ON k.id = kr.kayttaja
        JOIN toimenpideinstanssi tpi ON kt.toimenpideinstanssi = tpi.id
        JOIN toimenpide t ON tpi.toimenpide = t.id
 WHERE kt.sopimus = :sopimus-id
   AND tpi.urakka = :urakkaid
   AND ((kt.vuosi = :vuosi AND kt.kuukausi IN (10, 11, 12))
-      OR (vuosi = :vuosi + 1 AND kuukausi >= 1 AND kuukausi <= 9))
+      OR (kt.vuosi = :vuosi + 1 AND kt.kuukausi >= 1 AND kt.kuukausi <= 9))
   AND true = onko_mhu_hankintatoimenpide(t.koodi)
 ORDER BY viimeisin_muokkaus DESC
 LIMIT 1;
@@ -104,17 +108,22 @@ SELECT id,
 FROM kustannusarvioitu_tyo
 WHERE id = :id;
 
+
 -- name: hae-viimeisin-muokkaaja-erillishankinnoille
-SELECT GREATEST(kt.muokattu, kt.luotu) AS viimeisin_muokkaus, CONCAT(k.etunimi, ' ', k.sukunimi) AS viimeisin_muokkaaja
+SELECT GREATEST(kt.muokattu, kt.luotu) AS viimeisin_muokkaus,
+       CASE WHEN kr.rooli = 'jarjestelmavastuuhenkilo' THEN 'Järjestelmävastaava'
+            ELSE CONCAT(k.etunimi, ' ', k.sukunimi)
+           END AS viimeisin_muokkaaja
 FROM kustannusarvioitu_tyo kt
          LEFT JOIN kayttaja k ON COALESCE(kt.muokkaaja, kt.luoja) = k.id
-WHERE sopimus = :sopimus-id
-  AND ((vuosi = :vuosi AND kuukausi IN (10, 11, 12))
-      OR (vuosi = :vuosi + 1 AND kuukausi >= 1 AND kuukausi <= 9))
-  AND toimenpideinstanssi = :toimenpideinstanssi-id
-  AND tehtavaryhma = :tehtavaryhma-id
+         LEFT JOIN kayttaja_rooli kr ON k.id = kr.kayttaja
+WHERE kt.sopimus = :sopimus-id
+  AND ((kt.vuosi = :vuosi AND kt.kuukausi IN (10, 11, 12))
+      OR (kt.vuosi = :vuosi + 1 AND kt.kuukausi >= 1 AND kt.kuukausi <= 9))
+  AND kt.toimenpideinstanssi = :toimenpideinstanssi-id
+  AND kt.tehtavaryhma = :tehtavaryhma-id
 ORDER BY viimeisin_muokkaus DESC
-LIMIT 10;;
+LIMIT 1;
 
 -- name: paivita-kuukauden-erillishankinta<!
 UPDATE kustannusarvioitu_tyo
@@ -183,14 +192,18 @@ WHERE "toimenkuva-id" = :toimenkuva-id
 
 
 -- name: hae-viimeisin-muokkaaja-jjh
-SELECT GREATEST(jjh.muokattu, jjh.luotu) AS viimeisin_muokkaus, CONCAT(k.etunimi, ' ', k.sukunimi) AS viimeisin_muokkaaja
+SELECT GREATEST(jjh.muokattu, jjh.luotu) AS viimeisin_muokkaus,
+       CASE WHEN kr.rooli = 'jarjestelmavastuuhenkilo' THEN 'Järjestelmävastaava'
+            ELSE CONCAT(k.etunimi, ' ', k.sukunimi)
+           END AS viimeisin_muokkaaja
 FROM johto_ja_hallintokorvaus jjh
      LEFT JOIN kayttaja k ON COALESCE(jjh.muokkaaja, jjh.luoja) = k.id
-WHERE "urakka-id" = :urakka-id
-  AND ((vuosi = :vuosi AND kuukausi IN (10, 11, 12))
-      OR (vuosi = :vuosi + 1 AND kuukausi >= 1 AND kuukausi <= 9))
+     LEFT JOIN kayttaja_rooli kr ON k.id = kr.kayttaja
+WHERE jjh."urakka-id" = :urakka-id
+  AND ((jjh.vuosi = :vuosi AND jjh.kuukausi IN (10, 11, 12))
+      OR (jjh.vuosi = :vuosi + 1 AND jjh.kuukausi >= 1 AND jjh.kuukausi <= 9))
 ORDER BY viimeisin_muokkaus DESC
-LIMIT 10;
+LIMIT 1;
 
 -- name: paivita-kuukauden-johto-ja-hallintokorvaus<!
 -- Käytetään -25 ja myöhemmin alkaville urakoille, kun yksittäisellä toimenkuvalla ei ole merkitystä
@@ -237,14 +250,18 @@ FROM kustannusarvioitu_tyo
 WHERE id = :id;
 
 -- name: hae-viimeisin-muokkaaja-hoidonjohtopalkkiolle
-SELECT GREATEST(kt.muokattu, kt.luotu) AS viimeisin_muokkaus, CONCAT(k.etunimi, ' ', k.sukunimi) AS viimeisin_muokkaaja
+SELECT GREATEST(kt.muokattu, kt.luotu) AS viimeisin_muokkaus,
+       CASE WHEN kr.rooli = 'jarjestelmavastuuhenkilo' THEN 'Järjestelmävastaava'
+            ELSE CONCAT(k.etunimi, ' ', k.sukunimi)
+           END AS viimeisin_muokkaaja
 FROM kustannusarvioitu_tyo kt
          JOIN kayttaja k ON COALESCE(kt.muokkaaja, kt.luoja) = k.id
-WHERE sopimus = :sopimus-id
-  AND ((vuosi = :vuosi AND kuukausi IN (10, 11, 12))
+         LEFT JOIN kayttaja_rooli kr ON k.id = kr.kayttaja
+WHERE kt.sopimus = :sopimus-id
+  AND ((kt.vuosi = :vuosi AND kt.kuukausi IN (10, 11, 12))
       OR (vuosi = :vuosi + 1 AND kuukausi >= 1 AND kuukausi <= 9))
-  AND toimenpideinstanssi = :toimenpideinstanssi-id
-  AND tehtava = :tehtava-id
+  AND kt.toimenpideinstanssi = :toimenpideinstanssi-id
+  AND kt.tehtava = :tehtava-id
 ORDER BY viimeisin_muokkaus DESC
 LIMIT 10;
 

--- a/src/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_palvelu.clj
@@ -1,9 +1,11 @@
 (ns harja.palvelin.palvelut.suunnittelu.uusi-kustannussuunnitelma-palvelu
   (:require [harja.domain.mhu :as mhu]
+            [harja.kyselyt.indeksit :as indeksi-kyselyt]
             [harja.pvm :as pvm]
             [taoensso.timbre :as log]
             [com.stuartsierra.component :as component]
             [clojure.java.jdbc :as jdbc]
+            [clojure.string :as str]
             [harja.kyselyt.tarjous-kyselyt :as tarjous-kyselyt]
             [harja.kyselyt.urakat :as urakat-q]
             [harja.kyselyt.uusi-kustannussuunnitelma-kyselyt :as suunnitelma-q]
@@ -182,16 +184,33 @@
 (defn vahvista-tai-kumoa-tavoite-ja-kattohinta [db kayttaja {:keys [urakka-id hoitovuoden-alkuvuosi vahvista?] :as tiedot}]
   (log/debug "vahvista-tai-kumoa-tavoite-ja-kattohinta :: tiedot: " tiedot)
   (jdbc/with-db-transaction [db db]
-    (let [;; Tarkistetaan, että kilpailutettavat hankinnat, erillishankinnat, hoidonjohtopalkkiot on tallennettu.
+    (let [virhe []
+          ;; Onko indeksit valmiina
+          urakan-indeksit (indeksi-kyselyt/hae-urakan-indeksikertoimet db urakka-id)
+          indeksi-olemassa? (boolean (some #(= hoitovuoden-alkuvuosi (:vuosi %)) urakan-indeksit))
+          virhe (if indeksi-olemassa?
+                  virhe
+                  (conj virhe (str "Indeksit puuttuvat hoitovuodelle " hoitovuoden-alkuvuosi ". Indeksit on lisättävä ennen vahvistusta.")))
+
+          ;; Tarkistetaan, että kilpailutettavat hankinnat, erillishankinnat, hoidonjohtopalkkiot on tallennettu.
           ;; Muuten ei voida vahvistaa tavoitehintaa.
-          vahvistus-mahdollinen? (suunnitelma-q/voidaanko-vahvistaa-tavoitehintaa? db urakka-id hoitovuoden-alkuvuosi)
-          _ (when vahvistus-mahdollinen?
+          puuttuvat-suunnitelmat (suunnitelma-q/puuttuvat-suunnitelmat db urakka-id hoitovuoden-alkuvuosi)
+          suunnitelmat-annettu? (if (empty? puuttuvat-suunnitelmat)
+                                  true
+                                 false)
+          _ (when (and suunnitelmat-annettu? indeksi-olemassa?)
               (suunnitelma-q/vahvista-tavoite-ja-kattohinta db kayttaja urakka-id vahvista? hoitovuoden-alkuvuosi))
           vastaus (hae-kustannussuunnitelman-tiedot db kayttaja {:urakka-id urakka-id :hoitovuoden-alkuvuosi hoitovuoden-alkuvuosi})
-          vastaus (if vahvistus-mahdollinen?
-                    vastaus
-                    (assoc-in vastaus [:kustannussuunnitelma :vahvistus-virhe] "Tietoja ei voitu vahvistaa. Kustannustietoja puuttuu. Tarkista ja korjaa tiedot."))]
-      vastaus)))
+          virhe (if suunnitelmat-annettu?
+                    virhe
+                    (conj virhe (str "Kustannustietoja puuttuu. Tarkista " (str/join ", " puuttuvat-suunnitelmat))))]
+
+      (if-not (empty? virhe)
+        (assoc-in vastaus [:kustannussuunnitelma :vahvistus-virhe] (str/join " " virhe))
+        vastaus)
+
+
+      )))
 
 (defrecord UusiKustannussuunnitelmaPalvelu []
   component/Lifecycle

--- a/src/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_palvelu.clj
@@ -97,8 +97,8 @@
             (and (>= urakan-alkuvuosi 2019) (<= urakan-alkuvuosi 2024))
             (suunnitelma-q/hae-johto-ja-hallintokorvaukset-2019-2024 db urakka-id sopimus-id hoitovuoden-alkuvuosi urakan-alkuvuosi toimenkuvat-tarjouksesta)
             (>= urakan-alkuvuosi 2025)
-            (suunnitelma-q/hae-johto-ja-hallintokorvaukset db urakka-id hoitovuoden-alkuvuosi toimenkuvat-tarjouksesta)
-            :else (suunnitelma-q/hae-johto-ja-hallintokorvaukset db urakka-id hoitovuoden-alkuvuosi toimenkuvat-tarjouksesta))
+            (suunnitelma-q/hae-johto-ja-hallintokorvaukset-2025 db urakka-id hoitovuoden-alkuvuosi)
+            :else (suunnitelma-q/hae-johto-ja-hallintokorvaukset-2025 db urakka-id hoitovuoden-alkuvuosi))
 
           johto-ja-hallintokorvaukset-yht (cond
                                             ;; 2019 - 2021

--- a/src/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_palvelu.clj
@@ -153,7 +153,7 @@
   (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-suunnittelu-kustannussuunnittelu kayttaja urakka-id)
   (log/debug "tallenna-erillishankinnat :: tiedot: " tiedot)
   (jdbc/with-db-transaction [db db]
-    (suunnitelma-q/tallenna-erillishankinnat db kayttaja urakka-id (:erillishankinnat tiedot))
+    (suunnitelma-q/tallenna-erillishankinnat db kayttaja urakka-id (:erillishankinnat tiedot) hoitovuoden-alkuvuosi)
     (suunnitelma-q/paivita-tavoite-ja-kattohinta db kayttaja urakka-id hoitovuoden-alkuvuosi)
     (hae-kustannussuunnitelman-tiedot db kayttaja {:urakka-id urakka-id :hoitovuoden-alkuvuosi hoitovuoden-alkuvuosi})))
 
@@ -169,7 +169,7 @@
           avain (if (<= urakan-alkuvuosi 2024)
                   :johto-ja-hallintokorvaukset-2019
                   :johto-ja-hallintokorvaukset-2025)]
-      (suunnitelma-q/tallenna-johto-ja-hallintokorvaukset db kayttaja urakka-id (get tiedot avain))
+      (suunnitelma-q/tallenna-johto-ja-hallintokorvaukset db kayttaja urakka-id (get tiedot avain) hoitovuoden-alkuvuosi)
       (suunnitelma-q/paivita-tavoite-ja-kattohinta db kayttaja urakka-id hoitovuoden-alkuvuosi)
       (hae-kustannussuunnitelman-tiedot db kayttaja {:urakka-id urakka-id :hoitovuoden-alkuvuosi hoitovuoden-alkuvuosi}))))
 
@@ -177,7 +177,7 @@
   (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-suunnittelu-kustannussuunnittelu kayttaja urakka-id)
   (log/debug "tallenna-hoidonjohtopalkkiot :: tiedot: " tiedot)
   (jdbc/with-db-transaction [db db]
-    (suunnitelma-q/tallenna-hoidonjohtopalkkiot db kayttaja urakka-id (:hoidonjohtopalkkiot tiedot))
+    (suunnitelma-q/tallenna-hoidonjohtopalkkiot db kayttaja urakka-id (:hoidonjohtopalkkiot tiedot) hoitovuoden-alkuvuosi)
     (suunnitelma-q/paivita-tavoite-ja-kattohinta db kayttaja urakka-id hoitovuoden-alkuvuosi)
     (hae-kustannussuunnitelman-tiedot db kayttaja {:urakka-id urakka-id :hoitovuoden-alkuvuosi hoitovuoden-alkuvuosi})))
 

--- a/src/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_palvelu.clj
@@ -207,10 +207,7 @@
 
       (if-not (empty? virhe)
         (assoc-in vastaus [:kustannussuunnitelma :vahvistus-virhe] (str/join " " virhe))
-        vastaus)
-
-
-      )))
+        vastaus))))
 
 (defrecord UusiKustannussuunnitelmaPalvelu []
   component/Lifecycle

--- a/src/cljs/harja/tiedot/urakka/suunnittelu/tarjous_kustannussuunnitelma_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/suunnittelu/tarjous_kustannussuunnitelma_tiedot.cljs
@@ -11,8 +11,8 @@
 (defonce nakymassa? (atom false))
 
 (defn scrollaa-muutoksiin [elementin-id]
-  ;; Kutsutaan kun käyttäjä generoi kuukausittaiset summat
-  (siirrin/siirry-elementin-id elementin-id 450))
+  ;; Kutsutaan kun käyttäjä generoi kuukausittaiset summat tai vahvistaa koko kustannussuunnitelman
+  (siirrin/siirry-elementin-id elementin-id 200))
 
 (defn muunna-vuodet
   "Muunnetaan UI Gridin käyttämä tietomalli bäkkärin käyttämään muotoon.

--- a/src/cljs/harja/ui/kentat.cljs
+++ b/src/cljs/harja/ui/kentat.cljs
@@ -484,14 +484,15 @@
 (defmethod nayta-arvo :positiivinen-numero [kentta data]
   [nayta-arvo (assoc kentta :tyyppi :numero) data])
 
-(defmethod tee-kentta :euro [{:keys [fmt teksti-oikealla nayta-plus ei-yksikkoa?] :as kentta} data]
+(defmethod tee-kentta :euro [{:keys [fmt teksti-oikealla nayta-plus ei-yksikkoa? vaadi-ei-negatiivinen?] :as kentta} data]
   [tee-kentta (assoc kentta
                 :tyyppi :numero
                 :fmt (or fmt (partial fmt/euro-opt false nayta-plus))
                 :salli-whitespace? true
                 :yksikko (when-not ei-yksikkoa? (or teksti-oikealla "€"))
                 :desimaalien-maara 2
-                :veda-oikealle? true)
+                :veda-oikealle? true
+                :vaadi-ei-negatiivinen? (or vaadi-ei-negatiivinen? false))
    data])
 
 (defmethod nayta-arvo :euro [{:keys [fmt] :as kentta} data]

--- a/src/cljs/harja/views/urakka/suunnittelu.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu.cljs
@@ -49,7 +49,7 @@
          [bs/tabs {:style :tabs :classes "tabs-taso2"
                    :active (nav/valittu-valilehti-atom :suunnittelu)}
 
-          "Hoitovuoden alun tavoitehinta"
+          "Tarjouksen tiedot"
           :tarjous
           (when (and
                 (istunto/ominaisuus-kaytossa? :kustannussuunnitelma-tarjous)

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_nakyma.cljs
@@ -87,6 +87,7 @@
                      :voi-kumota? false
                      :piilota-toiminnot? false
                      :tunniste :nimi
+                     :jarjestys :toimenpideinstanssi-id
                      :muutos #(do
                                 (reset! yhteiset/tallenna-painettu false)
                                 (reset! yhteiset/grid-hankinnat-atom (vals (grid/hae-muokkaustila %)))
@@ -102,10 +103,10 @@
            {:otsikko "Pysyvät muutokset (€)" :nimi :pysyvat-muutokset :tyyppi :string
             :leveys "20%" :muokattava? (constantly false)}
            {:otsikko (str "Loka-joulukuu " (pvm/vuosi (first valittu-hoitokausi)) " (€)") :nimi :alkukausi :tyyppi :euro
-            :leveys "20%" :validoi [[:ei-tyhja "Anna positiivinen summa."]]
+            :leveys "20%" :validoi [[:ei-tyhja "Anna positiivinen summa."]] :vaadi-ei-negatiivinen? true
             :muokattava? (constantly (if vahvistettu? false true)) :tasaa :oikea :otsikkorivi-luokka "korkea"}
            {:otsikko (str "Tammi-syyskuu " (pvm/vuosi (second valittu-hoitokausi)) " (€)")
-            :nimi :loppukausi :tyyppi :euro
+            :nimi :loppukausi :tyyppi :euro :vaadi-ei-negatiivinen? true
             :leveys "20%" :validoi-kentta-fn (fn [numero] (v/validoi-numero numero 0 9999999 2))
             :muokattava? (constantly (if vahvistettu? false true)) :tasaa :oikea :otsikkorivi-luokka "korkea"}
            {:otsikko "Yhteensä (€)" :nimi :yhteensa :tyyppi :string :fmt #(fmt/euro-opt false %) :leveys "20%" :muokattava? (constantly false)
@@ -267,7 +268,8 @@
           [{:otsikko "Kalenterikuukausi" :nimi :kalenterikuukausi :tyyppi :string :leveys "60%"
             :muokattava? (constantly false) :otsikkorivi-luokka "korkea"}
            {:otsikko "Suunniteltu kustannus (€)" :nimi :summa :leveys "20%" :tyyppi :euro :tasaa :oikea
-            :fmt #(when % (fmt/euro-opt false %)) :muokattava? (constantly voi-muokata?) :otsikkorivi-luokka "korkea"}
+            :fmt #(when % (fmt/euro-opt false %)) :muokattava? (constantly voi-muokata?)
+            :otsikkorivi-luokka "korkea" :vaadi-ei-negatiivinen? true}
            {:otsikko "Indeksikorjattu (€)" :nimi :summa_indeksikorjattu :leveys "20%" :tyyppi :euro :tasaa :oikea
             :fmt #(if-not (= 0 yht-indeksikorjattu) (fmt/euro-opt false %) "-") :muokattava? (constantly false) :otsikkorivi-luokka "korkea"}]
           erillishankinnat]]]
@@ -349,8 +351,9 @@
                      :rivin-luokka (fn [_] "korkea")}
           [{:otsikko "Kalenterikuukausi" :nimi :kalenterikuukausi :tyyppi :string :leveys "60%"
             :muokattava? (constantly false) :otsikkorivi-luokka "korkea"}
-           {:otsikko "Suunniteltu kustannus (€)" :nimi :summa :leveys "20%" :tyyppi :euro :tasaa :oikea
-            :fmt #(when % (fmt/euro-opt false %)) :muokattava? (constantly voi-muokata?) :otsikkorivi-luokka "korkea"}
+           {:otsikko "Suunniteltu kustannus (€)" :nimi :summa :leveys "20%" :tyyppi :euro
+            :tasaa :oikea :fmt #(when % (fmt/euro-opt false %)) :muokattava? (constantly voi-muokata?)
+            :otsikkorivi-luokka "korkea" :vaadi-ei-negatiivinen? true}
            {:otsikko "Indeksikorjattu (€)" :nimi :summa_indeksikorjattu :leveys "20%" :tyyppi :euro :tasaa :oikea
             :fmt #(if-not (= 0 suunniteltu-yht-indeksikorjattu) (fmt/euro-opt false %) "-") :muokattava? (constantly false) :otsikkorivi-luokka "korkea"}]
           hoidonjohtopalkkiot]]]

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/yhteiset.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/yhteiset.cljs
@@ -68,8 +68,8 @@
       (when (and div4 (>= valittu-vuosi rajavuosi))
         [:div.col-xs-12.col-md-3
          [:div.small-text.bold "Indeksikorjattu"]
-         [:div.body-text (if vahvistettu? (fmt/euro-opt true tarjous-pysyvat-yhteensa-indeksikorjattu) "Indeksilukua ei ole saatavilla")]
-         (when vahvistettu?
+         [:div.body-text (if indeksikerroin (fmt/euro-opt true tarjous-pysyvat-yhteensa-indeksikorjattu) "Indeksilukua ei ole saatavilla")]
+         (when indeksikerroin
            [:div.body-text
             (str "(" indeksikerroin " * " (if tarjous-pysyvat-yhteensa (fmt/euro-opt false tarjous-pysyvat-yhteensa) "0,00 €") " )")])])
 
@@ -77,8 +77,8 @@
       (when (and div4 (< valittu-vuosi rajavuosi))
         [:div.col-xs-12.col-md-3
          [:div.small-text.bold "Indeksikorjattu"]
-         [:div.body-text (if vahvistettu? (fmt/euro-opt true suunniteltu-yhteensa-indeksikorjattu) "Indeksilukua ei ole saatavilla")]
-         (when vahvistettu?
+         [:div.body-text (if indeksikerroin (fmt/euro-opt true suunniteltu-yhteensa-indeksikorjattu) "Indeksilukua ei ole saatavilla")]
+         (when indeksikerroin
            [:div.body-text
             (str "(" indeksikerroin " * " (if suunniteltu-yhteensa (fmt/euro-opt false suunniteltu-yhteensa) "0,00 €") " )")])])]]))
 

--- a/test/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_test.clj
+++ b/test/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_test.clj
@@ -4,6 +4,7 @@
             [harja.palvelin.palvelut.suunnittelu.apurit :as apurit]
             [harja.palvelin.palvelut.suunnittelu.uusi-kustannussuunnitelma-palvelu :as kust-palvelu]
             [harja.palvelin.palvelut.suunnittelu.tarjous-palvelu :as tarjous-palvelu]
+            [harja.pvm :as pvm]
             [harja.testi :refer :all]
             [com.stuartsierra.component :as component]
             [harja.tyokalut.yleiset :refer :all]
@@ -91,17 +92,17 @@
                                                       {:toimenkuva-id 1 :toimenkuva "sopimusvastaava" :tunnit 1 :tuntipalkka 85.2 :vuosi 2025 :kuukausi 9 :kalenterikuukausi "Syyskuu 2025"}]}]})
 
 (def johto-ja-hallinto-tietomalli-2025 {:johto-ja-hallintokorvaukset-2025 [{:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2024 :kuukausi 10 :kalenterikuukausi "Lokakuu 2024"}
-                                                                      {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2024 :kuukausi 11 :kalenterikuukausi "Marraskuu 2024"}
-                                                                      {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2024 :kuukausi 12 :kalenterikuukausi "Joulukuu 2024"}
-                                                                      {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2025 :kuukausi 1 :kalenterikuukausi "Tammikuu 2025"}
-                                                                      {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2025 :kuukausi 2 :kalenterikuukausi "Helmikuu 2025"}
-                                                                      {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2025 :kuukausi 3 :kalenterikuukausi "Maaliskuu 2025"}
-                                                                      {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2025 :kuukausi 4 :kalenterikuukausi "Huhtikuu 2025"}
-                                                                      {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2025 :kuukausi 5 :kalenterikuukausi "Toukokuu 2025"}
-                                                                      {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2025 :kuukausi 6 :kalenterikuukausi "Kesäkuu 2025"}
-                                                                      {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2025 :kuukausi 7 :kalenterikuukausi "Heinäkuu 2025"}
-                                                                      {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2025 :kuukausi 8 :kalenterikuukausi "Elokuu 2025"}
-                                                                      {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2025 :kuukausi 9 :kalenterikuukausi "Syyskuu 2025"}]})
+                                                                           {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2024 :kuukausi 11 :kalenterikuukausi "Marraskuu 2024"}
+                                                                           {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2024 :kuukausi 12 :kalenterikuukausi "Joulukuu 2024"}
+                                                                           {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2025 :kuukausi 1 :kalenterikuukausi "Tammikuu 2025"}
+                                                                           {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2025 :kuukausi 2 :kalenterikuukausi "Helmikuu 2025"}
+                                                                           {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2025 :kuukausi 3 :kalenterikuukausi "Maaliskuu 2025"}
+                                                                           {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2025 :kuukausi 4 :kalenterikuukausi "Huhtikuu 2025"}
+                                                                           {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2025 :kuukausi 5 :kalenterikuukausi "Toukokuu 2025"}
+                                                                           {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2025 :kuukausi 6 :kalenterikuukausi "Kesäkuu 2025"}
+                                                                           {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2025 :kuukausi 7 :kalenterikuukausi "Heinäkuu 2025"}
+                                                                           {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2025 :kuukausi 8 :kalenterikuukausi "Elokuu 2025"}
+                                                                           {:summa 58 :summa_indeksikorjattu 85.2 :vuosi 2025 :kuukausi 9 :kalenterikuukausi "Syyskuu 2025"}]})
 
 (defn poista-yhteenvetorivi [tietomalli]
   {:toimenpiteet (filter #(not= (:nimi %) "Yhteensä") (:toimenpiteet tietomalli))})
@@ -270,8 +271,8 @@
         urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
         sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
         hoidonjohto-tpi-id (:id (first (tpi-kyselyt/hae-urakan-toimenpideinstanssi-toimenpidekoodilla db
-                      {:urakka urakka-id
-                       :koodi "23151"})))
+                                         {:urakka urakka-id
+                                          :koodi "23151"})))
         hoitovuoden-alkuvuosi 2024
         hoidonjohto-tpi-id (:id (first (tpi-kyselyt/hae-urakan-toimenpideinstanssi-toimenpidekoodilla db
                                          {:urakka urakka-id
@@ -321,8 +322,8 @@
         vastaus (try
                   (kutsu-palvelua (:http-palvelin jarjestelma)
                     :tallenna-johto-ja-hallintokorvaukset-2019 +kayttaja-jvh+ (merge johto-ja-hallinto-tietomalli-2019
-                                                                           {:urakka-id urakka-id
-                                                                            :hoitovuoden-alkuvuosi 2024}))
+                                                                                {:urakka-id urakka-id
+                                                                                 :hoitovuoden-alkuvuosi 2024}))
                   (catch Exception e
                     (println "Tapahtui virhe:" (.getMessage e))
                     {:error (.getMessage e)}))
@@ -375,8 +376,8 @@
         vastaus (try
                   (kutsu-palvelua (:http-palvelin jarjestelma)
                     :tallenna-johto-ja-hallintokorvaukset-2019 +kayttaja-jvh+ (merge johto-ja-hallinto-tietomalli-2019
-                                                                           {:urakka-id urakka-id
-                                                                            :hoitovuoden-alkuvuosi 2024}))
+                                                                                {:urakka-id urakka-id
+                                                                                 :hoitovuoden-alkuvuosi 2024}))
                   (catch Exception e
                     (println "Tapahtui virhe:" (.getMessage e))
                     {:error (.getMessage e)}))
@@ -392,9 +393,7 @@
                            (assoc-in [2 :kuukaudet 0 :tuntipalkka] 3500))
         muokattu-summa (apply + (map
                                   (fn [rivi]
-                                    (println "rivi:" rivi)
                                     (* (or (:tunnit rivi) 0) (or (:tuntipalkka rivi) 0)))
-
                                   (flatten (map :kuukaudet muokattu-vastaus))))
         muokattu-vastaus (try
                            (kutsu-palvelua (:http-palvelin jarjestelma)
@@ -405,7 +404,6 @@
                            (catch Exception e
                              (println "Tapahtui virhe:" (.getMessage e))
                              {:error (.getMessage e)}))
-        _ (println "(get-in muokattu-vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset]):" (get-in muokattu-vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset]))
         muokattu-vastaus-summa (apply +
                                  (map #(or (:yhteensa-kk %) 0)
                                    (flatten (map :kuukaudet (get-in muokattu-vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset])))))]
@@ -488,12 +486,22 @@
                     :vahvista-tavoite-ja-kattohinta +kayttaja-jvh+ tiedot)
                   (catch Exception e
                     (println "Tapahtui virhe:" (.getMessage e))
-                    {:error (.getMessage e)}))]
+                    {:error (.getMessage e)}))
+        _ (is (= (get-in vastaus [:kustannussuunnitelma :vahvistus-virhe]) "Kustannustietoja puuttuu. Tarkista Kilpailutettavat hankinnat, Erillishankinnat, Hoidonjohtopalkkiot"))
 
-    ;; Ei voi vahvistaa, koska tietoja puuttuu
-    (is (= (get-in vastaus [:kustannussuunnitelma :vahvistus-virhe]) "Tietoja ei voitu vahvistaa. Kustannustietoja puuttuu. Tarkista ja korjaa tiedot."))))
+        _ (u (format "update urakka set indeksi = null WHERE id = %s" urakka-id)) ;; Poistetaan urakan indeksi
+        vastaus-indeksi (try
+                          (kutsu-palvelua (:http-palvelin jarjestelma)
+                            :vahvista-tavoite-ja-kattohinta +kayttaja-jvh+ tiedot)
+                          (catch Exception e
+                            (println "Tapahtui virhe:" (.getMessage e))
+                            {:error (.getMessage e)}))
 
-(deftest vahvista-tavoite-ja-kattohinta-toimii
+        _ (is (= (get-in vastaus-indeksi [:kustannussuunnitelma :vahvistus-virhe])
+                (format "Indeksit puuttuvat hoitovuodelle %s. Indeksit on lisättävä ennen vahvistusta. Kustannustietoja puuttuu. Tarkista Kilpailutettavat hankinnat, Erillishankinnat, Hoidonjohtopalkkiot"
+                  hoitovuoden-alkuvuosi)))]))
+
+(deftest vahvista-ja-kumoa-tavoite-ja-kattohinta-toimii
   (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
         hoitovuoden-alkuvuosi 2024
 
@@ -532,14 +540,80 @@
                     (println "Tapahtui virhe:" (.getMessage e))
                     {:error (.getMessage e)}))]
 
-    ;; Ei voi vahvistaa, koska tietoja puuttuu
-    (is (nil? (get-in vastaus [:kustannussuunnitelma :vahvistus-virhe])))
-    (is (not (nil? (get-in vastaus [:tarjous]))))
-    (is (not (nil? (get-in vastaus [:kustannussuunnitelma]))))
-    (is (true? (get-in vastaus [:kustannussuunnitelma :vahvistettu?])))
-    (is (= 3 (count (get-in vastaus [:kustannussuunnitelma :rahavaraukset]))))
-    (is (= 7 (count (get-in vastaus [:kustannussuunnitelma :kilpailutettavat-hankinnat :toimenpiteet]))))
-    (is (= 12 (count (get-in vastaus [:kustannussuunnitelma :erillishankinnat]))))
-    (is (= 9 (count (get-in vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset]))))
-    (is (= 12 (count (:kuukaudet (first (get-in vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset]))))))
-    (is (= 12 (count (get-in vastaus [:kustannussuunnitelma :hoidonjohtopalkkiot]))))))
+    (is (nil? (get-in vastaus [:kustannussuunnitelma :vahvistus-virhe])) "Vahvistuksessa ei pitäisi olla virhettä")
+    (is (not (nil? (get-in vastaus [:tarjous]))) "Vastauksessa pitäisi olla tarjous")
+    (is (not (nil? (get-in vastaus [:kustannussuunnitelma]))) "Vastauksessa pitäisi olla kustannussuunnitelma")
+    (is (true? (get-in vastaus [:kustannussuunnitelma :vahvistettu?])) "Vahvistettu pitäisi olla true")
+    (is (= 3 (count (get-in vastaus [:kustannussuunnitelma :rahavaraukset]))) "Rahavarauksia pitäisi olla 3")
+    (is (= 7 (count (get-in vastaus [:kustannussuunnitelma :kilpailutettavat-hankinnat :toimenpiteet]))) "Kilpailutettavia hankintoja pitäisi olla 7")
+    (is (= 12 (count (get-in vastaus [:kustannussuunnitelma :erillishankinnat]))) "Erillishankintoja pitäisi olla 12 kuukautta")
+    (is (= 9 (count (get-in vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset]))) "Johto- ja hallintokorvauksia pitäisi olla 9 toimenkuvaa")
+    (is (= 12 (count (:kuukaudet (first (get-in vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset]))))) "Ensimmäisellä johto- ja hallintokorvauksella / toimenkuvalla pitäisi olla 12 kuukautta")
+    (is (= 12 (count (get-in vastaus [:kustannussuunnitelma :hoidonjohtopalkkiot]))) "Hoidonjohtopalkkioissa pitäisi olla 12 kuukautta")
+
+    ;; Kumotaan vahvistus
+    (let [kumous-vastaus (try
+                           (kutsu-palvelua (:http-palvelin jarjestelma)
+                             :vahvista-tavoite-ja-kattohinta +kayttaja-jvh+ (merge tiedot {:vahvista? false}))
+                           (catch Exception e
+                             (println "Tapahtui virhe:" (.getMessage e))
+                             {:error (.getMessage e)}))]
+      (is (false? (get-in kumous-vastaus [:kustannussuunnitelma :vahvistettu?])) "Vahvistettu pitäisi olla false"))))
+
+(deftest vahvista-kattohinta-toimii-tarkennettuna
+  (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
+        sopimus-id (hae-sopimus-id-urakka-idlla urakka-id)
+        hoitovuoden-alkuvuosi 2024
+        alkupvm (pvm/->pvm (str "01.10." hoitovuoden-alkuvuosi))
+        loppupvm (pvm/->pvm (str "30.09." (inc hoitovuoden-alkuvuosi)))
+
+        ;; Lisätään ensin kilpailutettavat hankinnat - Poista yhteenvetorivi ennen tallennusta
+        hankinnat-tietomalli (poista-yhteenvetorivi hankinnat-tietomalli)
+        _ (uusi-kust-kyselyt/tallenna-kilpailutettavat-hankinnat (:db jarjestelma) +kayttaja-jvh+ urakka-id hoitovuoden-alkuvuosi (:toimenpiteet hankinnat-tietomalli))
+        ;; Lisätään erillishankinnat
+        _ (uusi-kust-kyselyt/tallenna-erillishankinnat (:db jarjestelma) +kayttaja-jvh+ urakka-id (:erillishankinnat erillishankinnat-tietomalli))
+        ;; Lisätään hoidonjohtopalkkiot
+        _ (uusi-kust-kyselyt/tallenna-hoidonjohtopalkkiot (:db jarjestelma) +kayttaja-jvh+ urakka-id (:hoidonjohtopalkkiot hoidonjohtopalkkiot-tietomalli))
+        ;; Lisätään johto- ja hallintokorvaukset
+        _ (uusi-kust-kyselyt/tallenna-johto-ja-hallintokorvaukset (:db jarjestelma) +kayttaja-jvh+ urakka-id (:johto-ja-hallintokorvaukset-2019 johto-ja-hallinto-tietomalli-2019))
+
+        ;; Rahavaraukset vaativat tarjouksen täyttämisen.
+        kayttaja-id (:id +kayttaja-jvh+)
+        ;; Käytetään kattohintana 1.1 x tavoitehintaa
+        kattohintakerroin 1.1
+
+        ;; Haetaan urakan rahavaraukset
+        rahavaraukset (rahavaraus-kyselyt/hae-urakan-rahavaraukset (:db jarjestelma) {:urakka_id urakka-id})
+        ;; Vuodet tietomallista
+        vuodet (tarjous-kyselyt/vuodet-tietomallista apurit/tarjous-tietomalli)
+        tarjous (apurit/muodosta-tarjous-rahavarauksista rahavaraukset vuodet)
+        _ (tarjous-kyselyt/tallenna-tarjous-tietokantaan
+            (:db jarjestelma) urakka-id kayttaja-id kattohintakerroin tarjous)
+
+        ;; Vahvistetaan tavoite ja kattohinta
+        tiedot {:urakka-id urakka-id
+                :hoitovuoden-alkuvuosi hoitovuoden-alkuvuosi
+                :vahvista? true}
+        vastaus (try
+                  (kutsu-palvelua (:http-palvelin jarjestelma)
+                    :vahvista-tavoite-ja-kattohinta +kayttaja-jvh+ tiedot)
+                  (catch Exception e
+                    (println "Tapahtui virhe:" (.getMessage e))
+                    {:error (.getMessage e)}))
+
+        _ (is (true? (get-in vastaus [:kustannussuunnitelma :vahvistettu?])) "Vahvistettu pitäisi olla true")
+
+        jalkeen-kiinteat-rivit (q-map (format "SELECT summa, summa_indeksikorjattu, vahvistaja, indeksikorjaus_vahvistettu, vuosi, kuukausi, tpi.nimi
+                                               FROM kiinteahintainen_tyo kt
+                                                    join toimenpideinstanssi tpi ON kt.toimenpideinstanssi = tpi.id AND tpi.urakka = %s
+                                                    JOIN toimenpide t ON tpi.toimenpide = t.id
+                                              WHERE kt.sopimus = %s
+                                                AND (CONCAT(kt.vuosi, '-', kt.kuukausi, '-01')::DATE BETWEEN '%s'::DATE AND '%s'::DATE)
+                                                AND true = onko_mhu_hankintatoimenpide(t.koodi)
+                                              ORDER BY kt.vuosi, kt.kuukausi"
+                                      urakka-id sopimus-id alkupvm loppupvm))
+
+        ;; Varmistetaan rivi riviltä, että kaikki kiinteät on vahvistettu.
+        ;; Kiinteiden töiden vahvistamisessa on otettava huomioon se, että ihan kaikkia sieltä löytyviä riviä ei vahvisteta. Ainoastaan
+        ;; Hankintatoimenpiteet (onko_mhu_hankintatoimenpide(t.koodi) = true).
+        _ (is (every? #(not (nil? (:indeksikorjaus_vahvistettu %))) jalkeen-kiinteat-rivit) "Kaikilla kiinteähintaisilla riveillä pitäisi olla indeksi vahvistettu")]))

--- a/test/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_test.clj
+++ b/test/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_test.clj
@@ -554,7 +554,7 @@
     (is (= 3 (count (get-in vastaus [:kustannussuunnitelma :rahavaraukset]))) "Rahavarauksia pitäisi olla 3")
     (is (= 7 (count (get-in vastaus [:kustannussuunnitelma :kilpailutettavat-hankinnat :toimenpiteet]))) "Kilpailutettavia hankintoja pitäisi olla 7")
     (is (= 12 (count (get-in vastaus [:kustannussuunnitelma :erillishankinnat]))) "Erillishankintoja pitäisi olla 12 kuukautta")
-    (is (= 9 (count (get-in vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset]))) "Johto- ja hallintokorvauksia pitäisi olla 9 toimenkuvaa")
+    (is (= 10 (count (get-in vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset]))) "Johto- ja hallintokorvauksia pitäisi olla 9 toimenkuvaa")
     (is (= 12 (count (:kuukaudet (first (get-in vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset]))))) "Ensimmäisellä johto- ja hallintokorvauksella / toimenkuvalla pitäisi olla 12 kuukautta")
     (is (= 12 (count (get-in vastaus [:kustannussuunnitelma :hoidonjohtopalkkiot]))) "Hoidonjohtopalkkioissa pitäisi olla 12 kuukautta")
 

--- a/test/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_test.clj
+++ b/test/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_test.clj
@@ -178,7 +178,8 @@
                                          {:urakka urakka-id
                                           :koodi "23151"})))
 
-        _ (uusi-kust-kyselyt/tallenna-erillishankinnat db +kayttaja-jvh+ urakka-id (:erillishankinnat erillishankinnat-tietomalli))
+        _ (uusi-kust-kyselyt/tallenna-erillishankinnat db +kayttaja-jvh+ urakka-id
+            (:erillishankinnat erillishankinnat-tietomalli) hoitovuoden-alkuvuosi)
         erillishankinnat-tietokannasta (q-map (format "SELECT SUM(summa) as summa
                                                          FROM kustannusarvioitu_tyo
                                                   WHERE sopimus = %s
@@ -278,7 +279,8 @@
                                          {:urakka urakka-id
                                           :koodi "23151"})))
         tietomallin-summa (apply + (map :summa (:hoidonjohtopalkkiot hoidonjohtopalkkiot-tietomalli)))
-        _ (uusi-kust-kyselyt/tallenna-hoidonjohtopalkkiot db +kayttaja-jvh+ urakka-id (:hoidonjohtopalkkiot hoidonjohtopalkkiot-tietomalli))
+        _ (uusi-kust-kyselyt/tallenna-hoidonjohtopalkkiot db +kayttaja-jvh+ urakka-id
+            (:hoidonjohtopalkkiot hoidonjohtopalkkiot-tietomalli) hoitovuoden-alkuvuosi)
         hoidonjohtopalkkiot-tietokannasta (q-map (format "SELECT SUM(summa) as summa
                                                             FROM kustannusarvioitu_tyo
                                                            WHERE sopimus = %s
@@ -514,13 +516,17 @@
         ;; Lisätään ensin kilpailutettavat hankinnat
         ;; ;; Poista yhteenvetorivi ennen tallennusta
         hankinnat-tietomalli (poista-yhteenvetorivi hankinnat-tietomalli)
-        _ (uusi-kust-kyselyt/tallenna-kilpailutettavat-hankinnat (:db jarjestelma) +kayttaja-jvh+ urakka-id hoitovuoden-alkuvuosi (:toimenpiteet hankinnat-tietomalli))
+        _ (uusi-kust-kyselyt/tallenna-kilpailutettavat-hankinnat (:db jarjestelma) +kayttaja-jvh+ urakka-id
+            hoitovuoden-alkuvuosi (:toimenpiteet hankinnat-tietomalli))
         ;; Lisätään erillishankinnat
-        _ (uusi-kust-kyselyt/tallenna-erillishankinnat (:db jarjestelma) +kayttaja-jvh+ urakka-id (:erillishankinnat erillishankinnat-tietomalli))
+        _ (uusi-kust-kyselyt/tallenna-erillishankinnat (:db jarjestelma) +kayttaja-jvh+ urakka-id
+            (:erillishankinnat erillishankinnat-tietomalli) hoitovuoden-alkuvuosi)
         ;; Lisätään hoidonjohtopalkkiot
-        _ (uusi-kust-kyselyt/tallenna-hoidonjohtopalkkiot (:db jarjestelma) +kayttaja-jvh+ urakka-id (:hoidonjohtopalkkiot hoidonjohtopalkkiot-tietomalli))
+        _ (uusi-kust-kyselyt/tallenna-hoidonjohtopalkkiot (:db jarjestelma) +kayttaja-jvh+ urakka-id
+            (:hoidonjohtopalkkiot hoidonjohtopalkkiot-tietomalli) hoitovuoden-alkuvuosi)
         ;; Lisätään johto- ja hallintokorvaukset
-        _ (uusi-kust-kyselyt/tallenna-johto-ja-hallintokorvaukset (:db jarjestelma) +kayttaja-jvh+ urakka-id (:johto-ja-hallintokorvaukset-2019 johto-ja-hallinto-tietomalli-2019))
+        _ (uusi-kust-kyselyt/tallenna-johto-ja-hallintokorvaukset (:db jarjestelma) +kayttaja-jvh+ urakka-id
+            (:johto-ja-hallintokorvaukset-2019 johto-ja-hallinto-tietomalli-2019) hoitovuoden-alkuvuosi)
 
         ;; Rahavaraukset vaativat tarjouksen täyttämisen.
         kayttaja-id (:id +kayttaja-jvh+)
@@ -578,11 +584,14 @@
         hankinnat-tietomalli (poista-yhteenvetorivi hankinnat-tietomalli)
         _ (uusi-kust-kyselyt/tallenna-kilpailutettavat-hankinnat (:db jarjestelma) +kayttaja-jvh+ urakka-id hoitovuoden-alkuvuosi (:toimenpiteet hankinnat-tietomalli))
         ;; Lisätään erillishankinnat
-        _ (uusi-kust-kyselyt/tallenna-erillishankinnat (:db jarjestelma) +kayttaja-jvh+ urakka-id (:erillishankinnat erillishankinnat-tietomalli))
+        _ (uusi-kust-kyselyt/tallenna-erillishankinnat (:db jarjestelma) +kayttaja-jvh+ urakka-id
+            (:erillishankinnat erillishankinnat-tietomalli) hoitovuoden-alkuvuosi)
         ;; Lisätään hoidonjohtopalkkiot
-        _ (uusi-kust-kyselyt/tallenna-hoidonjohtopalkkiot (:db jarjestelma) +kayttaja-jvh+ urakka-id (:hoidonjohtopalkkiot hoidonjohtopalkkiot-tietomalli))
+        _ (uusi-kust-kyselyt/tallenna-hoidonjohtopalkkiot (:db jarjestelma) +kayttaja-jvh+ urakka-id
+            (:hoidonjohtopalkkiot hoidonjohtopalkkiot-tietomalli) hoitovuoden-alkuvuosi)
         ;; Lisätään johto- ja hallintokorvaukset
-        _ (uusi-kust-kyselyt/tallenna-johto-ja-hallintokorvaukset (:db jarjestelma) +kayttaja-jvh+ urakka-id (:johto-ja-hallintokorvaukset-2019 johto-ja-hallinto-tietomalli-2019))
+        _ (uusi-kust-kyselyt/tallenna-johto-ja-hallintokorvaukset (:db jarjestelma) +kayttaja-jvh+ urakka-id
+            (:johto-ja-hallintokorvaukset-2019 johto-ja-hallinto-tietomalli-2019) hoitovuoden-alkuvuosi)
 
         ;; Rahavaraukset vaativat tarjouksen täyttämisen.
         kayttaja-id (:id +kayttaja-jvh+)


### PR DESCRIPTION
Tässä on varmistettu, että tallennusvaiheessa kaikille tallennettaville summille lasketaan indeksikorjattu summa valmiiksi (jos indeksit on tietokannassa saatavilla). 

Kustiksessa on näytetty viimeisin muokkaaja. Tässä sitä on päivitetty niin, että jos muokkaaja on Järjestelmävalvoja (esim joku kehittäjistä), niin kehittäjän nimeä ei käytetä, vaan näytetään, että muutoksen on tehnyt Järjestelmävalvoja.

Vahvistuksen tai kumoamisen tuottamia virheilmoituksia on parannettu.

Tein vähän myös silmiin osunutta ylläpitohommaa, eli poistin käyttämätöntä koodia ja declaroin sql funktioita.