### PR TITLE
Harja 1697 kopioi tuleville vuosille

### DIFF
--- a/dev-resources/less/ikonit.less
+++ b/dev-resources/less/ikonit.less
@@ -6,3 +6,11 @@ span.ikoni {
     height: 20px;
     background-size: 20px 20px;
 }
+
+/* Käytä tarvittaessa 20px ikonin pienentämisessä yhden rivin korkuiseksi.*/
+.ikoni-16 img {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  object-fit: contain;
+}

--- a/src/clj/harja/kyselyt/tarjous_kyselyt.sql
+++ b/src/clj/harja/kyselyt/tarjous_kyselyt.sql
@@ -20,7 +20,7 @@ VALUES (:tarjous_id, :urakka_id, :hoitokauden_alkuvuosi, :summa, :maksukausi, :o
 -- name: hae-tarjouksen-tiedot
 SELECT t.id as "tarjous-id", t.hoitokauden_alkuvuosi, t.urakka_id, t.tarjous_tavoitehinta, t.tarjous_kattohinta,
        (SELECT array_agg(row(tk.id,
-           CASE WHEN tk.osio = 'tavoitehintaiset-rahavaraukset'::suunnittelu_osio THEN r.nimi
+           CASE WHEN tk.osio = 'tavoitehintaiset-rahavaraukset'::suunnittelu_osio THEN COALESCE(NULLIF(rvu.urakkakohtainen_nimi, ''), r.nimi)
                 WHEN tk.osio = 'hankintakustannukset'::suunnittelu_osio THEN 'Kilpailutettavat hankinnat'
                 WHEN tk.osio = 'erillishankinnat'::suunnittelu_osio THEN 'Erillishankinnat'
                 WHEN tk.osio = 'hoidonjohtopalkkio'::suunnittelu_osio THEN 'Hoidonjohtopalkkio'
@@ -29,6 +29,7 @@ SELECT t.id as "tarjous-id", t.hoitokauden_alkuvuosi, t.urakka_id, t.tarjous_tav
             tk.summa, tk.osio, tk.tehtava_id, tk.tehtavaryhma_id, tk.rahavaraus_id))
         FROM tarjous_kustannukset tk
                  LEFT JOIN rahavaraus r ON r.id = tk.rahavaraus_id
+                 LEFT JOIN rahavaraus_urakka rvu ON rvu.rahavaraus_id = r.id AND rvu.urakka_id = t.urakka_id
         WHERE tk.tarjous_id = t.id) as kustannukset,
        (SELECT array_agg(row(tj.id, UPPER(LEFT(jjht.toimenkuva, 1)) || RIGHT(jjht.toimenkuva, -1), tj.summa, tj.maksukausi, tj.osio, tj.johto_ja_hallintokorvaus_toimenkuva_id))
         FROM tarjous_johto_ja_hallintokorvaus tj

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
@@ -43,7 +43,8 @@
   vahvista-tai-kumoa-indeksikorjaukset-urakan-tavoitteille!
   indeksikorjaukset-vahvistettu? paivita-tavoite-ja-kattohinta<!
   lisaa-tavoite-ja-kattohinta<! hae-urakan-hoitovuoden-tavoitetiedot
-  hae-kustannussuunnitelman-osiot lisaa-kustannussuunnitelma-osio paivita-kustannussuunnitelma-osio)
+  hae-kustannussuunnitelman-osiot lisaa-kustannussuunnitelma-osio paivita-kustannussuunnitelma-osio
+  tulevilla-hoitovuosilla-arvoja?)
 
 (defn- laske-indeksikorjattu-summa
   "Indeksikorjattu summa lasketaan summasta ja urakan voimassaolevista indekseistä. Jos summaa ei ole annettu, palautetaan nil."
@@ -942,3 +943,21 @@
              :vahvistus-pvm vahvistus-pvm})
         ;; Lisää tavoite-ja-kattohinta tieto kantaan
         _ (paivita-kustannussuunnitelman-tila db vahvistetut-osiot vahvista? hoitovuosinro urakka-id "tavoite-ja-kattohinta" (:id kayttaja))]))
