### PR TITLE
Muutoksia Muutosten historian tietomalliin

### DIFF
--- a/.github/actions/setup-build-env-and-tools/action.yml
+++ b/.github/actions/setup-build-env-and-tools/action.yml
@@ -73,13 +73,27 @@ runs:
 #      with:
 #        #lein: 2.9.8
 
+
+    - name: Prepare nodejs
+      if: ${{ inputs.install-node-deps == 'true' }}
+      uses: actions/setup-node@v5
+      with:
+        # Haetaan nodejs versio package.json "engines" kentästä
+        node-version-file: 'package.json'
+        # Halutaan täysi kontrolli cachettamista, joten ei käytetä actionin omaa cachetusta
+        package-manager-cache: false
+        #cache: 'npm'
+
     # https://www.voorhoede.nl/en/blog/super-fast-npm-install-on-github-actions/
     - name: Cache NPM packages
       id: cache-npm
       uses: actions/cache@v4
       if: ${{ inputs.install-node-deps == 'true' }}
       with:
-        path: ~/.npm
+        # Cypress cachettaa binaryn omaan pathiin, https://docs.cypress.io/app/references/advanced-installation#Binary-cache
+        path: | 
+          ~/.npm
+          ~/.cache/Cypress
         key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
         # TODO: Testaa onko "restore-keys" enää tarpeen. Kommentoitu pois toistaiseksi.
         #       Halutaan, että uusi cache tallennetaan mikäli package-lock.json muuttuu, ja nyt sellaista ei

--- a/.github/docker/docker-compose.yml
+++ b/.github/docker/docker-compose.yml
@@ -66,30 +66,6 @@ services:
       start_period: 20s
       timeout: 10s
 
-  # Huom. Uudempi flyway v10 ei toimi enää tässä imagessa
-  harjadb-13-3.1:
-    image: ghcr.io/finnishtransportagency/harja_harjadb:13-3.1
-
-    container_name: harjadb
-    networks:
-      - harja_net
-    environment:
-      HARJA_TIETOKANTA_PORTTI: 5432
-    ports:
-      - "127.0.0.1:5432:5432"
-    # Estetään IPv6 käyttö, jotta testitietokannan migraatioiden ajossa ei tule yhteysongelmia
-    sysctls:
-      - net.ipv6.conf.all.disable_ipv6=1
-    # Huom: Mountissa viitataan Harja-repon juuressa olevaan tietokanta-hakemistoon, jossa migraatiotiedostot ovat.
-    volumes:
-      - ../../tietokanta:/var/lib/postgresql/harja/tietokanta
-    healthcheck:
-      test: [ "CMD", "pg_isready", "-U", "harja", "-d", "harja" ]
-      interval: 10s
-      retries: 5
-      start_period: 20s
-      timeout: 10s
-
 # Deprekoitu ActiveMQ Classic broker
 #  activemq-itmf:
 #    image: ghcr.io/finnishtransportagency/harja_activemq:latest

--- a/.github/workflows/harja_test_pr.yml
+++ b/.github/workflows/harja_test_pr.yml
@@ -31,14 +31,9 @@ jobs:
       checks: write
 
     with:
-      # HUOM: PR:t Testataan vanhemmalla PostgreSQL-versiolla, jotta on-prem ympäristöön ei lipsahda
-      #       siirtymäaikana vain uudemmissa PostgreSQL-versioissa toimivia kantamuutoksia, jotka voivat rikkoa
-      #       Harjan toimintoja on-prem ympäristössä
-      #       On-prem ympäristön deployment tapahtuu automaattisesti eri ympäristössä kuin GH Actions, joten
-      #       deploymenttiä ei voi täällä rajoittaa GH Actions testitulosten perusteella.
 
       # Katso saatavilla olevat harjadb servicet docker-compose.yml:stä
-      test-db-service: harjadb-13.13-3.3.3
+      test-db-service: harjadb-latest
       e2e-browsers: "['chrome']"
       # PR-testeissä ajetaan vain kevyt build ja testauksen kannalta epärelevantit osat on jätetty pois.
       build-harja: 'light'

--- a/src/clj/harja/kyselyt/muutos_kyselyt.sql
+++ b/src/clj/harja/kyselyt/muutos_kyselyt.sql
@@ -91,8 +91,7 @@ RETURNING id, versio;
 
 -- name: paivita-muutos<!
 UPDATE ONLY mhu_muutos
-   SET versio = versio + 1,
-       muokattu = NOW(),
+   SET muokattu = NOW(),
        muokkaaja = :kayttaja,
        nimi = :nimi,
        tyyppi = :tyyppi::MHU_MUUTOSTYYPPI,

--- a/tietokanta/src/main/resources/db/migration/R__Mhu_muutokset.sql
+++ b/tietokanta/src/main/resources/db/migration/R__Mhu_muutokset.sql
@@ -1,7 +1,8 @@
-DROP TRIGGER IF EXISTS mhu_muutos_historia_trigger ON mhu_muutos;
+-- Kaikki muutokset-tietorakenteen historian tallennukseen liittyvät funktiot ja triggerit
 
 CREATE OR REPLACE FUNCTION paivita_mhu_muutos_historia()
-    RETURNS TRIGGER AS $$
+    RETURNS TRIGGER AS
+$$
 BEGIN
     INSERT INTO mhu_muutos_historia
     VALUES (OLD.*);
@@ -12,12 +13,69 @@ BEGIN
        AND versio = OLD.versio;
 
     NEW.validi_aikana = TSTZRANGE(CURRENT_TIMESTAMP, 'infinity');
