### PR TITLE
Harja 1662 tarjousnakyma toimenkuvat

### DIFF
--- a/src/clj/harja/kyselyt/tarjous_kyselyt.clj
+++ b/src/clj/harja/kyselyt/tarjous_kyselyt.clj
@@ -1,9 +1,11 @@
 (ns harja.kyselyt.tarjous-kyselyt
-  (:require [harja.kyselyt.urakat :as urakat-kyselyt]
+  (:require [clojure.string :as str]
+            [harja.kyselyt.urakat :as urakat-kyselyt]
             [harja.pvm :as pvm]
             [jeesql.core :refer [defqueries]]
             [harja.kyselyt.konversio :as konversio]
-            [harja.kyselyt.rahavaraukset :as rahavaraus-kyselyt]))
+            [harja.kyselyt.rahavaraukset :as rahavaraus-kyselyt]
+            [harja.kyselyt.toimenkuvat-kyselyt :as toimenkuva-kyselyt]))
 
 (defqueries "harja/kyselyt/tarjous_kyselyt.sql"
   {:positional? true})
@@ -12,7 +14,7 @@
   tallenna-tarjouskustannus<! paivita-tarjouskustannus<!
   tallenna-tarjouksen-johto-ja-hallintokorvaus<! paivita-tarjouksen-johto-ja-hallintokorvaus<!
   hae-tarjouksen-tiedot hae-tarjous-vuodella
