### PR TITLE
Harja 1662 Tarjousnäkymän toimenkuvat - osa2

### DIFF
--- a/cypress/e2e/uusi_kustannussuunnitelma.cy.js
+++ b/cypress/e2e/uusi_kustannussuunnitelma.cy.js
@@ -29,23 +29,28 @@ function tarkistaToimenpideLuvut(toimenpide, luku1, luku2) {
         .should('have.value', luku2);
 }
 
-function tarkistaRahavarausLuvut(rahavaraus, luku1, luku2) {
+function tarkistaRahavarausLuvut(rahavaraus, luku1, luku2, luku3,) {
+    cy.get('#rahavaraukset-elementti table.grid')
+        .contains('td', rahavaraus)
+        .closest('tr')
+        .find('td').eq(1)
+        .contains(luku1);
     // Tyhjät arvot on parempi tarkistaa näin
-    if(luku1 === '') {
+    if(luku2 === '') {
        // Ei tarvitse tarkastaa mitään.
     } else {
         cy.get('#rahavaraukset-elementti table.grid')
             .contains('td', rahavaraus)
             .closest('tr')
-            .find('td').eq(1)
-            .contains(luku1);
+            .find('td').eq(2)
+            .contains(luku2);
     }
     // Indeksikorjattu luku
     cy.get('#rahavaraukset-elementti table.grid')
         .contains('td', rahavaraus)
         .closest('tr')
-        .find('td').eq(2)
-        .contains(luku2);
+        .find('td').eq(3)
+        .contains(luku3);
 }
 
 function tarkistaErillishankinnanLuvut(kuukausi, luku1, luku2) {
@@ -227,9 +232,9 @@ describe('Tavoitehintaiset rahavaraukset osio', function () {
 
             // Löytyyhän lukuja - Olisi hyvä, jos tarjouspuolella käytäisiin lisäämässä jotain, mitä tässä verrata,
             // mutta tätä tehtäessä tarjouspuoli on vielä niin kesken, ettei kannata vielä tehdä sinne cypress-testejä
-            tarkistaRahavarausLuvut('Tilaajan rahavaraus kannustinjärjestelmään', '', '-');
-            tarkistaRahavarausLuvut('Äkilliset hoitotyöt', '', '-');
-            tarkistaRahavarausLuvut('Vahinkojen korjaukset', '', '-');
+            tarkistaRahavarausLuvut('Tilaajan rahavaraus kannustinjärjestelmään', '0,00', '', '-');
+            tarkistaRahavarausLuvut('Äkilliset hoitotyöt', '0,00', '', '-');
+            tarkistaRahavarausLuvut('Vahinkojen korjaukset', '0,00', '', '-');
         });
     });
 

--- a/src/clj/harja/kyselyt/tarjous_kyselyt.clj
+++ b/src/clj/harja/kyselyt/tarjous_kyselyt.clj
@@ -156,26 +156,28 @@
 
         ;; Vaihdetut toimenkuvat jättää jälkensä :uusi-nimi arvoon. Haetaan sen nimen perusteella toimenkuvan id
         toimenkuvat-tarjouksesta (mapv
-                                  (fn [rivi]
-                                    (if (and (seq (:uusi-nimi rivi))
-                                             (not= (:uusi-nimi rivi) (:nimi rivi)))
-                                      (let [uusi-toimenkuva (first (toimenkuva-kyselyt/hae-toimenkuvat db {:nimi (:uusi-nimi rivi)}))]
-                                        (assoc rivi
-                                          :vanha-id (:toimenkuva-id rivi)
-                                          :toimenkuva-id (:id uusi-toimenkuva)
-                                          :nimi (:nimi uusi-toimenkuva)))
-                                      rivi))
-                                  toimenkuvat-tarjouksesta)
+                                   (fn [rivi]
+                                     (if (and (seq (:uusi-nimi rivi))
+                                           (not= (:uusi-nimi rivi) (:nimi rivi)))
+                                       (let [uusi-toimenkuva (first (toimenkuva-kyselyt/hae-toimenkuvat db {:nimi (:uusi-nimi rivi)}))]
+                                         (assoc rivi
+                                           :vanha-id (:toimenkuva-id rivi)
+                                           :toimenkuva-id (:id uusi-toimenkuva)
+                                           :nimi (:nimi uusi-toimenkuva)))
+                                       rivi))
+                                   toimenkuvat-tarjouksesta)
 
         ;; Poistettavat toimenkuvat - Poistetaan myös vaihtuneet toimenkuvat, koska ne on korvattu uusilla
         poistettavat-toimenkuvat (filter #(or (true? (:poistettu %)) (not (nil? (:vanha-id %)))) toimenkuvat-tarjouksesta)
         ;; Poistetaan toimenkuvat tietokannasta
         _ (mapv
             (fn [poistettava]
-              (poista-tarjouksen-johto-ja-hallintokorvaus<! db {:urakkaid urakka-id
-                                                                :toimenkuvaid (or (:vanha-id poistettava)
-                                                                                (:toimenkuva-id poistettava))})
-              (toimenkuva-kyselyt/poista-toimenkuva! db (:id poistettava)))
+              (let [;; Poista toimenkuva tarjoukselta
+                    _ (poista-tarjouksen-johto-ja-hallintokorvaus<! db {:urakkaid urakka-id
+                                                                        :toimenkuvaid (or (:vanha-id poistettava)
+                                                                                        (:toimenkuva-id poistettava))})
+                    ;; Poista toimenkuva urakalta
+                    _ (toimenkuva-kyselyt/poista-toimenkuva! db (:toimenkuva-id poistettava))]))
             poistettavat-toimenkuvat)
 
         ;; Päivitetään vain halutut toimenkuvat normaaliprosessilla
@@ -187,6 +189,7 @@
                                                             (fn [r]
                                                               {:id (:id rivi)
                                                                :nimi (:nimi rivi)
+                                                               :toimenkuva (:toimenkuva rivi)
                                                                :urakka_id urakka-id
                                                                :hoitokauden_alkuvuosi (:vuosi r)
                                                                :johto_ja_hallintokorvaus_toimenkuva_id (:toimenkuva-id rivi)
@@ -238,11 +241,11 @@
                                                                 ;; Tämä map pyörähtää jokaisena hoitovuonna. Mutta toimenkuvan kannalta riittää
                                                                 ;; että toimenkuvia lisätään vain kerran urakalle
                                                                 ;; Tarkistetaan siis, ettei toimenkuvaa löydy jo tietokannasta
-                                                                (when-not (seq (toimenkuva-kyselyt/hae-urakan-toimenkuva db {:nimi (:nimi toimenkuva)
-                                                                                                                         :urakkaid urakka-id}))
-                                                                  (toimenkuva-kyselyt/lisaa-urakan-toimenkuva<! db {:toimenkuva (:nimi toimenkuva)
-                                                                                                                  :urakkaid urakka-id
-                                                                                                                  :urakkakohtainen-nimi (:nimi toimenkuva)})))
+                                                                (when-not (seq (toimenkuva-kyselyt/hae-urakan-toimenkuva db {:toimenkuva (:toimenkuva toimenkuva)
+                                                                                                                             :urakkaid urakka-id}))
+                                                                  (toimenkuva-kyselyt/lisaa-urakan-toimenkuva<! db {:toimenkuva (:toimenkuva toimenkuva)
+                                                                                                                    :urakkaid urakka-id
+                                                                                                                    :urakkakohtainen-nimi (:nimi toimenkuva)})))
                                            toimenkuvadb (if (:id tarjousdb)
                                                           (first (hae-toimenkuva-tarjoukselle db
                                                                    {:tarjous_id (:id tarjousdb)
@@ -348,7 +351,9 @@
                                                toimenkuva-rivit))
         tarjousrivit (into [] (sort-by (fn [rivi] (get osiojarjestys (:osio rivi))) (vec (concat kustannus-rivit toimenkuva-rivit))))
 
-        kaikki-toimenkuvat (map #(assoc % :nimi (str/capitalize (:nimi %))) (toimenkuva-kyselyt/hae-toimenkuvat db))
+        kaikki-toimenkuvat (map #(assoc %
+                                   :toimenkuva (:nimi %)
+                                   :nimi (str/capitalize (:nimi %))) (toimenkuva-kyselyt/hae-toimenkuvat db))
 
         tarjous {:urakka-id urakka-id
                  :kaikki-toimenkuvat kaikki-toimenkuvat

--- a/src/clj/harja/kyselyt/tarjous_kyselyt.clj
+++ b/src/clj/harja/kyselyt/tarjous_kyselyt.clj
@@ -23,40 +23,52 @@
    "johto-ja-hallintokorvaus" 4
    "hoidonjohtopalkkio" 5})
 
+(defn jasenna-toimenkuvat-maksukausittain [toimenkuvat urakan-alkuvuosi]
+  (if (<= urakan-alkuvuosi 2021)
+    (reduce (fn [uudet-toimenkuvat toimenkuva]
+              (let [uusi-toimenkuva (cond (= "päätoiminen apulainen" (:toimenkuva toimenkuva))
+                                      {:toimenkuva "päätoiminen apulainen"
+                                       :nimike "Päätoiminen apulainen (talvikausi)"
+                                       :id (:id toimenkuva)
+                                       :toimenkuva-id (:toimenkuva-id toimenkuva)
+                                       :maksukausi "talvi"}
+                                      (= "apulainen/työnjohtaja" (:toimenkuva toimenkuva))
+                                      {:toimenkuva "apulainen/työnjohtaja"
+                                       :nimike "Apulainen/työnjohtaja (talvikausi)"
+                                       :id (:id toimenkuva)
+                                       :toimenkuva-id (:toimenkuva-id toimenkuva)
+                                       :maksukausi "talvi"}
+                                      :else nil)
+
+                    toimenkuva (cond (= "päätoiminen apulainen" (:toimenkuva toimenkuva))
+                                 (assoc toimenkuva
+                                   :nimike "Päätoiminen apulainen (kesäkausi)"
+                                   :maksukausi "kesä")
+                                 (= "apulainen/työnjohtaja" (:toimenkuva toimenkuva))
+                                 (assoc toimenkuva
+                                   :nimike "Apulainen/työnjohtaja (kesäkausi)"
+                                   :maksukausi "kesä")
+                                 :else (merge toimenkuva {:nimike (:toimenkuva toimenkuva)
+                                                          :maksukausi "vuosi"}))]
+
+                ;; Lisätään talvi/kesäkausi vain, jos ne on noita erikois kovakoodattuja toimenkuvia
+                (if uusi-toimenkuva
+                  (conj uudet-toimenkuvat uusi-toimenkuva toimenkuva)
+                  (conj uudet-toimenkuvat toimenkuva))))
+      [] toimenkuvat)
+    toimenkuvat))
+
 (defn hae-urakan-toimenkuvat [db urakka-id urakan-alkuvuosi hoitovuosittaiset-arvot]
   (let [toimenkuvat (toimenkuva-kyselyt/hae-urakan-toimenkuvat-alkuvuoden-perusteella db {:urakka-id urakka-id
                                                                                           :urakan-alkuvuosi urakan-alkuvuosi})
-        toimenkuvat (if (<= urakan-alkuvuosi 2021)
-                      (reduce (fn [uudet-toimenkuvat toimenkuva]
-                                (let [uusi-toimenkuva (cond (= "päätoiminen apulainen" (:toimenkuva toimenkuva))
-                                                        {:toimenkuva "päätoiminen apulainen"
-                                                         :nimike "Päätoiminen apulainen (talvikausi)"
-                                                         :id (:id toimenkuva)
-                                                         :toimenkuva-id (:toimenkuva-id toimenkuva)}
-                                                        (= "apulainen/työnjohtaja" (:toimenkuva toimenkuva))
-                                                        {:toimenkuva "apulainen/työnjohtaja"
-                                                         :nimike "Apulainen/työnjohtaja (talvikausi)"
-                                                         :id (:id toimenkuva)
-                                                         :toimenkuva-id (:toimenkuva-id toimenkuva)}
-                                                        :else nil)
-
-                                      toimenkuva (cond (= "päätoiminen apulainen" (:toimenkuva toimenkuva))
-                                                   (assoc toimenkuva :nimike "Päätoiminen apulainen (kesäkausi)")
-                                                   (= "apulainen/työnjohtaja" (:toimenkuva toimenkuva))
-                                                   (assoc toimenkuva :nimike "Apulainen/työnjohtaja (kesäkausi)")
-                                                   :else (merge toimenkuva {:nimike (:toimenkuva toimenkuva)}))]
-
-                                  ;; Lisätään talvi/kesäkausi vain, jos ne on noita erikois kovakoodattuja toimenkuvia
-                                  (if uusi-toimenkuva
-                                    (conj uudet-toimenkuvat uusi-toimenkuva toimenkuva)
-                                    (conj uudet-toimenkuvat toimenkuva))))
-                        [] toimenkuvat)
-                      toimenkuvat)
+        toimenkuvat (jasenna-toimenkuvat-maksukausittain toimenkuvat urakan-alkuvuosi)
 
         ;; Järjestetään toimenkuvat järkevään järjestykseen
         toimenkuvat (mapv (fn [toimenkuva]
                             (-> toimenkuva
                               (assoc :jarjestys (toimenkuva-kyselyt/paattele-toimenkuvan-jarjestys (:nimike toimenkuva))
+                                :toimenkuva (str/lower-case (:nimike toimenkuva))
+                                :maksukausi (or (:maksukausi toimenkuva) "vuosi")
                                 :nimi (str/capitalize (:nimike toimenkuva))
                                 :toimenkuva-id (:id toimenkuva)
                                 :osio "johto-ja-hallintokorvaus"
@@ -65,7 +77,7 @@
                                 :rahavaraus-id nil
                                 ;; Poistetaan hoitovuosittaiset arvot kovakoodatusti Valmistelukausi ennen urakka-ajan alkua toimenkuvalta
                                 :hoitovuosittaiset-arvot (if (= "valmistelukausi ennen urakka-ajan alkua" (:nimike toimenkuva))
-                                                           (first hoitovuosittaiset-arvot) hoitovuosittaiset-arvot))))
+                                                           [(first hoitovuosittaiset-arvot)] hoitovuosittaiset-arvot))))
                       toimenkuvat)
         toimenkuvat (sort-by :jarjestys toimenkuvat)]
     toimenkuvat))
@@ -190,6 +202,7 @@
                                                               {:id (:id rivi)
                                                                :nimi (:nimi rivi)
                                                                :toimenkuva (:toimenkuva rivi)
+                                                               :maksukausi (:maksukausi rivi)
                                                                :urakka_id urakka-id
                                                                :hoitokauden_alkuvuosi (:vuosi r)
                                                                :johto_ja_hallintokorvaus_toimenkuva_id (:toimenkuva-id rivi)
@@ -249,11 +262,10 @@
                                            toimenkuvadb (if (:id tarjousdb)
                                                           (first (hae-toimenkuva-tarjoukselle db
                                                                    {:tarjous_id (:id tarjousdb)
+                                                                    :maksukausi (:maksukausi toimenkuva)
                                                                     :urakka_id urakka-id
                                                                     :hoitokauden_alkuvuosi (:hoitokauden_alkuvuosi toimenkuva)
                                                                     :johto_ja_hallintokorvaus_toimenkuva_id (or (:id uusi-db-toimenkuva) (:johto_ja_hallintokorvaus_toimenkuva_id toimenkuva))
-                                                                    :tehtava_id (:tehtava_id toimenkuva)
-                                                                    :tehtavaryhma_id (:tehtavaryhma_id toimenkuva)
                                                                     :osio (:osio toimenkuva)}))
                                                           nil)]
                                        (if toimenkuvadb
@@ -263,6 +275,7 @@
                                          (let [toimenkuva (if uusi-db-toimenkuva
                                                             (assoc toimenkuva :johto_ja_hallintokorvaus_toimenkuva_id (:id uusi-db-toimenkuva))
                                                             toimenkuva)]
+
                                            (tallenna-tarjouksen-johto-ja-hallintokorvaus<! db (assoc toimenkuva
                                                                                                 :tarjous_id (:id tietokantatarjous)))))))
                                    vuosittaiset-toimenkuvat)]
@@ -270,25 +283,45 @@
                        vuosittaiset-tarjoushinnat)]
     tallennukset))
 