+
+(defn onko-tulevilla-hoitovuosilla-arvoja? [db urakka-id sopimus-id hoitovuoden-alkuvuosi]
+  (let [hoidonjohto-tpi-id (:id (first (tpi-kyselyt/hae-urakan-toimenpideinstanssi-toimenpidekoodilla db
+                                         {:urakka urakka-id
+                                          :koodi "23151"})))
+        erillishankinnat-tehtavaryhma (first (tehtavaryhma-kyselyt/hae-tehtavaryhma-tunnisteella db {:yksiloiva_tunniste "37d3752c-9951-47ad-a463-c1704cf22f4c"}))
+
+        ;; hankintatoimenpideinstanssit
+        hankinnan-toimenpiteet (flatten (map (juxt :toimenpideinstanssi-id) (hae-urakan-toimenpiteet db {:urakkaid urakka-id})))
+
+        tulevaisuudessa-arvoja (tulevilla-hoitovuosilla-arvoja? db
+                                 {:urakka-id urakka-id
+                                  :sopimus-id sopimus-id
+                                  :hoidon-johdon-tpi-id hoidonjohto-tpi-id
+                                  :hankinnan-toimenpideinstanssit hankinnan-toimenpiteet
+                                  :erillishankinnat-tehtavaryhma-id (:id erillishankinnat-tehtavaryhma)
+                                 :vuosi hoitovuoden-alkuvuosi})]
+    (boolean (some #(true? (:arvoja-tulevilla-hoitovuosilla? %)) tulevaisuudessa-arvoja))))

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
@@ -1,6 +1,5 @@
 (ns harja.kyselyt.uusi-kustannussuunnitelma-kyselyt
-  (:require [clojure.string :as str]
-            [harja.pvm :as pvm]
+  (:require [harja.pvm :as pvm]
             [jeesql.core :refer [defqueries]]
             [harja.tyokalut.yleiset :refer [round2] :as yleiset]
             [harja.domain.mhu :as mhu]
@@ -605,6 +604,7 @@
         ; Tallenna kuukausittaiset summat
         _ (doseq [rivi erillishankinnat]
             (let [dbrivi (first (hae-kuukauden-erillishankinta db {:id (:id rivi)}))
+                  vuosi (if (< (:kuukausi rivi) 10) (inc hoitovuoden-alkuvuosi) hoitovuoden-alkuvuosi)
                   _ (if (:id dbrivi)
                       (paivita-kuukauden-erillishankinta<! db
                         {:id (:id dbrivi)
@@ -615,19 +615,20 @@
                       (tallenna-kuukauden-erillishankinta<! db
                         {:sopimus-id sopimus-id
                          :toimenpideinstanssi-id hoidonjohto-tpi-id
-                         :vuosi (:vuosi rivi)
+                         :vuosi vuosi
                          :kuukausi (:kuukausi rivi)
                          :summa (:summa rivi)
                          :summa_indeksikorjattu (laske-indeksikorjattu-summa (:summa rivi) urakan-indeksit hoitovuosi-nro)
                          :tehtavaryhma-id (:id tehtavaryhma)
                          :luoja (:id kayttaja)}))]))]))
 
-(defn tallenna-kuukausittaiset-muut-kulut [db kuukaudet urakan-indeksit urakan-tiedot kayttaja sopimus-id
-                                           toimenpideinstanssi-id hoitovuosi-nro]
+(defn tallenna-kuukausittaiset-muut-kulut [db kuukaudet urakan-indeksit kayttaja sopimus-id
+                                           toimenpideinstanssi-id hoitovuosi-nro hoitovuoden-alkuvuosi]
   (let [tehtava (hae-tehtava-tunnisteella db {:tunniste "8376d9c4-3daf-4815-973d-cd95ca3bb388"})
         tehtava-id (:id (first tehtava))] ;; Muut kulut tehtävä
-    (doseq [{:keys [vuosi kuukausi yhteensa-kk summa] :as rivi} (sort-by (juxt :vuosi :kuukausi) kuukaudet)]
-      (let [;; Haetaan muut-kulut kuukaudelle
+    (doseq [{:keys [kuukausi yhteensa-kk ] :as rivi} (sort-by (juxt :vuosi :kuukausi) kuukaudet)]
+      (let [vuosi (if (< kuukausi 10) (inc hoitovuoden-alkuvuosi) hoitovuoden-alkuvuosi)
+            ;; Haetaan muut-kulut kuukaudelle
             db-kuukausi (first (hae-muut-kulut-kuukaudelle db {:sopimus-id sopimus-id
                                                                :toimenpideinstanssi-id toimenpideinstanssi-id
                                                                :vuosi vuosi
@@ -649,10 +650,11 @@
                    :muokkaaja (:id kayttaja)}))]))))
 
 (defn tallenna-kuukausittaiset-toimenkuvat [db kuukaudet urakan-indeksit urakan-tiedot kayttaja urakka-id
-                                            toimenkuva-id hoitovuosi-nro]
+                                            toimenkuva-id hoitovuosi-nro hoitovuoden-alkuvuosi]
   (let [urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))]
-    (doseq [{:keys [vuosi kuukausi tunnit tuntipalkka] :as rivi} (sort-by (juxt :vuosi :kuukausi) kuukaudet)]
-      (let [;; Haetaan toimenkuvan kuukauden johto-ja-hallintokorvaus
+    (doseq [{:keys [kuukausi tunnit tuntipalkka] :as rivi} (sort-by (juxt :vuosi :kuukausi) kuukaudet)]
+      (let [vuosi (if (< kuukausi 10) (inc hoitovuoden-alkuvuosi) hoitovuoden-alkuvuosi)
+            ;; Haetaan toimenkuvan kuukauden johto-ja-hallintokorvaus
             db-kuukausi (first (hae-toimenkuvan-kuukauden-johto-ja-hallintokorvaus db {:urakka-id urakka-id
                                                                                        :toimenkuva-id toimenkuva-id
                                                                                        :vuosi vuosi
@@ -678,8 +680,9 @@
                    :tuntipalkka_indeksikorjattu (laske-indeksikorjattu-summa tuntipalkka urakan-indeksit hoitovuosi-nro)
                    :muokkaaja (:id kayttaja)}))]))))
 
-(defn tallenna-vuosittaiset-toimenkuvat [db rivi urakan-indeksit kayttaja urakka-id toimenkuva-id hoitovuosi-nro]
-  (let [dbrivi (first (hae-kuukauden-johto-ja-hallintokorvaus db {:id (:id rivi)}))
+(defn tallenna-vuosittaiset-toimenkuvat [db rivi urakan-indeksit kayttaja urakka-id toimenkuva-id hoitovuosi-nro hoitovuoden-alkuvuosi]
+  (let [vuosi (if (< (:kuukausi rivi) 10) (inc hoitovuoden-alkuvuosi) hoitovuoden-alkuvuosi)
+        dbrivi (first (hae-kuukauden-johto-ja-hallintokorvaus db {:id (:id rivi)}))
         _ (if (:id dbrivi)
 
             (paivita-kuukauden-johto-ja-hallintokorvaus<! db
@@ -692,7 +695,7 @@
             (lisaa-kuukauden-johto-ja-hallintokorvaus<! db
               {:urakka-id urakka-id
                :toimenkuva-id toimenkuva-id
-               :vuosi (:vuosi rivi)
+               :vuosi vuosi
                :kuukausi (:kuukausi rivi)
                :tunnit 1
                :tuntipalkka (:summa rivi)
@@ -730,14 +733,14 @@
 
                   _ (if (<= urakan-alkuvuosi 2024)
                       (tallenna-kuukausittaiset-toimenkuvat db kuukaudet urakan-indeksit urakan-tiedot kayttaja
-                        urakka-id toimenkuva-id hoitovuosi-nro)
+                        urakka-id toimenkuva-id hoitovuosi-nro hoitovuoden-alkuvuosi)
                       (tallenna-vuosittaiset-toimenkuvat db toimenkuva urakan-indeksit kayttaja urakka-id
-                        toimenkuva-id hoitovuosi-nro))]))
+                        toimenkuva-id hoitovuosi-nro hoitovuoden-alkuvuosi))]))
 
         ;; Tallennetaan mahdolliset muut kulut
         _ (when muut-kulut
-            (tallenna-kuukausittaiset-muut-kulut db (:kuukaudet muut-kulut) urakan-indeksit urakan-tiedot kayttaja
-              sopimus-id toimenpideinstanssi-id hoitovuosi-nro))
+            (tallenna-kuukausittaiset-muut-kulut db (:kuukaudet muut-kulut) urakan-indeksit kayttaja
+              sopimus-id toimenpideinstanssi-id hoitovuosi-nro hoitovuoden-alkuvuosi))
 
         _ (ka-q/merkitse-kustannussuunnitelmat-likaisiksi! db {:toimenpideinstanssi toimenpideinstanssi-id})
         _ (kiint-kyselyt/merkitse-maksuerat-likaisiksi-hoidonjohdossa! db {:toimenpideinstanssi toimenpideinstanssi-id})]))
@@ -756,7 +759,8 @@
         tehtava (first (tehtava-kyselyt/hae-tehtava-tunnisteella db {:tunniste "53647ad8-0632-4dd3-8302-8dfae09908c8"}))
         ; Tallenna kuukausittaiset summat
         _ (doseq [rivi hoidonjohtopalkkiot]
-            (let [dbrivi (first (hae-kuukauden-hoidonjohtopalkkio db {:id (:id rivi)}))
+            (let [vuosi (if (< (:kuukausi rivi) 10) (inc hoitovuoden-alkuvuosi) hoitovuoden-alkuvuosi)
+                  dbrivi (first (hae-kuukauden-hoidonjohtopalkkio db {:id (:id rivi)}))
                   _ (if (:id dbrivi)
                       (paivita-kuukauden-hoidonjohtopalkkio<! db
                         {:id (:id dbrivi)
@@ -767,7 +771,7 @@
                       (tallenna-kuukauden-hoidonjohtopalkkio<! db
                         {:sopimus-id sopimus-id
                          :toimenpideinstanssi-id hoidonjohto-tpi-id
-                         :vuosi (:vuosi rivi)
+                         :vuosi vuosi
                          :kuukausi (:kuukausi rivi)
                          :summa (:summa rivi)
                          :summa_indeksikorjattu (laske-indeksikorjattu-summa (:summa rivi) urakan-indeksit hoitovuosi-nro)

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.sql
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.sql
@@ -483,3 +483,47 @@ SELECT id, nimi, yksikko, suunnitteluyksikko, tehtavaryhma, luoja, luotu, muokka
  WHERE yksiloiva_tunniste = :tunniste::UUID
    AND piilota IS NOT TRUE
    AND poistettu IS NOT TRUE;
+
+-- name: tulevilla-hoitovuosilla-arvoja?
+-- Käyttöliittymässä on mahdollista kopioida nykyisen hoitovuoden arvot tuleville hoitovuosille.
+-- Tämä kysely tarkistaa, onko tulevilla hoitovuosilla jo arvoja, jotta käyttäjää osataan varoittaa arvojen menettämisestä.
+-- Ensin toimenkuvat
+SELECT COUNT(jjh.*) > 0 AS "arvoja-tulevilla-hoitovuosilla?"
+FROM johto_ja_hallintokorvaus jjh
+WHERE jjh."urakka-id" = :urakka-id
+  AND ((jjh.vuosi > :vuosi AND jjh.kuukausi IN (10, 11, 12))
+    OR (jjh.vuosi > :vuosi + 1 AND jjh.kuukausi >= 1 AND jjh.kuukausi <= 9))
+UNION ALL
+-- Erillishankinnat
+SELECT COUNT(kt.*) > 0 AS "arvoja-tulevilla-hoitovuosilla?"
+FROM kustannusarvioitu_tyo kt
+WHERE kt.sopimus = :sopimus-id
+  AND ((kt.vuosi > :vuosi AND kt.kuukausi IN (10, 11, 12))
+    OR (kt.vuosi > :vuosi + 1 AND kt.kuukausi >= 1 AND kt.kuukausi <= 9))
+  AND kt.toimenpideinstanssi = :hoidon-johdon-tpi-id
+  AND kt.tehtavaryhma = :erillishankinnat-tehtavaryhma-id
+UNION ALL
+-- Muut kulut
+SELECT COUNT(kt.*) > 0 AS "arvoja-tulevilla-hoitovuosilla?"
+FROM kustannusarvioitu_tyo kt
+         JOIN tehtava t ON kt.tehtava = t.id AND t.yksiloiva_tunniste = '8376d9c4-3daf-4815-973d-cd95ca3bb388' -- Muut kulut
+WHERE kt.sopimus = :sopimus-id
+  AND ((kt.vuosi > :vuosi AND kt.kuukausi IN (10, 11, 12))
+    OR (kt.vuosi > :vuosi + 1 AND kt.kuukausi >= 1 AND kt.kuukausi <= 9))
+  AND kt.toimenpideinstanssi = :hoidon-johdon-tpi-id
+UNION ALL
+-- Rahavaraukset
+SELECT COUNT(kt.*) > 0 AS "arvoja-tulevilla-hoitovuosilla?"
+FROM kustannusarvioitu_tyo kt
+    WHERE kt.rahavaraus_id IS NOT NULL
+    AND kt.sopimus = :sopimus-id
+    AND ((kt.vuosi > :vuosi AND kt.kuukausi IN (10, 11, 12))
+        OR (kt.vuosi > :vuosi + 1 AND kt.kuukausi >= 1 AND kt.kuukausi <= 9))
+-- Hankinnat
+UNION ALL
+SELECT COUNT(kt.*) > 0 AS "arvoja-tulevilla-hoitovuosilla?"
+FROM kiinteahintainen_tyo kt
+WHERE ((kt.vuosi > :vuosi AND kt.kuukausi IN (10, 11, 12))
+    OR (kt.vuosi > :vuosi + 1 AND kt.kuukausi >= 1 AND kt.kuukausi <= 9))
+  AND toimenpideinstanssi IN (:hankinnan-toimenpideinstanssit)
+  AND sopimus = :sopimus-id;

--- a/src/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_palvelu.clj
@@ -172,7 +172,6 @@
   (jdbc/with-db-transaction [db db]
     (let [vuodet (jasenna-tallennettavat-vuodet db urakka-id hoitovuoden-alkuvuosi kopioi-tuleville-vuosille?)]
       (doseq [vuosi vuodet]
-        (println "tallenna-erillishankinnat :: vuosi: " vuosi)
         (suunnitelma-q/tallenna-erillishankinnat db kayttaja urakka-id (:erillishankinnat tiedot) vuosi)
         (suunnitelma-q/paivita-tavoite-ja-kattohinta db kayttaja urakka-id vuosi)))
     (hae-kustannussuunnitelman-tiedot db kayttaja {:urakka-id urakka-id :hoitovuoden-alkuvuosi hoitovuoden-alkuvuosi})))

--- a/src/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_palvelu.clj
@@ -119,10 +119,15 @@
                                             (* kattohintakerroin hoitovuoden-alun-tavoitehinta)) 0)
           hoitovuoden-alun-indeksikorjattu-kattohinta (or (when (and indeksikerroin hoitovuoden-alun-kattohinta)
                                                             (* indeksikerroin hoitovuoden-alun-kattohinta)) 0)
+
+          ;; Haetaan tieto, että onko tulevilla hoitovuosilla mitään arvoja tallennettuna.
+          tulevaisuudessa-arvoja (suunnitelma-q/onko-tulevilla-hoitovuosilla-arvoja? db urakka-id sopimus-id hoitovuoden-alkuvuosi)
+
           k {:urakka-id urakka-id
              :urakan-alkuvuosi urakan-alkuvuosi
              :valittu-hoitokausi [(pvm/->pvm (str "01.10." hoitovuoden-alkuvuosi)) (pvm/->pvm (str "30.09." (inc hoitovuoden-alkuvuosi)))]
              :tarjous tarjous
+             :tulevaisuudessa-arvoja? tulevaisuudessa-arvoja
              :kustannussuunnitelma {:kilpailutettavat-hankinnat {:toimenpiteet kiinteat}
                                     :rahavaraukset rahavaraukset
                                     :erillishankinnat erillishankinnat

--- a/src/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_palvelu.clj
@@ -50,6 +50,7 @@
                                   (< hoitovuoden-alkuvuosi urakan-alkuvuosi) urakan-alkuvuosi
                                   (>= hoitovuoden-alkuvuosi urakan-loppuvuosi) (dec urakan-loppuvuosi)
                                   :else hoitovuoden-alkuvuosi)
+          viimeinen-hoitovuosi? (boolean (= hoitovuoden-alkuvuosi (dec urakan-loppuvuosi)))
 
           vahvistukset (suunnitelma-q/indeksikorjaukset-vahvistettu? db
                          {:urakka-id urakka-id
@@ -128,6 +129,7 @@
              :valittu-hoitokausi [(pvm/->pvm (str "01.10." hoitovuoden-alkuvuosi)) (pvm/->pvm (str "30.09." (inc hoitovuoden-alkuvuosi)))]
              :tarjous tarjous
              :tulevaisuudessa-arvoja? tulevaisuudessa-arvoja
+             :viimeinen-hoitovuosi? viimeinen-hoitovuosi?
              :kustannussuunnitelma {:kilpailutettavat-hankinnat {:toimenpiteet kiinteat}
                                     :rahavaraukset rahavaraukset
                                     :erillishankinnat erillishankinnat

--- a/src/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_palvelu.clj
@@ -138,27 +138,52 @@
                                     :vahvistettu? indeksikorjaukset-vahvistettu?}}]
       k)))
 
-(defn tallenna-kilpailutettavat-hankinnat [db kayttaja {:keys [urakka-id hoitovuoden-alkuvuosi] :as tiedot}]
+(defn jasenna-tallennettavat-vuodet
+  "Jäsentää talletettavat hoitovuodet listaksi.
+  Jos kopioi-tuleville-vuosille? on true, niin palauttaa kaikki hoitovuodet urakan alkamisvuodesta urakan loppumisvuoteen asti.
+  Muuten palauttaa vain hoitovuoden-alkuvuoden."
+  [db urakka-id hoitovuoden-alkuvuosi kopioi-tuleville-vuosille?]
+  (if kopioi-tuleville-vuosille?
+    (let [urakan-tiedot (first (urakat-q/hae-urakan-tiedot db urakka-id))
+          urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
+          urakan-loppuvuosi (pvm/vuosi (:loppupvm urakan-tiedot))
+          ;; Varmista, että hoitovuoden-alkuvuosi on urakan sisällä
+          hoitovuoden-alkuvuosi (cond
+                                  (< hoitovuoden-alkuvuosi urakan-alkuvuosi) urakan-alkuvuosi
+                                  (>= hoitovuoden-alkuvuosi urakan-loppuvuosi) urakan-loppuvuosi
+                                  :else hoitovuoden-alkuvuosi)
+          vuodet (range hoitovuoden-alkuvuosi urakan-loppuvuosi)]
+      vuodet)
+    [hoitovuoden-alkuvuosi]))
+
+(defn tallenna-kilpailutettavat-hankinnat [db kayttaja {:keys [urakka-id hoitovuoden-alkuvuosi kopioi-tuleville-vuosille?] :as tiedot}]
   (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-suunnittelu-kustannussuunnittelu kayttaja urakka-id)
   (log/debug "tallenna-kilpailutettavat-hankinnat :: tiedot: " tiedot)
   (jdbc/with-db-transaction [db db]
-    (suunnitelma-q/tallenna-kilpailutettavat-hankinnat db kayttaja urakka-id hoitovuoden-alkuvuosi (:toimenpiteet tiedot))
-    (suunnitelma-q/paivita-tavoite-ja-kattohinta db kayttaja urakka-id hoitovuoden-alkuvuosi)
-    (hae-kustannussuunnitelman-tiedot db kayttaja {:urakka-id urakka-id :hoitovuoden-alkuvuosi hoitovuoden-alkuvuosi})))
+    (let [vuodet (jasenna-tallennettavat-vuodet db urakka-id hoitovuoden-alkuvuosi kopioi-tuleville-vuosille?)]
+      (doseq [vuosi vuodet]
+        (suunnitelma-q/tallenna-kilpailutettavat-hankinnat db kayttaja urakka-id vuosi (:toimenpiteet tiedot))
+        (suunnitelma-q/paivita-tavoite-ja-kattohinta db kayttaja urakka-id vuosi))
+      (hae-kustannussuunnitelman-tiedot db kayttaja {:urakka-id urakka-id :hoitovuoden-alkuvuosi hoitovuoden-alkuvuosi}))))
 
-(defn tallenna-erillishankinnat [db kayttaja {:keys [urakka-id hoitovuoden-alkuvuosi] :as tiedot}]
+(defn tallenna-erillishankinnat [db kayttaja {:keys [urakka-id hoitovuoden-alkuvuosi kopioi-tuleville-vuosille?] :as tiedot}]
   (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-suunnittelu-kustannussuunnittelu kayttaja urakka-id)
   (log/debug "tallenna-erillishankinnat :: tiedot: " tiedot)
   (jdbc/with-db-transaction [db db]
-    (suunnitelma-q/tallenna-erillishankinnat db kayttaja urakka-id (:erillishankinnat tiedot) hoitovuoden-alkuvuosi)
-    (suunnitelma-q/paivita-tavoite-ja-kattohinta db kayttaja urakka-id hoitovuoden-alkuvuosi)
+    (let [vuodet (jasenna-tallennettavat-vuodet db urakka-id hoitovuoden-alkuvuosi kopioi-tuleville-vuosille?)]
+      (doseq [vuosi vuodet]
+        (println "tallenna-erillishankinnat :: vuosi: " vuosi)
+        (suunnitelma-q/tallenna-erillishankinnat db kayttaja urakka-id (:erillishankinnat tiedot) vuosi)
+        (suunnitelma-q/paivita-tavoite-ja-kattohinta db kayttaja urakka-id vuosi)))
     (hae-kustannussuunnitelman-tiedot db kayttaja {:urakka-id urakka-id :hoitovuoden-alkuvuosi hoitovuoden-alkuvuosi})))
 
-(defn tallenna-tallenna-johto-ja-hallintokorvaukset [db kayttaja {:keys [urakka-id hoitovuoden-alkuvuosi] :as tiedot}]
+(defn tallenna-tallenna-johto-ja-hallintokorvaukset [db kayttaja {:keys [urakka-id hoitovuoden-alkuvuosi kopioi-tuleville-vuosille?] :as tiedot}]
   (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-suunnittelu-kustannussuunnittelu kayttaja urakka-id)
   (log/debug "tallenna-johto-ja-hallintokorvaukset :: tiedot: " tiedot)
   (jdbc/with-db-transaction [db db]
     (let [urakan-tiedot (first (urakat-q/hae-urakan-tiedot db urakka-id))
+          vuodet (jasenna-tallennettavat-vuodet db urakka-id hoitovuoden-alkuvuosi kopioi-tuleville-vuosille?)
+
           urakan-alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
           ;; Valitaan oikea avain riippuen urakan alkamisvuodesta
           ;; 2019-2024 käytetään vanhaa avainta, 2025- eteenpäin uutta avainta
@@ -166,16 +191,19 @@
           avain (if (<= urakan-alkuvuosi 2024)
                   :johto-ja-hallintokorvaukset-2019
                   :johto-ja-hallintokorvaukset-2025)]
-      (suunnitelma-q/tallenna-johto-ja-hallintokorvaukset db kayttaja urakka-id (get tiedot avain) hoitovuoden-alkuvuosi)
-      (suunnitelma-q/paivita-tavoite-ja-kattohinta db kayttaja urakka-id hoitovuoden-alkuvuosi)
+      (doseq [vuosi vuodet]
+        (suunnitelma-q/tallenna-johto-ja-hallintokorvaukset db kayttaja urakka-id (get tiedot avain) vuosi)
+        (suunnitelma-q/paivita-tavoite-ja-kattohinta db kayttaja urakka-id vuosi))
       (hae-kustannussuunnitelman-tiedot db kayttaja {:urakka-id urakka-id :hoitovuoden-alkuvuosi hoitovuoden-alkuvuosi}))))
 
-(defn tallenna-hoidonjohtopalkkiot [db kayttaja {:keys [urakka-id hoitovuoden-alkuvuosi] :as tiedot}]
+(defn tallenna-hoidonjohtopalkkiot [db kayttaja {:keys [urakka-id hoitovuoden-alkuvuosi kopioi-tuleville-vuosille?] :as tiedot}]
   (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-suunnittelu-kustannussuunnittelu kayttaja urakka-id)
   (log/debug "tallenna-hoidonjohtopalkkiot :: tiedot: " tiedot)
   (jdbc/with-db-transaction [db db]
-    (suunnitelma-q/tallenna-hoidonjohtopalkkiot db kayttaja urakka-id (:hoidonjohtopalkkiot tiedot) hoitovuoden-alkuvuosi)
-    (suunnitelma-q/paivita-tavoite-ja-kattohinta db kayttaja urakka-id hoitovuoden-alkuvuosi)
+    (let [vuodet (jasenna-tallennettavat-vuodet db urakka-id hoitovuoden-alkuvuosi kopioi-tuleville-vuosille?)]
+      (doseq [vuosi vuodet]
+        (suunnitelma-q/tallenna-hoidonjohtopalkkiot db kayttaja urakka-id (:hoidonjohtopalkkiot tiedot) vuosi)
+        (suunnitelma-q/paivita-tavoite-ja-kattohinta db kayttaja urakka-id vuosi)))
     (hae-kustannussuunnitelman-tiedot db kayttaja {:urakka-id urakka-id :hoitovuoden-alkuvuosi hoitovuoden-alkuvuosi})))
 
 (defn vahvista-tai-kumoa-tavoite-ja-kattohinta [db kayttaja {:keys [urakka-id hoitovuoden-alkuvuosi vahvista?] :as tiedot}]

--- a/src/cljs/harja/tiedot/urakka/suunnittelu/tarjous_kustannussuunnitelma_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/suunnittelu/tarjous_kustannussuunnitelma_tiedot.cljs
@@ -169,20 +169,20 @@
 (defrecord TallennaTarjouksenTiedotEpaonnistui [vastaus])
 
 ;; Tallennetaan kilpailutettavat hankinnat kustannussuunnitelmaan
-(defrecord TallennaKilpailutettavatHankinnat [kilpailutettavat-hankinnat])
+(defrecord TallennaKilpailutettavatHankinnat [kilpailutettavat-hankinnat kopioi-tuleville-vuosille?])
 (defrecord PaivitaKilpailutettavatHankinnat [kilpailutettavat-hankinnat])
 (defrecord TallennaKilpailutettavatHankinnatOnnistui [vastaus])
 (defrecord TallennaKilpailutettavatHankinnatEpaonnistui [vastaus])
 
 ;; Tallenna erillishankinnat
-(defrecord TallennaErillishankinnat [erillishankinnat])
+(defrecord TallennaErillishankinnat [erillishankinnat kopioi-tuleville-vuosille?])
 (defrecord PaivitaErillishankinnat [erillishankinnat])
 (defrecord TallennaErillishankinnatOnnistui [vastaus])
 (defrecord TallennaErillishankinnatEpaonnistui [vastaus])
 (defrecord JaaErillishankinnatTasan [summa elementti])
 
 ;; Johto-ja-hallintokorvaus-käsittelyt
-(defrecord TallennaJohtoJaHallintokorvaukset [johto-ja-hallintokorvaukset urakan-alkuvuosi])
+(defrecord TallennaJohtoJaHallintokorvaukset [johto-ja-hallintokorvaukset urakan-alkuvuosi kopioi-tuleville-vuosille?])
 (defrecord PaivitaJohtoJaHallintokorvaukset [johto-ja-hallintokorvaukset])
 (defrecord PaivitaJohtoJaHallintokorvaukset2019 [johto-ja-hallintokorvaukset toimenkuva])
 (defrecord TallennaJohtoJaHallintokorvauksetOnnistui [vastaus])
@@ -190,7 +190,7 @@
 (defrecord JaaJohtoJaHallintokorvauksetTasan [summa johto-ja-hallintokorvaukset-elementti])
 
 ;; Hoidonjohtopalkkio-käsittelyt
-(defrecord TallennaHoidonjohtopalkkiot [hoidonjohtopalkkiot])
+(defrecord TallennaHoidonjohtopalkkiot [hoidonjohtopalkkiot kopioi-tuleville-vuosille?])
 (defrecord PaivitaHoidonjohtopalkkiot [hoidonjohtopalkkiot])
 (defrecord TallennaHoidonjohtopalkkiotOnnistui [vastaus])
 (defrecord TallennaHoidonjohtopalkkiotEpaonnistui [vastaus])
@@ -405,12 +405,14 @@
 
   TallennaKilpailutettavatHankinnat
   (process-event
-    [{kilpailutettavat-hankinnat :kilpailutettavat-hankinnat} app]
+    [{kilpailutettavat-hankinnat :kilpailutettavat-hankinnat
+      kopioi-tuleville-vuosille? :kopioi-tuleville-vuosille?} app]
     (let [vuosi (pvm/vuosi (first (:valittu-hoitokausi app)))]
       (tuck-apurit/post! :tallenna-kilpailutettavat-hankinnat
         {:urakka-id (-> @tila/yleiset :urakka :id)
          :hoitovuoden-alkuvuosi vuosi
-         :toimenpiteet kilpailutettavat-hankinnat}
+         :toimenpiteet kilpailutettavat-hankinnat
+         :kopioi-tuleville-vuosille? kopioi-tuleville-vuosille?}
         {:onnistui ->TallennaKilpailutettavatHankinnatOnnistui
          :epaonnistui ->TallennaKilpailutettavatHankinnatEpaonnistui
          :paasta-virhe-lapi? true})
@@ -448,11 +450,12 @@
 
   TallennaErillishankinnat
   (process-event
-    [{erillishankinnat :erillishankinnat} app]
+    [{erillishankinnat :erillishankinnat kopioi-tuleville-vuosille? :kopioi-tuleville-vuosille?} app]
     (tuck-apurit/post! :tallenna-erillishankinnat
       {:urakka-id (-> @tila/yleiset :urakka :id)
        :hoitovuoden-alkuvuosi (pvm/vuosi (first (:valittu-hoitokausi app)))
-       :erillishankinnat erillishankinnat}
+       :erillishankinnat erillishankinnat
+       :kopioi-tuleville-vuosille? kopioi-tuleville-vuosille?}
       {:onnistui ->TallennaErillishankinnatOnnistui
        :epaonnistui ->TallennaErillishankinnatEpaonnistui
        :paasta-virhe-lapi? true})
@@ -503,11 +506,12 @@
 
   TallennaHoidonjohtopalkkiot
   (process-event
-    [{hoidonjohtopalkkiot :hoidonjohtopalkkiot} app]
+    [{hoidonjohtopalkkiot :hoidonjohtopalkkiot kopioi-tuleville-vuosille? :kopioi-tuleville-vuosille?} app]
     (tuck-apurit/post! :tallenna-hoidonjohtopalkkiot
       {:urakka-id (-> @tila/yleiset :urakka :id)
        :hoitovuoden-alkuvuosi (pvm/vuosi (first (:valittu-hoitokausi app)))
-       :hoidonjohtopalkkiot hoidonjohtopalkkiot}
+       :hoidonjohtopalkkiot hoidonjohtopalkkiot
+       :kopioi-tuleville-vuosille? kopioi-tuleville-vuosille?}
       {:onnistui ->TallennaHoidonjohtopalkkiotOnnistui
        :epaonnistui ->TallennaHoidonjohtopalkkiotEpaonnistui
        :paasta-virhe-lapi? true})
@@ -568,7 +572,7 @@
 
   TallennaJohtoJaHallintokorvaukset
   (process-event
-    [{johto-ja-hallintokorvaukset :johto-ja-hallintokorvaukset urakan-alkuvuosi :urakan-alkuvuosi} app]
+    [{:keys [johto-ja-hallintokorvaukset urakan-alkuvuosi kopioi-tuleville-vuosille?]} app]
     (let [endpoint (if (<= urakan-alkuvuosi 2024)
                      :tallenna-johto-ja-hallintokorvaukset-2019
                      :tallenna-johto-ja-hallintokorvaukset-2025)
@@ -578,7 +582,8 @@
       (tuck-apurit/post! endpoint
         {:urakka-id (-> @tila/yleiset :urakka :id)
          :hoitovuoden-alkuvuosi (pvm/vuosi (first (:valittu-hoitokausi app)))
-         avain johto-ja-hallintokorvaukset}
+         avain johto-ja-hallintokorvaukset
+         :kopioi-tuleville-vuosille? kopioi-tuleville-vuosille?}
         {:onnistui ->TallennaJohtoJaHallintokorvauksetOnnistui
          :epaonnistui ->TallennaJohtoJaHallintokorvauksetEpaonnistui
          :paasta-virhe-lapi? true})

--- a/src/cljs/harja/tiedot/urakka/suunnittelu/tarjous_kustannussuunnitelma_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/suunnittelu/tarjous_kustannussuunnitelma_tiedot.cljs
@@ -365,6 +365,7 @@
       (assoc :urakan-alkuvuosi (:urakan-alkuvuosi vastaus))
       (assoc :valittu-hoitokausi (:valittu-hoitokausi vastaus))
       (assoc :tarjous (:tarjous vastaus))
+      (assoc :tulevaisuudessa-arvoja? (:tulevaisuudessa-arvoja? vastaus))
       (assoc :kustannussuunnitelma (:kustannussuunnitelma vastaus))))
 
   HaeKustannussuunnitelmanTiedotEpaonnistui

--- a/src/cljs/harja/tiedot/urakka/suunnittelu/tarjous_kustannussuunnitelma_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/suunnittelu/tarjous_kustannussuunnitelma_tiedot.cljs
@@ -366,6 +366,7 @@
       (assoc :valittu-hoitokausi (:valittu-hoitokausi vastaus))
       (assoc :tarjous (:tarjous vastaus))
       (assoc :tulevaisuudessa-arvoja? (:tulevaisuudessa-arvoja? vastaus))
+      (assoc :viimeinen-hoitovuosi? (:viimeinen-hoitovuosi? vastaus))
       (assoc :kustannussuunnitelma (:kustannussuunnitelma vastaus))))
 
   HaeKustannussuunnitelmanTiedotEpaonnistui

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_johto_ja_hallintokorvaus.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_johto_ja_hallintokorvaus.cljs
@@ -456,7 +456,8 @@
            toimenkuvat-atom]]))
 
 (defn johto-ja-hallintokorvaus [e! {:keys [valittu-hoitokausi tallennus-kesken? tarjous
-                                           kustannussuunnitelma urakan-alkuvuosi tulevaisuudessa-arvoja?] :as app}]
+                                           kustannussuunnitelma urakan-alkuvuosi tulevaisuudessa-arvoja?
+                                           viimeinen-hoitovuosi?] :as app}]
   (let [johto-ja-hallintokorvaukset (:johto-ja-hallintokorvaukset kustannussuunnitelma)
         viimeisin-muokkaus (:viimeisin-muokkaus (first johto-ja-hallintokorvaukset))
         viimeisin-muokkaaja (:viimeisin-muokkaaja (first johto-ja-hallintokorvaukset))
@@ -554,7 +555,8 @@
         (yhteiset/tallenna-painike-rivi viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
           #(e! (kust-tiedot/->TallennaJohtoJaHallintokorvaukset @yhteiset/grid-johto-ja-hallintokorvaukset-atom urakan-alkuvuosi false))
           (when (>= urakan-alkuvuosi 2025) #(e! (kust-tiedot/->JaaJohtoJaHallintokorvauksetTasan tarjouksen-maara "johto-ja-hallintokorvaus-elementti")))
-          #(e! (kust-tiedot/->TallennaJohtoJaHallintokorvaukset @yhteiset/grid-johto-ja-hallintokorvaukset-atom urakan-alkuvuosi true))
+          (when-not viimeinen-hoitovuosi?
+            #(e! (kust-tiedot/->TallennaJohtoJaHallintokorvaukset @yhteiset/grid-johto-ja-hallintokorvaukset-atom urakan-alkuvuosi true)))
           tulevaisuudessa-arvoja?)])
 
      [:div.row
@@ -608,5 +610,6 @@
         (yhteiset/tallenna-painike-rivi viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
           #(e! (kust-tiedot/->TallennaJohtoJaHallintokorvaukset @yhteiset/grid-johto-ja-hallintokorvaukset-atom urakan-alkuvuosi false))
           (when (>= urakan-alkuvuosi 2025) #(e! (kust-tiedot/->JaaJohtoJaHallintokorvauksetTasan tarjouksen-maara "johto-ja-hallintokorvaus-elementti")))
-          #(e! (kust-tiedot/->TallennaJohtoJaHallintokorvaukset @yhteiset/grid-johto-ja-hallintokorvaukset-atom urakan-alkuvuosi true))
+          (when-not viimeinen-hoitovuosi?
+            #(e! (kust-tiedot/->TallennaJohtoJaHallintokorvaukset @yhteiset/grid-johto-ja-hallintokorvaukset-atom urakan-alkuvuosi true)))
           tulevaisuudessa-arvoja?)])]))

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_johto_ja_hallintokorvaus.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_johto_ja_hallintokorvaus.cljs
@@ -456,7 +456,7 @@
            toimenkuvat-atom]]))
 
 (defn johto-ja-hallintokorvaus [e! {:keys [valittu-hoitokausi tallennus-kesken? tarjous
-                                           kustannussuunnitelma urakan-alkuvuosi] :as app}]
+                                           kustannussuunnitelma urakan-alkuvuosi tulevaisuudessa-arvoja?] :as app}]
   (let [johto-ja-hallintokorvaukset (:johto-ja-hallintokorvaukset kustannussuunnitelma)
         viimeisin-muokkaus (:viimeisin-muokkaus (first johto-ja-hallintokorvaukset))
         viimeisin-muokkaaja (:viimeisin-muokkaaja (first johto-ja-hallintokorvaukset))
@@ -554,7 +554,8 @@
         (yhteiset/tallenna-painike-rivi viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
           #(e! (kust-tiedot/->TallennaJohtoJaHallintokorvaukset @yhteiset/grid-johto-ja-hallintokorvaukset-atom urakan-alkuvuosi false))
           (when (>= urakan-alkuvuosi 2025) #(e! (kust-tiedot/->JaaJohtoJaHallintokorvauksetTasan tarjouksen-maara "johto-ja-hallintokorvaus-elementti")))
-          #(e! (kust-tiedot/->TallennaJohtoJaHallintokorvaukset @yhteiset/grid-johto-ja-hallintokorvaukset-atom urakan-alkuvuosi true)))])
+          #(e! (kust-tiedot/->TallennaJohtoJaHallintokorvaukset @yhteiset/grid-johto-ja-hallintokorvaukset-atom urakan-alkuvuosi true))
+          tulevaisuudessa-arvoja?)])
 
      [:div.row
       [:div.col-xs-12
@@ -607,4 +608,5 @@
         (yhteiset/tallenna-painike-rivi viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
           #(e! (kust-tiedot/->TallennaJohtoJaHallintokorvaukset @yhteiset/grid-johto-ja-hallintokorvaukset-atom urakan-alkuvuosi false))
           (when (>= urakan-alkuvuosi 2025) #(e! (kust-tiedot/->JaaJohtoJaHallintokorvauksetTasan tarjouksen-maara "johto-ja-hallintokorvaus-elementti")))
-          #(e! (kust-tiedot/->TallennaJohtoJaHallintokorvaukset @yhteiset/grid-johto-ja-hallintokorvaukset-atom urakan-alkuvuosi true)))])]))
+          #(e! (kust-tiedot/->TallennaJohtoJaHallintokorvaukset @yhteiset/grid-johto-ja-hallintokorvaukset-atom urakan-alkuvuosi true))
+          tulevaisuudessa-arvoja?)])]))

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_johto_ja_hallintokorvaus.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_johto_ja_hallintokorvaus.cljs
@@ -552,8 +552,9 @@
                       [kuukausierat-modaali valittu-hoitokausi johto-ja-hallintokorvaukset]))
              {:style {:text-decoration :underline}}])]]
         (yhteiset/tallenna-painike-rivi viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
-          #(e! (kust-tiedot/->TallennaJohtoJaHallintokorvaukset @yhteiset/grid-johto-ja-hallintokorvaukset-atom urakan-alkuvuosi))
-          (when (>= urakan-alkuvuosi 2025) #(e! (kust-tiedot/->JaaJohtoJaHallintokorvauksetTasan tarjouksen-maara "johto-ja-hallintokorvaus-elementti"))))])
+          #(e! (kust-tiedot/->TallennaJohtoJaHallintokorvaukset @yhteiset/grid-johto-ja-hallintokorvaukset-atom urakan-alkuvuosi false))
+          (when (>= urakan-alkuvuosi 2025) #(e! (kust-tiedot/->JaaJohtoJaHallintokorvauksetTasan tarjouksen-maara "johto-ja-hallintokorvaus-elementti")))
+          #(e! (kust-tiedot/->TallennaJohtoJaHallintokorvaukset @yhteiset/grid-johto-ja-hallintokorvaukset-atom urakan-alkuvuosi true)))])
 
      [:div.row
       [:div.col-xs-12
@@ -604,5 +605,6 @@
             [yleiset/info-laatikko :varoitus (:johto-ja-hallintokorvaukset-virheet kustannussuunnitelma) nil nil {:sulje-nappi-id (gensym)}]]])
 
         (yhteiset/tallenna-painike-rivi viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
-          #(e! (kust-tiedot/->TallennaJohtoJaHallintokorvaukset @yhteiset/grid-johto-ja-hallintokorvaukset-atom urakan-alkuvuosi))
-          (when (>= urakan-alkuvuosi 2025) #(e! (kust-tiedot/->JaaJohtoJaHallintokorvauksetTasan tarjouksen-maara "johto-ja-hallintokorvaus-elementti"))))])]))
+          #(e! (kust-tiedot/->TallennaJohtoJaHallintokorvaukset @yhteiset/grid-johto-ja-hallintokorvaukset-atom urakan-alkuvuosi false))
+          (when (>= urakan-alkuvuosi 2025) #(e! (kust-tiedot/->JaaJohtoJaHallintokorvauksetTasan tarjouksen-maara "johto-ja-hallintokorvaus-elementti")))
+          #(e! (kust-tiedot/->TallennaJohtoJaHallintokorvaukset @yhteiset/grid-johto-ja-hallintokorvaukset-atom urakan-alkuvuosi true)))])]))

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_nakyma.cljs
@@ -73,7 +73,9 @@
 
        (when-not vahvistettu?
          (yhteiset/tallenna-painike-rivi viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
-           #(e! (kust-tiedot/->TallennaKilpailutettavatHankinnat @yhteiset/grid-hankinnat-atom)) nil))
+           #(e! (kust-tiedot/->TallennaKilpailutettavatHankinnat @yhteiset/grid-hankinnat-atom false))
+           nil
+           #(e! (kust-tiedot/->TallennaKilpailutettavatHankinnat @yhteiset/grid-hankinnat-atom true))))
 
        [:div.row
         [:div.col-xs-12
@@ -110,7 +112,9 @@
              [:div.col-xs-12
               [yleiset/info-laatikko :varoitus kilpailutettavat-hankinnat-virheet nil nil {:sulje-nappi-id (gensym)}]]])
           (yhteiset/tallenna-painike-rivi viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
-            #(e! (kust-tiedot/->TallennaKilpailutettavatHankinnat @yhteiset/grid-hankinnat-atom)) nil)])])))
+            #(e! (kust-tiedot/->TallennaKilpailutettavatHankinnat @yhteiset/grid-hankinnat-atom false))
+            nil
+            #(e! (kust-tiedot/->TallennaKilpailutettavatHankinnat @yhteiset/grid-hankinnat-atom true)))])])))
 
 (defn rahavaraukset [e! {:keys [valittu-hoitokausi tarjous kustannussuunnitelma] :as app}]
   (if (nil? (:rahavaraukset kustannussuunnitelma))
@@ -218,9 +222,10 @@
           [:div.row
            [:div.col-xs-12.body-text "Harja luo kulut kuukausille, kun tallennat tiedot."]]
           (yhteiset/tallenna-painike-rivi viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
-            #(e! (kust-tiedot/->TallennaErillishankinnat @yhteiset/grid-erillishankinnat-atom))
+            #(e! (kust-tiedot/->TallennaErillishankinnat @yhteiset/grid-erillishankinnat-atom false))
             (when (and tarjouksen-maara (> tarjouksen-maara 0))
-              #(e! (kust-tiedot/->JaaErillishankinnatTasan tarjouksen-maara "erillishankinnat-elementti"))))])
+              #(e! (kust-tiedot/->JaaErillishankinnatTasan tarjouksen-maara "erillishankinnat-elementti")))
+            #(e! (kust-tiedot/->TallennaErillishankinnat @yhteiset/grid-erillishankinnat-atom true)))])
 
        [:div.row
         [:div.col-xs-12
@@ -246,9 +251,10 @@
 
        (when-not vahvistettu?
          (yhteiset/tallenna-painike-rivi viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
-           #(e! (kust-tiedot/->TallennaErillishankinnat @yhteiset/grid-erillishankinnat-atom))
+           #(e! (kust-tiedot/->TallennaErillishankinnat @yhteiset/grid-erillishankinnat-atom false))
            (when (and tarjouksen-maara (> tarjouksen-maara 0))
-             #(e! (kust-tiedot/->JaaErillishankinnatTasan tarjouksen-maara "erillishankinnat-elementti")))))])))
+             #(e! (kust-tiedot/->JaaErillishankinnatTasan tarjouksen-maara "erillishankinnat-elementti")))
+           #(e! (kust-tiedot/->TallennaErillishankinnat @yhteiset/grid-erillishankinnat-atom true))))])))
 
 (defn hoidonjohtopalkkiot [e! {:keys [valittu-hoitokausi tallennus-kesken? tarjous kustannussuunnitelma] :as app}]
   (if (nil? (get-in app [:kustannussuunnitelma :hoidonjohtopalkkiot]))
@@ -294,9 +300,10 @@
           [:div.row
            [:div.col-xs-12.body-text "Harja luo kulut kuukausille, kun tallennat tiedot."]]
           (yhteiset/tallenna-painike-rivi viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
-            #(e! (kust-tiedot/->TallennaHoidonjohtopalkkiot @yhteiset/grid-hoidonjohtopalkkiot-atom))
+            #(e! (kust-tiedot/->TallennaHoidonjohtopalkkiot @yhteiset/grid-hoidonjohtopalkkiot-atom false))
             (when (and tarjouksen-maara (> tarjouksen-maara 0))
-              #(e! (kust-tiedot/->JaaHoidonjohtopalkkiotTasan tarjouksen-maara "hoidonjohtopalkkio-elementti"))))])
+              #(e! (kust-tiedot/->JaaHoidonjohtopalkkiotTasan tarjouksen-maara "hoidonjohtopalkkio-elementti")))
+            #(e! (kust-tiedot/->TallennaHoidonjohtopalkkiot @yhteiset/grid-hoidonjohtopalkkiot-atom true)))])
 
        [:div.row
         [:div.col-xs-12
@@ -322,9 +329,10 @@
 
        (when-not vahvistettu?
          (yhteiset/tallenna-painike-rivi viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
-           #(e! (kust-tiedot/->TallennaHoidonjohtopalkkiot @yhteiset/grid-hoidonjohtopalkkiot-atom))
+           #(e! (kust-tiedot/->TallennaHoidonjohtopalkkiot @yhteiset/grid-hoidonjohtopalkkiot-atom false))
            (when (and tarjouksen-maara (> tarjouksen-maara 0))
-            #(e! (kust-tiedot/->JaaHoidonjohtopalkkiotTasan tarjouksen-maara "hoidonjohtopalkkio-elementti")))))])))
+            #(e! (kust-tiedot/->JaaHoidonjohtopalkkiotTasan tarjouksen-maara "hoidonjohtopalkkio-elementti")))
+           #(e! (kust-tiedot/->TallennaHoidonjohtopalkkiot @yhteiset/grid-hoidonjohtopalkkiot-atom true))))])))
 
 (defn tavoite-ja-kattohinta [e! {:keys [valittu-hoitokausi tallennus-kesken? tarjous kustannussuunnitelma] :as app}]
   (let [{:keys [pysyvat-muutokset-maara hoitovuoden-alun-tavoitehinta

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_nakyma.cljs
@@ -16,7 +16,8 @@
             [harja.views.urakka.suunnittelu.tarjous-kustannussuunnitelma.kustannussuunnitelma-johto-ja-hallintokorvaus :as jjh]
             [harja.views.urakka.suunnittelu.tarjous-kustannussuunnitelma.yhteiset :as yhteiset]))
 
-(defn kilpailutettavat-hankinnat [e! {:keys [tallennus-kesken? valittu-hoitokausi tarjous kustannussuunnitelma tulevaisuudessa-arvoja?] :as app}]
+(defn kilpailutettavat-hankinnat [e! {:keys [tallennus-kesken? valittu-hoitokausi tarjous kustannussuunnitelma
+                                             tulevaisuudessa-arvoja? viimeinen-hoitovuosi?] :as app}]
   (if (nil? (get-in kustannussuunnitelma [:kilpailutettavat-hankinnat :toimenpiteet]))
     [yleiset/ajax-loader-pieni "Ladataan..."]
     (let [{:keys [kilpailutettavat-hankinnat vahvistettu?
@@ -75,7 +76,8 @@
          (yhteiset/tallenna-painike-rivi viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
            #(e! (kust-tiedot/->TallennaKilpailutettavatHankinnat @yhteiset/grid-hankinnat-atom false))
            nil
-           #(e! (kust-tiedot/->TallennaKilpailutettavatHankinnat @yhteiset/grid-hankinnat-atom true))
+           (when-not viimeinen-hoitovuosi?
+             #(e! (kust-tiedot/->TallennaKilpailutettavatHankinnat @yhteiset/grid-hankinnat-atom true)))
            tulevaisuudessa-arvoja?))
 
        [:div.row
@@ -115,7 +117,8 @@
           (yhteiset/tallenna-painike-rivi viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
             #(e! (kust-tiedot/->TallennaKilpailutettavatHankinnat @yhteiset/grid-hankinnat-atom false))
             nil
-            #(e! (kust-tiedot/->TallennaKilpailutettavatHankinnat @yhteiset/grid-hankinnat-atom true))
+            (when-not viimeinen-hoitovuosi?
+              #(e! (kust-tiedot/->TallennaKilpailutettavatHankinnat @yhteiset/grid-hankinnat-atom true)))
             tulevaisuudessa-arvoja?)])])))
 
 (defn rahavaraukset [e! {:keys [valittu-hoitokausi tarjous kustannussuunnitelma] :as app}]
@@ -180,7 +183,8 @@
               :fmt #(if-not (= 0 suunniteltu-yht-indeksikorjattu) (fmt/euro-opt false %) "-") :otsikkorivi-luokka "korkea"}])
           rahavaraukset]]]])))
 
-(defn erillishankinnat [e! {:keys [valittu-hoitokausi tallennus-kesken? tarjous kustannussuunnitelma tulevaisuudessa-arvoja?] :as app}]
+(defn erillishankinnat [e! {:keys [valittu-hoitokausi tallennus-kesken? tarjous kustannussuunnitelma
+                                   tulevaisuudessa-arvoja? viimeinen-hoitovuosi?] :as app}]
   (if (nil? (get-in app [:kustannussuunnitelma :erillishankinnat]))
     [yleiset/ajax-loader-pieni "Ladataan..."]
     (let [{:keys [erillishankinnat vahvistettu?]} kustannussuunnitelma
@@ -227,7 +231,8 @@
             #(e! (kust-tiedot/->TallennaErillishankinnat @yhteiset/grid-erillishankinnat-atom false))
             (when (and tarjouksen-maara (> tarjouksen-maara 0))
               #(e! (kust-tiedot/->JaaErillishankinnatTasan tarjouksen-maara "erillishankinnat-elementti")))
-            #(e! (kust-tiedot/->TallennaErillishankinnat @yhteiset/grid-erillishankinnat-atom true))
+            (when-not viimeinen-hoitovuosi?
+              #(e! (kust-tiedot/->TallennaErillishankinnat @yhteiset/grid-erillishankinnat-atom true)))
             tulevaisuudessa-arvoja?)])
 
        [:div.row
@@ -257,10 +262,12 @@
            #(e! (kust-tiedot/->TallennaErillishankinnat @yhteiset/grid-erillishankinnat-atom false))
            (when (and tarjouksen-maara (> tarjouksen-maara 0))
              #(e! (kust-tiedot/->JaaErillishankinnatTasan tarjouksen-maara "erillishankinnat-elementti")))
-           #(e! (kust-tiedot/->TallennaErillishankinnat @yhteiset/grid-erillishankinnat-atom true))
+           (when-not viimeinen-hoitovuosi?
+             #(e! (kust-tiedot/->TallennaErillishankinnat @yhteiset/grid-erillishankinnat-atom true)))
            tulevaisuudessa-arvoja?))])))
 
-(defn hoidonjohtopalkkiot [e! {:keys [valittu-hoitokausi tallennus-kesken? tarjous kustannussuunnitelma tulevaisuudessa-arvoja?] :as app}]
+(defn hoidonjohtopalkkiot [e! {:keys [valittu-hoitokausi tallennus-kesken? tarjous kustannussuunnitelma
+                                      tulevaisuudessa-arvoja? viimeinen-hoitovuosi?] :as app}]
   (if (nil? (get-in app [:kustannussuunnitelma :hoidonjohtopalkkiot]))
     [yleiset/ajax-loader-pieni "Ladataan..."]
     (let [{:keys [hoidonjohtopalkkiot vahvistettu?]} kustannussuunnitelma
@@ -307,7 +314,8 @@
             #(e! (kust-tiedot/->TallennaHoidonjohtopalkkiot @yhteiset/grid-hoidonjohtopalkkiot-atom false))
             (when (and tarjouksen-maara (> tarjouksen-maara 0))
               #(e! (kust-tiedot/->JaaHoidonjohtopalkkiotTasan tarjouksen-maara "hoidonjohtopalkkio-elementti")))
-            #(e! (kust-tiedot/->TallennaHoidonjohtopalkkiot @yhteiset/grid-hoidonjohtopalkkiot-atom true))
+            (when-not viimeinen-hoitovuosi?
+              #(e! (kust-tiedot/->TallennaHoidonjohtopalkkiot @yhteiset/grid-hoidonjohtopalkkiot-atom true)))
             tulevaisuudessa-arvoja?)])
 
        [:div.row
@@ -337,7 +345,8 @@
            #(e! (kust-tiedot/->TallennaHoidonjohtopalkkiot @yhteiset/grid-hoidonjohtopalkkiot-atom false))
            (when (and tarjouksen-maara (> tarjouksen-maara 0))
             #(e! (kust-tiedot/->JaaHoidonjohtopalkkiotTasan tarjouksen-maara "hoidonjohtopalkkio-elementti")))
-           #(e! (kust-tiedot/->TallennaHoidonjohtopalkkiot @yhteiset/grid-hoidonjohtopalkkiot-atom true))
+           (when-not viimeinen-hoitovuosi?
+             #(e! (kust-tiedot/->TallennaHoidonjohtopalkkiot @yhteiset/grid-hoidonjohtopalkkiot-atom true)))
            tulevaisuudessa-arvoja?))])))
 
 (defn tavoite-ja-kattohinta [e! {:keys [valittu-hoitokausi tallennus-kesken? tarjous kustannussuunnitelma] :as app}]

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/kustannussuunnitelma_nakyma.cljs
@@ -16,7 +16,7 @@
             [harja.views.urakka.suunnittelu.tarjous-kustannussuunnitelma.kustannussuunnitelma-johto-ja-hallintokorvaus :as jjh]
             [harja.views.urakka.suunnittelu.tarjous-kustannussuunnitelma.yhteiset :as yhteiset]))
 
-(defn kilpailutettavat-hankinnat [e! {:keys [tallennus-kesken? valittu-hoitokausi tarjous kustannussuunnitelma] :as app}]
+(defn kilpailutettavat-hankinnat [e! {:keys [tallennus-kesken? valittu-hoitokausi tarjous kustannussuunnitelma tulevaisuudessa-arvoja?] :as app}]
   (if (nil? (get-in kustannussuunnitelma [:kilpailutettavat-hankinnat :toimenpiteet]))
     [yleiset/ajax-loader-pieni "Ladataan..."]
     (let [{:keys [kilpailutettavat-hankinnat vahvistettu?
@@ -75,7 +75,8 @@
          (yhteiset/tallenna-painike-rivi viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
            #(e! (kust-tiedot/->TallennaKilpailutettavatHankinnat @yhteiset/grid-hankinnat-atom false))
            nil
-           #(e! (kust-tiedot/->TallennaKilpailutettavatHankinnat @yhteiset/grid-hankinnat-atom true))))
+           #(e! (kust-tiedot/->TallennaKilpailutettavatHankinnat @yhteiset/grid-hankinnat-atom true))
+           tulevaisuudessa-arvoja?))
 
        [:div.row
         [:div.col-xs-12
@@ -114,7 +115,8 @@
           (yhteiset/tallenna-painike-rivi viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
             #(e! (kust-tiedot/->TallennaKilpailutettavatHankinnat @yhteiset/grid-hankinnat-atom false))
             nil
-            #(e! (kust-tiedot/->TallennaKilpailutettavatHankinnat @yhteiset/grid-hankinnat-atom true)))])])))
+            #(e! (kust-tiedot/->TallennaKilpailutettavatHankinnat @yhteiset/grid-hankinnat-atom true))
+            tulevaisuudessa-arvoja?)])])))
 
 (defn rahavaraukset [e! {:keys [valittu-hoitokausi tarjous kustannussuunnitelma] :as app}]
   (if (nil? (:rahavaraukset kustannussuunnitelma))
@@ -178,7 +180,7 @@
               :fmt #(if-not (= 0 suunniteltu-yht-indeksikorjattu) (fmt/euro-opt false %) "-") :otsikkorivi-luokka "korkea"}])
           rahavaraukset]]]])))
 
-(defn erillishankinnat [e! {:keys [valittu-hoitokausi tallennus-kesken? tarjous kustannussuunnitelma] :as app}]
+(defn erillishankinnat [e! {:keys [valittu-hoitokausi tallennus-kesken? tarjous kustannussuunnitelma tulevaisuudessa-arvoja?] :as app}]
   (if (nil? (get-in app [:kustannussuunnitelma :erillishankinnat]))
     [yleiset/ajax-loader-pieni "Ladataan..."]
     (let [{:keys [erillishankinnat vahvistettu?]} kustannussuunnitelma
@@ -225,7 +227,8 @@
             #(e! (kust-tiedot/->TallennaErillishankinnat @yhteiset/grid-erillishankinnat-atom false))
             (when (and tarjouksen-maara (> tarjouksen-maara 0))
               #(e! (kust-tiedot/->JaaErillishankinnatTasan tarjouksen-maara "erillishankinnat-elementti")))
-            #(e! (kust-tiedot/->TallennaErillishankinnat @yhteiset/grid-erillishankinnat-atom true)))])
+            #(e! (kust-tiedot/->TallennaErillishankinnat @yhteiset/grid-erillishankinnat-atom true))
+            tulevaisuudessa-arvoja?)])
 
        [:div.row
         [:div.col-xs-12
@@ -254,9 +257,10 @@
            #(e! (kust-tiedot/->TallennaErillishankinnat @yhteiset/grid-erillishankinnat-atom false))
            (when (and tarjouksen-maara (> tarjouksen-maara 0))
              #(e! (kust-tiedot/->JaaErillishankinnatTasan tarjouksen-maara "erillishankinnat-elementti")))
-           #(e! (kust-tiedot/->TallennaErillishankinnat @yhteiset/grid-erillishankinnat-atom true))))])))
+           #(e! (kust-tiedot/->TallennaErillishankinnat @yhteiset/grid-erillishankinnat-atom true))
+           tulevaisuudessa-arvoja?))])))
 
-(defn hoidonjohtopalkkiot [e! {:keys [valittu-hoitokausi tallennus-kesken? tarjous kustannussuunnitelma] :as app}]
+(defn hoidonjohtopalkkiot [e! {:keys [valittu-hoitokausi tallennus-kesken? tarjous kustannussuunnitelma tulevaisuudessa-arvoja?] :as app}]
   (if (nil? (get-in app [:kustannussuunnitelma :hoidonjohtopalkkiot]))
     [yleiset/ajax-loader-pieni "Ladataan..."]
     (let [{:keys [hoidonjohtopalkkiot vahvistettu?]} kustannussuunnitelma
@@ -303,7 +307,8 @@
             #(e! (kust-tiedot/->TallennaHoidonjohtopalkkiot @yhteiset/grid-hoidonjohtopalkkiot-atom false))
             (when (and tarjouksen-maara (> tarjouksen-maara 0))
               #(e! (kust-tiedot/->JaaHoidonjohtopalkkiotTasan tarjouksen-maara "hoidonjohtopalkkio-elementti")))
-            #(e! (kust-tiedot/->TallennaHoidonjohtopalkkiot @yhteiset/grid-hoidonjohtopalkkiot-atom true)))])
+            #(e! (kust-tiedot/->TallennaHoidonjohtopalkkiot @yhteiset/grid-hoidonjohtopalkkiot-atom true))
+            tulevaisuudessa-arvoja?)])
 
        [:div.row
         [:div.col-xs-12
@@ -332,7 +337,8 @@
            #(e! (kust-tiedot/->TallennaHoidonjohtopalkkiot @yhteiset/grid-hoidonjohtopalkkiot-atom false))
            (when (and tarjouksen-maara (> tarjouksen-maara 0))
             #(e! (kust-tiedot/->JaaHoidonjohtopalkkiotTasan tarjouksen-maara "hoidonjohtopalkkio-elementti")))
-           #(e! (kust-tiedot/->TallennaHoidonjohtopalkkiot @yhteiset/grid-hoidonjohtopalkkiot-atom true))))])))
+           #(e! (kust-tiedot/->TallennaHoidonjohtopalkkiot @yhteiset/grid-hoidonjohtopalkkiot-atom true))
+           tulevaisuudessa-arvoja?))])))
 
 (defn tavoite-ja-kattohinta [e! {:keys [valittu-hoitokausi tallennus-kesken? tarjous kustannussuunnitelma] :as app}]
   (let [{:keys [pysyvat-muutokset-maara hoitovuoden-alun-tavoitehinta

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/yhteiset.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/yhteiset.cljs
@@ -7,6 +7,7 @@
             [harja.ui.ikonit :as ikonit]
             [harja.ui.yleiset :as yleiset]
             [harja.ui.napit :as napit]
+            [harja.ui.varmista-kayttajalta :as varmista-kayttajalta]
             [harja.tiedot.urakka.siirtymat :as siirtymat]
             [harja.tiedot.urakka.urakka :as tila]
             [harja.tiedot.navigaatio :as nav]))
@@ -23,8 +24,8 @@
 (def rajavuosi 2025)
 
 (defn otsikkotiedot [valittu-hoitokausi kustannussuunnitelma otsikko tarjouksen-maara
-                      pysyvamuutos-maara suunniteltu-yhteensa suunniteltu-yhteensa-indeksikorjattu
-                      {:keys [div1 div2 div3 div4] :as opts} valittu-vuosi]
+                     pysyvamuutos-maara suunniteltu-yhteensa suunniteltu-yhteensa-indeksikorjattu
+                     {:keys [div1 div2 div3 div4] :as opts} valittu-vuosi]
   (let [urakan-alkuvuosi (pvm/vuosi (-> @tila/yleiset :urakka :alkupvm))
         urakan-loppuvuosi (pvm/vuosi (-> @tila/yleiset :urakka :loppupvm))
         hoitovuodet (into [] (range urakan-alkuvuosi urakan-loppuvuosi))
@@ -71,7 +72,7 @@
          [:div.body-text (if indeksikerroin (fmt/euro-opt true tarjous-pysyvat-yhteensa-indeksikorjattu) "Indeksilukua ei ole saatavilla")]
          (when indeksikerroin
            [:div.body-text
-            (str "(" (fmt/desimaaliluku indeksikerroin nil nil false ) " * " (if tarjous-pysyvat-yhteensa (fmt/euro-opt false tarjous-pysyvat-yhteensa) "0,00 €") " )")])])
+            (str "(" (fmt/desimaaliluku indeksikerroin nil nil false) " * " (if tarjous-pysyvat-yhteensa (fmt/euro-opt false tarjous-pysyvat-yhteensa) "0,00 €") " )")])])
 
       ;; -23 vuoteen asti näytetään indeksikorjattu määrä suunnitellulle summalle, koska tarjousihintoja ja pysyviä muutoksia ei ole ollut
       (when (and div4 (< valittu-vuosi rajavuosi))
@@ -80,23 +81,30 @@
          [:div.body-text (if indeksikerroin (fmt/euro-opt true suunniteltu-yhteensa-indeksikorjattu) "Indeksilukua ei ole saatavilla")]
          (when indeksikerroin
            [:div.body-text
-            (str "(" (fmt/desimaaliluku indeksikerroin nil nil false ) " * " (if suunniteltu-yhteensa (fmt/euro-opt false suunniteltu-yhteensa) "0,00 €") " )")])])]]))
+            (str "(" (fmt/desimaaliluku indeksikerroin nil nil false) " * " (if suunniteltu-yhteensa (fmt/euro-opt false suunniteltu-yhteensa) "0,00 €") " )")])])]]))
 
-(defn tallenna-painike-rivi [viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken? tallenna-fn jaa-tasan-fn kopioi-tuleville-hoitovuosille-fn]
-  [:div.row.rivi-container
-   [:div.col-xs-12.text-right (if viimeisin-muokkaus
-                                (str "Viimeksi tallennettu: " (pvm/pvm-aika-klo viimeisin-muokkaus) " (" viimeisin-muokkaaja ")")
-                                "Ei tallennettuja muutoksia")
+(defn tallenna-painike-rivi [viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken?
+                             tallenna-fn jaa-tasan-fn kopioi-tuleville-hoitovuosille-fn
+                             tulevaisuudessa-arvoja?]
+  [:div {:style {:padding-top "1rem" :padding-right "1rem"}}
+   [:div.painikkeet.text-right
+    ;; Kopioi tuleville hoitovuosille.
     (when kopioi-tuleville-hoitovuosille-fn
       [:span {:style {:margin-left "1rem"}}
        [napit/yleinen-toissijainen "Kopioi tuleville hoitovuosille"
-        #(do
-           (reset! tallenna-painettu false)
-           (kopioi-tuleville-hoitovuosille-fn))
+        (fn []
+          (if tulevaisuudessa-arvoja?
+            (varmista-kayttajalta/varmista-kayttajalta
+              {:otsikko "Tulevilla hoitovuosilla on jo tietoja"
+               :sisalto (str "Tulevilla hoitovuosilla on jo tietoja. Ylikirjoitetaanko tiedot? Ylikirjoitetut tiedot menetetään pysyvästi.")
+               :hyvaksy "Ylikirjoita"
+               :toiminto-fn #(do
+                               (reset! tallenna-painettu false)
+                               (kopioi-tuleville-hoitovuosille-fn))})
+            (kopioi-tuleville-hoitovuosille-fn)))
         {:disabled tallennus-kesken?
          :luokka "ikoni-16"
          :ikoni (ikonit/action-copy)}]])
-
     (when jaa-tasan-fn
       [:span {:style {:margin-left "1rem"}}
        [napit/yleinen-toissijainen "Jaa tasan joka kuukaudelle"
@@ -109,7 +117,17 @@
       #(do
          (reset! tallenna-painettu false)
          (tallenna-fn))
-      {:disabled tallennus-kesken?}]]]])
+      {:disabled tallennus-kesken?}]]]
+   [:div.painikkeet.text-right {:style {:margin-top "0.5rem"}}
+    ;; Viimeisin muokkaaja
+    [:div.grid-status-viestit
+     (if viimeisin-muokkaus
+       [:<>
+        [:div.status-viesti.tallennettu
+         (str "Viimeksi tallennettu: " (pvm/pvm-aika-klo viimeisin-muokkaus) " (" viimeisin-muokkaaja ")")]]
+       [:<>
+        [:div.status-viesti.tallentamatta
+         "Ei tallennettuja muutoksia"]])]]])
 
 (defn grid-perusasetukset [voi-muokata? tunniste]
   {:tyhja "Ei tietoja."

--- a/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/yhteiset.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tarjous_kustannussuunnitelma/yhteiset.cljs
@@ -4,6 +4,7 @@
    Tämä sisältää esimerkiksi otsikkotiedot ja tallennusnapit."
   (:require [harja.fmt :as fmt]
             [harja.pvm :as pvm]
+            [harja.ui.ikonit :as ikonit]
             [harja.ui.yleiset :as yleiset]
             [harja.ui.napit :as napit]
             [harja.tiedot.urakka.siirtymat :as siirtymat]
@@ -81,11 +82,21 @@
            [:div.body-text
             (str "(" (fmt/desimaaliluku indeksikerroin nil nil false ) " * " (if suunniteltu-yhteensa (fmt/euro-opt false suunniteltu-yhteensa) "0,00 €") " )")])])]]))
 
-(defn tallenna-painike-rivi [viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken? tallenna-fn jaa-tasan-fn]
+(defn tallenna-painike-rivi [viimeisin-muokkaus viimeisin-muokkaaja tallennus-kesken? tallenna-fn jaa-tasan-fn kopioi-tuleville-hoitovuosille-fn]
   [:div.row.rivi-container
    [:div.col-xs-12.text-right (if viimeisin-muokkaus
                                 (str "Viimeksi tallennettu: " (pvm/pvm-aika-klo viimeisin-muokkaus) " (" viimeisin-muokkaaja ")")
                                 "Ei tallennettuja muutoksia")
+    (when kopioi-tuleville-hoitovuosille-fn
+      [:span {:style {:margin-left "1rem"}}
+       [napit/yleinen-toissijainen "Kopioi tuleville hoitovuosille"
+        #(do
+           (reset! tallenna-painettu false)
+           (kopioi-tuleville-hoitovuosille-fn))
+        {:disabled tallennus-kesken?
+         :luokka "ikoni-16"
+         :ikoni (ikonit/action-copy)}]])
+
     (when jaa-tasan-fn
       [:span {:style {:margin-left "1rem"}}
        [napit/yleinen-toissijainen "Jaa tasan joka kuukaudelle"

--- a/test/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_test.clj
+++ b/test/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_test.clj
@@ -45,8 +45,6 @@
                                            :alkukausi 100 :alkukausi-indeksikorjattu 111 :loppukausi 300 :loppukausi-indeksikorjattu 333 :yhteensa 400 :yhteensa-indeksikorjattu 444}
                                           {:nimi "MHU Korvausinvestointi", :osio "hankintakustannukset" :toimenpideinstanssi-id 95 :pysyvat-muutokset "Ei muutoksia"
                                            :alkukausi 100 :alkukausi-indeksikorjattu 111 :loppukausi 300 :loppukausi-indeksikorjattu 333 :yhteensa 400 :yhteensa-indeksikorjattu 444}
-                                          {:nimi "MHU ja HJU Hoidon johto", :osio "hankintakustannukset" :toimenpideinstanssi-id 96 :pysyvat-muutokset "Ei muutoksia"
-                                           :alkukausi 100 :alkukausi-indeksikorjattu 111 :loppukausi 300 :loppukausi-indeksikorjattu 333 :yhteensa 400 :yhteensa-indeksikorjattu 444}
                                           {:nimi "Yhteensä", :osio "hankintakustannukset" :toimenpideinstanssi-id 0 :pysyvat-muutokset "Ei muutoksia"
                                            :alkukausi 700 :alkukausi-indeksikorjattu 777 :loppukausi 2100 :loppukausi-indeksikorjattu 2331 :yhteensa 2800 :yhteensa-indeksikorjattu 3108}]})
 
@@ -107,10 +105,24 @@
 (defn poista-yhteenvetorivi [tietomalli]
   {:toimenpiteet (filter #(not= (:nimi %) "Yhteensä") (:toimenpiteet tietomalli))})
 
+(defn urakkakohtaiset-toimenpideinstanssit-toimenpiteille
+  "Tietomallissa toimenpideinstanssi on kovakoodattu. Aseta toimenpideinstanssi-id urakkakohtaisista toimenpiteistä."
+  [hankinnat-tietomalli urakkakohtaiset-toimenpiteet]
+  (assoc hankinnat-tietomalli :toimenpiteet
+    (map (fn [toimenpide]
+           (let [tpi (first (filter #(= (:nimi %) (:nimi toimenpide)) urakkakohtaiset-toimenpiteet))]
+             (if tpi
+               (assoc toimenpide :toimenpideinstanssi-id (:toimenpideinstanssi-id tpi))
+               toimenpide)))
+      (:toimenpiteet hankinnat-tietomalli))))
+
 (deftest hae-kilpailutettavat-hankinnat-tietokannasta-onnistuneesti
   (let [db (:db jarjestelma)
         urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
+        toimenpiteet (uusi-kust-kyselyt/hae-urakan-toimenpiteet db {:urakkaid urakka-id})
         hoitovuoden-alkuvuosi 2024
+        ;; Päivitä toimenpideinstanssien id:t tietokannasta haetuilla id:illä
+        hankinnat-tietomalli (urakkakohtaiset-toimenpideinstanssit-toimenpiteille hankinnat-tietomalli toimenpiteet)
         ;; Poista yhteenvetorivi ennen tallennusta
         hankinnat-tietomalli (poista-yhteenvetorivi hankinnat-tietomalli)
         _ (uusi-kust-kyselyt/tallenna-kilpailutettavat-hankinnat db +kayttaja-jvh+ urakka-id hoitovuoden-alkuvuosi (:toimenpiteet hankinnat-tietomalli))
@@ -120,7 +132,8 @@
 
     (is (= (count (:toimenpiteet hankinnat)) 7))
     (is (true? (some #(= (:nimi %) "Talvihoito laaja TPI") (:toimenpiteet hankinnat))))
-    (is (= (:nimi (last (:toimenpiteet hankinnat))) "Yhteensä"))))
+    (is (= (:nimi (last (:toimenpiteet hankinnat))) "Yhteensä"))
+    (is (= (:alkukausi (last (:toimenpiteet hankinnat))) 600M))))
 
 (deftest tallenna-kilpailutettavat-hankinnat-tietokantaan-onnistuneesti
   (let [db (:db jarjestelma)
@@ -148,20 +161,64 @@
     (is (true? (str/includes? (:error vastaus) "Palvelun :tallenna-kilpailutettavat-hankinnat kysely ei ole validi.")))))
 
 (deftest tallenna-kilpailutettavat-hankinnat-rajapinnasta-toimii
-  (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
+  (let [db (:db jarjestelma)
+        urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
+        sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
         hoitovuoden-alkuvuosi 2024
+        toimenpiteet (uusi-kust-kyselyt/hae-urakan-toimenpiteet db {:urakkaid urakka-id})
+        ;; Päivitä toimenpideinstanssien id:t tietokannasta haetuilla id:illä
+        hankinnat-tietomalli (urakkakohtaiset-toimenpideinstanssit-toimenpiteille hankinnat-tietomalli toimenpiteet)
         ;; Poista yhteenvetorivi ennen tallennusta
         hankinnat-tietomalli (poista-yhteenvetorivi hankinnat-tietomalli)
         vastaus (try
                   (kutsu-palvelua (:http-palvelin jarjestelma) :tallenna-kilpailutettavat-hankinnat +kayttaja-jvh+
                     (merge
                       {:urakka-id urakka-id
-                       :hoitovuoden-alkuvuosi hoitovuoden-alkuvuosi}
+                       :hoitovuoden-alkuvuosi hoitovuoden-alkuvuosi
+                       :kopioi-tuleville-vuosille? false}
                       hankinnat-tietomalli))
                   (catch Exception e
                     (println "Tapahtui virhe:" (.getMessage e))
-                    {:error (.getMessage e)}))]
-    (is (true? (nil? (:error vastaus))))))
+                    {:error (.getMessage e)}))
+
+        toimenkuvat (butlast (get-in vastaus [:kustannussuunnitelma :kilpailutettavat-hankinnat :toimenpiteet]))
+        alkukausi-summa-vastauksesta (apply + (map :alkukausi toimenkuvat))
+
+        alkukausi-tietokannasta (q-map (format "SELECT * FROM kiinteahintainen_tyo
+                                                  WHERE sopimus = %s
+                                                    AND vuosi = %s AND kuukausi IN (10,11,12)"
+                                         sopimus-id hoitovuoden-alkuvuosi))]
+    (is (true? (nil? (:error vastaus))))
+    (is (= (bigdec alkukausi-summa-vastauksesta) (bigdec (apply + (map :summa alkukausi-tietokannasta)))))))
+
+(deftest tallenna-kilpailutettavat-hankinnat-rajapinnasta-tuleville-vuosille-toimii
+  (let [db (:db jarjestelma)
+        urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
+        sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
+        hoitovuoden-alkuvuosi 2021
+        ;; Poista yhteenvetorivi ennen tallennusta
+        hankinnat-tietomalli (poista-yhteenvetorivi hankinnat-tietomalli)
+        vastaus (try
+                  (kutsu-palvelua (:http-palvelin jarjestelma) :tallenna-kilpailutettavat-hankinnat +kayttaja-jvh+
+                    (merge
+                      {:urakka-id urakka-id
+                       :hoitovuoden-alkuvuosi hoitovuoden-alkuvuosi
+                       :kopioi-tuleville-vuosille? true}
+                      hankinnat-tietomalli))
+                  (catch Exception e
+                    (println "Tapahtui virhe:" (.getMessage e))
+                    {:error (.getMessage e)}))
+        toimenkuvat (get-in vastaus [:kustannussuunnitelma :kilpailutettavat-hankinnat :toimenpiteet])
+        alkukausi-vastauksesta (apply + (map :alkukausi toimenkuvat))
+
+        ;; Vastauksesta saatiin kilpailutettavat hankinnat vuodelle 2021
+        ;; Haetaan kilpailutettavat hankinnat myös tuleville vuosille ja tarkistetaan, että ne on kopioitu oikein
+        alkukausi-tietokannasta (q-map (format "SELECT SUM(summa) as summa FROM kiinteahintainen_tyo
+                                                  WHERE sopimus = %s
+                                                    AND vuosi = %s AND kuukausi IN (10,11,12)"
+                                         sopimus-id (inc hoitovuoden-alkuvuosi)))
+        tietokantasumma (bigdec (:summa (first alkukausi-tietokannasta)))]
+    (is (= (bigdec alkukausi-vastauksesta) tietokantasumma))))
 
 ;; Erillishankinnat
 (deftest tallenna-erillishankinnat-tietokantaan-onnistuneesti

--- a/test/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_test.clj
+++ b/test/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_test.clj
@@ -1,6 +1,8 @@
 (ns harja.palvelin.palvelut.suunnittelu.uusi-kustannussuunnitelma-test
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest testing use-fixtures compose-fixtures is]]
+            [harja.kyselyt.tehtavaryhmat :as tehtavaryhma-kyselyt]
+            [harja.kyselyt.toimenpidekoodit :as tehtava-kyselyt]
             [harja.palvelin.palvelut.suunnittelu.apurit :as apurit]
             [harja.palvelin.palvelut.suunnittelu.uusi-kustannussuunnitelma-palvelu :as kust-palvelu]
             [harja.palvelin.palvelut.suunnittelu.tarjous-palvelu :as tarjous-palvelu]
@@ -225,9 +227,6 @@
   (let [db (:db jarjestelma)
         urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
         sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
-        hoidonjohto-tpi-id (:id (first (tpi-kyselyt/hae-urakan-toimenpideinstanssi-toimenpidekoodilla db
-                                         {:urakka urakka-id
-                                          :koodi "23151"})))
         hoitovuoden-alkuvuosi 2024
         tietomallin-summa (apply + (map :summa (:erillishankinnat erillishankinnat-tietomalli)))
 
@@ -288,6 +287,47 @@
     (is (nil? (:error vastaus)))
     (is (= (bigdec tietomallin-summa) (bigdec vastaus-summa)))))
 
+(deftest kopioi-erillishankinnat-tuleville-vuosille-toimii
+  (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
+        hoitovuoden-alkuvuosi 2021
+        db (:db jarjestelma)
+        sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
+        hoidonjohto-tpi-id (:id (first (tpi-kyselyt/hae-urakan-toimenpideinstanssi-toimenpidekoodilla db
+                                         {:urakka urakka-id
+                                          :koodi "23151"})))
+        tehtavaryhma (first (tehtavaryhma-kyselyt/hae-tehtavaryhma-tunnisteella db
+                              {:yksiloiva_tunniste "37d3752c-9951-47ad-a463-c1704cf22f4c"}))
+
+        tietomallin-summa (apply + (map :summa (:erillishankinnat erillishankinnat-tietomalli)))
+        vastaus (try
+                  (kutsu-palvelua (:http-palvelin jarjestelma)
+                    :tallenna-erillishankinnat +kayttaja-jvh+ (merge erillishankinnat-tietomalli
+                                                                {:urakka-id urakka-id
+                                                                 :hoitovuoden-alkuvuosi hoitovuoden-alkuvuosi
+                                                                 :kopioi-tuleville-vuosille? true}))
+                  (catch Exception e
+                    (println "Tapahtui virhe:" (.getMessage e))
+                    {:error (.getMessage e)}))
+        vastaus-summa (apply + (map :summa (get-in vastaus [:kustannussuunnitelma :erillishankinnat])))
+
+        ;; Hae seuraavan vuoden summa
+        seuraava-vuosi (inc hoitovuoden-alkuvuosi)
+        erillishankinnat-seuraava-vuosi (q-map (format "SELECT SUM(summa) as summa
+                                                         FROM kustannusarvioitu_tyo
+                                                  WHERE sopimus = %s
+                                                    AND toimenpideinstanssi = %s
+                                                    AND tehtavaryhma = %s
+                                                    AND (
+                                                    (vuosi = %s AND kuukausi in (10,11,12)) OR
+                                                    (vuosi = %s AND kuukausi IN (1,2,3,4,5,6,7,8,9)))"
+                                                 sopimus-id hoidonjohto-tpi-id (:id tehtavaryhma)
+                                                 seuraava-vuosi (inc seuraava-vuosi)))]
+
+    ;; Ei ole erroreita
+    (is (nil? (:error vastaus)))
+    (is (= (bigdec tietomallin-summa) (bigdec vastaus-summa)))
+    (is (= (bigdec tietomallin-summa) (bigdec (:summa (first erillishankinnat-seuraava-vuosi)))))))
+
 (deftest muokkaa-erillishankinnat-rajapinnasta-toimii
   (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
         ;; Tallenna ensin tietomallin tiedot
@@ -332,9 +372,6 @@
                                          {:urakka urakka-id
                                           :koodi "23151"})))
         hoitovuoden-alkuvuosi 2024
-        hoidonjohto-tpi-id (:id (first (tpi-kyselyt/hae-urakan-toimenpideinstanssi-toimenpidekoodilla db
-                                         {:urakka urakka-id
-                                          :koodi "23151"})))
         tietomallin-summa (apply + (map :summa (:hoidonjohtopalkkiot hoidonjohtopalkkiot-tietomalli)))
         _ (uusi-kust-kyselyt/tallenna-hoidonjohtopalkkiot db +kayttaja-jvh+ urakka-id
             (:hoidonjohtopalkkiot hoidonjohtopalkkiot-tietomalli) hoitovuoden-alkuvuosi)
@@ -360,6 +397,75 @@
     (is (true? (str/includes? (:error vastaus) "Palvelun :tallenna-hoidonjohtopalkkiot kysely ei ole validi.")))
     (is (true? (str/includes? (:error vastaus) "failed: (contains? % :hoidonjohtopalkkiot)")))))
 
+(deftest tallenna-hoidonjohtopalkkiot-rajapinnasta-toimi
+  (let [db (:db jarjestelma)
+        urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
+        sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
+        hoidonjohto-tpi-id (:id (first (tpi-kyselyt/hae-urakan-toimenpideinstanssi-toimenpidekoodilla db
+                                         {:urakka urakka-id
+                                          :koodi "23151"})))
+        tehtava-id (:id (first (tehtava-kyselyt/hae-tehtava-tunnisteella db {:tunniste "53647ad8-0632-4dd3-8302-8dfae09908c8"})))
+        hoitovuoden-alkuvuosi 2021
+        vastaus (try
+                  (kutsu-palvelua (:http-palvelin jarjestelma) :tallenna-hoidonjohtopalkkiot +kayttaja-jvh+
+                    (merge {:urakka-id urakka-id
+                            :hoitovuoden-alkuvuosi hoitovuoden-alkuvuosi
+                            :kopioi-tuleville-vuosille? false}
+                      hoidonjohtopalkkiot-tietomalli))
+                  (catch Exception e
+                    (println "Tapahtui virhe:" (.getMessage e))
+                    {:error (.getMessage e)}))
+
+        tietomallin-summa (apply + (map :summa (:hoidonjohtopalkkiot hoidonjohtopalkkiot-tietomalli)))
+
+        hoidonjohtopalkkiot-tietokannasta (q-map (format "SELECT SUM(summa) as summa
+                                                            FROM kustannusarvioitu_tyo
+                                                           WHERE sopimus = %s
+                                                             AND toimenpideinstanssi = %s
+                                                             AND tehtava = %s
+                                                             AND (
+                                                                  (vuosi = %s AND kuukausi in (10,11,12)) OR
+                                                                  (vuosi = %s AND kuukausi IN (1,2,3,4,5,6,7,8,9)))"
+                                                   sopimus-id hoidonjohto-tpi-id tehtava-id
+                                                   hoitovuoden-alkuvuosi (inc hoitovuoden-alkuvuosi)))]
+    (is (nil? (:error vastaus)))
+    (is (= (bigdec tietomallin-summa) (bigdec (:summa (first hoidonjohtopalkkiot-tietokannasta)))))))
+
+(deftest tallenna-hoidonjohtopalkkiot-tuleville-vuosille-toimi
+  (let [db (:db jarjestelma)
+        urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
+        sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
+        hoidonjohto-tpi-id (:id (first (tpi-kyselyt/hae-urakan-toimenpideinstanssi-toimenpidekoodilla db
+                                         {:urakka urakka-id
+                                          :koodi "23151"})))
+        tehtava-id (:id (first (tehtava-kyselyt/hae-tehtava-tunnisteella db {:tunniste "53647ad8-0632-4dd3-8302-8dfae09908c8"})))
+        hoitovuoden-alkuvuosi 2021
+        vastaus (try
+                  (kutsu-palvelua (:http-palvelin jarjestelma) :tallenna-hoidonjohtopalkkiot +kayttaja-jvh+
+                    (merge {:urakka-id urakka-id
+                            :hoitovuoden-alkuvuosi hoitovuoden-alkuvuosi
+                            :kopioi-tuleville-vuosille? true}
+                      hoidonjohtopalkkiot-tietomalli))
+                  (catch Exception e
+                    (println "Tapahtui virhe:" (.getMessage e))
+                    {:error (.getMessage e)}))
+
+        tietomallin-summa (apply + (map :summa (:hoidonjohtopalkkiot hoidonjohtopalkkiot-tietomalli)))
+
+        seuraava-vuosi (inc hoitovuoden-alkuvuosi)
+        hoidonjohtopalkkiot-tietokannasta (q-map (format "SELECT SUM(summa) as summa
+                                                            FROM kustannusarvioitu_tyo
+                                                           WHERE sopimus = %s
+                                                             AND toimenpideinstanssi = %s
+                                                             AND tehtava = %s
+                                                             AND (
+                                                                  (vuosi = %s AND kuukausi in (10,11,12)) OR
+                                                                  (vuosi = %s AND kuukausi IN (1,2,3,4,5,6,7,8,9)))"
+                                                   sopimus-id hoidonjohto-tpi-id tehtava-id
+                                                   seuraava-vuosi (inc seuraava-vuosi)))]
+    (is (nil? (:error vastaus)))
+    (is (= (bigdec tietomallin-summa) (bigdec (:summa (first hoidonjohtopalkkiot-tietokannasta)))))))
+
 (deftest tallenna-hoidonjohtopalkkiot-rajapinnasta-ei-toimi2
   (let [vastaus (try
                   (kutsu-palvelua (:http-palvelin jarjestelma)
@@ -372,6 +478,60 @@
     ;; Urakka-id puuttuu
     (is (true? (str/includes? (:error vastaus) "failed: (contains? % :urakka-id)")))))
 
+(deftest tallenna-hoidonjohtopalkkiot-rajapinnasta-toimii
+  (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
+        tietomallin-summa (apply + (map :summa (:hoidonjohtopalkkiot hoidonjohtopalkkiot-tietomalli)))
+        vastaus (try
+                  (kutsu-palvelua (:http-palvelin jarjestelma)
+                    :tallenna-hoidonjohtopalkkiot +kayttaja-jvh+ (merge hoidonjohtopalkkiot-tietomalli
+                                                                   {:urakka-id urakka-id
+                                                                    :hoitovuoden-alkuvuosi 2024}))
+                  (catch Exception e
+                    (println "Tapahtui virhe:" (.getMessage e))
+                    {:error (.getMessage e)}))
+        vastaus-summa (apply + (map :summa (get-in vastaus [:kustannussuunnitelma :hoidonjohtopalkkiot])))]
+
+    ;; Ei ole erroreita
+    (is (nil? (:error vastaus)))
+    (is (= (bigdec tietomallin-summa) (bigdec vastaus-summa)))))
+
+
+(deftest muokkaa-hoidonjohtopalkkiot-rajapinnasta-toimii
+  (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
+        ;; Tallenna ensin tietomallin tiedot
+        vastaus (try
+                  (kutsu-palvelua (:http-palvelin jarjestelma)
+                    :tallenna-hoidonjohtopalkkiot +kayttaja-jvh+ (merge hoidonjohtopalkkiot-tietomalli
+                                                                   {:urakka-id urakka-id
+                                                                    :hoitovuoden-alkuvuosi 2024}))
+                  (catch Exception e
+                    (println "Tapahtui virhe:" (.getMessage e))
+                    {:error (.getMessage e)}))
+        vastaus-hoidonjohtopalkkiot (into [] (get-in vastaus [:kustannussuunnitelma :hoidonjohtopalkkiot]))
+
+        ;; Varmistetaan, ettei ole erroreita
+        _ (is (nil? (:error vastaus)))
+
+        ;; Tallenna muokattu tietomalli
+        muokattu-vastaus (-> vastaus-hoidonjohtopalkkiot
+                           (assoc-in [0 :summa] 1500)
+                           (assoc-in [1 :summa] 2500)
+                           (assoc-in [2 :summa] 3500))
+        muokattu-summa (apply + (map :summa muokattu-vastaus))
+        muokattu-vastaus (try
+                           (kutsu-palvelua (:http-palvelin jarjestelma)
+                             :tallenna-hoidonjohtopalkkiot +kayttaja-jvh+
+                             (merge {:hoidonjohtopalkkiot muokattu-vastaus}
+                               {:urakka-id urakka-id
+                                :hoitovuoden-alkuvuosi 2024}))
+                           (catch Exception e
+                             (println "Tapahtui virhe:" (.getMessage e))
+                             {:error (.getMessage e)}))
+        muokattu-vastaus-summa (apply + (map :summa (get-in muokattu-vastaus [:kustannussuunnitelma :hoidonjohtopalkkiot])))]
+
+    (is (= (bigdec muokattu-summa) (bigdec muokattu-vastaus-summa)))))
+
+;; Johto- ja hallintokorvaukset
 (deftest tallenna-johto-ja-hallintokorvaukset-2019-rajapinnasta-toimii
   (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
         tietomallin-summa (apply + (map
@@ -391,6 +551,41 @@
     ;; Ei ole erroreita
     (is (nil? (:error vastaus)))
     (is (= (bigdec (round2 tietomallin-summa 2)) (bigdec (round2 vastaus-summa 2))))
+    ;; Viimeinen rivi on "Muut kulut"
+    (is (= "Muut kulut" (:toimenkuva (last (get-in vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset])))))))
+
+(deftest kopioi-johto-ja-hallintokorvaukset-2019-tuleville-vuosille-toimii
+  (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
+        hoitokauden-alkuvuosi 2021
+        tietomallin-summa (apply + (map
+                                     (fn [kuukausi]
+                                       (* (or (:tunnit kuukausi) 0) (or (:tuntipalkka kuukausi) 0)))
+                                     (flatten (map :kuukaudet (:johto-ja-hallintokorvaukset-2019 johto-ja-hallinto-tietomalli-2019)))))
+        vastaus (try
+                  (kutsu-palvelua (:http-palvelin jarjestelma)
+                    :tallenna-johto-ja-hallintokorvaukset-2019 +kayttaja-jvh+ (merge johto-ja-hallinto-tietomalli-2019
+                                                                                {:urakka-id urakka-id
+                                                                                 :hoitovuoden-alkuvuosi hoitokauden-alkuvuosi
+                                                                                 :kopioi-tuleville-vuosille? true}))
+                  (catch Exception e
+                    (println "Tapahtui virhe:" (.getMessage e))
+                    {:error (.getMessage e)}))
+        vastaus-summa (apply + (map :summa (get-in vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset])))
+
+        ;; Hae seuraavan vuoden summa
+        seuraava-vuosi (inc hoitokauden-alkuvuosi)
+        toimenkuvat-seuraava-vuosi (q-map (format "SELECT *
+                                                            FROM johto_ja_hallintokorvaus
+                                                           WHERE \"urakka-id\" = %s
+                                                             AND (
+                                                                  (vuosi = %s AND kuukausi in (10,11,12)) OR
+                                                                  (vuosi = %s AND kuukausi IN (1,2,3,4,5,6,7,8,9)))"
+                                                    urakka-id seuraava-vuosi (inc seuraava-vuosi)))]
+
+    ;; Ei ole erroreita
+    (is (nil? (:error vastaus)))
+    (is (= (bigdec (round2 tietomallin-summa 2)) (bigdec (round2 vastaus-summa 2))))
+    (is (= (bigdec (round2 2 tietomallin-summa)) (bigdec (round2 2 (apply + (map :tuntipalkka toimenkuvat-seuraava-vuosi))))))
     ;; Viimeinen rivi on "Muut kulut"
     (is (= "Muut kulut" (:toimenkuva (last (get-in vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset])))))))
 
@@ -434,6 +629,36 @@
     ;; Viimeinen rivi ei ole "Muut kulut" - -25 urakoilla ei ole muita kuluja
     (is (not= "Muut kulut" (:toimenkuva (last (get-in vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset])))))))
 