-  hae-kustannus-tarjoukselle hae-toimenkuva-tarjoukselle)
+  hae-kustannus-tarjoukselle hae-toimenkuva-tarjoukselle poista-tarjouksen-johto-ja-hallintokorvaus<!)
 
 (def osiojarjestys
   {"hankintakustannukset" 1
@@ -113,13 +115,13 @@
 (defn tallenna-tarjous-tietokantaan
   "Tarjous koostuu kolmesta kokonaisuudesta: Tarjouksen kokonaissummasta eli Tavoite- ja Kattohinnasta, Johto-ja-hallintokorvauksista (toimenkuvat) sekä
   Hankinnoista (Kilpailutettavat hankinnat, Erillishankinnat, Rahavarauksista, Hoidonjohtopalkkiosta)."
-  [db urakka-id kayttaja-id kattohintakerroin tarjous-tietomalli]
+  [db urakka-id kayttaja-id kattohintakerroin tarjous]
   (let [;; Vuodet ovat dynaamisia. Päätellään ne tietomallista
-        vuodet (vuodet-tietomallista tarjous-tietomalli)
+        vuodet (vuodet-tietomallista tarjous)
         ;; Muokkaa tietomallin vuosittaiset summat tarjous- ja kattohinnaksi
         vuosittaiset-tarjoushinnat (mapv
                                      (fn [vuosi-rivi]
-                                       (let [summa (tarjoustietomallista-vuosittaiset-hinnat tarjous-tietomalli (:vuosi vuosi-rivi))]
+                                       (let [summa (tarjoustietomallista-vuosittaiset-hinnat tarjous (:vuosi vuosi-rivi))]
                                          {:hoitokauden_alkuvuosi (:vuosi vuosi-rivi)
                                           :tarjous_tavoitehinta summa
                                           :urakka_id urakka-id,
@@ -128,7 +130,7 @@
                                      vuodet)
         hankinta-osiot #{"hankintakustannukset", "erillishankinnat", "hoidonjohtopalkkio", "tavoitehintaiset-rahavaraukset"}
         johto-ja-hallintokorvausosiot #{"johto-ja-hallintokorvaus"}
-        kustannukset-tarjouksesta (filter #(contains? hankinta-osiot (:osio %)) (:tarjous tarjous-tietomalli))
+        kustannukset-tarjouksesta (filter #(contains? hankinta-osiot (:osio %)) (:tarjous tarjous))
         kustannuksetlistaus (flatten (reduce
                                        (fn [kaikki rivi]
                                          (let [uudet-rivit (mapv
@@ -144,7 +146,19 @@
                                                              (:hoitovuosittaiset-arvot rivi))]
                                            (conj kaikki uudet-rivit)))
                                        [] kustannukset-tarjouksesta))
-        toimenkuvat-tarjouksesta (filter #(contains? johto-ja-hallintokorvausosiot (:osio %)) (:tarjous tarjous-tietomalli))
+        toimenkuvat-tarjouksesta (filter #(contains? johto-ja-hallintokorvausosiot (:osio %)) (:tarjous tarjous))
+        ;; Poistettavat toimenkuvat
+        poistettavat-toimenkuvat (filter #(true? (:poistettu %)) toimenkuvat-tarjouksesta)
+        ;; Poistetaan toimenkuvat tietokanansta
+        _ (mapv
+            (fn [poistettava]
+              (poista-tarjouksen-johto-ja-hallintokorvaus<! db {:urakkaid urakka-id
+                                                                :toimenkuvaid (:toimenkuva-id poistettava)})
+              (toimenkuva-kyselyt/poista-toimenkuva! db (:id poistettava)))
+            poistettavat-toimenkuvat)
+        paivitettavat-toimenkuvat (remove #(true? (:poistettu %)) toimenkuvat-tarjouksesta)
+
+
         toimenkuvatlistaus (flatten (reduce
                                       (fn [kaikki rivi]
                                         (let [uudet-rivit (mapv
@@ -159,7 +173,7 @@
                                                                :luoja kayttaja-id})
                                                             (:hoitovuosittaiset-arvot rivi))]
                                           (conj kaikki uudet-rivit)))
-                                      [] toimenkuvat-tarjouksesta))
+                                      [] paivitettavat-toimenkuvat))
 
         ;; Tallennetaan tarjous- ja kattohinnat tarjouksen päätauluun, johon muut tiedot linkitetään
         tallennukset (mapv
@@ -174,7 +188,6 @@
                                                    (tallenna-tarjous<! db rivi))
                                ;; Tallennetaan tarjouksen kustannukset ja toimenkuvat tietokantaan
                                vuosittaiset-kustannukset (filter #(= (:hoitokauden_alkuvuosi rivi) (:hoitokauden_alkuvuosi %)) kustannuksetlistaus)
-                               vuosittaiset-toimenkuvat (filter #(= (:hoitokauden_alkuvuosi rivi) (:hoitokauden_alkuvuosi %)) toimenkuvatlistaus)
                                _ (mapv (fn [kustannus]
                                          (let [; tarkistetaan, että löytyykö jo tietokannasta
                                                kustannusdb (if (:id tarjousdb)
@@ -191,6 +204,7 @@
                                                                               :muokkaaja kayttaja-id))
                                              (tallenna-tarjouskustannus<! db (assoc kustannus :tarjous_id (:id tietokantatarjous))))))
                                    vuosittaiset-kustannukset)
+                               vuosittaiset-toimenkuvat (filter #(= (:hoitokauden_alkuvuosi rivi) (:hoitokauden_alkuvuosi %)) toimenkuvatlistaus)
                                _ (mapv
                                    (fn [toimenkuva]
                                      (let [toimenkuvadb (if (:id tarjousdb)

--- a/src/clj/harja/kyselyt/tarjous_kyselyt.clj
+++ b/src/clj/harja/kyselyt/tarjous_kyselyt.clj
@@ -21,9 +21,54 @@
    "johto-ja-hallintokorvaus" 4
    "hoidonjohtopalkkio" 5})
 
+(defn hae-urakan-toimenkuvat [db urakka-id urakan-alkuvuosi hoitovuosittaiset-arvot]
+  (let [toimenkuvat (toimenkuva-kyselyt/hae-urakan-toimenkuvat-alkuvuoden-perusteella db {:urakka-id urakka-id
+                                                                                          :urakan-alkuvuosi urakan-alkuvuosi})
+        toimenkuvat (if (<= urakan-alkuvuosi 2021)
+                      (reduce (fn [uudet-toimenkuvat toimenkuva]
+                                (let [uusi-toimenkuva (cond (= "päätoiminen apulainen" (:toimenkuva toimenkuva))
+                                                        {:toimenkuva "päätoiminen apulainen"
+                                                         :nimike "Päätoiminen apulainen (talvikausi)"
+                                                         :id (:id toimenkuva)
+                                                         :toimenkuva-id (:toimenkuva-id toimenkuva)}
+                                                        (= "apulainen/työnjohtaja" (:toimenkuva toimenkuva))
+                                                        {:toimenkuva "apulainen/työnjohtaja"
+                                                         :nimike "Apulainen/työnjohtaja (talvikausi)"
+                                                         :id (:id toimenkuva)
+                                                         :toimenkuva-id (:toimenkuva-id toimenkuva)}
+                                                        :else nil)
+
+                                      toimenkuva (cond (= "päätoiminen apulainen" (:toimenkuva toimenkuva))
+                                                   (assoc toimenkuva :nimike "Päätoiminen apulainen (kesäkausi)")
+                                                   (= "apulainen/työnjohtaja" (:toimenkuva toimenkuva))
+                                                   (assoc toimenkuva :nimike "Apulainen/työnjohtaja (kesäkausi)")
+                                                   :else (merge toimenkuva {:nimike (:toimenkuva toimenkuva)}))]
+
+                                  ;; Lisätään talvi/kesäkausi vain, jos ne on noita erikois kovakoodattuja toimenkuvia
+                                  (if uusi-toimenkuva
+                                    (conj uudet-toimenkuvat uusi-toimenkuva toimenkuva)
+                                    (conj uudet-toimenkuvat toimenkuva))))
+                        [] toimenkuvat)
+                      toimenkuvat)
+
+        ;; Järjestetään toimenkuvat järkevään järjestykseen
+        toimenkuvat (mapv (fn [toimenkuva]
+                            (-> toimenkuva
+                              (assoc :jarjestys (toimenkuva-kyselyt/paattele-toimenkuvan-jarjestys (:nimike toimenkuva))
+                                :nimi (str/capitalize (:nimike toimenkuva))
+                                :toimenkuva-id (:id toimenkuva)
+                                :osio "johto-ja-hallintokorvaus"
+                                :tehtava-id nil
+                                :tehtavaryhma-id nil
+                                :rahavaraus-id nil
+                                :hoitovuosittaiset-arvot hoitovuosittaiset-arvot)))
+                      toimenkuvat)]
+    toimenkuvat))
+
 (defn luo-default-tarjous [db urakka-id]
   (let [urakan-tiedot (first (urakat-kyselyt/hae-urakka db {:id urakka-id}))
-        vuodet (range (pvm/vuosi (:alkupvm urakan-tiedot)) (pvm/vuosi (:loppupvm urakan-tiedot)))
+        urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
+        vuodet (range urakan-alkuvuosi (pvm/vuosi (:loppupvm urakan-tiedot)))
         hoitovuosittaiset-arvot (mapv (fn [vuosi] {:vuosi vuosi :summa 0.00}) vuodet)
         ;; Lisätään default tarjoukseen Kilpailutettavat hankinnat, Erillishankinnat ja Hoidonjohtopalkkio
         tarjous [{:nimi "Kilpailutettavat hankinnat", :osio "hankintakustannukset" :toimenkuva-id nil :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil
@@ -39,28 +84,8 @@
                                                              :hoitovuosittaiset-arvot hoitovuosittaiset-arvot :yhteensa 0.00}])))
                            [] rahavaraukset)
         tarjous (vec (concat tarjous rahavaraus-rivit))
-        ;; Pakotetaan tässä vaiheessa kehitystä tietyt toimenkuvat. Nämä voidaan asetaa myöhemmin defaulttina jostain hallintapaneelin käyttiksestä
-        ;; id 10, 'Valmistelukausi ennen urakka-ajan alkua',
-        ;; id 2, 'Vastuunalainen työnjohtaja'
-        ;; id 8, '2. työnjohtaja'
-        ;; id 9, '3. työnjohtaja'
-        ;; id 5, 'Viherhoidosta vastaava henkilö'
-        ;; id 7, 'Harjoittelija'
-        toimenkuvat [
-                     ;; Johto ja hallintokorvaukset eli toimenkuvat
-                     {:nimi "Valmistelukausi ennen urakka-ajan alkua", :osio "johto-ja-hallintokorvaus" :toimenkuva-id 10 :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil
-                      :hoitovuosittaiset-arvot hoitovuosittaiset-arvot, :yhteensa 0.00}
-                     {:nimi "Vastuunalainen työnjohtaja", :osio "johto-ja-hallintokorvaus" :toimenkuva-id 2 :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil
-                      :hoitovuosittaiset-arvot hoitovuosittaiset-arvot, :yhteensa 0.00}
-                     {:nimi "2. työnjohtaja", :osio "johto-ja-hallintokorvaus" :toimenkuva-id 8 :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil
-                      :hoitovuosittaiset-arvot hoitovuosittaiset-arvot, :yhteensa 0.00}
-                     {:nimi "3. työnjohtaja", :osio "johto-ja-hallintokorvaus" :toimenkuva-id 9 :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil
-                      :hoitovuosittaiset-arvot hoitovuosittaiset-arvot, :yhteensa 0.00}
-                     {:nimi "Viherhoidosta vastaava henkilö", :osio "johto-ja-hallintokorvaus" :toimenkuva-id 5 :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil
-                      :hoitovuosittaiset-arvot hoitovuosittaiset-arvot, :yhteensa 0.00}
-                     {:nimi "Harjoittelija", :osio "johto-ja-hallintokorvaus" :toimenkuva-id 7 :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil
-                      :hoitovuosittaiset-arvot hoitovuosittaiset-arvot, :yhteensa 0.00}]
-        tarjous (vec (concat tarjous (sort-by :toimenkuva-id toimenkuvat)))
+        toimenkuvat (hae-urakan-toimenkuvat db urakka-id urakan-alkuvuosi hoitovuosittaiset-arvot)
+        tarjous (vec (concat tarjous (sort-by :jarjestys toimenkuvat)))
         jarjestetty-tarjous (sort-by (fn [rivi] (get osiojarjestys (:osio rivi)))
                               tarjous)]
 
@@ -226,7 +251,9 @@
 
 
 (defn hae-tarjous [db urakka-id]
-  (let [tarjous-rivit (hae-tarjouksen-tiedot db {:urakka_id urakka-id})
+  (let [urakan-tiedot (first (urakat-kyselyt/hae-urakka db {:id urakka-id}))
+        urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
+        tarjous-rivit (hae-tarjouksen-tiedot db {:urakka_id urakka-id})
         ;; Mäppää tarjouksen tietokantarivit clojure-mapeiksi.
         tarjous-rivit (mapv
                         (fn [tarjous]
@@ -248,11 +275,17 @@
         toimenkuva-rivit (mapv #(muodosta-tarjous-rivi % (hae-tarjouksesta-rivit-vuodelle :toimenkuvat tarjous-rivit (:nimi %))) (:toimenkuvat (first tarjous-rivit)))
         tarjousrivit (into [] (sort-by (fn [rivi] (get osiojarjestys (:osio rivi))) (vec (concat kustannus-rivit toimenkuva-rivit))))
 
+        kaikki-toimenkuvat (if (>= urakan-alkuvuosi 2025)
+                             (map #(assoc % :nimi (str/capitalize (:nimi %))) (toimenkuva-kyselyt/hae-toimenkuvat db))
+                             nil)
         tarjous {:urakka-id urakka-id
+                 :kaikki-toimenkuvat kaikki-toimenkuvat
                  :tarjous tarjousrivit}
         ;; Tarkistetaan, että tarjous ei ole tyhjä
         tarjous (if (empty? (first (:tarjous tarjous)))
-                  {:urakka-id urakka-id :tarjous (luo-default-tarjous db urakka-id)}
+                  {:urakka-id urakka-id
+                   :kaikki-toimenkuvat kaikki-toimenkuvat
+                   :tarjous (luo-default-tarjous db urakka-id)}
                   tarjous)
 
         tarjous (lisaa-yhteenvetorivi-tarjoukseen tarjous)]

--- a/src/clj/harja/kyselyt/tarjous_kyselyt.clj
+++ b/src/clj/harja/kyselyt/tarjous_kyselyt.clj
@@ -116,8 +116,10 @@
   "Tarjous koostuu kolmesta kokonaisuudesta: Tarjouksen kokonaissummasta eli Tavoite- ja Kattohinnasta, Johto-ja-hallintokorvauksista (toimenkuvat) sekä
   Hankinnoista (Kilpailutettavat hankinnat, Erillishankinnat, Rahavarauksista, Hoidonjohtopalkkiosta)."
   [db urakka-id kayttaja-id kattohintakerroin tarjous]
-  (let [;; Vuodet ovat dynaamisia. Päätellään ne tietomallista
-        vuodet (vuodet-tietomallista tarjous)
+  (let [urakan-tiedot (first (urakat-kyselyt/hae-urakka db {:id urakka-id}))
+        vuodet (map (fn [vuosi]
+                      {:vuosi vuosi}) (range (pvm/vuosi (:alkupvm urakan-tiedot)) (pvm/vuosi (:loppupvm urakan-tiedot))))
+
         ;; Muokkaa tietomallin vuosittaiset summat tarjous- ja kattohinnaksi
         vuosittaiset-tarjoushinnat (mapv
                                      (fn [vuosi-rivi]
@@ -128,6 +130,7 @@
                                           :tarjous_kattohinta (* summa kattohintakerroin),
                                           :luoja kayttaja-id}))
                                      vuodet)
+        ;; Erota toimenkuvat ja muut kustannukset toisistaan
         hankinta-osiot #{"hankintakustannukset", "erillishankinnat", "hoidonjohtopalkkio", "tavoitehintaiset-rahavaraukset"}
         johto-ja-hallintokorvausosiot #{"johto-ja-hallintokorvaus"}
         kustannukset-tarjouksesta (filter #(contains? hankinta-osiot (:osio %)) (:tarjous tarjous))
@@ -147,6 +150,7 @@
                                            (conj kaikki uudet-rivit)))
                                        [] kustannukset-tarjouksesta))
         toimenkuvat-tarjouksesta (filter #(contains? johto-ja-hallintokorvausosiot (:osio %)) (:tarjous tarjous))
+
         ;; Poistettavat toimenkuvat
         poistettavat-toimenkuvat (filter #(true? (:poistettu %)) toimenkuvat-tarjouksesta)
         ;; Poistetaan toimenkuvat tietokanansta
@@ -156,14 +160,16 @@
                                                                 :toimenkuvaid (:toimenkuva-id poistettava)})
               (toimenkuva-kyselyt/poista-toimenkuva! db (:id poistettava)))
             poistettavat-toimenkuvat)
+
         paivitettavat-toimenkuvat (remove #(true? (:poistettu %)) toimenkuvat-tarjouksesta)
-
-
+        ;; Muutetaan toimenkuvat listaksi, jossa on yksi rivi per hoitovuosi
         toimenkuvatlistaus (flatten (reduce
                                       (fn [kaikki rivi]
                                         (let [uudet-rivit (mapv
                                                             (fn [r]
-                                                              {:urakka_id urakka-id
+                                                              {:id (:id rivi)
+                                                               :nimi (:nimi rivi)
+                                                               :urakka_id urakka-id
                                                                :hoitokauden_alkuvuosi (:vuosi r)
                                                                :johto_ja_hallintokorvaus_toimenkuva_id (:toimenkuva-id rivi)
                                                                :tehtava_id (:tehtava-id rivi)
@@ -204,22 +210,39 @@
                                                                               :muokkaaja kayttaja-id))
                                              (tallenna-tarjouskustannus<! db (assoc kustannus :tarjous_id (:id tietokantatarjous))))))
                                    vuosittaiset-kustannukset)
+
                                vuosittaiset-toimenkuvat (filter #(= (:hoitokauden_alkuvuosi rivi) (:hoitokauden_alkuvuosi %)) toimenkuvatlistaus)
+
                                _ (mapv
                                    (fn [toimenkuva]
-                                     (let [toimenkuvadb (if (:id tarjousdb)
-                                                          (first (hae-toimenkuva-tarjoukselle db {:tarjous_id (:id tarjousdb)
-                                                                                                  :urakka_id urakka-id
-                                                                                                  :hoitokauden_alkuvuosi (:hoitokauden_alkuvuosi toimenkuva)
-                                                                                                  :johto_ja_hallintokorvaus_toimenkuva_id (:johto_ja_hallintokorvaus_toimenkuva_id toimenkuva)
-                                                                                                  :tehtava_id (:tehtava_id toimenkuva)
-                                                                                                  :tehtavaryhma_id (:tehtavaryhma_id toimenkuva)
-                                                                                                  :osio (:osio toimenkuva)}))
+                                     (let [uusi-db-toimenkuva (when (= -1 (:id toimenkuva))
+                                                                ;; Tämä map pyörähtää jokaisena hoitovuonna. Mutta toimenkuvan kannalta riittää
+                                                                ;; että toimenkuvia lisätään vain kerran urakalle
+                                                                ;; Tarkistetaan siis, ettei toimenkuvaa löydy jo tietokannasta
+                                                                (when-not (seq (toimenkuva-kyselyt/hae-urakan-toimenkuva db {:nimi (:nimi toimenkuva)
+                                                                                                                         :urakkaid urakka-id}))
+                                                                  (toimenkuva-kyselyt/lisaa-urakan-toimenkuva<! db {:toimenkuva (:nimi toimenkuva)
+                                                                                                                  :urakkaid urakka-id
+                                                                                                                  :urakkakohtainen-nimi (:nimi toimenkuva)})))
+                                           toimenkuvadb (if (:id tarjousdb)
+                                                          (first (hae-toimenkuva-tarjoukselle db
+                                                                   {:tarjous_id (:id tarjousdb)
+                                                                    :urakka_id urakka-id
+                                                                    :hoitokauden_alkuvuosi (:hoitokauden_alkuvuosi toimenkuva)
+                                                                    :johto_ja_hallintokorvaus_toimenkuva_id (or (:id uusi-db-toimenkuva) (:johto_ja_hallintokorvaus_toimenkuva_id toimenkuva))
+                                                                    :tehtava_id (:tehtava_id toimenkuva)
+                                                                    :tehtavaryhma_id (:tehtavaryhma_id toimenkuva)
+                                                                    :osio (:osio toimenkuva)}))
                                                           nil)]
                                        (if toimenkuvadb
-                                         (paivita-tarjouksen-johto-ja-hallintokorvaus<! db (assoc toimenkuvadb :summa (:summa toimenkuva)
+                                         (paivita-tarjouksen-johto-ja-hallintokorvaus<! db (assoc toimenkuvadb
+                                                                                             :summa (:summa toimenkuva)
                                                                                              :muokkaaja kayttaja-id))
-                                         (tallenna-tarjouksen-johto-ja-hallintokorvaus<! db (assoc toimenkuva :tarjous_id (:id tietokantatarjous))))))
+                                         (let [toimenkuva (if uusi-db-toimenkuva
+                                                            (assoc toimenkuva :johto_ja_hallintokorvaus_toimenkuva_id (:id uusi-db-toimenkuva))
+                                                            toimenkuva)]
+                                           (tallenna-tarjouksen-johto-ja-hallintokorvaus<! db (assoc toimenkuva
+                                                                                                :tarjous_id (:id tietokantatarjous)))))))
                                    vuosittaiset-toimenkuvat)]
                            {:tarjousid (:id tietokantatarjous)}))
                        vuosittaiset-tarjoushinnat)]

--- a/src/clj/harja/kyselyt/tarjous_kyselyt.sql
+++ b/src/clj/harja/kyselyt/tarjous_kyselyt.sql
@@ -86,3 +86,8 @@ SET summa = :summa,
     muokkaaja = :muokkaaja,
     muokattu = NOW()
 WHERE id = :id;
+
+-- name: poista-tarjouksen-johto-ja-hallintokorvaus<!
+DELETE FROM tarjous_johto_ja_hallintokorvaus
+ WHERE johto_ja_hallintokorvaus_toimenkuva_id = :toimenkuvaid
+   AND urakka_id = :urakkaid;

--- a/src/clj/harja/kyselyt/tarjous_kyselyt.sql
+++ b/src/clj/harja/kyselyt/tarjous_kyselyt.sql
@@ -18,7 +18,7 @@ INSERT INTO tarjous_johto_ja_hallintokorvaus (tarjous_id, urakka_id, hoitokauden
 VALUES (:tarjous_id, :urakka_id, :hoitokauden_alkuvuosi, :summa, :osio::suunnittelu_osio, :johto_ja_hallintokorvaus_toimenkuva_id, :tehtavaryhma_id, :tehtava_id, :luoja, NOW());
 
 -- name: hae-tarjouksen-tiedot
-select t.id as "tarjous-id", t.hoitokauden_alkuvuosi, t.urakka_id, t.tarjous_tavoitehinta, t.tarjous_kattohinta,
+SELECT t.id as "tarjous-id", t.hoitokauden_alkuvuosi, t.urakka_id, t.tarjous_tavoitehinta, t.tarjous_kattohinta,
        (SELECT array_agg(row(tk.id,
            CASE WHEN tk.osio = 'tavoitehintaiset-rahavaraukset'::suunnittelu_osio THEN r.nimi
                 WHEN tk.osio = 'hankintakustannukset'::suunnittelu_osio THEN 'Kilpailutettavat hankinnat'
@@ -33,8 +33,9 @@ select t.id as "tarjous-id", t.hoitokauden_alkuvuosi, t.urakka_id, t.tarjous_tav
         FROM tarjous_johto_ja_hallintokorvaus tj
                  LEFT JOIN johto_ja_hallintokorvaus_toimenkuva jjht ON jjht.id = tj.johto_ja_hallintokorvaus_toimenkuva_id
         WHERE tj.tarjous_id = t.id) as toimenkuvat
-from tarjous t
-where t.urakka_id = :urakka_id;
+  FROM tarjous t
+ WHERE t.urakka_id = :urakka_id
+ ORDER BY t.hoitokauden_alkuvuosi ASC;
 
 -- name: hae-tarjous-vuodella
 -- Haetaan tarjousrivi urakan ja vuoden perusteella.

--- a/src/clj/harja/kyselyt/toimenkuvat_kyselyt.clj
+++ b/src/clj/harja/kyselyt/toimenkuvat_kyselyt.clj
@@ -1,5 +1,6 @@
 (ns harja.kyselyt.toimenkuvat-kyselyt
-  (:require [jeesql.core :refer [defqueries]]))
+  (:require [clojure.string :as str]
+            [jeesql.core :refer [defqueries]]))
 
 (defqueries "harja/kyselyt/toimenkuvat_kyselyt.sql"
   {:positional? true})
@@ -7,4 +8,25 @@
 (declare hae-toimenkuva hae-toimenkuva-idlla
   hae-2025-urakoiden-toimenkuvat hae-toimenkuvat hae-urakan-toimenkuva hae-urakan-toimenkuvat
   onko-toimenkuva-olemassa? onko-toimenkuva-kaytossa? poista-toimenkuva-urakoilta! poista-toimenkuva!
-  lisaa-uusi-toimenkuva<! lisaa-urakan-toimenkuva<! paivita-urakan-toimenkuva<! poista-urakan-toimenkuva<!)
+  lisaa-uusi-toimenkuva<! lisaa-urakan-toimenkuva<! paivita-urakan-toimenkuva<! poista-urakan-toimenkuva<!
+  hae-urakan-toimenkuvat-alkuvuoden-perusteella)
+
+(defn paattele-toimenkuvan-jarjestys
+  "Pakotetaan toimenkuvat oikeaan järjestykseen kovakoodauksen avulla."
+  [toimenkuva-nimike]
+  (case (str/lower-case toimenkuva-nimike)
+    "valmistelukausi ennen urakka-ajan alkua" 0
+    "sopimusvastaava" 1
+    "vastuunalainen työnjohtaja" 2
+    "2. työnjohtaja" 3
+    "3. työnjohtaja" 4
+    "päätoiminen apulainen" 5
+    "päätoiminen apulainen (talvikausi)" 5
+    "päätoiminen apulainen (kesäkausi)" 6
+    "apulainen/työnjohtaja" 7
+    "apulainen/työnjohtaja (talvikausi)" 7
+    "apulainen/työnjohtaja (kesäkausi)" 8
+    "viherhoidosta vastaava henkilö" 9
+    "hankintavastaava" 10
+    "harjoittelija" 11
+    99)) ;; Muu toimenkuva, joka ei ole listassa

--- a/src/clj/harja/kyselyt/toimenkuvat_kyselyt.sql
+++ b/src/clj/harja/kyselyt/toimenkuvat_kyselyt.sql
@@ -85,3 +85,28 @@ WHERE t.id = :id;
 -- name: onko-toimenkuva-olemassa?
 -- single?: true
 SELECT exists(SELECT id FROM johto_ja_hallintokorvaus_toimenkuva WHERE id = :toimenkuva-id :: BIGINT);
+
+-- name: hae-urakan-toimenkuvat-alkuvuoden-perusteella
+-- Hae urakkakohtaiset toimenkuvat
+WITH urakka_toimenkuvat AS (SELECT nimike
+                            FROM unnest(
+                                     CASE
+                                         WHEN (:urakan-alkuvuosi >= 2019 AND :urakan-alkuvuosi <= 2021)
+                                             THEN ARRAY ['sopimusvastaava', 'vastuunalainen työnjohtaja', 'päätoiminen apulainen', 'apulainen/työnjohtaja', 'viherhoidosta vastaava henkilö', 'hankintavastaava', 'harjoittelija']
+                                         WHEN (:urakan-alkuvuosi >= 2022 AND :urakan-alkuvuosi <= 2023)
+                                             THEN ARRAY ['valmistelukausi ennen urakka-ajan alkua','vastuunalainen työnjohtaja', 'päätoiminen apulainen','apulainen/työnjohtaja', 'viherhoidosta vastaava henkilö', 'hankintavastaava', 'harjoittelija']
+                                         WHEN (:urakan-alkuvuosi = 2024)
+                                             THEN ARRAY ['valmistelukausi ennen urakka-ajan alkua','vastuunalainen työnjohtaja','2. työnjohtaja', '3. työnjohtaja', 'viherhoidosta vastaava henkilö', 'harjoittelija']
+                                         ELSE ARRAY ['valmistelukausi ennen urakka-ajan alkua','vastuunalainen työnjohtaja','2. työnjohtaja', '3. työnjohtaja', 'viherhoidosta vastaava henkilö', 'harjoittelija']
+                                         END
+                                 ) AS nimike)
+SELECT id, toimenkuva, toimenkuva as nimike
+FROM johto_ja_hallintokorvaus_toimenkuva jht
+WHERE jht."urakka-id" = :urakka-id
+  AND jht.toimenkuva is not null
+UNION
+SELECT (select MIN(id) from johto_ja_hallintokorvaus_toimenkuva where toimenkuva = ut.nimike) AS id,
+       nimike                                                                                 AS toimenkuva,
+       nimike
+from urakka_toimenkuvat ut
+ORDER BY ID;

--- a/src/clj/harja/kyselyt/toimenkuvat_kyselyt.sql
+++ b/src/clj/harja/kyselyt/toimenkuvat_kyselyt.sql
@@ -97,7 +97,6 @@ WITH urakka_toimenkuvat AS (SELECT nimike
                                              THEN ARRAY ['valmistelukausi ennen urakka-ajan alkua','vastuunalainen työnjohtaja', 'päätoiminen apulainen','apulainen/työnjohtaja', 'viherhoidosta vastaava henkilö', 'hankintavastaava', 'harjoittelija']
                                          WHEN (:urakan-alkuvuosi = 2024)
                                              THEN ARRAY ['valmistelukausi ennen urakka-ajan alkua','vastuunalainen työnjohtaja','2. työnjohtaja', '3. työnjohtaja', 'viherhoidosta vastaava henkilö', 'harjoittelija']
-                                         ELSE ARRAY ['valmistelukausi ennen urakka-ajan alkua','vastuunalainen työnjohtaja','2. työnjohtaja', '3. työnjohtaja', 'viherhoidosta vastaava henkilö', 'harjoittelija']
                                          END
                                  ) AS nimike)
 SELECT id, toimenkuva, toimenkuva as nimike

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
@@ -13,7 +13,8 @@
             [harja.kyselyt.tarjous-kyselyt :as tarjous-kyselyt]
             [harja.kyselyt.kustannusarvioidut-tyot :as ka-q]
             [harja.kyselyt.kiinteahintaiset-tyot :as kiint-kyselyt]
-            [harja.kyselyt.rahavaraukset :as rahavaraus-kyselyt]))
+            [harja.kyselyt.rahavaraukset :as rahavaraus-kyselyt]
+            [harja.kyselyt.toimenkuvat-kyselyt :as toimenkuva-kyselyt]))
 
 (defqueries "harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.sql"
   {:positional? true})
@@ -31,7 +32,7 @@
   hae-johto-ja-hallintokorvaukset-kuukausittain
   hae-johto-ja-hallintokorvaukset-2019-mhu
   hae-kuukauden-johto-ja-hallintokorvaus hae-toimenkuvan-kuukauden-johto-ja-hallintokorvaus
-  hae-urakan-toimenkuvat hae-toimenkuvan-johto-ja-hallintokorvaukset-kuukausittain
+  hae-toimenkuvan-johto-ja-hallintokorvaukset-kuukausittain
   hae-muut-kulut-toimenkuviin-kuukausittain hae-muut-kulut-kuukaudelle
   lisaa-kuukauden-muu-kulu<! paivita-kuukauden-muu-kulu<!
   hae-tehtava-tunnisteella
@@ -197,32 +198,12 @@
       (and (= urakan-alkuvuosi 2024) (= toimenkuva-nimi "harjoittelija")) [10 11 12 1 2 3 4 5 6 7 8 9]
       :else [10 11 12 1 2 3 4 5 6 7 8 9])))
 
-(defn paattele-toimenkuvan-jarjestys
-  "Pakotetaan toimenkuvat oikeaan järjestykseen kovakoodauksen avulla."
-  [toimenkuva-nimike]
-  (case (str/lower-case toimenkuva-nimike)
-    "valmistelukausi ennen urakka-ajan alkua" 0
-    "sopimusvastaava" 1
-    "vastuunalainen työnjohtaja" 2
-    "2. työnjohtaja" 3
-    "3. työnjohtaja" 4
-    "päätoiminen apulainen" 5
-    "päätoiminen apulainen (talvikausi)" 5
-    "päätoiminen apulainen (kesäkausi)" 6
-    "apulainen/työnjohtaja" 7
-    "apulainen/työnjohtaja (talvikausi)" 7
-    "apulainen/työnjohtaja (kesäkausi)" 8
-    "viherhoidosta vastaava henkilö" 9
-    "hankintavastaava" 10
-    "harjoittelija" 11
-    99)) ;; Muu toimenkuva, joka ei ole listassa
-
 (defn hae-johto-ja-hallintokorvaukset-2019-2024 [db urakka-id sopimus-id hoitovuoden-alkuvuosi urakan-alkuvuosi toimenkuvat-tarjouksesta]
   (let [viimeisin-muokkaus (first (hae-viimeisin-muokkaaja-jjh
                                     db {:urakka-id urakka-id
                                         :vuosi hoitovuoden-alkuvuosi}))
         ;; Haetaan ensin urakkakohtaiset toimenkuvat
-        toimenkuvat (hae-urakan-toimenkuvat db {:urakka-id urakka-id
+        toimenkuvat (toimenkuva-kyselyt/hae-urakan-toimenkuvat-alkuvuoden-perusteella db {:urakka-id urakka-id
                                                 :urakan-alkuvuosi urakan-alkuvuosi})
         ;; 2019 - 2021 alkavien urakoiden toimenkuvat eivät löydy tietokantahaulla, koska ne on kovakoodattu fronttiin. Niille on kuitenkin annettu
         ;; joissain tapauksissa kaksi nimeä, mutta sama id. Joten joudumme taaksepäin yhteensopivuuden vuoksi tekemään muunnoksen
@@ -255,7 +236,7 @@
 
         ;; Järjestetään toimenkuvat järkevään järjestykseen
         toimenkuvat (map (fn [toimenkuva]
-                           (assoc toimenkuva :jarjestys (paattele-toimenkuvan-jarjestys (:nimike toimenkuva))))
+                           (assoc toimenkuva :jarjestys (toimenkuva-kyselyt/paattele-toimenkuvan-jarjestys (:nimike toimenkuva))))
                       toimenkuvat)
 
         ;; Haetaan raskaalla prosessilla toimenkuvakohtaisesti suunnitellut johto-ja-hallintokorvaukset

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.sql
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.sql
@@ -389,31 +389,6 @@ SELECT id, tavoitehinta, tavoitehinta_indeksikorjattu, kattohinta, kattohinta_in
 WHERE urakka = :urakka-id
   AND hoitokausi = :hoitokausinumero;
 
--- name: hae-urakan-toimenkuvat
--- Hae urakkakohtaiset toimenkuvat
-WITH urakka_toimenkuvat AS (SELECT nimike
-                            FROM unnest(
-                                     CASE
-                                         WHEN (:urakan-alkuvuosi >= 2019 AND :urakan-alkuvuosi <= 2021)
-                                             THEN ARRAY ['sopimusvastaava', 'vastuunalainen työnjohtaja', 'päätoiminen apulainen', 'apulainen/työnjohtaja', 'viherhoidosta vastaava henkilö', 'hankintavastaava', 'harjoittelija']
-                                         WHEN (:urakan-alkuvuosi >= 2022 AND :urakan-alkuvuosi <= 2023)
-                                             THEN ARRAY ['valmistelukausi ennen urakka-ajan alkua','vastuunalainen työnjohtaja', 'päätoiminen apulainen','apulainen/työnjohtaja', 'viherhoidosta vastaava henkilö', 'hankintavastaava', 'harjoittelija']
-                                         WHEN (:urakan-alkuvuosi = 2024)
-                                             THEN ARRAY ['valmistelukausi ennen urakka-ajan alkua','vastuunalainen työnjohtaja','2. työnjohtaja', '3. työnjohtaja', 'viherhoidosta vastaava henkilö', 'harjoittelija']
-                                         ELSE ARRAY ['valmistelukausi ennen urakka-ajan alkua','vastuunalainen työnjohtaja','2. työnjohtaja', '3. työnjohtaja', 'viherhoidosta vastaava henkilö', 'harjoittelija']
-                                         END
-                                 ) AS nimike)
-SELECT id, toimenkuva, toimenkuva as nimike
-FROM johto_ja_hallintokorvaus_toimenkuva jht
-WHERE jht."urakka-id" = :urakka-id
-AND jht.toimenkuva is not null
-UNION
-SELECT (select MIN(id) from johto_ja_hallintokorvaus_toimenkuva where toimenkuva = ut.nimike) AS id,
-       nimike                                                                                 AS toimenkuva,
-       nimike
-from urakka_toimenkuvat ut
-ORDER BY ID;
-
 -- name: hae-toimenkuvan-johto-ja-hallintokorvaukset-kuukausittain
 -- Uudessa kustannusten suunnittelussa suunnitellaan edelleen tunnit ja tuntipalkat 19-22 alkaville urakoille
 SELECT jh.tunnit,

--- a/src/clj/harja/palvelin/palvelut/suunnittelu/tarjous_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/suunnittelu/tarjous_palvelu.clj
@@ -13,7 +13,7 @@
   palauttaa tyhjät tiedot, jotka voidaan täyttää uudelleen."
   [db user tiedot]
   (oikeudet/vaadi-lukuoikeus oikeudet/urakat-suunnittelu-kustannussuunnittelu user (:urakka-id tiedot))
-  (let [tarjous (tarjous-kyselyt/hae-tarjous db (:urakka-id tiedot))]
+  (let [tarjous {:urakka-id (:urakka-id tiedot) :tarjous (tarjous-kyselyt/luo-default-tarjous db (:urakka-id tiedot))}]
     tarjous))
 
 (defn tallenna-tarjous [db kayttaja {:keys [urakka-id] :as tiedot}]

--- a/src/clj/harja/palvelin/palvelut/suunnittelu/tarjous_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/suunnittelu/tarjous_palvelu.clj
@@ -28,9 +28,11 @@
 
 (defn tallenna-tarjous [db kayttaja {:keys [urakka-id] :as tiedot}]
   (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-suunnittelu-kustannussuunnittelu kayttaja urakka-id)
-  (let [kattohintakerroin 1.1                               ;; Odotellaan vielä urakka_parametrit taulua
-        tarjousdb (tarjous-kyselyt/tallenna-tarjous-tietokantaan db urakka-id (:id kayttaja) kattohintakerroin tiedot)]
-    (tarjous-kyselyt/hae-tarjous db (:urakka-id tiedot))))
+  (jdbc/with-db-transaction [db db]
+    (let [urakan-parametrit (first (urakat-kyselyt/hae-urakan-parametrit db {:urakkaid urakka-id}))
+          kattohintakerroin (:hoitokauden_lopun_kattohinta_kerroin urakan-parametrit)
+          _ (tarjous-kyselyt/tallenna-tarjous-tietokantaan db urakka-id (:id kayttaja) kattohintakerroin tiedot)]
+      (tarjous-kyselyt/hae-tarjous db (:urakka-id tiedot)))))
 
 
 (defrecord Tarjous []

--- a/src/clj/harja/palvelin/palvelut/suunnittelu/tarjous_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/suunnittelu/tarjous_palvelu.clj
@@ -1,8 +1,12 @@
 (ns harja.palvelin.palvelut.suunnittelu.tarjous-palvelu
   (:require [com.stuartsierra.component :as component]
+            [clojure.java.jdbc :as jdbc]
             [harja.kyselyt.tarjous-kyselyt :as tarjous-kyselyt]
+            [harja.kyselyt.toimenkuvat-kyselyt :as toimenkuva-kyselyt]
+            [harja.kyselyt.urakat :as urakat-kyselyt]
             [harja.palvelin.komponentit.http-palvelin :refer [julkaise-palvelu poista-palvelut transit-vastaus]]
-            [harja.domain.oikeudet :as oikeudet]))
+            [harja.domain.oikeudet :as oikeudet]
+            [harja.pvm :as pvm]))
 
 (defn hae-tarjouksen-tiedot [db user {:keys [urakka-id] :as tiedot}]
   (oikeudet/vaadi-lukuoikeus oikeudet/urakat-suunnittelu-kustannussuunnittelu user urakka-id)
@@ -13,7 +17,13 @@
   palauttaa tyhjät tiedot, jotka voidaan täyttää uudelleen."
   [db user tiedot]
   (oikeudet/vaadi-lukuoikeus oikeudet/urakat-suunnittelu-kustannussuunnittelu user (:urakka-id tiedot))
-  (let [tarjous {:urakka-id (:urakka-id tiedot) :tarjous (tarjous-kyselyt/luo-default-tarjous db (:urakka-id tiedot))}]
+  (let [urakan-tiedot (first (urakat-kyselyt/hae-urakka db {:id (:urakka-id tiedot)}))
+        urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
+        tarjous {:urakka-id (:urakka-id tiedot)
+                 :kaikki-toimenkuvat (if (>= urakan-alkuvuosi 2025)
+                                       (toimenkuva-kyselyt/hae-toimenkuvat db)
+                                       nil)
+                 :tarjous (tarjous-kyselyt/luo-default-tarjous db (:urakka-id tiedot))}]
     tarjous))
 
 (defn tallenna-tarjous [db kayttaja {:keys [urakka-id] :as tiedot}]

--- a/src/cljs/harja/tiedot/urakka/suunnittelu/tarjous_kustannussuunnitelma_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/suunnittelu/tarjous_kustannussuunnitelma_tiedot.cljs
@@ -9,6 +9,8 @@
             [harja.tiedot.urakka.urakka :as tila]))
 
 (defonce nakymassa? (atom false))
+(defonce grid-tiedot-atom (atom [{}]))
+(defonce grid-toimenkuvat-atom (atom [{}]))
 
 (defn scrollaa-muutoksiin [elementin-id]
   ;; Kutsutaan kun käyttäjä generoi kuukausittaiset summat tai vahvistaa koko kustannussuunnitelman
@@ -43,7 +45,7 @@
 (defrecord HaeTyhjatTarjouksenTiedotEpaonnistui [vastaus])
 
 ;; Tallennetaan tarjouksen data
-(defrecord TallennaTarjouksenTiedot [tarjous])
+(defrecord TallennaTarjouksenTiedot [tarjous toimenkuvat])
 (defrecord TallennaTarjouksenTiedotOnnistui [vastaus])
 (defrecord TallennaTarjouksenTiedotEpaonnistui [vastaus])
 
@@ -83,7 +85,7 @@
 (defrecord ToggleVetolaatikonMuokkaus [tila])
 
 (defrecord ValitseHoitokausiKustannussuunnitelmaan [vuosi])
-(defrecord PoistaRivi [rivi])
+(defrecord PoistaToimenkuva [rivi])
 
 (defn hae-kustannussuunnitelman-tiedot
   "Haetaan kustannussuunnitelman tiedot, jotta voidaan näyttää ne UI Gridissä.
@@ -142,7 +144,9 @@
   (process-event [{:keys [vastaus]} app]
     (-> app
       (assoc :haku-kaynnissa? false)
-      (assoc :tarjous (:tarjous vastaus))))
+      (assoc :tarjous (:tarjous vastaus))
+      (assoc :kaikki-toimenkuvat (:kaikki-toimenkuvat vastaus))
+      (assoc :urakka-id (:urakka-id vastaus))))
 
   HaeTarjouksenTiedotEpaonnistui
   (process-event [{:keys [vastaus]} app]
@@ -173,9 +177,12 @@
 
   TallennaTarjouksenTiedot
   (process-event
-    [{tarjous :tarjous} app]
+    [{tarjous :tarjous toimenkuvat :toimenkuvat} app]
     (let [;; Muutetaan formilta saatu tarjous oikeaan muotoon
-          muunnettu-tarjous {:tarjous (map #(muunna-vuodet %) tarjous)}
+          muunnetut-tarjousrivit (map #(muunna-vuodet %) tarjous)
+          muunnetut-toimenkuvarivit (map #(muunna-vuodet %) toimenkuvat)
+          tarjous (concat muunnetut-tarjousrivit muunnetut-toimenkuvarivit)
+          muunnettu-tarjous {:tarjous tarjous}
           muunnettu-tarjous (assoc muunnettu-tarjous :urakka-id (-> @tila/yleiset :urakka :id))]
       (tuck-apurit/post! :tallenna-tarjouksen-tiedot
         muunnettu-tarjous
@@ -517,11 +524,21 @@
     (-> app
       (assoc :tallennus-kesken? false)))
 
-  PoistaRivi
+  PoistaToimenkuva
   (process-event [{:keys [rivi]} app ]
+    (let [toimenkuvat (into [] (filter #(some #{"johto-ja-hallintokorvaus"}
+                                          [(:osio %)]) (:tarjous app)))
+          muokatut-toimenkuvat (map (fn [m]
+                                         (if (= (:nimi m) (:nimi rivi))
+                                           (assoc m :poistettu true)
+                                           m)) toimenkuvat)
+          _ (reset! grid-toimenkuvat-atom muokatut-toimenkuvat)])
     (-> app
       (update :tarjous
-        #(remove (fn [m] (= (:nimi m) (:nimi rivi))) %))))
+        #(map (fn [m]
+                (if (= (:nimi m) (:nimi rivi))
+                  (assoc m :poistettu true)
+                  m)) %))))
 
   ToggleVetolaatikonMuokkaus
   (process-event [{:keys [tila]} app]

--- a/src/cljs/harja/views/urakka/suunnittelu.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu.cljs
@@ -38,7 +38,9 @@
             :kiintiot (= tyyppi :vesivayla-hoito)
             :kokonaishintaiset (not= tyyppi  :teiden-hoito )
             :yksikkohintaiset (not= tyyppi  :teiden-hoito )
-            :kustannussuunnitelma (= tyyppi  :teiden-hoito )))
+            :kustannussuunnitelma (= tyyppi  :teiden-hoito )
+            :uusi-kustannussuunnitelma (= tyyppi  :teiden-hoito )
+            :tarjous (= tyyppi  :teiden-hoito )))
 
 (defn suunnittelu [ur]
   (let [valitun-hoitokauden-yks-hint-kustannukset (s/valitun-hoitokauden-yks-hint-kustannukset ur)]
@@ -52,15 +54,17 @@
           "Tarjouksen tiedot"
           :tarjous
           (when (and
-                (istunto/ominaisuus-kaytossa? :kustannussuunnitelma-tarjous)
-                (istunto/ominaisuus-kaytossa? :mhu-urakka))
+                  (valilehti-mahdollinen? :tarjous ur)
+                  (istunto/ominaisuus-kaytossa? :kustannussuunnitelma-tarjous)
+                  (istunto/ominaisuus-kaytossa? :mhu-urakka))
             [tarjous-nakyma/tarjous])
 
           "Uusi Kustannussuunnitelma"
           :uusi-kustannussuunnitelma
           (when (and
-                (istunto/ominaisuus-kaytossa? :kustannussuunnitelma-tarjous)
-                (istunto/ominaisuus-kaytossa? :mhu-urakka))
+                  (valilehti-mahdollinen? :uusi-kustannussuunnitelma ur)
+                  (istunto/ominaisuus-kaytossa? :kustannussuunnitelma-tarjous)
+                  (istunto/ominaisuus-kaytossa? :mhu-urakka))
             [kustannussuunitelma-nakyma/kustannussuunitelma])
 
           "Kustannussuunnitelma"

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
@@ -29,17 +29,14 @@
        (e! (tarjous-tiedot/->TallennaTarjouksenTiedot @grid-tiedot-atom)))
     {:disabled (or tallennus-kesken? false)}]])
 
-(defn- yhteenvetorivi [otsikko yhteenveto]
-  (reduce (fn [y rivi]
-            (conj y {:teksti (fmt/euro false (:summa rivi)) :tasaa :oikea :luokka "yhteensa lihavoitu"}))
-    [{:teksti otsikko
-      :luokka "yhteensa disabled lihavoitu"
-      :yhteenveto-vayla true
-      :tyyppi :euro
-      :fmt #(fmt/euro false %)}
-     {:teksti ""
-      :luokka "yhteensa lihavoitu"}]
-    (:hoitovuosittaiset-arvot yhteenveto)))
+(defn- lopullinen-yhteenvetorivi [otsikko rivi]
+  (flatten (conj [{:teksti otsikko
+                   :luokka "yhteensa disabled lihavoitu"
+                   :yhteenveto-vayla true
+                   :tyyppi :string}
+                  {:teksti ""
+                   :luokka "yhteensa lihavoitu"}]
+             rivi)))
 ;; Lisätään vielä yhteenveto yhteenvetoriviin)
 
 (defn poista-rivi [e! rivi]
@@ -56,13 +53,14 @@
         v (->> vuosidata
             (sort-by key)
             (mapv (fn [[_ arvo]]
-                    {:teksti arvo
+                    {:teksti (fmt/euro-opt false arvo)
                      :luokka "yhteensa lihavoitu"
                      :tyyppi :euro
+                     :summa arvo
                      :tasaa :oikea
                      :fmt fmt/euro-opt})))
-        yhteensa (apply + (map #(get % :teksti 0) v))
-        v (conj v {:teksti yhteensa
+        yhteensa (apply + (map #(get % :summa 0) v))
+        v (conj v {:teksti (fmt/euro-opt false yhteensa)
                    :luokka "yhteensa lihavoitu"
                    :tyyppi :euro
                    :tasaa :oikea
@@ -86,10 +84,9 @@
                (reset! virheet-atom (grid/hae-virheet %)))
     :rivi-jalkeen-fn (fn [rivit]
                        (let [vuosi-arvot (map :nimi vuositaulukon-otsikot)
-                             summat (laske-vuosisummat rivit vuosi-arvot)]
+                             yhteenvetorivi (laske-vuosisummat rivit vuosi-arvot)]
                          ^{:luokka "yhteenveto"}
-                         (into (yhteenvetorivi "Johto- ja hallintokorvaus yhteensä" (:hoitovuosittaiset-arvot yhteenveto))
-                           summat)))}
+                         (lopullinen-yhteenvetorivi "Johto- ja hallintokorvaus yhteensä" yhteenvetorivi)))}
 
    ;; Otsikot
    (concat [{:otsikko "Johto- ja hallintokorvaus"

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
@@ -29,16 +29,17 @@
        (e! (tarjous-tiedot/->TallennaTarjouksenTiedot @grid-tiedot-atom)))
     {:disabled (or tallennus-kesken? false)}]])
 
-(defn- yhteenvetorivi [otsikko yhteenveto] (reduce (fn [y rivi]
-                                                     (conj y {:teksti (fmt/euro false (:summa rivi)) :tasaa :oikea :luokka "yhteensa lihavoitu"}))
-                                             [{:teksti otsikko
-                                               :luokka "yhteensa disabled lihavoitu"
-                                               :yhteenveto-vayla true
-                                               :tyyppi :euro
-                                               :fmt #(fmt/euro false %)}
-                                              {:teksti ""
-                                               :luokka "yhteensa lihavoitu"}]
-                                             (:hoitovuosittaiset-arvot yhteenveto)))
+(defn- yhteenvetorivi [otsikko yhteenveto]
+  (reduce (fn [y rivi]
+            (conj y {:teksti (fmt/euro false (:summa rivi)) :tasaa :oikea :luokka "yhteensa lihavoitu"}))
+    [{:teksti otsikko
+      :luokka "yhteensa disabled lihavoitu"
+      :yhteenveto-vayla true
+      :tyyppi :euro
+      :fmt #(fmt/euro false %)}
+     {:teksti ""
+      :luokka "yhteensa lihavoitu"}]
+    (:hoitovuosittaiset-arvot yhteenveto)))
 ;; Lisätään vielä yhteenveto yhteenvetoriviin)
 
 (defn poista-rivi [e! rivi]
@@ -50,16 +51,68 @@
 
 (defn laske-vuosisummat [rivit vuosikentat]
   (let [vuosidata (->> rivit
-          (map #(select-keys % vuosikentat))
-          (apply merge-with +))]
-    (->> vuosidata
-      (sort-by key)
-      (mapv (fn [[_ arvo]]
-              {:teksti arvo
-               :luokka "yhteensa lihavoitu"
-               :tyyppi :euro
-               :tasaa :oikea
-               :fmt fmt/euro-opt})))))
+                    (map #(select-keys % vuosikentat))
+                    (apply merge-with +))
+        v (->> vuosidata
+            (sort-by key)
+            (mapv (fn [[_ arvo]]
+                    {:teksti arvo
+                     :luokka "yhteensa lihavoitu"
+                     :tyyppi :euro
+                     :tasaa :oikea
+                     :fmt fmt/euro-opt})))
+        yhteensa (apply + (map #(get % :teksti 0) v))
+        v (conj v {:teksti yhteensa
+                   :luokka "yhteensa lihavoitu"
+                   :tyyppi :euro
+                   :tasaa :oikea
+                   :fmt fmt/euro-opt})]
+    v))
+
+(defn johto-ja-hallintokorvaukset [e! joha-tiedot vuositaulukon-otsikot yhteenveto nimi-leveys vuosi-leveys yhteensa-leveys]
+  [grid/grid
+   {:otsikko ""
+    :muokkaa-aina true
+    :voi-muokata? true
+    :muokattava? (constantly true)
+    :voi-poistaa? (constantly false)
+    :voi-lisata? true
+    :voi-kumota? false
+    :piilota-toiminnot? false
+    :tunniste :nimi
+    :muutos #(do
+               (reset! tallenna-painettu false)
+               (reset! grid-tiedot-atom (vals (grid/hae-muokkaustila %)))
+               (reset! virheet-atom (grid/hae-virheet %)))
+    :rivi-jalkeen-fn (fn [rivit]
+                       (let [vuosi-arvot (map :nimi vuositaulukon-otsikot)
+                             summat (laske-vuosisummat rivit vuosi-arvot)]
+                         ^{:luokka "yhteenveto"}
+                         (into (yhteenvetorivi "Johto- ja hallintokorvaus yhteensä" (:hoitovuosittaiset-arvot yhteenveto))
+                           summat)))}
+
+   ;; Otsikot
+   (concat [{:otsikko "Johto- ja hallintokorvaus"
+             :nimi :nimi
+             :tyyppi :valinta
+             :valinnat (map :nimi joha-tiedot)
+             :luokka "yhteensa"
+             :leveys (str nimi-leveys "%")
+             :muokattava? (constantly true)}]
+     [{:otsikko ""
+       :tyyppi :komponentti
+       :komponentti (fn [rivi]
+                      (napit/yleinen "Poista rivi"
+                        :toissijainen
+                        #(poista-rivi e! rivi)
+                        {:ikoni (ikonit/livicon-trash) :luokka "btn-xs"}))
+       :leveys (str vuosi-leveys "%")}]
+     (mapv #(assoc % :muokattava false) vuositaulukon-otsikot)
+     [{:otsikko "Yhteensä (€)" :nimi :yhteensa :tyyppi :euro
+       :muokattava? (constantly false) :luokka "yhteensa"
+       :hae (fn [rivi] (laske-rivit-yhteen rivi))
+       :fmt (fn [arvo] (if arvo (fmt/euro false arvo) 0.00)) :leveys (str yhteensa-leveys "%") :tasaa :oikea}])
+   joha-tiedot])
 
 (defn tarjous-nakyma [e! app]
   (let [tarjouksen-tiedot (:tarjous app)
@@ -142,7 +195,7 @@
                           (let [vuosi-arvot (map :nimi vuositaulukon-otsikot)
                                 summat (laske-vuosisummat rivit vuosi-arvot)]
                             (into
-                              [{:teksti "Kaikki hankinnat yhteensä", :luokka "yhteensa lihavoitu" :yhteenveto-vayla true :tyyppi :euro }
+                              [{:teksti "Kaikki hankinnat yhteensä", :luokka "yhteensa lihavoitu" :yhteenveto-vayla true :tyyppi :euro}
                                {:teksti "" :luokka "yhteensa lihavoitu"}]
                               summat)))}
 
@@ -157,7 +210,7 @@
           :hae (fn [rivi] (laske-rivit-yhteen rivi))
           :tasaa :oikea
           :muokattava? (fn [rivi] (if (:yhteensa rivi) false true))}])
-          hankinnat-tiedot]
+      hankinnat-tiedot]
 
      ;;Erillisihankinnat
      [grid/grid
@@ -183,52 +236,11 @@
           :leveys (str yhteensa-leveys "%")
           :hae (fn [rivi] (laske-rivit-yhteen rivi))
           :tasaa :oikea
-          :muokattava?(constantly false)}])
+          :muokattava? (constantly false)}])
       [{:nimi "Erillishankinnat" :yhteensa 0 :vuosi-2021 0 :vuosi-2022 0 :vuosi-2023 0 :vuosi-2024 0 :vuosi-2025 0 :eperhoitovuosi 0}]]
 
      ;;Johto- ja hallintokorvaus
-     [grid/grid
-      {:otsikko ""
-       :muokkaa-aina true
-       :voi-muokata? true
-       :muokattava? (constantly true)
-       :voi-poistaa? (constantly false)
-       :voi-lisata? true
-       :voi-kumota? false
-       :piilota-toiminnot? false
-       :tunniste :nimi
-       :muutos #(do
-                  (reset! tallenna-painettu false)
-                  (reset! grid-tiedot-atom (vals (grid/hae-muokkaustila %)))
-                  (reset! virheet-atom (grid/hae-virheet %)))
-       :rivi-jalkeen-fn (fn [rivit]
-                          (let [vuosi-arvot (map :nimi vuositaulukon-otsikot)
-                                summat (laske-vuosisummat rivit vuosi-arvot)]
-                            ^{:luokka "yhteenveto"}
-                            (into (yhteenvetorivi "Johto- ja hallintokorvaus yhteensä" (:hoitovuosittaiset-arvot yhteenveto))
-                              summat)))}
-
-      (concat [{:otsikko "Johto- ja hallintokorvaus"
-                :nimi :nimi
-                :tyyppi :valinta
-                :valinnat (map :nimi joha-tiedot)
-                :luokka "yhteensa"
-                :leveys (str nimi-leveys "%")
-                :muokattava? (constantly true)}]
-        [{:otsikko ""
-          :tyyppi :komponentti
-          :komponentti (fn [rivi rivit]
-                         (napit/yleinen "Poista rivi"
-                           :toissijainen
-                           #(poista-rivi e! rivi)
-                           {:ikoni (ikonit/livicon-trash) :luokka "btn-xs"}))
-          :leveys (str vuosi-leveys "%")}]
-        (mapv #(assoc % :muokattava false) vuositaulukon-otsikot)
-                [{:otsikko "Yhteensä (€)" :nimi :yhteensa :tyyppi :euro
-                  :muokattava? (constantly false) :luokka "yhteensa"
-                  :hae (fn [rivi] (laske-rivit-yhteen rivi))
-                  :fmt (fn [arvo] (if arvo (fmt/euro false arvo) 0.00)) :leveys (str yhteensa-leveys "%") :tasaa :oikea}])
-      joha-tiedot]
+     (johto-ja-hallintokorvaukset e! joha-tiedot vuositaulukon-otsikot yhteenveto nimi-leveys vuosi-leveys yhteensa-leveys)
 
      ;;Hoidonjohtopalkkio
      [grid/grid
@@ -284,14 +296,14 @@
                 :tyyppi :string
                 :leveys (str nimi-leveys "%")
                 :muokattava? (constantly false)}]
-                vuositaulukon-otsikot
-                [{:otsikko "Yhteensä (€)" :nimi :yhteensa :tyyppi :euro
-                  :muokattava? (constantly false) :luokka "yhteensa" :tasaa :oikea
-                  :fmt (fn [arvo] (if arvo (fmt/euro false arvo) 0.00)) :leveys (str yhteensa-leveys "%")}])
-                [{:nimi "Tarjouksen tavoitehinta" :yhteensa 0 :vuosi-2021 0 :vuosi-2022 0 :vuosi-2023 0 :vuosi-2024 0 :vuosi-2025 0 :eperhoitovuosi 0}
-                 {:nimi "Tarjouksen kattohinta (1,1 x tarjouksen tavoitehinta)" :yhteensa 0 :vuosi-2021 0 :vuosi-2022 0 :vuosi-2023 0 :vuosi-2024 0 :vuosi-2025 0 :eperhoitovuosi 0}]]
-      ;; Custom-toteutus. Tallennusnapit on taulukon jälkeen
-      [tallennus-painikkeet e! app]]))
+        vuositaulukon-otsikot
+        [{:otsikko "Yhteensä (€)" :nimi :yhteensa :tyyppi :euro
+          :muokattava? (constantly false) :luokka "yhteensa" :tasaa :oikea
+          :fmt (fn [arvo] (if arvo (fmt/euro false arvo) 0.00)) :leveys (str yhteensa-leveys "%")}])
+      [{:nimi "Tarjouksen tavoitehinta" :yhteensa 0 :vuosi-2021 0 :vuosi-2022 0 :vuosi-2023 0 :vuosi-2024 0 :vuosi-2025 0 :eperhoitovuosi 0}
+       {:nimi "Tarjouksen kattohinta (1,1 x tarjouksen tavoitehinta)" :yhteensa 0 :vuosi-2021 0 :vuosi-2022 0 :vuosi-2023 0 :vuosi-2024 0 :vuosi-2025 0 :eperhoitovuosi 0}]]
+     ;; Custom-toteutus. Tallennusnapit on taulukon jälkeen
+     [tallennus-painikkeet e! app]]))
 
 (defn nakyma* [e! app]
   (komp/luo

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
@@ -2,6 +2,7 @@
   "Kustannussuunnitelman etusivu määrittää, että renderöidäänkö tarjous vai kustannussuunnitelma"
   (:require [harja.fmt :as fmt]
             [clojure.string :as str]
+            [harja.pvm :as pvm]
             [harja.ui.debug :as debug]
             [harja.tiedot.urakka.urakka :as tila]
             [harja.ui.ikonit :as ikonit]
@@ -15,6 +16,9 @@
 (defonce tallenna-painettu (atom false))
 (defonce virheet-atom (atom {}))
 (defonce grid-tiedot-atom (atom [{}]))
+;; Määritellään kaikkien kolumnien leveyksiä
+(def nimi-leveys 20)
+(def yhteensa-leveys 20)
 
 (defn- tallennus-painikkeet [e! {:keys [tallennus-kesken?] :as app}]
   [:div.painikkeet.text-right
@@ -67,55 +71,69 @@
                    :fmt fmt/euro-opt})]
     v))
 