-(defn hae-tarjouksesta-rivit-vuodelle [avain tarjous-rivit nimi]
+(defn hae-kustannuksista-rivit-vuodelle [avain tarjous-rivit nimi]
   (let [;; Etsitään kustannus, joka vastaa annettua nimeä
         rivit (into [] (sort-by :vuosi (reduce (fn [r rivi]
                                                  (let [r-rivit (keep #(when (= nimi (:nimi %))
                                                                         (dissoc (merge % {:vuosi (:hoitokauden_alkuvuosi rivi)})
-                                                                          :id :nimi :osio :tehtava_id :tehtavaryhma_id :rahavaraus_id
+                                                                          :id :nimi :maksukausi :osio :tehtava_id :tehtavaryhma_id :rahavaraus_id
                                                                           :johto_ja_hallintokorvaus_toimenkuva_id))
                                                                  (avain rivi))]
                                                    (vec (concat r r-rivit))))
                                          [] tarjous-rivit)))]
     rivit))
 
-(defn- muodosta-tarjous-rivi [r hoitovuosittaiset-arvot]
+(defn hae-toimenkuvista-rivit-vuodelle [avain tarjous-rivit nimi maksukausi]
+  (let [;; Etsitään kustannus, joka vastaa annettua nimeä
+        rivit (into [] (sort-by :vuosi (reduce (fn [r rivi]
+                                                 (let [r-rivit (keep #(when (and (= nimi (:nimi %)) (= maksukausi (:maksukausi %)))
+                                                                        (dissoc (merge % {:vuosi (:hoitokauden_alkuvuosi rivi)})
+                                                                          :id :nimi :maksukausi :osio :tehtava_id :tehtavaryhma_id :rahavaraus_id
+                                                                          :johto_ja_hallintokorvaus_toimenkuva_id))
+                                                                 (avain rivi))]
+                                                   (vec (concat r r-rivit))))
+                                         [] tarjous-rivit)))]
+    rivit))
+
+(defn- muodosta-kustannusrivi [r hoitovuosittaiset-arvot]
   (-> {:osio (:osio r)
        :nimi (:nimi r)
        :toimenkuva-id (:johto_ja_hallintokorvaus_toimenkuva_id r)
        :tehtava-id (:tehtava_id r)
        :tehtavaryhma-id (:tehtavaryhma_id r)
        :rahavaraus-id (:rahavaraus_id r)
+       :hoitovuosittaiset-arvot hoitovuosittaiset-arvot
+       :yhteensa (apply + (mapv :summa hoitovuosittaiset-arvot))}))
+
+(defn- muodosta-toimenkuvarivi [r hoitovuosittaiset-arvot]
+  (-> {:osio (:osio r)
+       :maksukausi (:maksukausi r)
+       :nimi (:nimi r)
+       :toimenkuva-id (:johto_ja_hallintokorvaus_toimenkuva_id r)
        :hoitovuosittaiset-arvot hoitovuosittaiset-arvot
        :yhteensa (apply + (mapv :summa hoitovuosittaiset-arvot))}))
 
@@ -311,8 +344,9 @@
 
 (defn hae-tarjous [db urakka-id]
   (let [urakan-tiedot (first (urakat-kyselyt/hae-urakka db {:id urakka-id}))
+        urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
         vuodet (map (fn [vuosi]
-                      {:vuosi vuosi}) (range (pvm/vuosi (:alkupvm urakan-tiedot)) (pvm/vuosi (:loppupvm urakan-tiedot))))
+                      {:vuosi vuosi}) (range urakan-alkuvuosi (pvm/vuosi (:loppupvm urakan-tiedot))))
         hoitovuosittaiset-arvot (mapv (fn [vuosi] {:vuosi (:vuosi vuosi) :summa 0.00M}) vuodet)
         tarjous-rivit (hae-tarjouksen-tiedot db {:urakka_id urakka-id})
         ;; Mäppää tarjouksen tietokantarivit clojure-mapeiksi.
@@ -327,17 +361,35 @@
                             (assoc :toimenkuvat
                               (mapv
                                 (fn [k]
-                                  (konversio/pgobject->map k :id :long :nimi :string :summa :double :osio :string :johto_ja_hallintokorvaus_toimenkuva_id :long))
+                                  (konversio/pgobject->map k :id :long :nimi :string :summa :double
+                                    :maksukausi :string :osio :string :johto_ja_hallintokorvaus_toimenkuva_id :long))
                                 (konversio/pgarray->vector (:toimenkuvat tarjous))))))
                         tarjous-rivit)
 
         ;; Muutetaan ui:lle välitettävään muotoon