+(deftest kopioi-johto-ja-hallintokorvaukset-2025-tuleville-vuosille-toimii
+  (let [urakka-id (hae-urakan-id-nimella "Kittilän MHU 2025-2030")
+        hoitovuoden-alkuvuosi 2025
+        ;; Tallenna ensin tietomallin tiedot
+        vastaus (try
+                  (kutsu-palvelua (:http-palvelin jarjestelma)
+                    :tallenna-johto-ja-hallintokorvaukset-2025 +kayttaja-jvh+ (merge johto-ja-hallinto-tietomalli-2025
+                                                                                {:urakka-id urakka-id
+                                                                                 :hoitovuoden-alkuvuosi hoitovuoden-alkuvuosi
+                                                                                 :kopioi-tuleville-vuosille? true}))
+                  (catch Exception e
+                    (println "Tapahtui virhe:" (.getMessage e))
+                    {:error (.getMessage e)}))
+        vastaus-toimenkuvat (into [] (get-in vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset]))
+        vastaus-toimenkuvat (into [] (get-in vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset]))
+        vastaus-summa (apply + (map :summa vastaus-toimenkuvat))
+        ;; Varmistetaan, ettei ole erroreita
+        _ (is (nil? (:error vastaus)))
+
+        ;; Hae seuraavan vuoden summa
+        seuraava-vuosi (inc hoitovuoden-alkuvuosi)
+        toimenkuvat-seuraava-vuosi (q-map (format "SELECT *
+                                                            FROM johto_ja_hallintokorvaus
+                                                           WHERE \"urakka-id\" = %s
+                                                             AND (
+                                                                  (vuosi = %s AND kuukausi in (10,11,12)) OR
+                                                                  (vuosi = %s AND kuukausi IN (1,2,3,4,5,6,7,8,9)))"
+                                            urakka-id seuraava-vuosi (inc seuraava-vuosi)))]
+    (is (= (bigdec (round2 2 vastaus-summa)) (bigdec (round2 2 (apply + (map :tuntipalkka toimenkuvat-seuraava-vuosi))))))))
+
 (deftest muokkaa-johto-ja-hallintokorvaukset-2019-rajapinnasta-toimii
   (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
         ;; Tallenna ensin tietomallin tiedot
@@ -472,58 +697,6 @@
         muokattu-vastaus-summa (apply +
                                  (map #(or (:yhteensa-kk %) 0)
                                    (flatten (map :kuukaudet (get-in muokattu-vastaus [:kustannussuunnitelma :johto-ja-hallintokorvaukset])))))]
-
-    (is (= (bigdec muokattu-summa) (bigdec muokattu-vastaus-summa)))))
-
-(deftest tallenna-hoidonjohtopalkkiot-rajapinnasta-toimii
-  (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
-        tietomallin-summa (apply + (map :summa (:hoidonjohtopalkkiot hoidonjohtopalkkiot-tietomalli)))
-        vastaus (try
-                  (kutsu-palvelua (:http-palvelin jarjestelma)
-                    :tallenna-hoidonjohtopalkkiot +kayttaja-jvh+ (merge hoidonjohtopalkkiot-tietomalli
-                                                                   {:urakka-id urakka-id
-                                                                    :hoitovuoden-alkuvuosi 2024}))
-                  (catch Exception e
-                    (println "Tapahtui virhe:" (.getMessage e))
-                    {:error (.getMessage e)}))
-        vastaus-summa (apply + (map :summa (get-in vastaus [:kustannussuunnitelma :hoidonjohtopalkkiot])))]
-
-    ;; Ei ole erroreita
-    (is (nil? (:error vastaus)))
-    (is (= (bigdec tietomallin-summa) (bigdec vastaus-summa)))))
-
-(deftest muokkaa-hoidonjohtopalkkiot-rajapinnasta-toimii
-  (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
-        ;; Tallenna ensin tietomallin tiedot
-        vastaus (try
-                  (kutsu-palvelua (:http-palvelin jarjestelma)
-                    :tallenna-hoidonjohtopalkkiot +kayttaja-jvh+ (merge hoidonjohtopalkkiot-tietomalli
-                                                                   {:urakka-id urakka-id
-                                                                    :hoitovuoden-alkuvuosi 2024}))
-                  (catch Exception e
-                    (println "Tapahtui virhe:" (.getMessage e))
-                    {:error (.getMessage e)}))
-        vastaus-hoidonjohtopalkkiot (into [] (get-in vastaus [:kustannussuunnitelma :hoidonjohtopalkkiot]))
-
-        ;; Varmistetaan, ettei ole erroreita
-        _ (is (nil? (:error vastaus)))
-
-        ;; Tallenna muokattu tietomalli
-        muokattu-vastaus (-> vastaus-hoidonjohtopalkkiot
-                           (assoc-in [0 :summa] 1500)
-                           (assoc-in [1 :summa] 2500)
-                           (assoc-in [2 :summa] 3500))
-        muokattu-summa (apply + (map :summa muokattu-vastaus))
-        muokattu-vastaus (try
-                           (kutsu-palvelua (:http-palvelin jarjestelma)
-                             :tallenna-hoidonjohtopalkkiot +kayttaja-jvh+
-                             (merge {:hoidonjohtopalkkiot muokattu-vastaus}
-                               {:urakka-id urakka-id
-                                :hoitovuoden-alkuvuosi 2024}))
-                           (catch Exception e
-                             (println "Tapahtui virhe:" (.getMessage e))
-                             {:error (.getMessage e)}))
-        muokattu-vastaus-summa (apply + (map :summa (get-in muokattu-vastaus [:kustannussuunnitelma :hoidonjohtopalkkiot])))]
 
     (is (= (bigdec muokattu-summa) (bigdec muokattu-vastaus-summa)))))
 
@@ -684,7 +857,7 @@
                                                 AND (CONCAT(kt.vuosi, '-', kt.kuukausi, '-01')::DATE BETWEEN '%s'::DATE AND '%s'::DATE)
                                                 AND true = onko_mhu_hankintatoimenpide(t.koodi)
                                               ORDER BY kt.vuosi, kt.kuukausi"
-                                      urakka-id sopimus-id alkupvm loppupvm))
+                                        urakka-id sopimus-id alkupvm loppupvm))
 
         ;; Varmistetaan rivi riviltä, että kaikki kiinteät on vahvistettu.
         ;; Kiinteiden töiden vahvistamisessa on otettava huomioon se, että ihan kaikkia sieltä löytyviä riviä ei vahvisteta. Ainoastaan


### PR DESCRIPTION
Mahdollista kopiointi tuleville hoitovuosille.
Estä kopiointi (piilottamalla nappi) viimeisenä hoitovuonna.
Varoita kopioinnin aiheuttavan mahdollisesti tietojen menettämistä, jos tulevilla hoitovuosilla on jo jotain dataa tallennettuna.
Varmista toiminta yksikkötesteillä.