-(defn johto-ja-hallintokorvaukset [e! joha-tiedot vuositaulukon-otsikot yhteenveto nimi-leveys vuosi-leveys yhteensa-leveys]
-  [grid/grid
-   {:otsikko ""
-    :muokkaa-aina true
-    :voi-muokata? true
-    :muokattava? (constantly true)
-    :voi-poistaa? (constantly false)
-    :voi-lisata? true
-    :voi-kumota? false
-    :piilota-toiminnot? false
-    :tunniste :nimi
-    :muutos #(do
-               (reset! tallenna-painettu false)
-               (reset! grid-tiedot-atom (vals (grid/hae-muokkaustila %)))
-               (reset! virheet-atom (grid/hae-virheet %)))
-    :rivi-jalkeen-fn (fn [rivit]
-                       (let [vuosi-arvot (map :nimi vuositaulukon-otsikot)
-                             yhteenvetorivi (laske-vuosisummat rivit vuosi-arvot)]
-                         ^{:luokka "yhteenveto"}
-                         (lopullinen-yhteenvetorivi "Johto- ja hallintokorvaus yhteensä" yhteenvetorivi)))}
+(defn johto-ja-hallintokorvaukset [e! joha-tiedot vuositaulukon-otsikot vuosi-leveys]
+  (let [urakan-alkuvuosi (pvm/vuosi (-> @tila/yleiset :urakka :alkupvm))]
+    [grid/grid
+        {:otsikko ""
+         :muokkaa-aina true
+         :voi-muokata? true
+         :muokattava? (constantly true)
+         :voi-poistaa? (constantly false)
+         :voi-lisata? true
+         :voi-kumota? false
+         :piilota-toiminnot? false
+         :tunniste :nimi
+         :muutos #(do
+                    (reset! tallenna-painettu false)
+                    (reset! grid-tiedot-atom (vals (grid/hae-muokkaustila %)))
+                    (reset! virheet-atom (grid/hae-virheet %)))
+         :rivi-jalkeen-fn (fn [rivit]
+                            (let [vuosi-arvot (map :nimi vuositaulukon-otsikot)
+                                  yhteenvetorivi (laske-vuosisummat rivit vuosi-arvot)]
+                              ^{:luokka "yhteenveto"}
+                              (lopullinen-yhteenvetorivi "Johto- ja hallintokorvaus yhteensä" yhteenvetorivi)))}
 
-   ;; Otsikot
-   (concat [{:otsikko "Johto- ja hallintokorvaus"
-             :nimi :nimi
-             :tyyppi :valinta
-             :valinnat (map :nimi joha-tiedot)
-             :luokka "yhteensa"
-             :leveys (str nimi-leveys "%")
-             :muokattava? (constantly true)}]
-     [{:otsikko ""
-       :tyyppi :komponentti
-       :komponentti (fn [rivi]
-                      (napit/yleinen "Poista rivi"
-                        :toissijainen
-                        #(poista-rivi e! rivi)
-                        {:ikoni (ikonit/livicon-trash) :luokka "btn-xs"}))
-       :leveys (str vuosi-leveys "%")}]
-     (mapv #(assoc % :muokattava false) vuositaulukon-otsikot)
-     [{:otsikko "Yhteensä (€)" :nimi :yhteensa :tyyppi :euro
-       :muokattava? (constantly false) :luokka "yhteensa"
-       :hae (fn [rivi] (laske-rivit-yhteen rivi))
-       :fmt (fn [arvo] (if arvo (fmt/euro false arvo) 0.00)) :leveys (str yhteensa-leveys "%") :tasaa :oikea}])
-   joha-tiedot])
+        ;; Otsikot
+        (concat [;; ennen 2025 alkaneet urakat eivät voi valita toimenkuvia tästä tarjouslomakkeesta
+                 (if (< urakan-alkuvuosi 2025)
+                   {:otsikko "Johto- ja hallintokorvaus (vain 2025 tai myöhemmin alkaville urakoille)"
+                    :nimi :nimi
+                    :tyyppi :string
+                    :luokka "yhteensa disabled"
+                    :leveys (str nimi-leveys "%")
+                    :muokattava? (constantly false)}
+                   {:otsikko "Johto- ja hallintokorvaus"
+                    :nimi :nimi
+                    :tyyppi :valinta
+                    :valinnat (map :nimi joha-tiedot)
+                    :luokka "yhteensa"
+                    :leveys (str nimi-leveys "%")
+                    :muokattava? (constantly true)})]
+          [;; Poista nappi vain 2025 tai jälkeen alkaneissa urakoissa
+           (if (>= urakan-alkuvuosi 2025)
+            {:otsikko ""
+             :tyyppi :komponentti
+             :komponentti (fn [rivi]
+                            (napit/yleinen "Poista rivi"
+                              :toissijainen
+                              #(poista-rivi e! rivi)
+                              {:ikoni (ikonit/livicon-trash) :luokka "btn-xs"}))
+             :leveys (str vuosi-leveys "%")}
+             {:otsikko ""
+              :tyyppi :komponentti
+              :komponentti (fn [rivi]
+                             [:span])
+              :leveys (str vuosi-leveys "%")})]
+          (mapv #(assoc % :muokattava false) vuositaulukon-otsikot)
+          [{:otsikko "Yhteensä (€)" :nimi :yhteensa :tyyppi :euro
+            :muokattava? (constantly false) :luokka "yhteensa"
+            :hae (fn [rivi] (laske-rivit-yhteen rivi))
+            :fmt (fn [arvo] (if arvo (fmt/euro false arvo) 0.00)) :leveys (str yhteensa-leveys "%") :tasaa :oikea}])
+        joha-tiedot]))
 
 (defn tarjous-nakyma [e! app]
   (let [tarjouksen-tiedot (:tarjous app)
         hoitokausien-maara (count (:hoitovuosittaiset-arvot (first tarjouksen-tiedot)))
-        nimi-leveys 20
-        yhteensa-leveys 20
         vuosi-leveys (/ (- 100 nimi-leveys yhteensa-leveys) hoitokausien-maara)
         ;; Muodostetaan otsikot, jotka voivat olla erilaisia eri mittaisilla urakoilla
         vuositaulukon-otsikot (reduce (fn [rivit vuosi-rivi]
@@ -237,7 +255,7 @@
       [{:nimi "Erillishankinnat" :yhteensa 0 :vuosi-2021 0 :vuosi-2022 0 :vuosi-2023 0 :vuosi-2024 0 :vuosi-2025 0 :eperhoitovuosi 0}]]
 
      ;;Johto- ja hallintokorvaus
-     (johto-ja-hallintokorvaukset e! joha-tiedot vuositaulukon-otsikot yhteenveto nimi-leveys vuosi-leveys yhteensa-leveys)
+     (johto-ja-hallintokorvaukset e! joha-tiedot vuositaulukon-otsikot vuosi-leveys)
 
      ;;Hoidonjohtopalkkio
      [grid/grid

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
@@ -70,68 +70,89 @@
   (let [;; Estetään käyttöliittymässä poistettujen toimenkuvien näkyminen listauksessa, vaikka ei ole vielä tallennettu muutoksia kantaan
         toimenkuvat (remove #(true? (:poistettu %)) joha-tiedot)
         urakan-alkuvuosi (pvm/vuosi (-> @tila/yleiset :urakka :alkupvm))
+        urakan-loppuvuosi (pvm/vuosi (-> @tila/yleiset :urakka :loppupvm))
         ;; Rajaa toimenkuvavalinnaksi vain ne, jotka eivät ole vielä käytössä
         muut-toimenkuvat (filter
                            (fn [toimenkuva]
                              (not (some #(= (:nimi toimenkuva) (:nimi %)) toimenkuvat)))
-                           kaikki-toimenkuvat)]
+                           kaikki-toimenkuvat)
+        vuosiavaimet (flatten (map :nimi vuositaulukon-otsikot))
+        vuosi-map (zipmap vuosiavaimet (repeat 0))]
     [grid/grid
-        {:otsikko ""
-         :muokkaa-aina true
-         :voi-muokata? true
-         :muokattava? (constantly true)
-         :voi-poistaa? (constantly false)
-         :voi-lisata? true
-         :voi-kumota? false
-         :piilota-toiminnot? false
-         :tunniste :nimi
-         :muutos #(do
-                    (reset! tallenna-painettu false)
-                    (reset! tarjous-tiedot/grid-toimenkuvat-atom (vals (grid/hae-muokkaustila %)))
-                    (reset! virheet-atom (grid/hae-virheet %)))
-         :rivi-jalkeen-fn (fn [rivit]
-                            (let [vuosi-arvot (map :nimi vuositaulukon-otsikot)
-                                  yhteenvetorivi (laske-vuosisummat rivit vuosi-arvot)]
-                              ^{:luokka "yhteenveto"}
-                              (lopullinen-yhteenvetorivi "Johto- ja hallintokorvaus yhteensä" yhteenvetorivi)))}
+     {:otsikko ""
+      :muokkaa-aina true
+      :voi-muokata? true
+      :muokattava? (constantly true)
+      :voi-poistaa? (constantly false)
+      :voi-lisata? true
+      :uusi-rivi (fn [rivi]
+                   (merge (assoc rivi :id -1 :nimi "" :yhteensa 0)
+                     vuosi-map))
+      :voi-kumota? false
+      :piilota-toiminnot? false
+      :tunniste :nimi
+      :muutos #(do
+                 (let [toimenkuvat (vals (grid/hae-muokkaustila %))
+                       ;; Jos muutos on ollut uuden rivin lisäys, niin asetetaan valittu toimenkuva
+                       toimenkuvat (map (fn [toimenkuva]
+                                          (if (= -1 (:id toimenkuva))
+                                            (let [uusi-toimenkuva-kaikista (first (filter (fn [t]
+                                                                                            (= (:nimi t) (:nimi toimenkuva)))
+                                                                                    kaikki-toimenkuvat))]
+                                              (assoc toimenkuva
+                                                :osio "johto-ja-hallintokorvaus"
+                                                :poistettu nil
+                                                :yhteensa 0
+                                                :rahavaraus-id nil
+                                                :toimenkuva-id (:id uusi-toimenkuva-kaikista)))
+                                            toimenkuva))
+                                     toimenkuvat)]
+                   (reset! tallenna-painettu false)
+                   (reset! tarjous-tiedot/grid-toimenkuvat-atom toimenkuvat)
+                   (reset! virheet-atom (grid/hae-virheet %))))
+      :rivi-jalkeen-fn (fn [rivit]
+                         (let [vuosi-arvot (map :nimi vuositaulukon-otsikot)
+                               yhteenvetorivi (laske-vuosisummat rivit vuosi-arvot)]
+                           ^{:luokka "yhteenveto"}
+                           (lopullinen-yhteenvetorivi "Johto- ja hallintokorvaus yhteensä" yhteenvetorivi)))}
 
-        ;; Otsikot
-        (concat [;; ennen 2025 alkaneet urakat eivät voi valita toimenkuvia tästä tarjouslomakkeesta
-                 (if (< urakan-alkuvuosi 2025)
-                   {:otsikko "Johto- ja hallintokorvaus (vain 2025 tai myöhemmin alkaville urakoille)"
-                    :nimi :nimi
-                    :tyyppi :string
-                    :luokka "yhteensa disabled"
-                    :leveys (str nimi-leveys "%")
-                    :muokattava? (constantly false)}
-                   {:otsikko "Johto- ja hallintokorvaus"
-                    :nimi :nimi
-                    :tyyppi :valinta
-                    ;:valinnat #(map :nimi (conj muut-toimenkuvat %))
-                    :valinnat-fn #(map :nimi muut-toimenkuvat)
-                    :luokka "yhteensa"
-                    :leveys (str nimi-leveys "%")
-                    :muokattava? (constantly true)})]
-          [;; Poista nappi vain 2025 tai jälkeen alkaneissa urakoissa
-           (if (>= urakan-alkuvuosi 2025)
-             {:otsikko ""
-              :tyyppi :komponentti
-             :komponentti (fn [rivi]
-                            (napit/yleinen "Poista rivi"
-                              :toissijainen
-                              #(e! (tarjous-tiedot/->PoistaToimenkuva rivi))
-                              {:ikoni (ikonit/livicon-trash) :luokka "btn-xs"}))
-             :leveys (str vuosi-leveys "%")}
-             {:otsikko ""
-              :tyyppi :komponentti
-              :komponentti (fn [rivi]
-                             [:span])
-              :leveys (str vuosi-leveys "%")})]
-          (mapv #(assoc % :muokattava false) vuositaulukon-otsikot)
-          [{:otsikko "Yhteensä (€)" :nimi :yhteensa :tyyppi :euro
-            :muokattava? (constantly false) :luokka "yhteensa"
-            :hae (fn [rivi] (laske-rivit-yhteen rivi))
-            :fmt (fn [arvo] (if arvo (fmt/euro false arvo) 0.00)) :leveys (str yhteensa-leveys "%") :tasaa :oikea}])
+     ;; Otsikot
+     (concat [;; ennen 2025 alkaneet urakat eivät voi valita toimenkuvia tästä tarjouslomakkeesta
+              (if (< urakan-alkuvuosi 2025)
+                {:otsikko "Johto- ja hallintokorvaus (vain 2025 tai myöhemmin alkaville urakoille)"
+                 :nimi :nimi
+                 :tyyppi :string
+                 :luokka "yhteensa disabled"
+                 :leveys (str nimi-leveys "%")
+                 :muokattava? (constantly false)}
+                {:otsikko "Johto- ja hallintokorvaus"
+                 :nimi :nimi
+                 :tyyppi :valinta
+                 ;:valinnat #(map :nimi (conj muut-toimenkuvat %))
+                 :valinnat-fn #(map :nimi muut-toimenkuvat)
+                 :luokka "yhteensa"
+                 :leveys (str nimi-leveys "%")
+                 :muokattava? (constantly true)})]
+       [;; Poista nappi vain 2025 tai jälkeen alkaneissa urakoissa
+        (if (>= urakan-alkuvuosi 2025)
+          {:otsikko ""
+           :tyyppi :komponentti
+           :komponentti (fn [rivi]
+                          (napit/yleinen "Poista rivi"
+                            :toissijainen
+                            #(e! (tarjous-tiedot/->PoistaToimenkuva rivi))
+                            {:ikoni (ikonit/livicon-trash) :luokka "btn-xs"}))
+           :leveys (str vuosi-leveys "%")}
+          {:otsikko ""
+           :tyyppi :komponentti
+           :komponentti (fn [rivi]
+                          [:span])
+           :leveys (str vuosi-leveys "%")})]
+       (mapv #(assoc % :muokattava false) vuositaulukon-otsikot)
+       [{:otsikko "Yhteensä (€)" :nimi :yhteensa :tyyppi :euro
+         :muokattava? (constantly false) :luokka "yhteensa"
+         :hae (fn [rivi] (laske-rivit-yhteen rivi))
+         :fmt (fn [arvo] (if arvo (fmt/euro false arvo) 0.00)) :leveys (str yhteensa-leveys "%") :tasaa :oikea}])
      toimenkuvat]))
 
 (defn tarjous-nakyma [e! app]

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
@@ -21,7 +21,7 @@
    [napit/yleinen-toissijainen "Tyhjennä"
     #(do
        (reset! tallenna-painettu false)
-       (e! (tarjous-tiedot/->HaeTarjouksenTiedot)))
+       (e! (tarjous-tiedot/->HaeTyhjatTarjouksenTiedot)))
     {:disabled (or tallennus-kesken? false)}]
    [napit/yleinen-ensisijainen "Tallenna muutokset"
     #(do

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
@@ -15,7 +15,6 @@
 
 (defonce tallenna-painettu (atom false))
 (defonce virheet-atom (atom {}))
-(defonce grid-tiedot-atom (atom [{}]))
 ;; Määritellään kaikkien kolumnien leveyksiä
 (def nimi-leveys 20)
 (def yhteensa-leveys 20)
@@ -30,7 +29,7 @@
    [napit/yleinen-ensisijainen "Tallenna muutokset"
     #(do
        (reset! tallenna-painettu false)
-       (e! (tarjous-tiedot/->TallennaTarjouksenTiedot @grid-tiedot-atom)))
+       (e! (tarjous-tiedot/->TallennaTarjouksenTiedot @tarjous-tiedot/grid-tiedot-atom @tarjous-tiedot/grid-toimenkuvat-atom)))
     {:disabled (or tallennus-kesken? false)}]])
 
 (defn- lopullinen-yhteenvetorivi [otsikko rivi]
@@ -41,10 +40,6 @@
                   {:teksti ""
                    :luokka "yhteensa lihavoitu"}]
              rivi)))