-        kustannus-rivit (mapv #(muodosta-tarjous-rivi % (hae-tarjouksesta-rivit-vuodelle :kustannukset tarjous-rivit (:nimi %))) (:kustannukset (first tarjous-rivit)))
-        toimenkuva-rivit (mapv #(muodosta-tarjous-rivi % (hae-tarjouksesta-rivit-vuodelle :toimenkuvat tarjous-rivit (:nimi %))) (:toimenkuvat (first tarjous-rivit)))
+        kustannus-rivit (mapv #(muodosta-kustannusrivi % (hae-kustannuksista-rivit-vuodelle :kustannukset tarjous-rivit (:nimi %))) (:kustannukset (first tarjous-rivit)))
+        toimenkuva-rivit (mapv #(muodosta-toimenkuvarivi % (hae-toimenkuvista-rivit-vuodelle :toimenkuvat tarjous-rivit (:nimi %) (:maksukausi %))) (:toimenkuvat (first tarjous-rivit)))
+        ;; Päivitä mahdolliset toimenkuvan nimet, jos kesä ja talvikausi on vaikuttamassa tilanteeseen
+        toimenkuva-rivit (mapv (fn [rivi]
+                                  (let [toimenkuva (str/lower-case (:nimi rivi))
+                                        nimi (cond
+                                               (and (= "Päätoiminen apulainen" (:nimi rivi)) (= "talvi" (:maksukausi rivi)))
+                                               "Päätoiminen apulainen (talvikausi)"
+                                               (and (= "Päätoiminen apulainen" (:nimi rivi)) (= "kesä" (:maksukausi rivi)))
+                                               "Päätoiminen apulainen (kesäkausi)"
+                                               (and (= "Apulainen/työnjohtaja" (:nimi rivi)) (= "talvi" (:maksukausi rivi)))
+                                               "Apulainen/työnjohtaja (talvikausi)"
+                                               (and (= "Apulainen/työnjohtaja" (:nimi rivi)) (= "kesä" (:maksukausi rivi)))
+                                               "Apulainen/työnjohtaja (kesäkausi)"
+                                               :else (:nimi rivi))]
+                                    (assoc rivi :nimi nimi :toimenkuva toimenkuva)))
+                                toimenkuva-rivit)
 
         ;; Tarjouksen mukana ei välttämättä tule kaikkia toimenkuvia, jos niitä on tarjouksen tallentamisen jälkeen lisätty urakkalle hallintapaneelista.
         ;; Varmistetaan siis, että kaikki urakan toimenkuvat ovat mukana, kun ne renderöidään frontilla
-        kaikki-urakan-toimenkuvat (hae-urakan-toimenkuvat db urakka-id (pvm/vuosi (:alkupvm urakan-tiedot)) hoitovuosittaiset-arvot)
+        kaikki-urakan-toimenkuvat (hae-urakan-toimenkuvat db urakka-id urakan-alkuvuosi hoitovuosittaiset-arvot)
+        kaikki-urakan-toimenkuvat (jasenna-toimenkuvat-maksukausittain kaikki-urakan-toimenkuvat urakan-alkuvuosi)
+
         ;; Vertaillaan toimenkuvat-rivit ja kaikki-urakan-toimenkuvat ja lisätään puuttuvat toimenkuvat nollasummilla
         puuttuvat-toimenkuvat (filter
                                 (fn [kt]
@@ -359,7 +411,7 @@
                  :kaikki-toimenkuvat kaikki-toimenkuvat
                  :tarjous tarjousrivit}
         ;; Tarkistetaan, että tarjous ei ole tyhjä
-        tarjous (if (empty? (first (:tarjous tarjous)))
+        tarjous (if (not= "Kilpailutettavat hankinnat" (:nimi (first (:tarjous tarjous))))
                   {:urakka-id urakka-id
                    :kaikki-toimenkuvat kaikki-toimenkuvat
                    :tarjous (luo-default-tarjous db urakka-id)}

--- a/src/clj/harja/kyselyt/tarjous_kyselyt.clj
+++ b/src/clj/harja/kyselyt/tarjous_kyselyt.clj
@@ -72,7 +72,7 @@
   (let [urakan-tiedot (first (urakat-kyselyt/hae-urakka db {:id urakka-id}))
         urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
         vuodet (range urakan-alkuvuosi (pvm/vuosi (:loppupvm urakan-tiedot)))
-        hoitovuosittaiset-arvot (mapv (fn [vuosi] {:vuosi vuosi :summa 0.00}) vuodet)
+        hoitovuosittaiset-arvot (mapv (fn [vuosi] {:vuosi vuosi :summa 0.00M}) vuodet)
         ;; Lisätään default tarjoukseen Kilpailutettavat hankinnat, Erillishankinnat ja Hoidonjohtopalkkio
         tarjous [{:nimi "Kilpailutettavat hankinnat", :osio "hankintakustannukset" :toimenkuva-id nil :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil
                   :hoitovuosittaiset-arvot hoitovuosittaiset-arvot :yhteensa 0.00}
@@ -305,7 +305,11 @@
 
 
 (defn hae-tarjous [db urakka-id]
-  (let [tarjous-rivit (hae-tarjouksen-tiedot db {:urakka_id urakka-id})
+  (let [urakan-tiedot (first (urakat-kyselyt/hae-urakka db {:id urakka-id}))
+        vuodet (map (fn [vuosi]
+                      {:vuosi vuosi}) (range (pvm/vuosi (:alkupvm urakan-tiedot)) (pvm/vuosi (:loppupvm urakan-tiedot))))
+        hoitovuosittaiset-arvot (mapv (fn [vuosi] {:vuosi (:vuosi vuosi) :summa 0.00M}) vuodet)
+        tarjous-rivit (hae-tarjouksen-tiedot db {:urakka_id urakka-id})
         ;; Mäppää tarjouksen tietokantarivit clojure-mapeiksi.
         tarjous-rivit (mapv
                         (fn [tarjous]
@@ -325,6 +329,18 @@
         ;; Muutetaan ui:lle välitettävään muotoon
         kustannus-rivit (mapv #(muodosta-tarjous-rivi % (hae-tarjouksesta-rivit-vuodelle :kustannukset tarjous-rivit (:nimi %))) (:kustannukset (first tarjous-rivit)))
         toimenkuva-rivit (mapv #(muodosta-tarjous-rivi % (hae-tarjouksesta-rivit-vuodelle :toimenkuvat tarjous-rivit (:nimi %))) (:toimenkuvat (first tarjous-rivit)))
+
+        ;; Tarjouksen mukana ei välttämättä tule kaikkia toimenkuvia, jos niitä on tarjouksen tallentamisen jälkeen lisätty urakkalle hallintapaneelista.
+        ;; Varmistetaan siis, että kaikki urakan toimenkuvat ovat mukana, kun ne renderöidään frontilla
+        kaikki-urakan-toimenkuvat (hae-urakan-toimenkuvat db urakka-id (pvm/vuosi (:alkupvm urakan-tiedot)) hoitovuosittaiset-arvot)
+        ;; Vertaillaan toimenkuvat-rivit ja kaikki-urakan-toimenkuvat ja lisätään puuttuvat toimenkuvat nollasummilla
+        puuttuvat-toimenkuvat (filter
+                                (fn [kt]
+                                  (not (some #(= (:toimenkuva-id kt) (:toimenkuva-id %)) toimenkuva-rivit)))
+                                kaikki-urakan-toimenkuvat)
+
+        toimenkuva-rivit (vec (concat toimenkuva-rivit puuttuvat-toimenkuvat))
+
         toimenkuva-rivit (sort-by :jarjestys (map
                                                #(assoc % :jarjestys (toimenkuva-kyselyt/paattele-toimenkuvan-jarjestys (:nimi %)))
                                                toimenkuva-rivit))

--- a/src/clj/harja/kyselyt/tarjous_kyselyt.clj
+++ b/src/clj/harja/kyselyt/tarjous_kyselyt.clj
@@ -151,16 +151,31 @@
                                        [] kustannukset-tarjouksesta))
         toimenkuvat-tarjouksesta (filter #(contains? johto-ja-hallintokorvausosiot (:osio %)) (:tarjous tarjous))
 
-        ;; Poistettavat toimenkuvat
-        poistettavat-toimenkuvat (filter #(true? (:poistettu %)) toimenkuvat-tarjouksesta)
-        ;; Poistetaan toimenkuvat tietokanansta
+        ;; Vaihdetut toimenkuvat jättää jälkensä :uusi-nimi arvoon. Haetaan sen nimen perusteella toimenkuvan id
+        toimenkuvat-tarjouksesta (mapv
+                                  (fn [rivi]
+                                    (if (and (seq (:uusi-nimi rivi))
+                                             (not= (:uusi-nimi rivi) (:nimi rivi)))
+                                      (let [uusi-toimenkuva (first (toimenkuva-kyselyt/hae-toimenkuvat db {:nimi (:uusi-nimi rivi)}))]
+                                        (assoc rivi
+                                          :vanha-id (:toimenkuva-id rivi)
+                                          :toimenkuva-id (:id uusi-toimenkuva)
+                                          :nimi (:nimi uusi-toimenkuva)))
+                                      rivi))
+                                  toimenkuvat-tarjouksesta)
+
+        ;; Poistettavat toimenkuvat - Poistetaan myös vaihtuneet toimenkuvat, koska ne on korvattu uusilla
+        poistettavat-toimenkuvat (filter #(or (true? (:poistettu %)) (not (nil? (:vanha-id %)))) toimenkuvat-tarjouksesta)
+        ;; Poistetaan toimenkuvat tietokannasta
         _ (mapv
             (fn [poistettava]
               (poista-tarjouksen-johto-ja-hallintokorvaus<! db {:urakkaid urakka-id
-                                                                :toimenkuvaid (:toimenkuva-id poistettava)})
+                                                                :toimenkuvaid (or (:vanha-id poistettava)
+                                                                                (:toimenkuva-id poistettava))})
               (toimenkuva-kyselyt/poista-toimenkuva! db (:id poistettava)))
             poistettavat-toimenkuvat)
 
+        ;; Päivitetään vain halutut toimenkuvat normaaliprosessilla
         paivitettavat-toimenkuvat (remove #(true? (:poistettu %)) toimenkuvat-tarjouksesta)
         ;; Muutetaan toimenkuvat listaksi, jossa on yksi rivi per hoitovuosi
         toimenkuvatlistaus (flatten (reduce
@@ -213,6 +228,7 @@
 
                                vuosittaiset-toimenkuvat (filter #(= (:hoitokauden_alkuvuosi rivi) (:hoitokauden_alkuvuosi %)) toimenkuvatlistaus)
 
+                               ;; Loopataan vuosittaiset toimenkuvat ja lisätään tarvittaessa uudet ja päivitetään olemassaolevat
                                _ (mapv
                                    (fn [toimenkuva]
                                      (let [uusi-db-toimenkuva (when (= -1 (:id toimenkuva))
@@ -310,11 +326,13 @@
         ;; Muutetaan ui:lle välitettävään muotoon
         kustannus-rivit (mapv #(muodosta-tarjous-rivi % (hae-tarjouksesta-rivit-vuodelle :kustannukset tarjous-rivit (:nimi %))) (:kustannukset (first tarjous-rivit)))
         toimenkuva-rivit (mapv #(muodosta-tarjous-rivi % (hae-tarjouksesta-rivit-vuodelle :toimenkuvat tarjous-rivit (:nimi %))) (:toimenkuvat (first tarjous-rivit)))
+        toimenkuva-rivit (sort-by :jarjestys (map
+                                               #(assoc % :jarjestys (toimenkuva-kyselyt/paattele-toimenkuvan-jarjestys (:nimi %)))
+                                               toimenkuva-rivit))
         tarjousrivit (into [] (sort-by (fn [rivi] (get osiojarjestys (:osio rivi))) (vec (concat kustannus-rivit toimenkuva-rivit))))
 
-        kaikki-toimenkuvat (if (>= urakan-alkuvuosi 2025)
-                             (map #(assoc % :nimi (str/capitalize (:nimi %))) (toimenkuva-kyselyt/hae-toimenkuvat db))
-                             nil)
+        kaikki-toimenkuvat (map #(assoc % :nimi (str/capitalize (:nimi %))) (toimenkuva-kyselyt/hae-toimenkuvat db))
+
         tarjous {:urakka-id urakka-id
                  :kaikki-toimenkuvat kaikki-toimenkuvat
                  :tarjous tarjousrivit}

--- a/src/clj/harja/kyselyt/tarjous_kyselyt.clj
+++ b/src/clj/harja/kyselyt/tarjous_kyselyt.clj
@@ -64,7 +64,8 @@
                                 :tehtavaryhma-id nil
                                 :rahavaraus-id nil
                                 :hoitovuosittaiset-arvot hoitovuosittaiset-arvot)))
-                      toimenkuvat)]
+                      toimenkuvat)
+        toimenkuvat (sort-by :jarjestys toimenkuvat)]
     toimenkuvat))
 
 (defn luo-default-tarjous [db urakka-id]
@@ -87,7 +88,7 @@
                            [] rahavaraukset)
         tarjous (vec (concat tarjous rahavaraus-rivit))
         toimenkuvat (hae-urakan-toimenkuvat db urakka-id urakan-alkuvuosi hoitovuosittaiset-arvot)
-        tarjous (vec (concat tarjous (sort-by :jarjestys toimenkuvat)))
+        tarjous (vec (concat tarjous toimenkuvat))
         jarjestetty-tarjous (sort-by (fn [rivi] (get osiojarjestys (:osio rivi)))
                               tarjous)]
 
@@ -304,9 +305,7 @@
 
 
 (defn hae-tarjous [db urakka-id]
-  (let [urakan-tiedot (first (urakat-kyselyt/hae-urakka db {:id urakka-id}))
-        urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
-        tarjous-rivit (hae-tarjouksen-tiedot db {:urakka_id urakka-id})
+  (let [tarjous-rivit (hae-tarjouksen-tiedot db {:urakka_id urakka-id})
         ;; Mäppää tarjouksen tietokantarivit clojure-mapeiksi.
         tarjous-rivit (mapv
                         (fn [tarjous]

--- a/src/clj/harja/kyselyt/tarjous_kyselyt.clj
+++ b/src/clj/harja/kyselyt/tarjous_kyselyt.clj
@@ -23,32 +23,39 @@
    "johto-ja-hallintokorvaus" 4
    "hoidonjohtopalkkio" 5})
 
-(defn jasenna-toimenkuvat-maksukausittain [toimenkuvat urakan-alkuvuosi]
+(defn jasenna-toimenkuvat-maksukausittain
+  "Tietokannasta saadaan vain osa toimenkuvista 2019-2024 alkavilla urakoilla. Näillä urakoilla osa toimenkuvista
+  on kovakoodattu frontissa. Tästä syystä otetaan tietokannasta saadut toimenkuvat ja lisätään niihin samalla
+  toimenkuva-id:llä uusia toimenkuvia ja muutetaan nimi ja maksukausi arvot maksukausittain."
+  [toimenkuvat urakan-alkuvuosi]
   (if (<= urakan-alkuvuosi 2021)
     (reduce (fn [uudet-toimenkuvat toimenkuva]
-              (let [uusi-toimenkuva (cond (= "päätoiminen apulainen" (:toimenkuva toimenkuva))
+              (let [;; Tässä lisätään puuttuva aiemmin frontin puolella kovakoodattu talvikauden toimenkuva
+                    uusi-toimenkuva (cond (= "päätoiminen apulainen" (:toimenkuva toimenkuva))
                                       {:toimenkuva "päätoiminen apulainen"
-                                       :nimike "Päätoiminen apulainen (talvikausi)"
+                                       :nimi "Päätoiminen apulainen (talvikausi)"
+                                       :toimenkuva-id (:id toimenkuva)
                                        :id (:id toimenkuva)
-                                       :toimenkuva-id (:toimenkuva-id toimenkuva)
                                        :maksukausi "talvi"}
                                       (= "apulainen/työnjohtaja" (:toimenkuva toimenkuva))
                                       {:toimenkuva "apulainen/työnjohtaja"
-                                       :nimike "Apulainen/työnjohtaja (talvikausi)"
+                                       :nimi "Apulainen/työnjohtaja (talvikausi)"
+                                       :toimenkuva-id (:id toimenkuva)
                                        :id (:id toimenkuva)
-                                       :toimenkuva-id (:toimenkuva-id toimenkuva)
                                        :maksukausi "talvi"}
                                       :else nil)
-
+                    ;; Tässä muokataan kannasta saatu toimenkuva olemaan kesäkauden toimenkuva
                     toimenkuva (cond (= "päätoiminen apulainen" (:toimenkuva toimenkuva))
                                  (assoc toimenkuva
-                                   :nimike "Päätoiminen apulainen (kesäkausi)"
+                                   :nimi "Päätoiminen apulainen (kesäkausi)"
+                                   :toimenkuva-id (:id toimenkuva)
                                    :maksukausi "kesä")
                                  (= "apulainen/työnjohtaja" (:toimenkuva toimenkuva))
                                  (assoc toimenkuva
-                                   :nimike "Apulainen/työnjohtaja (kesäkausi)"
+                                   :nimi "Apulainen/työnjohtaja (kesäkausi)"
+                                   :toimenkuva-id (:id toimenkuva)
                                    :maksukausi "kesä")
-                                 :else (merge toimenkuva {:nimike (:toimenkuva toimenkuva)
+                                 :else (merge toimenkuva {:nimi (str/capitalize (:toimenkuva toimenkuva))
                                                           :maksukausi "vuosi"}))]
 
                 ;; Lisätään talvi/kesäkausi vain, jos ne on noita erikois kovakoodattuja toimenkuvia
@@ -56,27 +63,34 @@
                   (conj uudet-toimenkuvat uusi-toimenkuva toimenkuva)
                   (conj uudet-toimenkuvat toimenkuva))))
       [] toimenkuvat)
-    toimenkuvat))
+    ;; -25 urakoiden toimenkuvat
+    (map (fn [toimenkuva]
+           (assoc toimenkuva :nimi (:toimenkuva toimenkuva)))
+      toimenkuvat)))
 
-(defn hae-urakan-toimenkuvat [db urakka-id urakan-alkuvuosi hoitovuosittaiset-arvot]
+(defn hae-urakan-toimenkuvat
+  "Haetaan urakan toimenkuvat urakan alkuvuoden perusteella.
+  1. Lisätään niitä tarvittaessa, koska tietokannasta ei löydy vanhoille urakoille kaikkia toimenkuvia (lisäämällä kesä ja talvikausille omat).
+  2. Päivitetään toimenkuvalle hoitovuosittaiset arvot frontilla käsittelyä helpottamaan.
+  3. Järjestetään toimenkuvat järkevään järjestykseen."
+  [db urakka-id urakan-alkuvuosi hoitovuosittaiset-arvot]
   (let [toimenkuvat (toimenkuva-kyselyt/hae-urakan-toimenkuvat-alkuvuoden-perusteella db {:urakka-id urakka-id
                                                                                           :urakan-alkuvuosi urakan-alkuvuosi})
         toimenkuvat (jasenna-toimenkuvat-maksukausittain toimenkuvat urakan-alkuvuosi)
-
         ;; Järjestetään toimenkuvat järkevään järjestykseen
         toimenkuvat (mapv (fn [toimenkuva]
                             (-> toimenkuva
-                              (assoc :jarjestys (toimenkuva-kyselyt/paattele-toimenkuvan-jarjestys (:nimike toimenkuva))
-                                :toimenkuva (str/lower-case (:nimike toimenkuva))
+                              (assoc
+                                :id (:id toimenkuva)
+                                :toimenkuva-id (:id toimenkuva)
+                                :jarjestys (toimenkuva-kyselyt/paattele-toimenkuvan-jarjestys (:toimenkuva toimenkuva))
+                                :toimenkuva (:toimenkuva toimenkuva)
                                 :maksukausi (or (:maksukausi toimenkuva) "vuosi")
-                                :nimi (str/capitalize (:nimike toimenkuva))
+                                :nimi (str/capitalize (:nimi toimenkuva))
                                 :toimenkuva-id (:id toimenkuva)
                                 :osio "johto-ja-hallintokorvaus"
-                                :tehtava-id nil
-                                :tehtavaryhma-id nil
-                                :rahavaraus-id nil
-                                ;; Poistetaan hoitovuosittaiset arvot kovakoodatusti Valmistelukausi ennen urakka-ajan alkua toimenkuvalta
-                                :hoitovuosittaiset-arvot (if (= "valmistelukausi ennen urakka-ajan alkua" (:nimike toimenkuva))
+                                ;; Poistetaan hoitovuosittaiset arvot kovakoodatusti 'Valmistelukausi ennen urakka-ajan alkua' -toimenkuvalta
+                                :hoitovuosittaiset-arvot (if (= "valmistelukausi ennen urakka-ajan alkua" (:toimenkuva toimenkuva))
                                                            [(first hoitovuosittaiset-arvot)] hoitovuosittaiset-arvot))))
                       toimenkuvat)
         toimenkuvat (sort-by :jarjestys toimenkuvat)]
@@ -206,8 +220,6 @@
                                                                :urakka_id urakka-id
                                                                :hoitokauden_alkuvuosi (:vuosi r)
                                                                :johto_ja_hallintokorvaus_toimenkuva_id (:toimenkuva-id rivi)
-                                                               :tehtava_id (:tehtava-id rivi)
-                                                               :tehtavaryhma_id (:tehtavaryhma-id rivi)
                                                                :summa (:summa r)
                                                                :osio (:osio rivi)
                                                                :luoja kayttaja-id})
@@ -295,10 +307,10 @@
                                          [] tarjous-rivit)))]
     rivit))
 
-(defn hae-toimenkuvista-rivit-vuodelle [avain tarjous-rivit nimi maksukausi]
-  (let [;; Etsitään kustannus, joka vastaa annettua nimeä
+(defn hae-toimenkuvista-rivit-vuodelle [avain tarjous-rivit id maksukausi]
+  (let [;; Etsitään toimenkuva, joka vastaa annettua nimeä ja maksukautta
         rivit (into [] (sort-by :vuosi (reduce (fn [r rivi]
-                                                 (let [r-rivit (keep #(when (and (= nimi (:nimi %)) (= maksukausi (:maksukausi %)))
+                                                 (let [r-rivit (keep #(when (and (= id (:johto_ja_hallintokorvaus_toimenkuva_id %)) (= maksukausi (:maksukausi %)))
                                                                         (dissoc (merge % {:vuosi (:hoitokauden_alkuvuosi rivi)})
                                                                           :id :nimi :maksukausi :osio :tehtava_id :tehtavaryhma_id :rahavaraus_id
                                                                           :johto_ja_hallintokorvaus_toimenkuva_id))
@@ -318,9 +330,11 @@
        :yhteensa (apply + (mapv :summa hoitovuosittaiset-arvot))}))
 
 (defn- muodosta-toimenkuvarivi [r hoitovuosittaiset-arvot]
-  (-> {:osio (:osio r)
+  (-> {:id (:id r)
+       :osio (:osio r)
        :maksukausi (:maksukausi r)
        :nimi (:nimi r)
+       :toimenkuva (str/lower-case (:nimi r))
        :toimenkuva-id (:johto_ja_hallintokorvaus_toimenkuva_id r)
        :hoitovuosittaiset-arvot hoitovuosittaiset-arvot
        :yhteensa (apply + (mapv :summa hoitovuosittaiset-arvot))}))
@@ -365,30 +379,29 @@
                                     :maksukausi :string :osio :string :johto_ja_hallintokorvaus_toimenkuva_id :long))
                                 (konversio/pgarray->vector (:toimenkuvat tarjous))))))
                         tarjous-rivit)
-
         ;; Muutetaan ui:lle välitettävään muotoon
         kustannus-rivit (mapv #(muodosta-kustannusrivi % (hae-kustannuksista-rivit-vuodelle :kustannukset tarjous-rivit (:nimi %))) (:kustannukset (first tarjous-rivit)))
-        toimenkuva-rivit (mapv #(muodosta-toimenkuvarivi % (hae-toimenkuvista-rivit-vuodelle :toimenkuvat tarjous-rivit (:nimi %) (:maksukausi %))) (:toimenkuvat (first tarjous-rivit)))
+        toimenkuva-rivit (mapv #(muodosta-toimenkuvarivi % (hae-toimenkuvista-rivit-vuodelle :toimenkuvat tarjous-rivit (:johto_ja_hallintokorvaus_toimenkuva_id %) (:maksukausi %))) (:toimenkuvat (first tarjous-rivit)))
         ;; Päivitä mahdolliset toimenkuvan nimet, jos kesä ja talvikausi on vaikuttamassa tilanteeseen
         toimenkuva-rivit (mapv (fn [rivi]
-                                  (let [toimenkuva (str/lower-case (:nimi rivi))
-                                        nimi (cond
-                                               (and (= "Päätoiminen apulainen" (:nimi rivi)) (= "talvi" (:maksukausi rivi)))
-                                               "Päätoiminen apulainen (talvikausi)"
-                                               (and (= "Päätoiminen apulainen" (:nimi rivi)) (= "kesä" (:maksukausi rivi)))
-                                               "Päätoiminen apulainen (kesäkausi)"
-                                               (and (= "Apulainen/työnjohtaja" (:nimi rivi)) (= "talvi" (:maksukausi rivi)))
-                                               "Apulainen/työnjohtaja (talvikausi)"
-                                               (and (= "Apulainen/työnjohtaja" (:nimi rivi)) (= "kesä" (:maksukausi rivi)))
-                                               "Apulainen/työnjohtaja (kesäkausi)"
-                                               :else (:nimi rivi))]
-                                    (assoc rivi :nimi nimi :toimenkuva toimenkuva)))
-                                toimenkuva-rivit)
+                                 (let [toimenkuva (str/lower-case (:nimi rivi))
+                                       nimi (cond
+                                              (and (= "päätoiminen apulainen" toimenkuva) (= "talvi" (:maksukausi rivi)))
+                                              "Päätoiminen apulainen (talvikausi)"
+                                              (and (= "päätoiminen apulainen" toimenkuva) (= "kesä" (:maksukausi rivi)))
+                                              "Päätoiminen apulainen (kesäkausi)"
+                                              (and (= "apulainen/työnjohtaja" toimenkuva) (= "talvi" (:maksukausi rivi)))
+                                              "Apulainen/työnjohtaja (talvikausi)"
+                                              (and (= "apulainen/työnjohtaja" toimenkuva) (= "kesä" (:maksukausi rivi)))
+                                              "Apulainen/työnjohtaja (kesäkausi)"
+                                              :else (:nimi rivi))]
+                                   (assoc rivi :nimi nimi :toimenkuva toimenkuva)))
+                           toimenkuva-rivit)
 
         ;; Tarjouksen mukana ei välttämättä tule kaikkia toimenkuvia, jos niitä on tarjouksen tallentamisen jälkeen lisätty urakkalle hallintapaneelista.
         ;; Varmistetaan siis, että kaikki urakan toimenkuvat ovat mukana, kun ne renderöidään frontilla
         kaikki-urakan-toimenkuvat (hae-urakan-toimenkuvat db urakka-id urakan-alkuvuosi hoitovuosittaiset-arvot)
-        kaikki-urakan-toimenkuvat (jasenna-toimenkuvat-maksukausittain kaikki-urakan-toimenkuvat urakan-alkuvuosi)
+        ;kaikki-urakan-toimenkuvat (jasenna-toimenkuvat-maksukausittain kaikki-urakan-toimenkuvat urakan-alkuvuosi)
 
         ;; Vertaillaan toimenkuvat-rivit ja kaikki-urakan-toimenkuvat ja lisätään puuttuvat toimenkuvat nollasummilla
         puuttuvat-toimenkuvat (filter
@@ -397,9 +410,8 @@
                                 kaikki-urakan-toimenkuvat)
 
         toimenkuva-rivit (vec (concat toimenkuva-rivit puuttuvat-toimenkuvat))
-
         toimenkuva-rivit (sort-by :jarjestys (map
-                                               #(assoc % :jarjestys (toimenkuva-kyselyt/paattele-toimenkuvan-jarjestys (:nimi %)))
+                                               #(assoc % :jarjestys (toimenkuva-kyselyt/paattele-toimenkuvan-jarjestys (:toimenkuva %)))
                                                toimenkuva-rivit))
         tarjousrivit (into [] (sort-by (fn [rivi] (get osiojarjestys (:osio rivi))) (vec (concat kustannus-rivit toimenkuva-rivit))))
 

--- a/src/clj/harja/kyselyt/tarjous_kyselyt.clj
+++ b/src/clj/harja/kyselyt/tarjous_kyselyt.clj
@@ -63,7 +63,9 @@
                                 :tehtava-id nil
                                 :tehtavaryhma-id nil
                                 :rahavaraus-id nil
-                                :hoitovuosittaiset-arvot hoitovuosittaiset-arvot)))
+                                ;; Poistetaan hoitovuosittaiset arvot kovakoodatusti Valmistelukausi ennen urakka-ajan alkua toimenkuvalta
+                                :hoitovuosittaiset-arvot (if (= "valmistelukausi ennen urakka-ajan alkua" (:nimike toimenkuva))
+                                                           (first hoitovuosittaiset-arvot) hoitovuosittaiset-arvot))))
                       toimenkuvat)
         toimenkuvat (sort-by :jarjestys toimenkuvat)]
     toimenkuvat))

--- a/src/clj/harja/kyselyt/tarjous_kyselyt.sql
+++ b/src/clj/harja/kyselyt/tarjous_kyselyt.sql
@@ -14,8 +14,8 @@ INSERT INTO tarjous_kustannukset (tarjous_id, urakka_id, hoitokauden_alkuvuosi, 
 VALUES (:tarjous_id, :urakka_id, :hoitokauden_alkuvuosi, :summa, :osio::suunnittelu_osio, :tehtava_id, :tehtavaryhma_id, :rahavaraus_id, :luoja, NOW());
 
 -- name: tallenna-tarjouksen-johto-ja-hallintokorvaus<!
-INSERT INTO tarjous_johto_ja_hallintokorvaus (tarjous_id, urakka_id, hoitokauden_alkuvuosi, summa, osio, johto_ja_hallintokorvaus_toimenkuva_id, tehtavaryhma_id, tehtava_id, luoja, luotu)
-VALUES (:tarjous_id, :urakka_id, :hoitokauden_alkuvuosi, :summa, :osio::suunnittelu_osio, :johto_ja_hallintokorvaus_toimenkuva_id, :tehtavaryhma_id, :tehtava_id, :luoja, NOW());
+INSERT INTO tarjous_johto_ja_hallintokorvaus (tarjous_id, urakka_id, hoitokauden_alkuvuosi, summa, maksukausi, osio, johto_ja_hallintokorvaus_toimenkuva_id, luoja, luotu)
+VALUES (:tarjous_id, :urakka_id, :hoitokauden_alkuvuosi, :summa, :maksukausi,:osio::suunnittelu_osio, :johto_ja_hallintokorvaus_toimenkuva_id, :luoja, NOW());
 
 -- name: hae-tarjouksen-tiedot
 SELECT t.id as "tarjous-id", t.hoitokauden_alkuvuosi, t.urakka_id, t.tarjous_tavoitehinta, t.tarjous_kattohinta,
@@ -29,13 +29,13 @@ SELECT t.id as "tarjous-id", t.hoitokauden_alkuvuosi, t.urakka_id, t.tarjous_tav
         FROM tarjous_kustannukset tk
                  LEFT JOIN rahavaraus r ON r.id = tk.rahavaraus_id
         WHERE tk.tarjous_id = t.id) as kustannukset,
-       (SELECT array_agg(row(tj.id, UPPER(LEFT(jjht.toimenkuva, 1)) || RIGHT(jjht.toimenkuva, -1), tj.summa, tj.osio, tj.johto_ja_hallintokorvaus_toimenkuva_id))
+       (SELECT array_agg(row(tj.id, UPPER(LEFT(jjht.toimenkuva, 1)) || RIGHT(jjht.toimenkuva, -1), tj.summa, tj.maksukausi, tj.osio, tj.johto_ja_hallintokorvaus_toimenkuva_id))
         FROM tarjous_johto_ja_hallintokorvaus tj
                  LEFT JOIN johto_ja_hallintokorvaus_toimenkuva jjht ON jjht.id = tj.johto_ja_hallintokorvaus_toimenkuva_id
         WHERE tj.tarjous_id = t.id) as toimenkuvat
   FROM tarjous t
  WHERE t.urakka_id = :urakka_id
- ORDER BY t.hoitokauden_alkuvuosi ASC;
+ ORDER BY t.hoitokauden_alkuvuosi;
 
 -- name: hae-tarjous-vuodella
 -- Haetaan tarjousrivi urakan ja vuoden perusteella.
@@ -66,24 +66,22 @@ SET summa = :summa,
 WHERE id = :id;
 
 -- name: hae-toimenkuva-tarjoukselle
-SELECT id, tarjous_id, urakka_id, hoitokauden_alkuvuosi, summa, osio::text,
-       johto_ja_hallintokorvaus_toimenkuva_id, tehtavaryhma_id, tehtava_id
+SELECT id, tarjous_id, urakka_id, hoitokauden_alkuvuosi, summa, maksukausi, osio::text,
+       johto_ja_hallintokorvaus_toimenkuva_id
   FROM tarjous_johto_ja_hallintokorvaus
  WHERE tarjous_id = :tarjous_id
    AND johto_ja_hallintokorvaus_toimenkuva_id = :johto_ja_hallintokorvaus_toimenkuva_id
    AND urakka_id = :urakka_id
    AND hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
    AND osio = :osio::suunnittelu_osio
-   AND (:tehtava_id::INTEGER IS NULL OR tehtava_id = :tehtava_id)
-   AND (:tehtavaryhma_id::INTEGER IS NULL OR tehtavaryhma_id = :tehtavaryhma_id);
+   AND maksukausi = :maksukausi;
 
 -- name: paivita-tarjouksen-johto-ja-hallintokorvaus<!
 UPDATE tarjous_johto_ja_hallintokorvaus
 SET summa = :summa,
+    maksukausi = :maksukausi,
     osio = :osio::suunnittelu_osio,
     johto_ja_hallintokorvaus_toimenkuva_id = :johto_ja_hallintokorvaus_toimenkuva_id,
-    tehtavaryhma_id = :tehtavaryhma_id,
-    tehtava_id = :tehtava_id,
     muokkaaja = :muokkaaja,
     muokattu = NOW()
 WHERE id = :id;

--- a/src/clj/harja/kyselyt/toimenkuvat_kyselyt.sql
+++ b/src/clj/harja/kyselyt/toimenkuvat_kyselyt.sql
@@ -66,7 +66,7 @@ SELECT t.id, t.toimenkuva, COALESCE(t.urakkakohtainen_nimi, '') AS urakkakohtain
 -- Haetaan yksittäinen toimenkuva.
 SELECT t.id, t.toimenkuva, COALESCE(t.urakkakohtainen_nimi, '') AS urakkakohtainen_nimi
 FROM johto_ja_hallintokorvaus_toimenkuva t
-WHERE t.toimenkuva = :nimi
+WHERE t.toimenkuva = :toimenkuva
   AND t."urakka-id" = :urakkaid;
 
 -- name: hae-toimenkuva

--- a/src/clj/harja/kyselyt/toimenkuvat_kyselyt.sql
+++ b/src/clj/harja/kyselyt/toimenkuvat_kyselyt.sql
@@ -88,7 +88,7 @@ SELECT exists(SELECT id FROM johto_ja_hallintokorvaus_toimenkuva WHERE id = :toi
 
 -- name: hae-urakan-toimenkuvat-alkuvuoden-perusteella
 -- Hae urakkakohtaiset toimenkuvat
-WITH urakka_toimenkuvat AS (SELECT nimike
+WITH urakka_toimenkuvat AS (SELECT toimenkuva
                             FROM unnest(
                                      CASE
                                          WHEN (:urakan-alkuvuosi >= 2019 AND :urakan-alkuvuosi <= 2021)
@@ -98,14 +98,13 @@ WITH urakka_toimenkuvat AS (SELECT nimike
                                          WHEN (:urakan-alkuvuosi = 2024)
                                              THEN ARRAY ['valmistelukausi ennen urakka-ajan alkua','vastuunalainen työnjohtaja','2. työnjohtaja', '3. työnjohtaja', 'viherhoidosta vastaava henkilö', 'harjoittelija']
                                          END
-                                 ) AS nimike)
-SELECT id, toimenkuva, toimenkuva as nimike
+                                 ) AS toimenkuva)
+SELECT id, toimenkuva
 FROM johto_ja_hallintokorvaus_toimenkuva jht
 WHERE jht."urakka-id" = :urakka-id
   AND jht.toimenkuva is not null
 UNION
-SELECT (select MIN(id) from johto_ja_hallintokorvaus_toimenkuva where toimenkuva = ut.nimike) AS id,
-       nimike                                                                                 AS toimenkuva,
-       nimike
+SELECT (select MIN(id) from johto_ja_hallintokorvaus_toimenkuva where toimenkuva = ut.toimenkuva) AS id,
+       toimenkuva
 from urakka_toimenkuvat ut
 ORDER BY ID;

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
@@ -268,7 +268,7 @@
 
         ;; Järjestetään toimenkuvat järkevään järjestykseen
         toimenkuvat (map (fn [toimenkuva]
-                           (assoc toimenkuva :jarjestys (toimenkuva-kyselyt/paattele-toimenkuvan-jarjestys (:nimike toimenkuva))))
+                           (assoc toimenkuva :jarjestys (toimenkuva-kyselyt/paattele-toimenkuvan-jarjestys (:toimenkuva toimenkuva))))
                       toimenkuvat)
 
         ;; Haetaan raskaalla prosessilla toimenkuvakohtaisesti suunnitellut johto-ja-hallintokorvaukset

--- a/src/clj/harja/palvelin/palvelut/hallinta/toimenkuvat_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/hallinta/toimenkuvat_palvelu.clj
@@ -51,7 +51,7 @@
         uusi-rivi (and (not (nil? id)) (= -1 id))
         ;; Haetaan urakan toimenkuva
         urakan-toimenkuva (first (toimenkuvat-kyselyt/hae-urakan-toimenkuva db {:urakkaid urakka
-                                                                                :nimi nimi}))
+                                                                                :toimenkuva nimi}))
         ;; Käyttöliittymän yksinkertaistamiseksi logiikkamuutos tänne bäackendiin.
         ;; Jos käyttäjä lisää urakkakohtainen-nimi arvon, niin se on päätös ottaa toimenkuva käyttöön.
         valittu? (cond

--- a/src/clj/harja/palvelin/palvelut/suunnittelu/tarjous_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/suunnittelu/tarjous_palvelu.clj
@@ -18,9 +18,7 @@
   palauttaa tyhjät tiedot, jotka voidaan täyttää uudelleen."
   [db user tiedot]
   (oikeudet/vaadi-lukuoikeus oikeudet/urakat-suunnittelu-kustannussuunnittelu user (:urakka-id tiedot))
-  (let [urakan-tiedot (first (urakat-kyselyt/hae-urakka db {:id (:urakka-id tiedot)}))
-        urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
-        tarjous {:urakka-id (:urakka-id tiedot)
+  (let [tarjous {:urakka-id (:urakka-id tiedot)
                  :kaikki-toimenkuvat (map #(assoc % :nimi (str/capitalize (:nimi %))) (toimenkuva-kyselyt/hae-toimenkuvat db))
                  :tarjous (tarjous-kyselyt/luo-default-tarjous db (:urakka-id tiedot))}]
     tarjous))

--- a/src/clj/harja/palvelin/palvelut/suunnittelu/tarjous_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/suunnittelu/tarjous_palvelu.clj
@@ -1,5 +1,6 @@
 (ns harja.palvelin.palvelut.suunnittelu.tarjous-palvelu
-  (:require [com.stuartsierra.component :as component]
+  (:require [clojure.string :as str]
+            [com.stuartsierra.component :as component]
             [clojure.java.jdbc :as jdbc]
             [harja.kyselyt.tarjous-kyselyt :as tarjous-kyselyt]
             [harja.kyselyt.toimenkuvat-kyselyt :as toimenkuva-kyselyt]
@@ -20,9 +21,7 @@
   (let [urakan-tiedot (first (urakat-kyselyt/hae-urakka db {:id (:urakka-id tiedot)}))
         urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
         tarjous {:urakka-id (:urakka-id tiedot)
-                 :kaikki-toimenkuvat (if (>= urakan-alkuvuosi 2025)
-                                       (toimenkuva-kyselyt/hae-toimenkuvat db)
-                                       nil)
+                 :kaikki-toimenkuvat (map #(assoc % :nimi (str/capitalize (:nimi %))) (toimenkuva-kyselyt/hae-toimenkuvat db))
                  :tarjous (tarjous-kyselyt/luo-default-tarjous db (:urakka-id tiedot))}]
     tarjous))
 

--- a/src/clj/harja/palvelin/palvelut/suunnittelu/tarjous_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/suunnittelu/tarjous_palvelu.clj
@@ -19,7 +19,9 @@
   [db user tiedot]
   (oikeudet/vaadi-lukuoikeus oikeudet/urakat-suunnittelu-kustannussuunnittelu user (:urakka-id tiedot))
   (let [tarjous {:urakka-id (:urakka-id tiedot)
-                 :kaikki-toimenkuvat (map #(assoc % :nimi (str/capitalize (:nimi %))) (toimenkuva-kyselyt/hae-toimenkuvat db))
+                 :kaikki-toimenkuvat (map #(assoc %
+                                             :toimenkuva (:nimi %)
+                                             :nimi (str/capitalize (:nimi %))) (toimenkuva-kyselyt/hae-toimenkuvat db))
                  :tarjous (tarjous-kyselyt/luo-default-tarjous db (:urakka-id tiedot))}]
     tarjous))
 

--- a/src/cljs/harja/tiedot/urakka/suunnittelu/tarjous_kustannussuunnitelma_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/suunnittelu/tarjous_kustannussuunnitelma_tiedot.cljs
@@ -16,6 +16,23 @@
   ;; Kutsutaan kun käyttäjä generoi kuukausittaiset summat tai vahvistaa koko kustannussuunnitelman
   (siirrin/siirry-elementin-id elementin-id 200))
 
+(defn konvertoi-grid-muotoon [data]
+  (into [] (reduce (fn [rivit tarjous-rivi]
+                     (let [vuosiarvot (reduce (fn [uusi rivi]
+                                                (-> uusi
+                                                  (assoc :poistettu (:poistettu tarjous-rivi))
+                                                  (assoc :rahavaraus-id (:rahavaraus-id tarjous-rivi))
+                                                  (assoc :toimenkuva-id (:toimenkuva-id tarjous-rivi))
+                                                  (assoc :tehtava-id (:tehtava-id tarjous-rivi))
+                                                  (assoc :tehtavaryhma-id (:tehtavaryhma-id tarjous-rivi))
+                                                  (assoc :osio (:osio tarjous-rivi))
+                                                  (assoc (keyword (str "vuosi-" (:vuosi rivi))) (:summa rivi))))
+                                        {} (:hoitovuosittaiset-arvot tarjous-rivi))
+                           nimiarvot {:nimi (:nimi tarjous-rivi) :yhteensa (:yhteensa tarjous-rivi)}
+                           lopputulos (merge vuosiarvot nimiarvot)]
+                       (concat rivit [lopputulos])))
+             [] data)))
+
 (defn muunna-vuodet
   "Muunnetaan UI Gridin käyttämä tietomalli bäkkärin käyttämään muotoon.
   UI Grille on oltava jokainen vuosi omassa avaimeessaa tyyliin :vuosi-2023, :vuosi-2024 jne.
@@ -166,9 +183,15 @@
 
   HaeTyhjatTarjouksenTiedotOnnistui
   (process-event [{:keys [vastaus]} app]
-    (-> app
-      (assoc :haku-kaynnissa? false)
-      (assoc :tarjous (:tarjous vastaus))))
+    (let [toimenkuvat (filter #(some #{"johto-ja-hallintokorvaus"} [(:osio %)]) (:tarjous vastaus))
+          toimenkuva-rivit (konvertoi-grid-muotoon toimenkuvat)
+          ;; Asetetaan tyhjät tiedot grid atomeihin
+          _ (reset! grid-toimenkuvat-atom toimenkuva-rivit)]
+
+      (-> app
+        (assoc :haku-kaynnissa? false)
+        (assoc :kaikki-toimenkuvat (:kaikki-toimenkuvat vastaus))
+        (assoc :tarjous (:tarjous vastaus)))))
 
   HaeTyhjatTarjouksenTiedotEpaonnistui
   (process-event [{:keys [vastaus]} app]

--- a/src/cljs/harja/tiedot/urakka/suunnittelu/tarjous_kustannussuunnitelma_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/suunnittelu/tarjous_kustannussuunnitelma_tiedot.cljs
@@ -20,6 +20,7 @@
   (into [] (reduce (fn [rivit tarjous-rivi]
                      (let [vuosiarvot (reduce (fn [uusi rivi]
                                                 (-> uusi
+                                                  (assoc :maksukausi (:maksukausi tarjous-rivi))
                                                   (assoc :poistettu (:poistettu tarjous-rivi))
                                                   (assoc :rahavaraus-id (:rahavaraus-id tarjous-rivi))
                                                   (assoc :toimenkuva-id (:toimenkuva-id tarjous-rivi))

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_nakyma.cljs
@@ -239,7 +239,8 @@
            [:div.col-xs-12.body-text "Harja luo kulut kuukausille, kun tallennat tiedot."]]
           (yhteiset/tallenna-painike-rivi viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
             #(e! (kust-tiedot/->TallennaErillishankinnat @yhteiset/grid-erillishankinnat-atom))
-            #(e! (kust-tiedot/->JaaErillishankinnatTasan tarjouksen-maara "erillishankinnat-elementti")))])
+            (when (and tarjouksen-maara (> tarjouksen-maara 0))
+              #(e! (kust-tiedot/->JaaErillishankinnatTasan tarjouksen-maara "erillishankinnat-elementti"))))])
 
        [:div.row
         [:div.col-xs-12
@@ -276,7 +277,8 @@
        (when-not vahvistettu?
          (yhteiset/tallenna-painike-rivi viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
            #(e! (kust-tiedot/->TallennaErillishankinnat @yhteiset/grid-erillishankinnat-atom))
-           #(e! (kust-tiedot/->JaaErillishankinnatTasan tarjouksen-maara "erillishankinnat-elementti"))))])))
+           (when (and tarjouksen-maara (> tarjouksen-maara 0))
+             #(e! (kust-tiedot/->JaaErillishankinnatTasan tarjouksen-maara "erillishankinnat-elementti")))))])))
 
 (defn hoidonjohtopalkkiot [e! {:keys [valittu-hoitokausi tallennus-kesken? tarjous kustannussuunnitelma] :as app}]
   (if (nil? (get-in app [:kustannussuunnitelma :hoidonjohtopalkkiot]))
@@ -323,7 +325,8 @@
            [:div.col-xs-12.body-text "Harja luo kulut kuukausille, kun tallennat tiedot."]]
           (yhteiset/tallenna-painike-rivi viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
             #(e! (kust-tiedot/->TallennaHoidonjohtopalkkiot @yhteiset/grid-hoidonjohtopalkkiot-atom))
-            #(e! (kust-tiedot/->JaaHoidonjohtopalkkiotTasan tarjouksen-maara "hoidonjohtopalkkio-elementti")))])
+            (when (and tarjouksen-maara (> tarjouksen-maara 0))
+              #(e! (kust-tiedot/->JaaHoidonjohtopalkkiotTasan tarjouksen-maara "hoidonjohtopalkkio-elementti"))))])
 
        [:div.row
         [:div.col-xs-12
@@ -360,7 +363,8 @@
        (when-not vahvistettu?
          (yhteiset/tallenna-painike-rivi viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
            #(e! (kust-tiedot/->TallennaHoidonjohtopalkkiot @yhteiset/grid-hoidonjohtopalkkiot-atom))
-           #(e! (kust-tiedot/->JaaHoidonjohtopalkkiotTasan tarjouksen-maara "hoidonjohtopalkkio-elementti"))))])))
+           (when (and tarjouksen-maara (> tarjouksen-maara 0))
+            #(e! (kust-tiedot/->JaaHoidonjohtopalkkiotTasan tarjouksen-maara "hoidonjohtopalkkio-elementti")))))])))
 
 (defn tavoite-ja-kattohinta [e! {:keys [valittu-hoitokausi tallennus-kesken? tarjous kustannussuunnitelma] :as app}]
   (let [valittu-vuosi (pvm/vuosi (first valittu-hoitokausi))

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
@@ -85,9 +85,7 @@
       :muokattava? (constantly true)
       :voi-poistaa? (constantly false)
       :voi-lisata? true
-      :uusi-rivi (fn [rivi]
-                   (merge (assoc rivi :id -1 :nimi "" :yhteensa 0)
-                     vuosi-map))
+      :uusi-rivi (fn [rivi] (merge (assoc rivi :id -1 :nimi "" :yhteensa 0) vuosi-map))
       :voi-kumota? false
       :piilota-toiminnot? false
       :tunniste :nimi
@@ -100,12 +98,13 @@
                                             (let [uusi-toimenkuva-kaikista (first (filter (fn [t]
                                                                                             (= (:nimi t) (:nimi toimenkuva)))
                                                                                     kaikki-toimenkuvat))]
-                                              (assoc toimenkuva
-                                                :osio "johto-ja-hallintokorvaus"
-                                                :poistettu nil
-                                                :yhteensa 0
-                                                :rahavaraus-id nil
-                                                :toimenkuva-id (:id uusi-toimenkuva-kaikista)))
+                                              (merge (assoc toimenkuva
+                                                       :osio "johto-ja-hallintokorvaus"
+                                                       :poistettu nil
+                                                       :yhteensa 0
+                                                       :rahavaraus-id nil
+                                                       :toimenkuva-id (:id uusi-toimenkuva-kaikista))
+                                                vuosi-map))
                                             toimenkuva))
                                      toimenkuvat)]
                    (reset! tallenna-painettu false)
@@ -125,7 +124,12 @@
                  :tyyppi :valinta
                  :valinnat-fn #(map :nimi muut-toimenkuvat)
                  :aseta (fn [rivi arvo]
-                          (assoc rivi :id -1 :nimi arvo :paivtetty? true :uusi-nimi arvo :vanha-id (:toimenkuva-id rivi)))
+                          (assoc rivi :id -1
+                            :nimi arvo
+                            :uusi-nimi arvo
+                            :vanha-id (:toimenkuva-id rivi)
+                            :osio "johto-ja-hallintokorvaus"
+                            :rahavaraus-id nil))
                  :luokka "yhteensa"
                  :leveys (str nimi-leveys "%")
                  :muokattava? (fn [rivi arvo] (if (= -1 (:id rivi)) true false))}
@@ -137,7 +141,8 @@
                           (assoc rivi :id -1 :nimi arvo :paivtetty? true :uusi-nimi arvo :vanha-id (:toimenkuva-id rivi)))
                  :luokka "yhteensa"
                  :leveys (str nimi-leveys "%")
-                 :muokattava? (constantly true)})]
+                 ;; Jos on vielä mahdollista vaihtaa toimenkuvaa, niin näytä valikko. Muuten ei näytetä valikkoa.
+                 :muokattava? (if (seq muut-toimenkuvat) (constantly true) (constantly false))})]
        [;; Poista nappi vain 2025 tai jälkeen alkaneissa urakoissa
         (if (>= urakan-alkuvuosi 2025)
           {:otsikko ""
@@ -153,7 +158,7 @@
            :komponentti (fn [rivi]
                           [:span])
            :leveys (str vuosi-leveys "%")})]
-       (mapv #(assoc % :muokattava false) vuositaulukon-otsikot)
+       vuositaulukon-otsikot
        [{:otsikko "Yhteensä (€)" :nimi :yhteensa :tyyppi :euro
          :muokattava? (constantly false) :luokka "yhteensa"
          :hae (fn [rivi] (laske-rivit-yhteen rivi))
@@ -171,7 +176,9 @@
                                                           :nimi (keyword (str "vuosi-" (:vuosi vuosi-rivi)))
                                                           :tyyppi :euro
                                                           :leveys (str vuosi-leveys "%")
-                                                          :muokattava? (fn [rivi] (if (or (= (:nimi rivi) "Äkilliset hoitotyöt")
+                                                          :muokattava? (fn [rivi] (if (or
+                                                                                        (and (not= 1 index) (= (:nimi rivi) "Valmistelukausi ennen urakka-ajan alkua"))
+                                                                                        (= (:nimi rivi) "Äkilliset hoitotyöt")
                                                                                         (= (:nimi rivi) "Hoidonjohtopalkkio")
                                                                                         (= (:nimi rivi) "Erillishankinnat")
                                                                                         (= (:nimi rivi) "Vahinkojen korjaukset")

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
@@ -180,25 +180,9 @@
                                                           :tasaa :oikea}])))
                                 [] (:hoitovuosittaiset-arvot (first tarjouksen-tiedot)))
 
-        taulukon-tiedot (into [] (reduce (fn [rivit tarjous-rivi]
-                                           (let [vuosiarvot (reduce (fn [uusi rivi]
-                                                                      (-> uusi
-                                                                        (assoc :poistettu (:poistettu tarjous-rivi))
-                                                                        (assoc :rahavaraus-id (:rahavaraus-id tarjous-rivi))
-                                                                        (assoc :toimenkuva-id (:toimenkuva-id tarjous-rivi))
-                                                                        (assoc :tehtava-id (:tehtava-id tarjous-rivi))
-                                                                        (assoc :tehtavaryhma-id (:tehtavaryhma-id tarjous-rivi))
-                                                                        (assoc :osio (:osio tarjous-rivi))
-                                                                        (assoc (keyword (str "vuosi-" (:vuosi rivi))) (:summa rivi))))
-                                                              {} (:hoitovuosittaiset-arvot tarjous-rivi))
-                                                 nimiarvot {:nimi (:nimi tarjous-rivi) :yhteensa (:yhteensa tarjous-rivi)}
-                                                 lopputulos (merge vuosiarvot nimiarvot)]
-                                             (concat rivit [lopputulos])))
-                                   [] (drop-last tarjouksen-tiedot))) ;; Jätetään viimeinen rivi pois, koska se on yhteenvetorivi
-        hankinnat-tiedot (into [] (filter #(some #{"hankintakustannukset" "tavoitehintaiset-rahavaraukset"}
-                                             [(:osio %)]) taulukon-tiedot))
-        joha-tiedot (into [] (filter #(some #{"johto-ja-hallintokorvaus"}
-                                        [(:osio %)]) taulukon-tiedot))]
+        taulukon-tiedot (tarjous-tiedot/konvertoi-grid-muotoon (drop-last tarjouksen-tiedot)) ;; Jätetään viimeinen rivi pois, koska se on yhteenvetorivi
+        hankinnat-tiedot (into [] (filter #(some #{"hankintakustannukset" "tavoitehintaiset-rahavaraukset"} [(:osio %)]) taulukon-tiedot))
+        joha-tiedot (into [] (filter #(some #{"johto-ja-hallintokorvaus"} [(:osio %)]) taulukon-tiedot))]
 
     [:div
      [:hr]

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
@@ -91,6 +91,7 @@
       :voi-kumota? false
       :piilota-toiminnot? false
       :tunniste :nimi
+      :jarjesta :toimenkuva-id
       :muutos #(do
                  (let [toimenkuvat (vals (grid/hae-muokkaustila %))
                        ;; Jos muutos on ollut uuden rivin lisäys, niin asetetaan valittu toimenkuva
@@ -119,17 +120,21 @@
      ;; Otsikot
      (concat [;; ennen 2025 alkaneet urakat eivät voi valita toimenkuvia tästä tarjouslomakkeesta
               (if (< urakan-alkuvuosi 2025)
-                {:otsikko "Johto- ja hallintokorvaus (vain 2025 tai myöhemmin alkaville urakoille)"
-                 :nimi :nimi
-                 :tyyppi :string
-                 :luokka "yhteensa disabled"
-                 :leveys (str nimi-leveys "%")
-                 :muokattava? (constantly false)}
                 {:otsikko "Johto- ja hallintokorvaus"
                  :nimi :nimi
                  :tyyppi :valinta
-                 ;:valinnat #(map :nimi (conj muut-toimenkuvat %))
                  :valinnat-fn #(map :nimi muut-toimenkuvat)
+                 :aseta (fn [rivi arvo]
+                          (assoc rivi :id -1 :nimi arvo :paivtetty? true :uusi-nimi arvo :vanha-id (:toimenkuva-id rivi)))
+                 :luokka "yhteensa"
+                 :leveys (str nimi-leveys "%")
+                 :muokattava? (fn [rivi arvo] (if (= -1 (:id rivi)) true false))}
+                {:otsikko "Johto- ja hallintokorvaus"
+                 :nimi :nimi
+                 :tyyppi :valinta
+                 :valinnat-fn #(map :nimi muut-toimenkuvat)
+                 :aseta (fn [rivi arvo]
+                          (assoc rivi :id -1 :nimi arvo :paivtetty? true :uusi-nimi arvo :vanha-id (:toimenkuva-id rivi)))
                  :luokka "yhteensa"
                  :leveys (str nimi-leveys "%")
                  :muokattava? (constantly true)})]

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
@@ -124,12 +124,15 @@
                  :tyyppi :valinta
                  :valinnat-fn #(map :nimi muut-toimenkuvat)
                  :aseta (fn [rivi arvo]
-                          (assoc rivi :id -1
-                            :nimi arvo
-                            :uusi-nimi arvo
-                            :vanha-id (:toimenkuva-id rivi)
-                            :osio "johto-ja-hallintokorvaus"
-                            :rahavaraus-id nil))
+                          (merge
+                            (assoc rivi :id -1
+                                   :nimi arvo
+                                   :toimenkuva (str/lower-case arvo)
+                                   :uusi-nimi arvo
+                                   :vanha-id (:toimenkuva-id rivi)
+                                   :osio "johto-ja-hallintokorvaus"
+                                   :rahavaraus-id nil)
+                            vuosi-map))
                  :luokka "yhteensa"
                  :leveys (str nimi-leveys "%")
                  :muokattava? (fn [rivi arvo] (if (= -1 (:id rivi)) true false))}
@@ -138,11 +141,24 @@
                  :tyyppi :valinta
                  :valinnat-fn #(map :nimi muut-toimenkuvat)
                  :aseta (fn [rivi arvo]
-                          (assoc rivi :id -1 :nimi arvo :paivtetty? true :uusi-nimi arvo :vanha-id (:toimenkuva-id rivi)))
+                          (merge (assoc rivi :id -1
+                                   :nimi arvo
+                                   :toimenkuva (str/lower-case arvo)
+                                   :paivtetty? true
+                                   :uusi-nimi arvo
+                                   :vanha-id (:toimenkuva-id rivi)
+                                   :osio "johto-ja-hallintokorvaus"
+                                   :rahavaraus-id nil)
+                            vuosi-map))
                  :luokka "yhteensa"
                  :leveys (str nimi-leveys "%")
-                 ;; Jos on vielä mahdollista vaihtaa toimenkuvaa, niin näytä valikko. Muuten ei näytetä valikkoa.
-                 :muokattava? (if (seq muut-toimenkuvat) (constantly true) (constantly false))})]
+                 ;; Jos on vielä mahdollista vaihtaa toimenkuvaa ja toimenkuva ei ole 'Valmistelukausi ennen urakka-ajan alkua'
+                 ;; niin näytä valikko. Muuten ei näytetä valikkoa.
+                 :muokattava? (fn [rivi]
+                                (if (and
+                                      (not= "Valmistelukausi ennen urakka-ajan alkua" (:nimi rivi))
+                                      (seq muut-toimenkuvat))
+                                  true false))})]
        [;; Poista nappi vain 2025 tai jälkeen alkaneissa urakoissa
         (if (>= urakan-alkuvuosi 2025)
           {:otsikko ""

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/tarjous_nakyma.cljs
@@ -100,6 +100,7 @@
                                                                                     kaikki-toimenkuvat))]
                                               (merge (assoc toimenkuva
                                                        :osio "johto-ja-hallintokorvaus"
+                                                       :maksukausi "vuosi"
                                                        :poistettu nil
                                                        :yhteensa 0
                                                        :rahavaraus-id nil
@@ -126,12 +127,13 @@
                  :aseta (fn [rivi arvo]
                           (merge
                             (assoc rivi :id -1
-                                   :nimi arvo
-                                   :toimenkuva (str/lower-case arvo)
-                                   :uusi-nimi arvo
-                                   :vanha-id (:toimenkuva-id rivi)
-                                   :osio "johto-ja-hallintokorvaus"
-                                   :rahavaraus-id nil)
+                              :nimi arvo
+                              :toimenkuva (str/lower-case arvo)
+                              :uusi-nimi arvo
+                              :vanha-id (:toimenkuva-id rivi)
+                              :osio "johto-ja-hallintokorvaus"
+                              :maksukausi "vuosi"
+                              :rahavaraus-id nil)
                             vuosi-map))
                  :luokka "yhteensa"
                  :leveys (str nimi-leveys "%")
@@ -148,6 +150,7 @@
                                    :uusi-nimi arvo
                                    :vanha-id (:toimenkuva-id rivi)
                                    :osio "johto-ja-hallintokorvaus"
+                                   :maksukausi "vuosi"
                                    :rahavaraus-id nil)
                             vuosi-map))
                  :luokka "yhteensa"

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/yhteiset.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/yhteiset.cljs
@@ -19,7 +19,7 @@
 (defonce grid-johto-ja-hallintokorvaukset-atom (atom [{}]))
 
 ;; Rajavuotta aiemmilla ei ole pysyviä muutoksia
-(def rajavuosi 2024)
+(def rajavuosi 2025)
 
 (defn otsikkotiedot [e! {:keys [valittu-hoitokausi kustannussuunnitelma] :as app} otsikko tarjouksen-maara
                       pysyvamuutos-maara suunniteltu-yhteensa suunniteltu-yhteensa-indeksikorjattu

--- a/test/clj/harja/palvelin/palvelut/suunnittelu/apurit.clj
+++ b/test/clj/harja/palvelin/palvelut/suunnittelu/apurit.clj
@@ -1,6 +1,6 @@
 (ns harja.palvelin.palvelut.suunnittelu.apurit)
 
-(def tarjous-tietomalli {:tarjous [{:nimi "Kilpailutettavat hankinnat", :osio "hankintakustannukset" :toimenkuva-id nil :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil
+(def tarjous-tietomalli-2019 {:tarjous [{:nimi "Kilpailutettavat hankinnat", :osio "hankintakustannukset" :toimenkuva-id nil :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil
                                     :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}] :yhteensa 60.00}
                                    ;; Rahavaraukset
                                    {:nimi "Äkilliset hoitotyöt", :osio "tavoitehintaiset-rahavaraukset" :toimenkuva-id nil :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id 1
@@ -14,20 +14,37 @@
                                    {:nimi "Erillishankinnat", :osio "erillishankinnat" :toimenkuva-id nil :tehtava-id nil :tehtavaryhma-id 28 :rahavaraus-id nil
                                     :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}], :yhteensa 60.00}
 
-                                   ;; Johto ja hallintokorvaukset eli toimenkuvat
-                                   {:nimi "Vastuunalainen työnjohtaja", :osio "johto-ja-hallintokorvaus" :toimenkuva-id 2 :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil
-                                    :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}], :yhteensa 60.00}
-                                   {:nimi "Apulainen/työnjohtaja", :osio "johto-ja-hallintokorvaus" :toimenkuva-id 4 :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil
-                                    :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}], :yhteensa 60.00}
-                                   {:nimi "Valmistelukausi ennen urakka-ajan alkua", :osio "johto-ja-hallintokorvaus" :toimenkuva-id 10 :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil
-                                    :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}], :yhteensa 60.00}
+                                   ;; Johto ja hallintokorvaukset eli toimenkuvat - tulevat tietokannasta urakkavuoden mukaan, ei yritetä syöttää tässä
 
                                    ;; Hoidonjohtopalkkio
                                    {:nimi "Hoidonjohtopalkkio", :osio "hoidonjohtopalkkio" :toimenkuva-id nil :tehtava-id 3061 :tehtavaryhma-id nil :rahavaraus-id nil
                                     :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 10.00} {:vuosi 2024 :summa 20.00} {:vuosi 2025 :summa 30.00}], :yhteensa 60.00}
                                    ;; Yhteensä rivi
                                    {:nimi "Yhteensä tavoitehinta", :osio "yhteensa"
-                                    :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 90.00} {:vuosi 2024 :summa 180.00} {:vuosi 2025 :summa 270.00}], :yhteensa 540.00}]})
+                                    :hoitovuosittaiset-arvot [{:vuosi 2021 :summa 0.00} {:vuosi 2022 :summa 0.00} {:vuosi 2023 :summa 90.00} {:vuosi 2024 :summa 180.00} {:vuosi 2029 :summa 270.00}], :yhteensa 540.00}]})
+
+(def tarjous-tietomalli-2025 {:tarjous [{:nimi "Kilpailutettavat hankinnat", :osio "hankintakustannukset" :toimenkuva-id nil :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil
+                                    :hoitovuosittaiset-arvot [{:vuosi 2025 :summa 0.00} {:vuosi 2026 :summa 0.00} {:vuosi 2027 :summa 10.00} {:vuosi 2028 :summa 20.00} {:vuosi 2029 :summa 30.00}] :yhteensa 60.00}
+                                   ;; Rahavaraukset
+                                   {:nimi "Äkilliset hoitotyöt", :osio "tavoitehintaiset-rahavaraukset" :toimenkuva-id nil :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id 1
+                                    :hoitovuosittaiset-arvot [{:vuosi 2025 :summa 0.00} {:vuosi 2026 :summa 0.00} {:vuosi 2027 :summa 10.00} {:vuosi 2028 :summa 20.00} {:vuosi 2029 :summa 30.00}] :yhteensa 60.00}
+                                   {:nimi "Vahinkojen korjaukset", :osio "tavoitehintaiset-rahavaraukset" :toimenkuva-id nil :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id 2
+                                    :hoitovuosittaiset-arvot [{:vuosi 2025 :summa 0.00} {:vuosi 2026 :summa 0.00} {:vuosi 2027 :summa 10.00} {:vuosi 2028 :summa 20.00} {:vuosi 2029 :summa 30.00}] :yhteensa 60.00}
+                                   {:nimi "Tilaajan rahavaraus kannustinjärjestelmään", :osio "tavoitehintaiset-rahavaraukset" :toimenkuva-id nil :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id 3
+                                    :hoitovuosittaiset-arvot [{:vuosi 2025 :summa 0.00} {:vuosi 2026 :summa 0.00} {:vuosi 2027 :summa 10.00} {:vuosi 2028 :summa 20.00} {:vuosi 2029 :summa 30.00}] :yhteensa 60.00}
+
+                                   ;; Erillishankinnat
+                                   {:nimi "Erillishankinnat", :osio "erillishankinnat" :toimenkuva-id nil :tehtava-id nil :tehtavaryhma-id 28 :rahavaraus-id nil
+                                    :hoitovuosittaiset-arvot [{:vuosi 2025 :summa 0.00} {:vuosi 2026 :summa 0.00} {:vuosi 2027 :summa 10.00} {:vuosi 2028 :summa 20.00} {:vuosi 2029 :summa 30.00}], :yhteensa 60.00}
+
+                                   ;; Johto ja hallintokorvaukset eli toimenkuvat - tulevat tietokannasta urakkavuoden mukaan, ei yritetä syöttää tässä
+
+                                   ;; Hoidonjohtopalkkio
+                                   {:nimi "Hoidonjohtopalkkio", :osio "hoidonjohtopalkkio" :toimenkuva-id nil :tehtava-id 3061 :tehtavaryhma-id nil :rahavaraus-id nil
+                                    :hoitovuosittaiset-arvot [{:vuosi 2025 :summa 0.00} {:vuosi 2026 :summa 0.00} {:vuosi 2027 :summa 10.00} {:vuosi 2028 :summa 20.00} {:vuosi 2029 :summa 30.00}], :yhteensa 60.00}
+                                   ;; Yhteensä rivi
+                                   {:nimi "Yhteensä tavoitehinta", :osio "yhteensa"
+                                    :hoitovuosittaiset-arvot [{:vuosi 2025 :summa 0.00} {:vuosi 2026 :summa 0.00} {:vuosi 2027 :summa 90.00} {:vuosi 2028 :summa 180.00} {:vuosi 2029 :summa 270.00}], :yhteensa 540.00}]})
 
 (defn muodosta-tarjous-rahavarauksista [rahavaraukset vuodet]
   {:tarjous (mapv

--- a/test/clj/harja/palvelin/palvelut/suunnittelu/tarjous_test.clj
+++ b/test/clj/harja/palvelin/palvelut/suunnittelu/tarjous_test.clj
@@ -31,15 +31,40 @@
 
 (use-fixtures :each (compose-fixtures tietokanta-fixture jarjestelma-fixture))
 
+;; Helpperit
+
 (defn generoi-toimenkuville-vuosisummat [toimenkuvat vuodet]
   {:tarjous (mapv
               (fn [toimenkuva]
-                (merge toimenkuva
-                  {:hoitovuosittaiset-arvot (mapv
-                                              (fn [vuosi]
-                                                {:vuosi (:vuosi vuosi) :summa (rand-int 1000)}) ;; Generoidaan satunnaiset summat
-                                              vuodet)}))
+                (let [hoitovuosittaiset-arvot (mapv
+                                                (fn [vuosi]
+                                                  {:vuosi (:vuosi vuosi) :summa (round2 1 (rand-int 1000))}) ;; Generoidaan satunnaiset summat
+                                                vuodet)
+                      yhteensa (reduce + (map :summa hoitovuosittaiset-arvot))
+                      toimenkuva (merge toimenkuva
+                                   {:hoitovuosittaiset-arvot hoitovuosittaiset-arvot
+                                    :yhteensa yhteensa})]
+                  toimenkuva)
+                )
               toimenkuvat)})
+
+(defn lisaa-ja-generoi-toimenkuvat [db urakka-id urakan-alkuvuosi tietomallitarjous hoitovuosittaiset-arvot]
+  (let [;; Lisää tarjoukselle urakkavuoden mukaiset toimenkuvat
+        kaikki-urakan-toimenkuvat (tarjous-kyselyt/hae-urakan-toimenkuvat db urakka-id urakan-alkuvuosi hoitovuosittaiset-arvot)
+
+        tarjous (generoi-toimenkuville-vuosisummat kaikki-urakan-toimenkuvat hoitovuosittaiset-arvot)
+        tarjousrivit (concat (:tarjous tietomallitarjous) (:tarjous tarjous))
+        ;; Poistetaan yhteensä rivi
+        tarjousrivit (filter #(not= "yhteensa" (:osio %)) tarjousrivit)
+        ;; Lisätään uusi yhteensä rivi
+        tarjous (tarjous-kyselyt/lisaa-yhteenvetorivi-tarjoukseen {:tarjous tarjousrivit})]
+    tarjous))
+
+(defn ota-toimenkuvat-ja-poista-id [tarjous]
+  (map #(dissoc % :id) ;; Id ei aina testeissä oikein täsmää
+    (filter (fn [rivi]
+              (= (:osio rivi) "johto-ja-hallintokorvaus"))
+      (:tarjous tarjous))))
 
 (deftest tallenna-yksinkertainen-tarjous-tietokantaan-onnistuneesti
   (let [db (:db jarjestelma)
@@ -47,7 +72,7 @@
         kayttaja-id (:id +kayttaja-jvh+)
         ;; Käytetään kattohintana 1.1 x tavoitehintaa
         kattohintakerroin 1.1
-        vuosittaiset-tarjoushinnat (tarjous-kyselyt/tallenna-tarjous-tietokantaan db urakka-id kayttaja-id kattohintakerroin apurit/tarjous-tietomalli)
+        vuosittaiset-tarjoushinnat (tarjous-kyselyt/tallenna-tarjous-tietokantaan db urakka-id kayttaja-id kattohintakerroin apurit/tarjous-tietomalli-2019)
         tarjoukset-tietokannasta (q-map "SELECT * from tarjous")]
     (is (= (count tarjoukset-tietokannasta) (count vuosittaiset-tarjoushinnat)))))
 
@@ -61,7 +86,7 @@
         ;; Haetaan urakan rahavaraukset
         rahavaraukset (rahavaraus-kyselyt/hae-urakan-rahavaraukset db {:urakka_id urakka-id})
         ;; Vuodet tietomallista
-        vuodet (tarjous-kyselyt/vuodet-tietomallista apurit/tarjous-tietomalli)
+        vuodet (tarjous-kyselyt/vuodet-tietomallista apurit/tarjous-tietomalli-2019)
         tarjous (apurit/muodosta-tarjous-rahavarauksista rahavaraukset vuodet)
         vuosittaiset-tarjoushinnat (tarjous-kyselyt/tallenna-tarjous-tietokantaan db urakka-id kayttaja-id kattohintakerroin tarjous)
         tarjoukset-tietokannasta (q-map "SELECT * from tarjous")
@@ -82,7 +107,7 @@
         ;; Haetaan urakan rahavaraukset
         rahavaraukset (rahavaraus-kyselyt/hae-urakan-rahavaraukset db {:urakka_id urakka-id})
         ;; Vuodet tietomallista
-        vuodet (tarjous-kyselyt/vuodet-tietomallista apurit/tarjous-tietomalli)
+        vuodet (tarjous-kyselyt/vuodet-tietomallista apurit/tarjous-tietomalli-2019)
         tarjous (apurit/muodosta-tarjous-rahavarauksista rahavaraukset vuodet)
         ;; Tallenna tarjous kantaan
         vuosittaiset-tarjoushinnat (tarjous-kyselyt/tallenna-tarjous-tietokantaan db urakka-id kayttaja-id kattohintakerroin tarjous)
@@ -102,7 +127,7 @@
         ;; Haetaan urakan rahavaraukset
         rahavaraukset (rahavaraus-kyselyt/hae-urakan-rahavaraukset db {:urakka_id urakka-id})
         ;; Vuodet tietomallista
-        vuodet (tarjous-kyselyt/vuodet-tietomallista apurit/tarjous-tietomalli)
+        vuodet (tarjous-kyselyt/vuodet-tietomallista apurit/tarjous-tietomalli-2019)
         tarjous (apurit/muodosta-tarjous-rahavarauksista rahavaraukset vuodet)
 
         ;; Lisätään rahavarausten lisäksi myös muita kustannuksia
@@ -135,7 +160,7 @@
                    {:nimi "Hoidonjohtopalkkio", :osio "hoidonjohtopalkkio" :toimenkuva-id nil :tehtava-id 3061 :tehtavaryhma-id nil :rahavaraus-id nil}]
 
         ;; Vuodet tietomallista
-        vuodet (tarjous-kyselyt/vuodet-tietomallista apurit/tarjous-tietomalli)
+        vuodet (tarjous-kyselyt/vuodet-tietomallista apurit/tarjous-tietomalli-2019)
         tarjous {:tarjous (mapv
                             (fn [hankinta]
                               {:nimi (:nimi hankinta)
@@ -174,7 +199,7 @@
 
 
         ;; Vuodet tietomallista
-        vuodet (tarjous-kyselyt/vuodet-tietomallista apurit/tarjous-tietomalli)
+        vuodet (tarjous-kyselyt/vuodet-tietomallista apurit/tarjous-tietomalli-2019)
         tarjous (generoi-toimenkuville-vuosisummat johto-ja-hallintokorvaukset vuodet)
 
         vuosittaiset-tarjoushinnat (tarjous-kyselyt/tallenna-tarjous-tietokantaan db urakka-id kayttaja-id kattohintakerroin tarjous)
@@ -229,7 +254,6 @@
         kayttaja-id (:id +kayttaja-jvh+)
 
         kaikki-urakan-toimenkuvat (tarjous-kyselyt/hae-urakan-toimenkuvat db urakka-id urakan-alkuvuosi hoitovuosittaiset-arvot)
-        kaikki-urakan-toimenkuvat (tarjous-kyselyt/jasenna-toimenkuvat-maksukausittain kaikki-urakan-toimenkuvat urakan-alkuvuosi)
 
         tarjous (generoi-toimenkuville-vuosisummat kaikki-urakan-toimenkuvat hoitovuosittaiset-arvot)
 
@@ -257,7 +281,6 @@
         kayttaja-id (:id +kayttaja-jvh+)
 
         kaikki-urakan-toimenkuvat (tarjous-kyselyt/hae-urakan-toimenkuvat db urakka-id urakan-alkuvuosi hoitovuosittaiset-arvot)
-        kaikki-urakan-toimenkuvat (tarjous-kyselyt/jasenna-toimenkuvat-maksukausittain kaikki-urakan-toimenkuvat urakan-alkuvuosi)
 
         tarjous (generoi-toimenkuville-vuosisummat kaikki-urakan-toimenkuvat hoitovuosittaiset-arvot)
 
@@ -310,7 +333,6 @@
         kayttaja-id (:id +kayttaja-jvh+)
 
         kaikki-urakan-toimenkuvat (tarjous-kyselyt/hae-urakan-toimenkuvat db urakka-id urakan-alkuvuosi hoitovuosittaiset-arvot)
-        kaikki-urakan-toimenkuvat (tarjous-kyselyt/jasenna-toimenkuvat-maksukausittain kaikki-urakan-toimenkuvat urakan-alkuvuosi)
 
         tarjous (generoi-toimenkuville-vuosisummat kaikki-urakan-toimenkuvat hoitovuosittaiset-arvot)
 
@@ -337,30 +359,127 @@
 
 
 ;; Rajanpintatestit
-(deftest tallenna-tarjous-rajapinnasta-onnistuu
+(deftest tallenna-tarjous-2021-urakalle-rajapinnasta-onnistuu
   (let [db (:db jarjestelma)
         urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
-        tarjous (assoc apurit/tarjous-tietomalli :urakka-id urakka-id)
-        ;; Testi failaa, jos tämän kommentoinnin ottaa pois.
-        ;tarjous (assoc-in tarjous [:tarjous 0 :hoitovuosittaiset-arvot 0 :summa] 100M) ;; Muutetaan ensimmäisen rivin summa
-        vastaus (kutsu-palvelua (:http-palvelin jarjestelma) :tallenna-tarjouksen-tiedot +kayttaja-jvh+ tarjous)]
-    (is (= (:tarjous vastaus) (:tarjous apurit/tarjous-tietomalli)))))
+        urakan-tiedot (first (urakat-kyselyt/hae-urakka db {:id urakka-id}))
+        urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
+        vuodet (range urakan-alkuvuosi (pvm/vuosi (:loppupvm urakan-tiedot)))
+        hoitovuosittaiset-arvot (mapv (fn [vuosi] {:vuosi vuosi :summa 0.00M}) vuodet)
+        tietomallitarjous (assoc apurit/tarjous-tietomalli-2019 :urakka-id urakka-id)
+        ;; Lisätään urakalle kuuluvat toimenkuvat ja niille generoidut summat
+        tietomallitarjous (merge
+                            {:urakka-id urakka-id}
+                            (lisaa-ja-generoi-toimenkuvat db urakka-id urakan-alkuvuosi tietomallitarjous hoitovuosittaiset-arvot))
+        hankinta-osiot #{"hankintakustannukset", "erillishankinnat", "hoidonjohtopalkkio", "tavoitehintaiset-rahavaraukset"}
+        hoidonjohtopalkkio-tietomallista (filter #(= (:osio %) "hoidonjohtopalkkio") (:tarjous tietomallitarjous))
+        hankinnat-tietomallista (filter #(contains? hankinta-osiot (:osio %)) (:tarjous tietomallitarjous))
+        toimenkuvat-tietomallista (map #(dissoc % :id) ;; Id ei aina testeissä oikein täsmää
+                                    (filter (fn [rivi]
+                                              (= (:osio rivi) "johto-ja-hallintokorvaus"))
+                                      (:tarjous tietomallitarjous)))
 
-(deftest muokkaa-tarjous-rajapinnasta-onnistuu
-  (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
-        tarjous (assoc apurit/tarjous-tietomalli :urakka-id urakka-id)
-        uusi-summa 500M
+        vastaus (kutsu-palvelua (:http-palvelin jarjestelma) :tallenna-tarjouksen-tiedot +kayttaja-jvh+ tietomallitarjous)
+        hoidonjohtopalkkio-vastauksesta (filter #(= (:osio %) "hoidonjohtopalkkio") (:tarjous vastaus))
+        hankinnat-vastauksesta (filter #(contains? hankinta-osiot (:osio %)) (:tarjous vastaus))
+        toimenkuvat-vastauksesta (map #(dissoc % :id) ;; Id ei aina testeissä oikein täsmää
+                                   (filter (fn [rivi]
+                                             (= (:osio rivi) "johto-ja-hallintokorvaus"))
+                                     (:tarjous vastaus)))]
+    (is (= hoidonjohtopalkkio-tietomallista hoidonjohtopalkkio-vastauksesta))
+    (is (= toimenkuvat-tietomallista toimenkuvat-vastauksesta))
+    (is (= hankinnat-tietomallista hankinnat-vastauksesta))))
+
+(deftest tallenna-tarjous-2025-urakalle-rajapinnasta-onnistuu
+  (let [db (:db jarjestelma)
+        urakka-id (hae-urakan-id-nimella "POP MHU Kajaani 2025-2030")
+        urakan-tiedot (first (urakat-kyselyt/hae-urakka db {:id urakka-id}))
+        urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
+        vuodet (range urakan-alkuvuosi (pvm/vuosi (:loppupvm urakan-tiedot)))
+        hoitovuosittaiset-arvot (mapv (fn [vuosi] {:vuosi vuosi :summa 0.00M}) vuodet)
+        tietomallitarjous (assoc apurit/tarjous-tietomalli-2025 :urakka-id urakka-id)
+        ;; Lisätään urakalle kuuluvat toimenkuvat ja niille generoidut summat
+        tietomallitarjous (merge
+                            {:urakka-id urakka-id}
+                            (lisaa-ja-generoi-toimenkuvat db urakka-id urakan-alkuvuosi tietomallitarjous hoitovuosittaiset-arvot))
+        hankinta-osiot #{"hankintakustannukset", "erillishankinnat", "hoidonjohtopalkkio", "tavoitehintaiset-rahavaraukset"}
+        hoidonjohtopalkkio-tietomallista (filter #(= (:osio %) "hoidonjohtopalkkio") (:tarjous tietomallitarjous))
+        hankinnat-tietomallista (filter #(contains? hankinta-osiot (:osio %)) (:tarjous tietomallitarjous))
+        toimenkuvat-tietomallista (ota-toimenkuvat-ja-poista-id tietomallitarjous)
+
+        vastaus (kutsu-palvelua (:http-palvelin jarjestelma) :tallenna-tarjouksen-tiedot +kayttaja-jvh+ tietomallitarjous)
+        hoidonjohtopalkkio-vastauksesta (filter #(= (:osio %) "hoidonjohtopalkkio") (:tarjous vastaus))
+        hankinnat-vastauksesta (filter #(contains? hankinta-osiot (:osio %)) (:tarjous vastaus))
+        toimenkuvat-vastauksesta (ota-toimenkuvat-ja-poista-id vastaus)]
+
+    (is (= hoidonjohtopalkkio-tietomallista hoidonjohtopalkkio-vastauksesta))
+    (is (= toimenkuvat-tietomallista toimenkuvat-vastauksesta))
+    (is (= hankinnat-tietomallista hankinnat-vastauksesta))))
+
+(deftest muokkaa-tarjouksen-kilpailutettavat-hankinnat-2021-rajapinnasta-onnistuu
+  (let [db (:db jarjestelma)
+        urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
+        urakan-tiedot (first (urakat-kyselyt/hae-urakka db {:id urakka-id}))
+        urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
+        vuodet (range urakan-alkuvuosi (pvm/vuosi (:loppupvm urakan-tiedot)))
+        hoitovuosittaiset-arvot (mapv (fn [vuosi] {:vuosi vuosi :summa 0.00M}) vuodet)
+
+        tarjous (assoc apurit/tarjous-tietomalli-2019 :urakka-id urakka-id)
+        ;; Lisätään urakalle kuuluvat toimenkuvat ja niille generoidut summat
+        tarjous (merge
+                  {:urakka-id urakka-id}
+                  (lisaa-ja-generoi-toimenkuvat db urakka-id urakan-alkuvuosi tarjous hoitovuosittaiset-arvot))
+        tietomalli-rahavaraukset (filter #(= (:osio %) "tavoitehintaiset-rahavaraukset") (:tarjous tarjous))
+        tietomalli-toimenkuvat (ota-toimenkuvat-ja-poista-id tarjous)
+        uusi-summa 500M ;; Uusi summa vuodelle Kilpailitettaville hankinnoille
+
         ;; Tallennetaan tarjous ensin
         ensivastaus (kutsu-palvelua (:http-palvelin jarjestelma) :tallenna-tarjouksen-tiedot +kayttaja-jvh+ tarjous)
         ensivastaus-kustannus (first (:tarjous ensivastaus))
+        ensivastaus-rahavaraukset (filter #(= (:osio %) "tavoitehintaiset-rahavaraukset") (:tarjous ensivastaus))
+        ensivastaus-toimenkuvat (ota-toimenkuvat-ja-poista-id ensivastaus)
 
         ;; Muokataan tarjousta
         muokattu-tarjous (assoc-in tarjous [:tarjous 0 :hoitovuosittaiset-arvot 0 :summa] uusi-summa)
         muokkausvastaus (kutsu-palvelua (:http-palvelin jarjestelma) :tallenna-tarjouksen-tiedot +kayttaja-jvh+ muokattu-tarjous)
         muokkausvastaus-kustannus (first (:tarjous muokkausvastaus))]
+
     (is (= 10.00 (get-in ensivastaus-kustannus [:hoitovuosittaiset-arvot 2 :summa])) "Vuoden 2023 summa on 10")
     (is (= uusi-summa (bigdec (get-in muokkausvastaus-kustannus [:hoitovuosittaiset-arvot 0 :summa]))))
-    ;; Ensivastauksen rivimäärä on sama
-    (is (= (count (:tarjous apurit/tarjous-tietomalli)) (count (:tarjous ensivastaus))))
-    ;; Muokkausvastauksen rivimäärä on sama
-    (is (= (count (:tarjous apurit/tarjous-tietomalli)) (count (:tarjous muokkausvastaus))))))
+    ;; Rahavaraukset ovat samat
+    (is (= tietomalli-rahavaraukset ensivastaus-rahavaraukset))
+    (is (= tietomalli-toimenkuvat ensivastaus-toimenkuvat))))
+
+(deftest muokkaa-tarjouksen-kilpailutettavat-hankinnat-2025-rajapinnasta-onnistuu
+  (let [db (:db jarjestelma)
+        urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
+        urakan-tiedot (first (urakat-kyselyt/hae-urakka db {:id urakka-id}))
+        urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
+        vuodet (range urakan-alkuvuosi (pvm/vuosi (:loppupvm urakan-tiedot)))
+        hoitovuosittaiset-arvot (mapv (fn [vuosi] {:vuosi vuosi :summa 0.00M}) vuodet)
+
+        tarjous (assoc apurit/tarjous-tietomalli-2019 :urakka-id urakka-id)
+        ;; Lisätään urakalle kuuluvat toimenkuvat ja niille generoidut summat
+        tarjous (merge
+                  {:urakka-id urakka-id}
+                  (lisaa-ja-generoi-toimenkuvat db urakka-id urakan-alkuvuosi tarjous hoitovuosittaiset-arvot))
+        tietomalli-rahavaraukset (filter #(= (:osio %) "tavoitehintaiset-rahavaraukset") (:tarjous tarjous))
+        tietomalli-toimenkuvat (ota-toimenkuvat-ja-poista-id tarjous)
+        uusi-summa 500M ;; Uusi summa vuodelle Kilpailitettaville hankinnoille
+
+        ;; Tallennetaan tarjous ensin
+        ensivastaus (kutsu-palvelua (:http-palvelin jarjestelma) :tallenna-tarjouksen-tiedot +kayttaja-jvh+ tarjous)
+        ensivastaus-kustannus (first (:tarjous ensivastaus))
+        ensivastaus-rahavaraukset (filter #(= (:osio %) "tavoitehintaiset-rahavaraukset") (:tarjous ensivastaus))
+        ensivastaus-toimenkuvat (ota-toimenkuvat-ja-poista-id ensivastaus)
+
+        ;; Muokataan tarjousta
+        muokattu-tarjous (assoc-in tarjous [:tarjous 0 :hoitovuosittaiset-arvot 0 :summa] uusi-summa)
+        muokkausvastaus (kutsu-palvelua (:http-palvelin jarjestelma) :tallenna-tarjouksen-tiedot +kayttaja-jvh+ muokattu-tarjous)
+        muokkausvastaus-kustannus (first (:tarjous muokkausvastaus))]
+
+    (is (= 10.00 (get-in ensivastaus-kustannus [:hoitovuosittaiset-arvot 2 :summa])) "Vuoden 2027 summa on 10")
+    (is (= uusi-summa (bigdec (get-in muokkausvastaus-kustannus [:hoitovuosittaiset-arvot 0 :summa]))))
+    ;; Rahavaraukset ovat samat
+    (is (= tietomalli-rahavaraukset ensivastaus-rahavaraukset))
+    (is (= tietomalli-toimenkuvat ensivastaus-toimenkuvat))))

--- a/test/clj/harja/palvelin/palvelut/suunnittelu/tarjous_test.clj
+++ b/test/clj/harja/palvelin/palvelut/suunnittelu/tarjous_test.clj
@@ -2,12 +2,15 @@
   (:require [clojure.test :refer [deftest testing use-fixtures compose-fixtures is]]
             [harja.palvelin.palvelut.budjettisuunnittelu :as bs]
             [harja.palvelin.palvelut.suunnittelu.tarjous-palvelu :as tarjous-palvelu]
+            [harja.pvm :as pvm]
             [harja.testi :refer :all]
             [com.stuartsierra.component :as component]
             [harja.tyokalut.yleiset :refer :all]
             [harja.palvelin.palvelut.suunnittelu.apurit :as apurit]
             [harja.kyselyt.tarjous-kyselyt :as tarjous-kyselyt]
-            [harja.kyselyt.rahavaraukset :as rahavaraus-kyselyt]))
+            [harja.kyselyt.rahavaraukset :as rahavaraus-kyselyt]
+            [harja.kyselyt.toimenkuvat-kyselyt :as toimenkuva-kyselyt]
+            [harja.kyselyt.urakat :as urakat-kyselyt]))
 
 (defn jarjestelma-fixture [testit]
   (alter-var-root #'jarjestelma
@@ -28,19 +31,14 @@
 
 (use-fixtures :each (compose-fixtures tietokanta-fixture jarjestelma-fixture))
 
-(defn muodosta-tarjous-toimenkuvista [toimenkuvat vuodet]
+(defn generoi-toimenkuville-vuosisummat [toimenkuvat vuodet]
   {:tarjous (mapv
               (fn [toimenkuva]
-                {:nimi (:nimi toimenkuva)
-                 :osio (:osio toimenkuva)
-                 :toimenkuva-id (:toimenkuva-id toimenkuva)
-                 :tehtava-id (:tehtava-id toimenkuva)
-                 :tehtavaryhma-id (:tehtavaryhma-id toimenkuva)
-                 :rahavaraus-id (:rahavaraus-id toimenkuva)
-                 :hoitovuosittaiset-arvot (mapv
-                                            (fn [vuosi]
-                                              {:vuosi (:vuosi vuosi) :summa (rand-int 1000)}) ;; Generoidaan satunnaiset summat
-                                            vuodet)})
+                (merge toimenkuva
+                  {:hoitovuosittaiset-arvot (mapv
+                                              (fn [vuosi]
+                                                {:vuosi (:vuosi vuosi) :summa (rand-int 1000)}) ;; Generoidaan satunnaiset summat
+                                              vuodet)}))
               toimenkuvat)})
 
 (deftest tallenna-yksinkertainen-tarjous-tietokantaan-onnistuneesti
@@ -177,7 +175,7 @@
 
         ;; Vuodet tietomallista
         vuodet (tarjous-kyselyt/vuodet-tietomallista apurit/tarjous-tietomalli)
-        tarjous (muodosta-tarjous-toimenkuvista johto-ja-hallintokorvaukset vuodet)
+        tarjous (generoi-toimenkuville-vuosisummat johto-ja-hallintokorvaukset vuodet)
 
         vuosittaiset-tarjoushinnat (tarjous-kyselyt/tallenna-tarjous-tietokantaan db urakka-id kayttaja-id kattohintakerroin tarjous)
         tarjoukset-tietokannasta (q-map "SELECT * from tarjous")
@@ -188,28 +186,155 @@
     (is (= (count tarjoukset-tietokannasta) (count vuosittaiset-tarjoushinnat)))
     (is (= (count tietokantajohto-ja-hallintokorvaukset) (* (count vuodet) (count johto-ja-hallintokorvaukset))) "Tietokannasta löytyy johto-ja-hallintokorvaukset jokaiselle vuodelle.")))
 
-(deftest tallenna-ja-hae-johto-ja-hallintokorvaukset-tarjoukselle-onnistuu
+(deftest tallenna-ja-hae-johto-ja-hallintokorvaukset-tarjoukselle-2019-onnistuu
   (let [db (:db jarjestelma)
         urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
+        urakan-tiedot (first (urakat-kyselyt/hae-urakka db {:id urakka-id}))
+        urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
+        urakan-parametrit (first (urakat-kyselyt/hae-urakan-parametrit (:db jarjestelma) {:urakkaid urakka-id}))
+        kattohintakerroin (:hoitokauden_lopun_kattohinta_kerroin urakan-parametrit)
+
+        vuodet (range urakan-alkuvuosi (pvm/vuosi (:loppupvm urakan-tiedot)))
+        hoitovuosittaiset-arvot (mapv (fn [vuosi] {:vuosi vuosi :summa 0.00M}) vuodet)
         kayttaja-id (:id +kayttaja-jvh+)
-        ;; Käytetään kattohintana 1.1 x tavoitehintaa
-        kattohintakerroin 1.1
 
         ;; Muodostetaan johto-ja-hallinto-kustannuksia, joilla voi testata tallennuksia
         ;; Muodostetaan hankintakustannuksia, joilla voi testata tallennuksia
-        johto-ja-hallintokorvaukset [{:nimi "Valmistelukausi ennen urakka-ajan alkua", :osio "johto-ja-hallintokorvaus" :toimenkuva-id 10 :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil}
-                                     {:nimi "Vastuunalainen työnjohtaja", :osio "johto-ja-hallintokorvaus" :toimenkuva-id 2 :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil}
-                                     {:nimi "Päätoiminen apulainen / työnjohtaja", :osio "johto-ja-hallintokorvaus" :toimenkuva-id 4 :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil}]
+        muokattavat-jjh-korvaukset [{:nimi "Sopimusvastaava" :toimenkuva "sopimusvastaava" :osio "johto-ja-hallintokorvaus" :toimenkuva-id 1 :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil}
+                                    {:nimi "Vastuunalainen työnjohtaja", :toimenkuva "Vastuunalainen työnjohtaja" :osio "johto-ja-hallintokorvaus" :toimenkuva-id 2 :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil}
+                                    {:nimi "Viherhoidosta vastaava henkilö", :toimenkuva "viherhoidosta vastaava henkilö" :osio "johto-ja-hallintokorvaus" :toimenkuva-id 3 :tehtava-id nil :tehtavaryhma-id nil :rahavaraus-id nil}]
 
-
-        ;; Vuodet tietomallista
-        vuodet (tarjous-kyselyt/vuodet-tietomallista apurit/tarjous-tietomalli)
-        tarjous (muodosta-tarjous-toimenkuvista johto-ja-hallintokorvaukset vuodet)
+        tarjous (generoi-toimenkuville-vuosisummat muokattavat-jjh-korvaukset hoitovuosittaiset-arvot)
 
         _ (tarjous-kyselyt/tallenna-tarjous-tietokantaan db urakka-id kayttaja-id kattohintakerroin tarjous)
-        tarjoukset-tietokannasta (:tarjous (tarjous-kyselyt/hae-tarjous db urakka-id))]
+        tarjous-tietokannasta (:tarjous (tarjous-kyselyt/hae-tarjous db urakka-id))
 
-    (is (= (count (butlast tarjoukset-tietokannasta)) (count johto-ja-hallintokorvaukset)))))
+        ;; Haetaan default toimenkuvat tietokannasta
+        urakan-toimenkuvat (tarjous-kyselyt/hae-urakan-toimenkuvat db urakka-id urakan-alkuvuosi hoitovuosittaiset-arvot)
+
+        toimenkuvat-tarjouksesta (filter #(contains? #{"johto-ja-hallintokorvaus"} (:osio %)) tarjous-tietokannasta)]
+
+    (is (= (count toimenkuvat-tarjouksesta) (count urakan-toimenkuvat)))))
+
+(deftest tallenna-ja-hae-johto-ja-hallintokorvaukset-tarjoukselle-2025-onnistuu
+  (let [db (:db jarjestelma)
+        urakka-id (hae-urakan-id-nimella "POP MHU Kajaani 2025-2030")
+        urakan-tiedot (first (urakat-kyselyt/hae-urakka db {:id urakka-id}))
+        urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
+        urakan-parametrit (first (urakat-kyselyt/hae-urakan-parametrit (:db jarjestelma) {:urakkaid urakka-id}))
+        kattohintakerroin (:hoitokauden_lopun_kattohinta_kerroin urakan-parametrit)
+
+        vuodet (range urakan-alkuvuosi (pvm/vuosi (:loppupvm urakan-tiedot)))
+        hoitovuosittaiset-arvot (mapv (fn [vuosi] {:vuosi vuosi :summa 0.00M}) vuodet)
+        kayttaja-id (:id +kayttaja-jvh+)
+
+        kaikki-urakan-toimenkuvat (tarjous-kyselyt/hae-urakan-toimenkuvat db urakka-id urakan-alkuvuosi hoitovuosittaiset-arvot)
+        kaikki-urakan-toimenkuvat (tarjous-kyselyt/jasenna-toimenkuvat-maksukausittain kaikki-urakan-toimenkuvat urakan-alkuvuosi)
+
+        tarjous (generoi-toimenkuville-vuosisummat kaikki-urakan-toimenkuvat hoitovuosittaiset-arvot)
+
+        _ (tarjous-kyselyt/tallenna-tarjous-tietokantaan db urakka-id kayttaja-id kattohintakerroin tarjous)
+        tarjous-tietokannasta (:tarjous (tarjous-kyselyt/hae-tarjous db urakka-id))
+
+        ;; Haetaan default toimenkuvat tietokannasta
+        urakan-toimenkuvat (tarjous-kyselyt/hae-urakan-toimenkuvat db urakka-id (pvm/vuosi (:alkupvm urakan-tiedot)) hoitovuosittaiset-arvot)
+
+        toimenkuvat-tarjouksesta (filter #(contains? #{"johto-ja-hallintokorvaus"} (:osio %)) tarjous-tietokannasta)]
+
+    (is (= (count toimenkuvat-tarjouksesta) (count urakan-toimenkuvat)))
+    (is (= (:hoitovuosittaiset-arvot (first toimenkuvat-tarjouksesta)) (:hoitovuosittaiset-arvot (first urakan-toimenkuvat))))))
+
+(deftest muokkaa-johto-ja-hallintokorvaukset-tarjoukselle-2025-onnistuu
+  (let [db (:db jarjestelma)
+        urakka-id (hae-urakan-id-nimella "POP MHU Kajaani 2025-2030")
+        urakan-tiedot (first (urakat-kyselyt/hae-urakka db {:id urakka-id}))
+        urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
+        urakan-parametrit (first (urakat-kyselyt/hae-urakan-parametrit (:db jarjestelma) {:urakkaid urakka-id}))
+        kattohintakerroin (:hoitokauden_lopun_kattohinta_kerroin urakan-parametrit)
+
+        vuodet (range urakan-alkuvuosi (pvm/vuosi (:loppupvm urakan-tiedot)))
+        hoitovuosittaiset-arvot (mapv (fn [vuosi] {:vuosi vuosi :summa 0.00M}) vuodet)
+        kayttaja-id (:id +kayttaja-jvh+)
+
+        kaikki-urakan-toimenkuvat (tarjous-kyselyt/hae-urakan-toimenkuvat db urakka-id urakan-alkuvuosi hoitovuosittaiset-arvot)
+        kaikki-urakan-toimenkuvat (tarjous-kyselyt/jasenna-toimenkuvat-maksukausittain kaikki-urakan-toimenkuvat urakan-alkuvuosi)
+
+        tarjous (generoi-toimenkuville-vuosisummat kaikki-urakan-toimenkuvat hoitovuosittaiset-arvot)
+
+        _ (tarjous-kyselyt/tallenna-tarjous-tietokantaan db urakka-id kayttaja-id kattohintakerroin tarjous)
+        tarjous-tietokannasta (:tarjous (tarjous-kyselyt/hae-tarjous db urakka-id))
+
+        ;; Haetaan default toimenkuvat tietokannasta
+        urakan-toimenkuvat (tarjous-kyselyt/hae-urakan-toimenkuvat db urakka-id (pvm/vuosi (:alkupvm urakan-tiedot)) hoitovuosittaiset-arvot)
+
+        toimenkuvat-tarjouksesta (filter #(contains? #{"johto-ja-hallintokorvaus"} (:osio %)) tarjous-tietokannasta)
+
+        ;; Varmistetaan, että tallennuksen jälkeen summat ovat oikein
+        _ (is (= (count toimenkuvat-tarjouksesta) (count urakan-toimenkuvat)))
+        _ (is (= (:hoitovuosittaiset-arvot (second toimenkuvat-tarjouksesta)) (:hoitovuosittaiset-arvot (second urakan-toimenkuvat))))
+
+        ;; Muokataan toisen toimenkuvan summia - Ensimmäinen on vain ennen urakkakauden alkua, joten se on vähä poikkeus
+        vuosisumma 999.0
+        muokatut-toimenkuvat (mapv (fn [toimenkuva]
+                                     (if (= (:toimenkuva-id toimenkuva) (:toimenkuva-id (second toimenkuvat-tarjouksesta)))
+                                       (assoc toimenkuva :hoitovuosittaiset-arvot (mapv (fn [vuosi]
+                                                                                          (if (= (:vuosi vuosi) urakan-alkuvuosi)
+                                                                                            (assoc vuosi :summa vuosisumma)
+                                                                                            vuosi))
+                                                                                    (:hoitovuosittaiset-arvot toimenkuva)))
+                                       toimenkuva))
+                               toimenkuvat-tarjouksesta)
+
+        ;; Poista vanhat toimenkuvat
+        muokattu-tarjous (remove #(contains? #{"johto-ja-hallintokorvaus"} (:osio %)) tarjous-tietokannasta)
+        ;; Päivitä tilalle muokatut
+        muokattu-tarjous (vec (concat muokattu-tarjous muokatut-toimenkuvat))
+
+        ;; Tallennetaan muokatut toimenkuvat
+        _ (tarjous-kyselyt/tallenna-tarjous-tietokantaan db urakka-id kayttaja-id kattohintakerroin {:tarjous muokattu-tarjous})
+        muokattu-tarjous-tietokannasta (:tarjous (tarjous-kyselyt/hae-tarjous db urakka-id))
+
+        muokatut-toimenkuvat-tarjouksesta (filter #(contains? #{"johto-ja-hallintokorvaus"} (:osio %)) muokattu-tarjous-tietokannasta)
+        _ (is (= vuosisumma (:summa (first (:hoitovuosittaiset-arvot (second muokatut-toimenkuvat-tarjouksesta))))))]))
+
+(deftest poista-toimenkuva-2025-onnistuu
+  (let [db (:db jarjestelma)
+        urakka-id (hae-urakan-id-nimella "POP MHU Kajaani 2025-2030")
+        urakan-tiedot (first (urakat-kyselyt/hae-urakka db {:id urakka-id}))
+        urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
+        urakan-parametrit (first (urakat-kyselyt/hae-urakan-parametrit (:db jarjestelma) {:urakkaid urakka-id}))
+        kattohintakerroin (:hoitokauden_lopun_kattohinta_kerroin urakan-parametrit)
+
+        vuodet (range urakan-alkuvuosi (pvm/vuosi (:loppupvm urakan-tiedot)))
+        hoitovuosittaiset-arvot (mapv (fn [vuosi] {:vuosi vuosi :summa 0.00M}) vuodet)
+        kayttaja-id (:id +kayttaja-jvh+)
+
+        kaikki-urakan-toimenkuvat (tarjous-kyselyt/hae-urakan-toimenkuvat db urakka-id urakan-alkuvuosi hoitovuosittaiset-arvot)
+        kaikki-urakan-toimenkuvat (tarjous-kyselyt/jasenna-toimenkuvat-maksukausittain kaikki-urakan-toimenkuvat urakan-alkuvuosi)
+
+        tarjous (generoi-toimenkuville-vuosisummat kaikki-urakan-toimenkuvat hoitovuosittaiset-arvot)
+
+        _ (tarjous-kyselyt/tallenna-tarjous-tietokantaan db urakka-id kayttaja-id kattohintakerroin tarjous)
+        tarjous-tietokannasta (:tarjous (tarjous-kyselyt/hae-tarjous db urakka-id))
+        toimenkuvat-tarjouksesta (filter #(contains? #{"johto-ja-hallintokorvaus"} (:osio %)) tarjous-tietokannasta)
+        ;; Merkitään yksi poistetuksi
+        muokatut-toimenkuvat (mapv (fn [toimenkuva]
+                                     (if (= (:toimenkuva-id toimenkuva) (:toimenkuva-id (second toimenkuvat-tarjouksesta)))
+                                       (assoc toimenkuva :poistettu true)
+                                       toimenkuva))
+                               toimenkuvat-tarjouksesta)
+        ;; Poista vanhat toimenkuvat
+        muokattu-tarjous (remove #(contains? #{"johto-ja-hallintokorvaus"} (:osio %)) tarjous-tietokannasta)
+        ;; Päivitä tilalle muokatut
+        muokattu-tarjous (vec (concat muokattu-tarjous muokatut-toimenkuvat))
+
+        _ (tarjous-kyselyt/tallenna-tarjous-tietokantaan db urakka-id kayttaja-id kattohintakerroin {:tarjous muokattu-tarjous})
+        muokattu-tarjous-tietokannasta (:tarjous (tarjous-kyselyt/hae-tarjous db urakka-id))
+        muokatut-toimenkuvat-tarjouksesta (filter #(contains? #{"johto-ja-hallintokorvaus"} (:osio %)) muokattu-tarjous-tietokannasta)]
+
+    ;; Toimenkuvia on poiston jälkeen yksi vähemmän
+    (is (= (dec (count toimenkuvat-tarjouksesta)) (count muokatut-toimenkuvat-tarjouksesta)))))
+
 
 ;; Rajanpintatestit
 (deftest tallenna-tarjous-rajapinnasta-onnistuu

--- a/test/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_test.clj
+++ b/test/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_test.clj
@@ -536,7 +536,7 @@
         ;; Haetaan urakan rahavaraukset
         rahavaraukset (rahavaraus-kyselyt/hae-urakan-rahavaraukset (:db jarjestelma) {:urakka_id urakka-id})
         ;; Vuodet tietomallista
-        vuodet (tarjous-kyselyt/vuodet-tietomallista apurit/tarjous-tietomalli)
+        vuodet (tarjous-kyselyt/vuodet-tietomallista apurit/tarjous-tietomalli-2019)
         tarjous (apurit/muodosta-tarjous-rahavarauksista rahavaraukset vuodet)
         _ (tarjous-kyselyt/tallenna-tarjous-tietokantaan
             (:db jarjestelma) urakka-id kayttaja-id kattohintakerroin tarjous)
@@ -601,7 +601,7 @@
         ;; Haetaan urakan rahavaraukset
         rahavaraukset (rahavaraus-kyselyt/hae-urakan-rahavaraukset (:db jarjestelma) {:urakka_id urakka-id})
         ;; Vuodet tietomallista
-        vuodet (tarjous-kyselyt/vuodet-tietomallista apurit/tarjous-tietomalli)
+        vuodet (tarjous-kyselyt/vuodet-tietomallista apurit/tarjous-tietomalli-2019)
         tarjous (apurit/muodosta-tarjous-rahavarauksista rahavaraukset vuodet)
         _ (tarjous-kyselyt/tallenna-tarjous-tietokantaan
             (:db jarjestelma) urakka-id kayttaja-id kattohintakerroin tarjous)

--- a/tietokanta/src/main/resources/db/migration/V1_1202__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1202__.sql
@@ -1,0 +1,5 @@
+-- Poistetaan tarjous_johto_ja_hallintokorvaus-taulusta columnit joita ei tarvittu ja lisätään maksukausi
+ALTER TABLE tarjous_johto_ja_hallintokorvaus
+    DROP COLUMN IF EXISTS tehtavaryhma_id,
+    DROP COLUMN IF EXISTS tehtava_id,
+    ADD COLUMN IF NOT EXISTS maksukausi VARCHAR(20);


### PR DESCRIPTION
Tarjouksen toimenkuvat nyt toimintakunnossa.
2019-2024 urakoille on omat toiminnot. Toimenkuvia voi lisätä, muttei muokata tai poistaa.

2025+ urakoilla on toimenkuvat, joita voi hallita hallintapaneelista. Lisäämällä/Poistamalla toimenkuvan tarjoukselta se poistuu myös hallinnasta. Toimenkuvia voi myös alasvetovalikosta vaihtaa tajroukselle. Alasvetovalikko tarjoaa vain ne toimenkuvat, joita ei ole vielä valittuna. Kun kaikki toimenkuvat on valittuna, niin alasvetovalikko poistuu.

Toimenkuvien hallintaan on myös lisätty hieman yksikkötestejä.