+    NEW.versio = OLD.versio + 1;
 
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER mhu_muutos_historia_trigger
-    BEFORE UPDATE OR DELETE ON mhu_muutos
+CREATE OR REPLACE TRIGGER mhu_muutos_historia_trigger
+    BEFORE UPDATE OR DELETE
+    ON mhu_muutos
     FOR EACH ROW
 EXECUTE FUNCTION paivita_mhu_muutos_historia();
+
+
+--
+
+CREATE OR REPLACE FUNCTION paivita_mhu_muutos_liite_historia()
+    RETURNS TRIGGER AS
+$$
+BEGIN
+    INSERT INTO mhu_muutos_liite_historia
+    VALUES (OLD.*);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER mhu_muutos_liite_historia_trigger
+    BEFORE UPDATE OR DELETE
+    ON mhu_muutos_liite
+    FOR EACH ROW
+EXECUTE FUNCTION paivita_mhu_muutos_liite_historia();
+
+--
+
+CREATE OR REPLACE FUNCTION paivita_mhu_muutos_kustannusvaikutus_historia()
+    RETURNS TRIGGER AS
+$$
+BEGIN
+    INSERT INTO mhu_muutos_kustannusvaikutus_historia
+    VALUES (OLD.*);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER paivita_mhu_muutos_kustannusvaikutus_historia_trigger
+    BEFORE UPDATE OR DELETE
+    ON mhu_muutos_kustannusvaikutus
+    FOR EACH ROW
+EXECUTE FUNCTION paivita_mhu_muutos_kustannusvaikutus_historia();
+
+--
+
+CREATE OR REPLACE FUNCTION paivita_mhu_muutos_tehtava_ja_maaraluettelo_historia()
+    RETURNS TRIGGER AS
+$$
+BEGIN
+    INSERT INTO mhu_muutos_tehtava_ja_maaraluettelo_historia
+    VALUES (OLD.*);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER mhu_muutos_tehtava_ja_maaraluettelo_historia_trigger
+    BEFORE UPDATE OR DELETE
+    ON mhu_muutos_tehtava_ja_maaraluettelo
+    FOR EACH ROW
+EXECUTE FUNCTION paivita_mhu_muutos_tehtava_ja_maaraluettelo_historia();

--- a/tietokanta/src/main/resources/db/migration/V1_1404__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1404__.sql
@@ -1,0 +1,48 @@
+DROP TABLE IF EXISTS mhu_muutos_historia;
+DROP TABLE IF EXISTS mhu_muutos_liite_historia;
+DROP TABLE IF EXISTS mhu_muutos_kustannusvaikutus_historia;
+DROP TABLE IF EXISTS mhu_muutos_tehtava_ja_maaraluettelo_historia;
+DROP TABLE IF EXISTS mhu_muutos_kulu_historia;
+
+
+-- TODO: Tarkista mitä asioita ei haluta kopioida historiatauluihin LIKE komennolla käyttäen EXCLUDING
+-- Historiataulut --
+-- https://www.postgresql.org/docs/current/sql-createtable.html#SQL-CREATETABLE-PARMS-LIKE
+
+CREATE TABLE mhu_muutos_historia
+(
+    LIKE mhu_muutos EXCLUDING CONSTRAINTS EXCLUDING INDEXES
+);
+-- Varmistetaan että samaa (id, versio)-yhdistelmää on vain yksi
+CREATE UNIQUE INDEX mhu_muutos_historia_id_versio ON mhu_muutos_historia (id, versio);
+
+-- Tee validi_aikana sarakkeelle indeksi
+CREATE INDEX mhu_muutos_historia_validi_idx ON mhu_muutos_historia USING GIST (validi_aikana);
+
+--
+
+CREATE TABLE mhu_muutos_liite_historia
+(
+    LIKE mhu_muutos_liite EXCLUDING CONSTRAINTS EXCLUDING INDEXES
+);
+
+--
+
+CREATE TABLE mhu_muutos_kustannusvaikutus_historia
+(
+    LIKE mhu_muutos_kustannusvaikutus EXCLUDING CONSTRAINTS EXCLUDING INDEXES
+);
+
+--
+
+CREATE TABLE mhu_muutos_tehtava_ja_maaraluettelo_historia
+(
+    LIKE mhu_muutos_tehtava_ja_maaraluettelo EXCLUDING CONSTRAINTS EXCLUDING INDEXES
+);
+
+--
+
+CREATE TABLE mhu_muutos_kulu_historia
+(
+    LIKE mhu_muutos_kulu EXCLUDING CONSTRAINTS EXCLUDING INDEXES
+);


### PR DESCRIPTION
**TODO: Sulje PR**

Voidaan mergettää myöhemmin, eikä ole vielä kiire tämän kanssa.

Merge voidaan tehdä esimerkiksi sen jälkeen, kun pysyvät muutokset on saatu developpiin.
Ideaalitilanne mergettämiselle on siinä kohtaa, kun muutosten päätauluihin ei tule enää isompia muutoksia -> voidaan ajaa niiden jälkeen tietomallin historiataulujen muutoksia sisältävä migraatio.

Sisältää myös korjauksia CI-putkeen:
1. Jatkossa PR-testeissä käytetään uudempaa 15.x PosgreSQL-tietokantaa
   * Pilvisiirtymän jälkeen ei ole enää tarvetta varmistaa yhteensopivuutta vanhemman ja uudemman PostgreSQL versioiden välillä. Voidaan huoletta alkaa käyttämään Harjan laajuisesti kaikkia PostgreSQL 15.x ominaisuuksia.
2. Cypress-binäärin korruptoituneisiin latauksiin tehty korjaus cachettamalla binääri, jolloin binääriä ei tarvitse ladata joka kerta uusiksi, kun kutsutaan ```npm ci``` testiputkessa. Tämä vähentää korruptoituneen latauksen esiintyvyyttä, koska binäärin latauksia tehdään huomattavasti vähemmän ulkoverkosta ci-putkeen.