-;; Lisätään vielä yhteenveto yhteenvetoriviin)
-
-(defn poista-rivi [e! rivi]
-  (e! (tarjous-tiedot/->PoistaRivi rivi)))
 
 (defn laske-rivit-yhteen [rivi]
   (let [kustannukset (vals (filter #(str/starts-with? (name (key %)) "vuosi-") rivi))]
@@ -71,8 +66,15 @@
                    :fmt fmt/euro-opt})]
     v))
 
-(defn johto-ja-hallintokorvaukset [e! joha-tiedot vuositaulukon-otsikot vuosi-leveys]
-  (let [urakan-alkuvuosi (pvm/vuosi (-> @tila/yleiset :urakka :alkupvm))]
+(defn johto-ja-hallintokorvaukset [e! joha-tiedot kaikki-toimenkuvat vuositaulukon-otsikot vuosi-leveys]
+  (let [;; Estetään käyttöliittymässä poistettujen toimenkuvien näkyminen listauksessa, vaikka ei ole vielä tallennettu muutoksia kantaan
+        toimenkuvat (remove #(true? (:poistettu %)) joha-tiedot)
+        urakan-alkuvuosi (pvm/vuosi (-> @tila/yleiset :urakka :alkupvm))
+        ;; Rajaa toimenkuvavalinnaksi vain ne, jotka eivät ole vielä käytössä
+        muut-toimenkuvat (filter
+                           (fn [toimenkuva]
+                             (not (some #(= (:nimi toimenkuva) (:nimi %)) toimenkuvat)))
+                           kaikki-toimenkuvat)]
     [grid/grid
         {:otsikko ""
          :muokkaa-aina true
@@ -85,7 +87,7 @@
          :tunniste :nimi
          :muutos #(do
                     (reset! tallenna-painettu false)
-                    (reset! grid-tiedot-atom (vals (grid/hae-muokkaustila %)))
+                    (reset! tarjous-tiedot/grid-toimenkuvat-atom (vals (grid/hae-muokkaustila %)))
                     (reset! virheet-atom (grid/hae-virheet %)))
          :rivi-jalkeen-fn (fn [rivit]
                             (let [vuosi-arvot (map :nimi vuositaulukon-otsikot)
@@ -105,18 +107,19 @@
                    {:otsikko "Johto- ja hallintokorvaus"
                     :nimi :nimi
                     :tyyppi :valinta
-                    :valinnat (map :nimi joha-tiedot)
+                    ;:valinnat #(map :nimi (conj muut-toimenkuvat %))
+                    :valinnat-fn #(map :nimi muut-toimenkuvat)
                     :luokka "yhteensa"
                     :leveys (str nimi-leveys "%")
                     :muokattava? (constantly true)})]
           [;; Poista nappi vain 2025 tai jälkeen alkaneissa urakoissa
            (if (>= urakan-alkuvuosi 2025)
-            {:otsikko ""
-             :tyyppi :komponentti
+             {:otsikko ""
+              :tyyppi :komponentti
              :komponentti (fn [rivi]
                             (napit/yleinen "Poista rivi"
                               :toissijainen
-                              #(poista-rivi e! rivi)
+                              #(e! (tarjous-tiedot/->PoistaToimenkuva rivi))
                               {:ikoni (ikonit/livicon-trash) :luokka "btn-xs"}))
              :leveys (str vuosi-leveys "%")}
              {:otsikko ""
@@ -129,7 +132,7 @@
             :muokattava? (constantly false) :luokka "yhteensa"
             :hae (fn [rivi] (laske-rivit-yhteen rivi))
             :fmt (fn [arvo] (if arvo (fmt/euro false arvo) 0.00)) :leveys (str yhteensa-leveys "%") :tasaa :oikea}])
-        joha-tiedot]))
+     toimenkuvat]))
 
 (defn tarjous-nakyma [e! app]
   (let [tarjouksen-tiedot (:tarjous app)
@@ -151,25 +154,10 @@
                                                           :tasaa :oikea}])))
                                 [] (:hoitovuosittaiset-arvot (first tarjouksen-tiedot)))
 
-        ;; Riittää, että käytetään esimerkkinä ensimmäistä riviä
-        ;; Otetaan taulukosta yhteenvetorivi pois ennen käsittelyä
-        yhteenveto (last tarjouksen-tiedot)
-        yhteenveto-rivit (reduce (fn [y rivi]
-                                   (conj y {:teksti (fmt/euro false (:summa rivi)) :tasaa :oikea :luokka "yhteensa lihavoitu"}))
-                           [{:teksti "Kaikki hankinnat yhteensä" :luokka "yhteensa lihavoitu" :yhteenveto-vayla true :tyyppi :euro :fmt #(fmt/euro false %)}]
-                           (:hoitovuosittaiset-arvot yhteenveto))
-        ;; Lisätään vielä yhteenveto yhteenvetoriviin
-        yhteenveto-rivit (conj yhteenveto-rivit
-                           {:teksti (if (:yhteensa yhteenveto) (fmt/euro false (:yhteensa yhteenveto)) "0,00")
-                            :luokka "yhteensa lihavoitu"
-                            :tasaa :oikea
-                            :tyyppi :euro
-                            :fmt #(fmt/euro false %)
-                            :muokattava? false
-                            :rivi-disabled? true})
         taulukon-tiedot (into [] (reduce (fn [rivit tarjous-rivi]
                                            (let [vuosiarvot (reduce (fn [uusi rivi]
                                                                       (-> uusi
+                                                                        (assoc :poistettu (:poistettu tarjous-rivi))
                                                                         (assoc :rahavaraus-id (:rahavaraus-id tarjous-rivi))
                                                                         (assoc :toimenkuva-id (:toimenkuva-id tarjous-rivi))
                                                                         (assoc :tehtava-id (:tehtava-id tarjous-rivi))
@@ -204,7 +192,7 @@
        :tunniste :nimi
        :muutos #(do
                   (reset! tallenna-painettu false)
-                  (reset! grid-tiedot-atom (vals (grid/hae-muokkaustila %)))
+                  (reset! tarjous-tiedot/grid-tiedot-atom (vals (grid/hae-muokkaustila %)))
                   (reset! virheet-atom (grid/hae-virheet %)))
        :rivi-jalkeen-fn (fn [rivit]
                           (let [vuosi-arvot (map :nimi vuositaulukon-otsikot)
@@ -240,7 +228,7 @@
        :tunniste :nimi
        :muutos #(do
                   (reset! tallenna-painettu false)
-                  (reset! grid-tiedot-atom (vals (grid/hae-muokkaustila %)))
+                  (reset! tarjous-tiedot/grid-tiedot-atom (vals (grid/hae-muokkaustila %)))
                   (reset! virheet-atom (grid/hae-virheet %)))}
       (concat [{:otsikko "Erillishankinnat" :nimi :nimi :tyyppi :string :luokka "yhteensa" :leveys (str nimi-leveys "%") :muokattava? (constantly false)}]
         [{:otsikko "€ / hoitovuosi" :nimi :eperhoitovuosi :tyyppi :euro :leveys (str vuosi-leveys "%") :muokattava? (constantly true)}]
@@ -255,7 +243,7 @@
       [{:nimi "Erillishankinnat" :yhteensa 0 :vuosi-2021 0 :vuosi-2022 0 :vuosi-2023 0 :vuosi-2024 0 :vuosi-2025 0 :eperhoitovuosi 0}]]
 
      ;;Johto- ja hallintokorvaus
-     (johto-ja-hallintokorvaukset e! joha-tiedot vuositaulukon-otsikot vuosi-leveys)
+     (johto-ja-hallintokorvaukset e! joha-tiedot (:kaikki-toimenkuvat app) vuositaulukon-otsikot vuosi-leveys)
 
      ;;Hoidonjohtopalkkio
      [grid/grid
@@ -270,7 +258,7 @@
        :tunniste :nimi
        :muutos #(do
                   (reset! tallenna-painettu false)
-                  (reset! grid-tiedot-atom (vals (grid/hae-muokkaustila %)))
+                  (reset! tarjous-tiedot/grid-tiedot-atom (vals (grid/hae-muokkaustila %)))
                   (reset! virheet-atom (grid/hae-virheet %)))
        :rivi-jalkeen-fn nil}
 
@@ -302,7 +290,7 @@
        :tunniste :nimi
        :muutos #(do
                   (reset! tallenna-painettu false)
-                  (reset! grid-tiedot-atom (vals (grid/hae-muokkaustila %)))
+                  (reset! tarjous-tiedot/grid-tiedot-atom (vals (grid/hae-muokkaustila %)))
                   (reset! virheet-atom (grid/hae-virheet %)))
        :rivi-jalkeen-fn nil}
 

--- a/test/clj/harja/palvelin/palvelut/suunnittelu/apurit.clj
+++ b/test/clj/harja/palvelin/palvelut/suunnittelu/apurit.clj
@@ -1,33 +1,33 @@
 (ns harja.palvelin.palvelut.suunnittelu.apurit)
 
 (def tarjous-tietomalli {:tarjous [{:nimi "Kilpailutettavat hankinnat", :osio "hankintakustannukset" :toimenkuva-id nil :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil
-                                    :hoitovuosittaiset-arvot [{:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}] :yhteensa 60.00}
+                                    :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}] :yhteensa 60.00}
                                    ;; Rahavaraukset
                                    {:nimi "Äkilliset hoitotyöt", :osio "tavoitehintaiset-rahavaraukset" :toimenkuva-id nil :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id 1
-                                    :hoitovuosittaiset-arvot [{:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}] :yhteensa 60.00}
+                                    :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}] :yhteensa 60.00}
                                    {:nimi "Vahinkojen korjaukset", :osio "tavoitehintaiset-rahavaraukset" :toimenkuva-id nil :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id 2
-                                    :hoitovuosittaiset-arvot [{:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}] :yhteensa 60.00}
+                                    :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}] :yhteensa 60.00}
                                    {:nimi "Tilaajan rahavaraus kannustinjärjestelmään", :osio "tavoitehintaiset-rahavaraukset" :toimenkuva-id nil :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id 3
-                                    :hoitovuosittaiset-arvot [{:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}] :yhteensa 60.00}
+                                    :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}] :yhteensa 60.00}
 
                                    ;; Erillishankinnat
                                    {:nimi "Erillishankinnat", :osio "erillishankinnat" :toimenkuva-id nil :tehtava-id nil :tehtavaryhma-id 28 :rahavaraus-id nil
-                                    :hoitovuosittaiset-arvot [{:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}], :yhteensa 60.00}
+                                    :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}], :yhteensa 60.00}
 
                                    ;; Johto ja hallintokorvaukset eli toimenkuvat
                                    {:nimi "Vastuunalainen työnjohtaja", :osio "johto-ja-hallintokorvaus" :toimenkuva-id 2 :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil
-                                    :hoitovuosittaiset-arvot [{:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}], :yhteensa 60.00}
+                                    :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}], :yhteensa 60.00}
                                    {:nimi "Apulainen/työnjohtaja", :osio "johto-ja-hallintokorvaus" :toimenkuva-id 4 :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil
-                                    :hoitovuosittaiset-arvot [{:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}], :yhteensa 60.00}
+                                    :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}], :yhteensa 60.00}
                                    {:nimi "Valmistelukausi ennen urakka-ajan alkua", :osio "johto-ja-hallintokorvaus" :toimenkuva-id 10 :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil
-                                    :hoitovuosittaiset-arvot [{:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}], :yhteensa 60.00}
+                                    :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}], :yhteensa 60.00}
 
                                    ;; Hoidonjohtopalkkio
                                    {:nimi "Hoidonjohtopalkkio", :osio "hoidonjohtopalkkio" :toimenkuva-id nil :tehtava-id 3061 :tehtavaryhma-id nil :rahavaraus-id nil
-                                    :hoitovuosittaiset-arvot [{:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}], :yhteensa 60.00}
+                                    :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}], :yhteensa 60.00}
                                    ;; Yhteensä rivi
                                    {:nimi "Yhteensä tavoitehinta", :osio "yhteensa"
-                                    :hoitovuosittaiset-arvot [{:vuosi 2023 :summa 90.00} {:vuosi 2024 :summa 180.00} {:vuosi 2025 :summa 270.00}], :yhteensa 540.00}]})
+                                    :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 90.00} {:vuosi 2024 :summa 180.00} {:vuosi 2025 :summa 270.00}], :yhteensa 540.00}]})
 
 (defn muodosta-tarjous-rahavarauksista [rahavaraukset vuodet]
   {:tarjous (mapv

--- a/test/clj/harja/palvelin/palvelut/suunnittelu/tarjous_test.clj
+++ b/test/clj/harja/palvelin/palvelut/suunnittelu/tarjous_test.clj
@@ -89,9 +89,10 @@
         ;; Tallenna tarjous kantaan
         vuosittaiset-tarjoushinnat (tarjous-kyselyt/tallenna-tarjous-tietokantaan db urakka-id kayttaja-id kattohintakerroin tarjous)
         ;; Hae tarjous tietokannasta
-        tarjous-rivit-tietokannasta (:tarjous (tarjous-kyselyt/hae-tarjous db urakka-id))]
+        tarjousdb (tarjous-kyselyt/hae-tarjous db urakka-id)
+        tarjous-rivit-tietokannasta (filter #(contains? #{"tavoitehintaiset-rahavaraukset"} (:osio %)) (:tarjous tarjousdb))]
 
-    (is (= (count (butlast tarjous-rivit-tietokannasta)) (count rahavaraukset)) "Rahavarausten lisäksi tarjous palauttaa yhteenvetorivin.")))
+    (is (= (count tarjous-rivit-tietokannasta) (count rahavaraukset)) "Rahavarausten lisäksi tarjous palauttaa yhteenvetorivin.")))
 
 (deftest tallenna-laajat-kustannukset-ja-hae-kustannukset-tarjoukselle-onnistuu
   (let [db (:db jarjestelma)
@@ -110,17 +111,18 @@
         tarjous (update tarjous :tarjous (fn [rivit]
                                            (vec (concat rivit
                                                   [{:nimi "Erillishankinnat", :osio "erillishankinnat" :toimenkuva-id nil :tehtava-id nil :tehtavaryhma-id 28 :rahavaraus-id nil
-                                                    :hoitovuosittaiset-arvot [{:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}], :yhteensa 60.00}
+                                                    :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}], :yhteensa 60.00}
                                                    {:nimi "Kilpailutettavat hankinnat", :osio "hankintakustannukset" :toimenkuva-id nil :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil
-                                                    :hoitovuosittaiset-arvot [{:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}] :yhteensa 60.00}
+                                                    :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}] :yhteensa 60.00}
                                                    {:nimi "Hoidonjohtopalkkio", :osio "hoidonjohtopalkkio" :toimenkuva-id nil :tehtava-id 3061 :tehtavaryhma-id nil :rahavaraus-id nil
-                                                    :hoitovuosittaiset-arvot [{:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}], :yhteensa 60.00}]))))
+                                                    :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}], :yhteensa 60.00}]))))
         ;; Tallenna tarjous kantaan
         _ (tarjous-kyselyt/tallenna-tarjous-tietokantaan db urakka-id kayttaja-id kattohintakerroin tarjous)
         ;; Hae tarjous tietokannasta
-        tarjoukset-tietokannasta (:tarjous (tarjous-kyselyt/hae-tarjous db urakka-id))]
+        tarjousdb (tarjous-kyselyt/hae-tarjous db urakka-id)
+        tarjoukset-tietokannasta (filter #(contains? #{"tavoitehintaiset-rahavaraukset" "erillishankinnat" "hoidonjohtopalkkio" "hankintakustannukset"} (:osio %)) (:tarjous tarjousdb))]
     ;; Varmistetaan, että tietokannasta löytyy oikea määrä rivejä
-    (is (= (count (butlast tarjoukset-tietokannasta)) (+ 3 (count rahavaraukset))))))
+    (is (= (count tarjoukset-tietokannasta) (+ 3 (count rahavaraukset))))))
 
 (deftest tallenna-hankintoja-tarjoukselle-onnistuu
   (let [db (:db jarjestelma)
@@ -231,7 +233,7 @@
         muokattu-tarjous (assoc-in tarjous [:tarjous 0 :hoitovuosittaiset-arvot 0 :summa] uusi-summa)
         muokkausvastaus (kutsu-palvelua (:http-palvelin jarjestelma) :tallenna-tarjouksen-tiedot +kayttaja-jvh+ muokattu-tarjous)
         muokkausvastaus-kustannus (first (:tarjous muokkausvastaus))]
-    (is (= 10.00 (get-in ensivastaus-kustannus [:hoitovuosittaiset-arvot 0 :summa])))
+    (is (= 10.00 (get-in ensivastaus-kustannus [:hoitovuosittaiset-arvot 2 :summa])) "Vuoden 2023 summa on 10")
     (is (= uusi-summa (bigdec (get-in muokkausvastaus-kustannus [:hoitovuosittaiset-arvot 0 :summa]))))
     ;; Ensivastauksen rivimäärä on sama
     (is (= (count (:tarjous apurit/tarjous-tietomalli)) (count (:tarjous ensivastaus))))


### PR DESCRIPTION
Tämä on välipr. Toimenkuvat osio ei ole vielä täysin valmis, mutta toiminnallisuutta on tässä jo lisätty.
Tehdään välipr, jotta vältetään myöhemmin mergekonflikteilta.

Tässä PR:ssä toteutettua.

1. Toimenkuvat grid erotettu omaksi funktiokseen.
2. Toimenkuvat gridin atomi eroteltu muista lomakkeen tiedoista ja sen kautta toimenkuvia voi nyt muokata bäkkäriin asti. Tämä muutos pitää ulottaa muissa pr:ssiä myöhemmin myös muihin grideihin.
3. Toimenkuvat tulevat nyt tietokannasta urakka/vuosikohtaisesti. Ne eivät ole enää kovakoodattuja.
4. Hallintapuolen toimenkuvat ja tarjouspuolen toimenkuvat eivät ole vielä täysin yhteneväiset. Tämän työstö jatkuu myöemmin.
5. 19-24 alkaneille urakoille toimenpidenäkymä on erilainen kuin -25+ urakoille. Vain -25+ urakoiden toimenkuvia voi muokata alasvetovalikoilla
6. Toimenkuvia voi nyt lisätä -25 urakoille. Tämä mahdollisuus todennäköisesti pitää lisätä myös 19-24 urakoille.
7. Toimenkuvia voi nyt poistaa käyttöliittymän kautta ihan bäkkäristä asti.
