### PR TITLE
HARJA 1498 - Pysyvat muutokset jalostus, muutos-näkymän parannukset ja lisäykset

### DIFF
--- a/.github/workflows/harja_test_pr.yml
+++ b/.github/workflows/harja_test_pr.yml
@@ -33,7 +33,9 @@ jobs:
     with:
 
       # Katso saatavilla olevat harjadb servicet docker-compose.yml:stä
-      test-db-service: harjadb-latest
+      # Testataan vanhempaa PostgreSQL versiota vasten vanhojen testipalvelimien yhteensopivuuden varmistamiseksi.
+      # TODO: Käytä harjadb-latest, kun vanhempien versioiden tuesta voidaan luopua.
+      test-db-service: 13.13-3.3.3
       e2e-browsers: "['chrome']"
       # PR-testeissä ajetaan vain kevyt build ja testauksen kannalta epärelevantit osat on jätetty pois.
       build-harja: 'light'

--- a/.github/workflows/harja_test_pr.yml
+++ b/.github/workflows/harja_test_pr.yml
@@ -35,7 +35,7 @@ jobs:
       # Katso saatavilla olevat harjadb servicet docker-compose.yml:stä
       # Testataan vanhempaa PostgreSQL versiota vasten vanhojen testipalvelimien yhteensopivuuden varmistamiseksi.
       # TODO: Käytä harjadb-latest, kun vanhempien versioiden tuesta voidaan luopua.
-      test-db-service: 13.13-3.3.3
+      test-db-service: harjadb-13.13-3.3.3
       e2e-browsers: "['chrome']"
       # PR-testeissä ajetaan vain kevyt build ja testauksen kannalta epärelevantit osat on jätetty pois.
       build-harja: 'light'

--- a/dev-resources/less/pages/muutos_tyylit.less
+++ b/dev-resources/less/pages/muutos_tyylit.less
@@ -8,11 +8,15 @@
   }
 
   .muutosten-vaikutus {
-    margin-top: @valistys-32;
+    margin-top: @valistys-24;
+
     .muutosten-vaikutus-container {
       background: @blue-lighter;
       padding: @valistys-8 @valistys-16;
+      border: 1px solid @blue-default;
+      border-radius: @valistys-4;
       max-width: 550px;
+
       .tietorivi {
         span.tietokentta {
           font-weight: normal;
@@ -45,6 +49,8 @@
   }
 
   .muutoslistaus {
+    margin-top: @valistys-24;
+
     .toast-viesti {
       padding: 0 @valistys-4;
     }

--- a/dev-resources/less/pages/muutos_tyylit.less
+++ b/dev-resources/less/pages/muutos_tyylit.less
@@ -5,13 +5,13 @@
     .muutosten-vaikutus-container {
       background: @blue-lighter;
       padding: @valistys-8 @valistys-16;
-      max-width: 600px;
+      max-width: 550px;
       .tietorivi {
         span.tietokentta {
           font-weight: normal;
         }
         span.tietoarvo {
-          font-weight: bold;
+          font-weight: normal;
         }
         display: flex;
         justify-content: space-between;

--- a/dev-resources/less/pages/muutos_tyylit.less
+++ b/dev-resources/less/pages/muutos_tyylit.less
@@ -1,5 +1,11 @@
+@import "../vayla/colors.less";
+
 // Muutokset-sivun tyylit
 .muutokset-sivu {
+  .harmaa-tumma-teksti {
+    color: @harmaa-tumma;
+  }
+
   .muutosten-vaikutus {
     margin-top: @valistys-32;
     .muutosten-vaikutus-container {
@@ -12,6 +18,7 @@
         }
         span.tietoarvo {
           font-weight: normal;
+          white-space: pre;
         }
         display: flex;
         justify-content: space-between;

--- a/dev-resources/less/pages/muutos_tyylit.less
+++ b/dev-resources/less/pages/muutos_tyylit.less
@@ -37,7 +37,7 @@
           margin: @valistys-8;
 
           .vihjeen-sisalto {
-            padding: 0.25rem 0.5rem;
+            padding: 0.25rem 0.75rem;
           }
         }
       }

--- a/dev-resources/less/pages/muutos_tyylit.less
+++ b/dev-resources/less/pages/muutos_tyylit.less
@@ -1,3 +1,4 @@
+@import "../yleiset.less";
 @import "../vayla/colors.less";
 
 // Muutokset-sivun tyylit
@@ -22,6 +23,23 @@
         }
         display: flex;
         justify-content: space-between;
+
+        &.keskita-rivin-sisalto {
+          justify-content: center;
+        }
+
+        &.piilota-rivin-sisalto {
+          display: none;
+        }
+
+        .vihje-indeksikorjaus {
+          border: 1px solid @blue-default;
+          margin: @valistys-8;
+
+          .vihjeen-sisalto {
+            padding: 0.25rem 0.5rem;
+          }
+        }
       }
     }
   }

--- a/dev-resources/less/pages/uusi-kustannussuunnitelma.less
+++ b/dev-resources/less/pages/uusi-kustannussuunnitelma.less
@@ -35,9 +35,9 @@
     display: flex;
     align-items: center;
   }
-}
 
-/* Taulukon rivien korkeuden vuoksi vetolaatikon nuoli ei ole täysin yhteensopiva muiden kanssa*/
-.vetolaatikon-sailio {
-  margin-top: -20px;
+  /* Taulukon rivien korkeuden vuoksi vetolaatikon nuoli ei ole täysin yhteensopiva muiden kanssa*/
+  .vetolaatikon-sailio {
+    margin-top: -20px;
+  }
 }

--- a/src/clj/harja/kyselyt/budjettisuunnittelu.clj
+++ b/src/clj/harja/kyselyt/budjettisuunnittelu.clj
@@ -6,7 +6,7 @@
 (defqueries "harja/kyselyt/budjettisuunnittelu.sql"
   {:positional? false})
 
-(declare lisaa-suunnitelmalle-tila hae-budjettitavoite hae-valikatselmus-siirrot-ed-vuodelta
+(declare lisaa-suunnitelmalle-tila hae-urakan-tavoitehintojen-tilat hae-budjettitavoite hae-valikatselmus-siirrot-ed-vuodelta
   onko-kustannussuunnitelma-vahvistettu hae-suunnitelman-tilat paivita-kiinteahintaiset-tyot-indeksille!
   paivita-kustannusarvioidut-tyot-indeksille! paivita-johto-ja-hallintokorvaus-indeksille!
   paivita-urakka-tavoite-indeksille! tallenna-budjettitavoite<! paivita-budjettitavoite<!
@@ -17,6 +17,9 @@
   (let [{:keys [hoitovuosi osio vahvistettu]} tila
         osio (keyword osio)]
     (assoc-in tilat [osio hoitovuosi] vahvistettu)))
+
+(defn urakan-tavoitehintojen-tilat [db urakka-id]
+  (hae-urakan-tavoitehintojen-tilat db {:urakka urakka-id}))
 
 (defn budjettitavoite-vuodelle [db urakka-id hoitokauden-alkuvuosi]
   (->>

--- a/src/clj/harja/kyselyt/budjettisuunnittelu.sql
+++ b/src/clj/harja/kyselyt/budjettisuunnittelu.sql
@@ -16,6 +16,30 @@ UPDATE urakka_tavoite
    AND hoitokausi = :hoitokausi;
 
 
+-- name: hae-urakan-tavoitehintojen-tilat
+SELECT ut.id,
+       ut.urakka,
+       ut.hoitokausi,
+       ut.tavoitehinta,
+       ut.tavoitehinta_siirretty,
+       ut.kattohinta,
+       ut.luotu,
+       ut.luoja,
+       ut.muokattu,
+       ut.muokkaaja,
+       ut.tavoitehinta_indeksikorjattu                                                        AS "tavoitehinta-indeksikorjattu",
+       ut.tavoitehinta_siirretty_indeksikorjattu                                              AS "tavoitehinta-siirretty-indeksikorjattu",
+       ut.kattohinta_indeksikorjattu                                                          AS "kattohinta-indeksikorjattu",
+       ut.indeksikorjaus_vahvistettu                                                          AS "indeksikorjaus-vahvistettu",
+       ut.vahvistaja,
+       ut.versio,
+       (EXTRACT(YEAR from u.alkupvm) + ut.hoitokausi - 1)::INTEGER                            AS "hoitokauden-alkuvuosi",
+       ut.tarjous_tavoitehinta                                                                AS "tarjous-tavoitehinta"
+  FROM urakka_tavoite ut
+           LEFT JOIN urakka u ON ut.urakka = u.id
+ WHERE urakka = :urakka
+ ORDER BY ut.hoitokausi;
+
 -- name: hae-budjettitavoite
 WITH tavoitehinnan_oikaisut AS
          (SELECT sum(summa) AS summa, "urakka-id", "hoitokauden-alkuvuosi"

--- a/src/clj/harja/kyselyt/muutos_kyselyt.sql
+++ b/src/clj/harja/kyselyt/muutos_kyselyt.sql
@@ -1,4 +1,4 @@
--- name: hae-urakan-hoitovuoden-muutostiedot
+-- name: hae-urakan-hoitovuoden-kirjatut-muutokset
 SELECT m.id,
        m.versio,
        m.urakka,

--- a/src/clj/harja/kyselyt/muutos_kyselyt.sql
+++ b/src/clj/harja/kyselyt/muutos_kyselyt.sql
@@ -72,10 +72,19 @@ SELECT m.id,
   FROM ONLY mhu_muutos m
        LEFT JOIN ONLY mhu_muutos_liite lii ON (m.id = lii.muutos)
   WHERE m.urakka = :urakka
-    -- Kirjatuista muutoksista taulukossa saa näyttää vain ne, joiden voimassa_alkaen osuu valitulle hoitokaudelle
-    AND (m.tyyppi IN ('pysyva', 'muutostyo', 'johto-ja-hallintokorvaus') AND
-         m.voimassa_alkaen BETWEEN (SELECT TO_DATE(:hoitokauden_alkuvuosi || '-10-01', 'YYYY-MM-DD')) AND
-                 (SELECT TO_DATE(:hoitokauden_alkuvuosi + 1 || '-09-30', 'YYYY-MM-DD')))
+    AND CASE
+        --- Mahdollistetaan myös suodatus tyypin ja voimassa_ennen_hoitovuotta perusteella
+            WHEN :tyyppi::TEXT IS NOT NULL AND
+                 :voimassa_ennen_hoitovuotta::TEXT IS NOT NULL THEN
+                (m.tyyppi = :tyyppi::MHU_MUUTOSTYYPPI AND
+                 m.voimassa_alkaen < (SELECT TO_DATE(:voimassa_ennen_hoitovuotta || '-10-01', 'YYYY-MM-DD')))
+        -- Kirjatuista muutoksista taulukossa saa näyttää vain ne, joiden voimassa_alkaen osuu valitulle hoitokaudelle
+            ELSE
+                m.tyyppi IN
+                ('pysyva', 'muutostyo', 'johto-ja-hallintokorvaus') AND
+                m.voimassa_alkaen BETWEEN (SELECT TO_DATE(:hoitokauden_alkuvuosi || '-10-01', 'YYYY-MM-DD')) AND
+                        (SELECT TO_DATE(:hoitokauden_alkuvuosi + 1 || '-09-30', 'YYYY-MM-DD'))
+      END
     AND m.poistettu IS FALSE
   GROUP BY m.id, m.versio, m.urakka, m.voimassa_alkaen, m.tyyppi, m.nimi,
            m.syy, m.kulu_kohdistus, m.luonnos;

--- a/src/clj/harja/kyselyt/muutos_kyselyt.sql
+++ b/src/clj/harja/kyselyt/muutos_kyselyt.sql
@@ -4,6 +4,7 @@ SELECT m.id,
        m.urakka,
        m.voimassa_alkaen,
        m.tyyppi,
+       m.alityyppi,
        m.nimi,
        m.syy,
        m.kulu_kohdistus,
@@ -69,16 +70,16 @@ SELECT m.id,
                'id', lii.liite)) END AS liitteet
 -- ONLY tarvitaan, jottei kysellä historiatauluista
   FROM ONLY mhu_muutos m
-           LEFT JOIN ONLY mhu_muutos_liite lii ON (m.id = lii.muutos
-      -- FIXME Versiointi ei toimi kunnolla tapauksissa, joissa useita riveja
-      --       liittyy yhteen muutokseen. .. sama teksti kuin yllä
-      -- AND m.versio = lii.versio
-      )
- WHERE m.urakka = :urakka
-   -- hox: on myös sellaisia muutoksia, jotka ovat voimassa vain meneillään olevan hoitokauden
-   -- niiden käsittely puuttuu vielä tästä kyselystä
-   AND m.voimassa_alkaen <= (SELECT TO_DATE(:hoitokauden_alkuvuosi || '-10-01', 'YYYY-MM-DD'))
- GROUP BY m.id, m.versio, m.urakka, m.voimassa_alkaen, m.tyyppi, m.nimi, m.syy, m.kulu_kohdistus, m.luonnos;
+       LEFT JOIN ONLY mhu_muutos_liite lii ON (m.id = lii.muutos)
+  WHERE m.urakka = :urakka
+    -- Kirjatuista muutoksista taulukossa saa näyttää vain ne, joiden voimassa_alkaen osuu valitulle hoitokaudelle
+    AND (m.tyyppi IN ('pysyva', 'muutostyo', 'johto-ja-hallintokorvaus') AND
+         m.voimassa_alkaen BETWEEN (SELECT TO_DATE(:hoitokauden_alkuvuosi || '-10-01', 'YYYY-MM-DD')) AND
+                 (SELECT TO_DATE(:hoitokauden_alkuvuosi + 1 || '-09-30', 'YYYY-MM-DD')))
+    AND m.poistettu IS FALSE
+  GROUP BY m.id, m.versio, m.urakka, m.voimassa_alkaen, m.tyyppi, m.nimi,
+           m.syy, m.kulu_kohdistus, m.luonnos;
+
 
 -- name: rahavarausten-toteumat
 SELECT rv.id, SUM(kk.summa) as toteumat

--- a/src/clj/harja/kyselyt/muutos_kyselyt.sql
+++ b/src/clj/harja/kyselyt/muutos_kyselyt.sql
@@ -73,12 +73,12 @@ SELECT m.id,
        LEFT JOIN ONLY mhu_muutos_liite lii ON (m.id = lii.muutos)
   WHERE m.urakka = :urakka
     AND CASE
-        --- Mahdollistetaan myös suodatus tyypin ja voimassa_ennen_hoitovuotta perusteella
-            WHEN :tyyppi::TEXT IS NOT NULL AND
-                 :voimassa_ennen_hoitovuotta::TEXT IS NOT NULL THEN
-                (m.tyyppi = :tyyppi::MHU_MUUTOSTYYPPI AND
-                 m.voimassa_alkaen < (SELECT TO_DATE(:voimassa_ennen_hoitovuotta || '-10-01', 'YYYY-MM-DD')))
+        -- Mahdollistetaan aiempien vuosien pysyvien muutosten haku samalla kyselyllä
+            WHEN :hae-vain-aiemmat-pysyvat-muutokset?::BOOLEAN THEN
+                (m.tyyppi = 'pysyva'::MHU_MUUTOSTYYPPI AND
+                 m.voimassa_alkaen < (SELECT TO_DATE(:hoitokauden_alkuvuosi || '-10-01', 'YYYY-MM-DD')))
         -- Kirjatuista muutoksista taulukossa saa näyttää vain ne, joiden voimassa_alkaen osuu valitulle hoitokaudelle
+        -- Haetaan kaikkien kirjattujen muutostyyppien tiedot
             ELSE
                 m.tyyppi IN
                 ('pysyva', 'muutostyo', 'johto-ja-hallintokorvaus') AND

--- a/src/clj/harja/kyselyt/muutos_kyselyt.sql
+++ b/src/clj/harja/kyselyt/muutos_kyselyt.sql
@@ -42,14 +42,23 @@ SELECT m.id,
            (SELECT JSON_AGG(
                        JSONB_BUILD_OBJECT(
                            'tehtava', tjm.tehtava,
-                           'edellinen_maara', tjm.edellinen_maara,
+                           'suunniteltu_maara', ut.maara,
                            'maaramuutos', tjm.maaramuutos,
+                           -- TODO: Edellinen_maara ja uusi_maara tietokannan tasolla voivat olla obsolete,
+                           --       koska on sovittu suunniteltu_maara tiedon olevan baseline, jonka päälle määrämuutokset
+                           --      lasketaan. Katsotaan myöhemmin, voidaanko nämä sarakkeet poistaa, vai tarvitaanko niitä.
+                           'edellinen_maara', tjm.edellinen_maara,
                            'uusi_maara', tjm.uusi_maara,
                            'hoitokauden_alkuvuosi', tjm.hoitokauden_alkuvuosi,
                            'versio', tjm.versio)
                        ORDER BY tjm.tehtava, tjm.hoitokauden_alkuvuosi
                    )
               FROM ONLY mhu_muutos_tehtava_ja_maaraluettelo tjm
+                   LEFT JOIN urakka_tehtavamaara ut
+                             ON ut.urakka = :urakka
+                                 AND ut."hoitokauden-alkuvuosi" = tjm.hoitokauden_alkuvuosi
+                                 AND ut.poistettu IS NOT TRUE
+                                 AND tjm.tehtava = ut.tehtava
              WHERE tjm.muutos = m.id
                AND tjm.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi),
            '[]'::json) AS tehtavat_ja_maarat,
@@ -307,14 +316,23 @@ SELECT
         (SELECT JSON_AGG(
                     JSONB_BUILD_OBJECT(
                         'tehtava', tjm.tehtava,
-                        'edellinen_maara', tjm.edellinen_maara,
+                        'suunniteltu_maara', ut.maara,
                         'maaramuutos', tjm.maaramuutos,
+                        -- TODO: Edellinen_maara ja uusi_maara tietokannan tasolla voivat olla obsolete,
+                        --       koska on sovittu suunniteltu_maara tiedon olevan baseline, jonka päälle määrämuutokset
+                        --      lasketaan. Katsotaan myöhemmin, voidaanko nämä sarakkeet poistaa, vai tarvitaanko niitä.
+                        'edellinen_maara', tjm.edellinen_maara,
                         'uusi_maara', tjm.uusi_maara,
                         'hoitokauden_alkuvuosi', tjm.hoitokauden_alkuvuosi,
                         'versio', tjm.versio)
                     ORDER BY tjm.tehtava, tjm.hoitokauden_alkuvuosi
                 )
            FROM ONLY mhu_muutos_tehtava_ja_maaraluettelo tjm
+                LEFT JOIN urakka_tehtavamaara ut
+                          ON ut.urakka = :urakka
+                              AND ut."hoitokauden-alkuvuosi" = tjm.hoitokauden_alkuvuosi
+                              AND ut.poistettu IS NOT TRUE
+                              AND tjm.tehtava = ut.tehtava
           WHERE tjm.muutos = m.id
             AND tjm.tehtava IN (SELECT id FROM tehtava WHERE emo = tp.id)),
         '[]'::json) AS tehtavat_ja_maarat,

--- a/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
@@ -333,10 +333,9 @@
                                                                            :hoitokaudet hoitokaudet
                                                                            :valittu-hoitokausi valittu-hoitokausi})
 
-        kirjatut-muutokset-yht (reduce + 0
-                                      (remove nil?
-                                        (concat
-                                          (map :tavoitehinnan-muutos kirjatut-muutokset))))
+        kirjatut-muutokset-yht (reduce + (map :tavoitehinnan-muutos kirjatut-muutokset))
+        ;; TODO: Luo indeksikorjattu summa aiempien vuosien pysyville muutoksille
+        aiemmat-pysyvat-muutokset-indeksikorjattu-yht (reduce + (map :tavoitehinnan-muutos aiempien-vuosien-pysyvat-muutokset))
         toteumiin-perustuvat-muutokset-yht (reduce + 0
                                                (remove nil?
                                                  (concat
@@ -344,6 +343,7 @@
                                                    (map :tavoitehinnan_muutos tehtava-ja-maaramuutokset))))
         muutosten-vaikutus-yht (+
                                  (or (:tavoitehinta-indeksikorjattu budjettitavoiteet) 0)
+                                 (or aiemmat-pysyvat-muutokset-indeksikorjattu-yht 0)
                                  kirjatut-muutokset-yht
                                  toteumiin-perustuvat-muutokset-yht)]
 
@@ -359,6 +359,7 @@
      :suunniteltujen-maarien-muutokset []
      :budjettitavoitteet {:indeksikorjaus-vahvistettu? (:indeksikorjaus-vahvistettu budjettitavoiteet)
                           :hoitovuoden-alun-indeksikorjattu-tavoitehinta (:tavoitehinta-indeksikorjattu budjettitavoiteet)
+                          :aiemmat-pysyvat-muutokset-indeksikorjattu-yht aiemmat-pysyvat-muutokset-indeksikorjattu-yht
                           :kirjatut-muutokset-yht kirjatut-muutokset-yht
                           :toteumiin-perustuvat-muutokset-yht toteumiin-perustuvat-muutokset-yht
                           :muutosten-vaikutus-yht muutosten-vaikutus-yht}}))

--- a/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
@@ -292,8 +292,23 @@
                                          (update :tehtavat_ja_maarat #(konv/jsonb->clojuremap %))
                                          (update :liitteet #(konv/jsonb->clojuremap %))))
                                      (muutos-kyselyt/hae-urakan-hoitovuoden-kirjatut-muutokset db {:urakka urakka-id
-                                                                                                   :hoitokauden_alkuvuosi hoitokauden-alkuvuosi}))
+                                                                                                   :hoitokauden_alkuvuosi hoitokauden-alkuvuosi
+                                                                                                   :tyyppi nil
+                                                                                                   :voimassa_ennen_hoitovuotta nil}))
         kirjatut-muutokset (tavoitehinnan-muutos kirjatut-muutokset-vastaus)
+        ;; TODO: Vielä kesken. Tämä on hahmotelma aiempien vuosien pysyville muutoksisien hausta.
+        aiempien-vuosien-pysyvat-muutokset-vastaus (mapv
+                                                     (fn [rivi]
+                                                       (-> rivi
+                                                         (update :kustannusvaikutukset #(konv/jsonb->clojuremap %))
+                                                         (update :tehtavat_ja_maarat #(konv/jsonb->clojuremap %))
+                                                         (update :liitteet #(konv/jsonb->clojuremap %))))
+                                                     (muutos-kyselyt/hae-urakan-hoitovuoden-kirjatut-muutokset db
+                                                       {:urakka urakka-id
+                                                        :hoitokauden_alkuvuosi hoitokauden-alkuvuosi
+                                                        :tyyppi "pysyva"
+                                                        :voimassa_ennen_hoitovuotta hoitokauden-alkuvuosi}))
+        aiempien-vuosien-pysyvat-muutokset (tavoitehinnan-muutos aiempien-vuosien-pysyvat-muutokset-vastaus)
         rahavarausten-suunnitelmat (map
                                      #(select-keys % [:id :nimi :summa-indeksikorjattu])
                                      (rahavaraus-kyselyt/hae-urakan-suunnitellut-rahavarausten-kustannukset db {:urakka_id urakka-id
@@ -339,6 +354,7 @@
 
     {;; kirjatut muutokset jos hoitokausi 2025-2026 tai jälkeen
      :kirjatut-muutokset kirjatut-muutokset
+     :aiempien-hoitovuosien-pysyvat-muutokset aiempien-vuosien-pysyvat-muutokset
      ;; laskennat lasketuille muutoksille jos hoitokausi 2025-2026 tai jälkeen
      :lasketut-muutokset tehtava-ja-maaramuutokset
      :rahavarausten-muutokset rahavaraukset

--- a/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
@@ -279,36 +279,31 @@
                                               :hoitokaudet hoitokaudet
                                               :valittu-hoitokausi valittu-hoitokausi))))
 
+(defn- parsi-kirjatut-muutokset-vastaus [vastaus]
+  (->> vastaus
+    (mapv (fn [rivi]
+      (-> rivi
+        (update :kustannusvaikutukset #(konv/jsonb->clojuremap %))
+        (update :tehtavat_ja_maarat #(konv/jsonb->clojuremap %))
+        (update :liitteet #(konv/jsonb->clojuremap %)))))
+    (tavoitehinnan-muutos)))
 
 (defn hae-urakan-muutostiedot
   [db kayttaja {:keys [urakka-id hoitokaudet valittu-hoitokausi] :as tiedot}]
   (oikeudet/vaadi-lukuoikeus oikeudet/urakat-suunnittelu-kustannussuunnittelu kayttaja urakka-id)
   (log/debug "hae-urakan-muutostiedot: " tiedot)
   (let [hoitokauden-alkuvuosi (pvm/vuosi (first valittu-hoitokausi))
-        kirjatut-muutokset-vastaus (mapv
-                                     (fn [rivi]
-                                       (-> rivi
-                                         (update :kustannusvaikutukset #(konv/jsonb->clojuremap %))
-                                         (update :tehtavat_ja_maarat #(konv/jsonb->clojuremap %))
-                                         (update :liitteet #(konv/jsonb->clojuremap %))))
-                                     (muutos-kyselyt/hae-urakan-hoitovuoden-kirjatut-muutokset db {:urakka urakka-id
-                                                                                                   :hoitokauden_alkuvuosi hoitokauden-alkuvuosi
-                                                                                                   :tyyppi nil
-                                                                                                   :voimassa_ennen_hoitovuotta nil}))
-        kirjatut-muutokset (tavoitehinnan-muutos kirjatut-muutokset-vastaus)
-        ;; TODO: Vielä kesken. Tämä on hahmotelma aiempien vuosien pysyville muutoksisien hausta.
-        aiempien-vuosien-pysyvat-muutokset-vastaus (mapv
-                                                     (fn [rivi]
-                                                       (-> rivi
-                                                         (update :kustannusvaikutukset #(konv/jsonb->clojuremap %))
-                                                         (update :tehtavat_ja_maarat #(konv/jsonb->clojuremap %))
-                                                         (update :liitteet #(konv/jsonb->clojuremap %))))
-                                                     (muutos-kyselyt/hae-urakan-hoitovuoden-kirjatut-muutokset db
-                                                       {:urakka urakka-id
-                                                        :hoitokauden_alkuvuosi hoitokauden-alkuvuosi
-                                                        :tyyppi "pysyva"
-                                                        :voimassa_ennen_hoitovuotta hoitokauden-alkuvuosi}))
-        aiempien-vuosien-pysyvat-muutokset (tavoitehinnan-muutos aiempien-vuosien-pysyvat-muutokset-vastaus)
+        kirjatut-muutokset (->
+                             (muutos-kyselyt/hae-urakan-hoitovuoden-kirjatut-muutokset db
+                               {:urakka urakka-id
+                                :hoitokauden_alkuvuosi hoitokauden-alkuvuosi
+                                :hae-vain-aiemmat-pysyvat-muutokset? false})
+                             (parsi-kirjatut-muutokset-vastaus))
+        aiempien-vuosien-pysyvat-muutokset (-> (muutos-kyselyt/hae-urakan-hoitovuoden-kirjatut-muutokset db
+                                                 {:urakka urakka-id
+                                                  :hoitokauden_alkuvuosi hoitokauden-alkuvuosi
+                                                  :hae-vain-aiemmat-pysyvat-muutokset? true})
+                                             (parsi-kirjatut-muutokset-vastaus))
         rahavarausten-suunnitelmat (map
                                      #(select-keys % [:id :nimi :summa-indeksikorjattu])
                                      (rahavaraus-kyselyt/hae-urakan-suunnitellut-rahavarausten-kustannukset db {:urakka_id urakka-id

--- a/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
@@ -340,6 +340,7 @@
         rahavaraukset-yhteensa (rahavarausten-summarivi rahavaraukset)
         rahavaraukset (conj rahavaraukset rahavaraukset-yhteensa)
         budjettitavoiteet (budjettisuunnittelu-q/budjettitavoite-vuodelle db urakka-id hoitokauden-alkuvuosi)
+        ;; Mapataan hoitokausien alkuvuodet, joille urakan tavoitehinnat on indeksikorjattu ja vahvistettu
         tavoitehinnat-indeksikorjattu (urakan-tavoitehinnat-indeksikorjattu db urakka-id hoitokaudet)
 
         ;; Tehtävä- ja määrätoteumiin perustuvat tavoitehintamuutokset
@@ -371,7 +372,7 @@
      :tavoitehinnan-muutokset []
      ;; TODO: laskennat vanhojen suunniteltujen määrien muutoksille jos hoitokausi ennen 2025-2026
      :suunniteltujen-maarien-muutokset []
-     :budjettitavoitteet {:urakan-tavoitehinnat-indeksikorjattu tavoitehinnat-indeksikorjattu
+     :budjettitavoitteet {:tavoitehinta-indeksikorjattu-per-hoitovuosi tavoitehinnat-indeksikorjattu
                           :hoitovuoden-alun-indeksikorjattu-tavoitehinta (:tavoitehinta-indeksikorjattu budjettitavoiteet)
                           :aiemmat-pysyvat-muutokset-indeksikorjattu-yht aiemmat-pysyvat-muutokset-indeksikorjattu-yht
                           :kirjatut-muutokset-yht kirjatut-muutokset-yht

--- a/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
@@ -582,9 +582,12 @@
       (when (pos? (:tehtava maaramuutos))
         (let [maaramuutos (luo-tehtava-ja-maaramuutos muutos-id (or muutos-versio 1)
                             (assoc maaramuutos
-                              ;; TODO: Nämä pitäisi laskea
-                              :uusi_maara 0
-                              :edellinen_maara 0))]
+                              ;; TODO: Edellinen_maara ja uusi_maara tietokannan tasolla voivat olla obsolete,
+                              ;;       koska on sovittu suunniteltu_maara tiedon olevan baseline, jonka päälle määrämuutokset
+                              ;;       lasketaan. Katsotaan myöhemmin voidaanko nämä sarakkeet poistaa, vai tarvitaanko niitä.
+                              ;;       Ja kuinka monimutkaiseksi useamman muutoksen tietojen yhdistely menee.
+                              #_:uusi_maara 0
+                              #_:edellinen_maara 0))]
           (muutos-kyselyt/luo-tai-paivita-tehtavan-maaramuutos<! db maaramuutos))))))
 
 

--- a/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
@@ -279,6 +279,19 @@
                                               :hoitokaudet hoitokaudet
                                               :valittu-hoitokausi valittu-hoitokausi))))
 
+(defn urakan-tavoitehinnat-indeksikorjattu
+  "Palauttaa hoitokausien alkuvuodet, joille urakan tavoitehinnat on indeksikorjattu ja vahvistettu"
+  [db urakka-id hoitokaudet]
+  (let [tavoitehintojen-tilat (budjettisuunnittelu-q/urakan-tavoitehintojen-tilat db urakka-id)]
+    (into {}
+      (mapv (fn [hoitokausi]
+              (let [hoitokauden-alkuvuosi (pvm/vuosi (first hoitokausi))
+                    vahvistettu? (boolean (some #(and (= (:hoitokauden-alkuvuosi %) hoitokauden-alkuvuosi)
+                                                   (:indeksikorjaus-vahvistettu %))
+                                            tavoitehintojen-tilat))]
+                [hoitokauden-alkuvuosi vahvistettu?]))
+        hoitokaudet))))
+
 (defn- parsi-kirjatut-muutokset-vastaus [vastaus]
   (->> vastaus
     (mapv (fn [rivi]
@@ -327,6 +340,7 @@
         rahavaraukset-yhteensa (rahavarausten-summarivi rahavaraukset)
         rahavaraukset (conj rahavaraukset rahavaraukset-yhteensa)
         budjettitavoiteet (budjettisuunnittelu-q/budjettitavoite-vuodelle db urakka-id hoitokauden-alkuvuosi)
+        tavoitehinnat-indeksikorjattu (urakan-tavoitehinnat-indeksikorjattu db urakka-id hoitokaudet)
 
         ;; Tehtävä- ja määrätoteumiin perustuvat tavoitehintamuutokset
         tehtava-ja-maaramuutokset (hae-tehtava-maaramuutokset db kayttaja {:urakka-id urakka-id
@@ -357,7 +371,7 @@
      :tavoitehinnan-muutokset []
      ;; TODO: laskennat vanhojen suunniteltujen määrien muutoksille jos hoitokausi ennen 2025-2026
      :suunniteltujen-maarien-muutokset []
-     :budjettitavoitteet {:indeksikorjaus-vahvistettu? (:indeksikorjaus-vahvistettu budjettitavoiteet)
+     :budjettitavoitteet {:urakan-tavoitehinnat-indeksikorjattu tavoitehinnat-indeksikorjattu
                           :hoitovuoden-alun-indeksikorjattu-tavoitehinta (:tavoitehinta-indeksikorjattu budjettitavoiteet)
                           :aiemmat-pysyvat-muutokset-indeksikorjattu-yht aiemmat-pysyvat-muutokset-indeksikorjattu-yht
                           :kirjatut-muutokset-yht kirjatut-muutokset-yht
@@ -383,7 +397,7 @@
 
 (defn hae-pysyvan-muutoksen-pohjatiedot
   "Hakee pohjatiedot uuden pysyvän muutoksen lomakkeelle"
-  [db kayttaja {:keys [urakka-id hoitokauden-alkuvuosi muutos-id muutos-versio] :as tiedot}]
+  [db kayttaja {:keys [urakka-id muutos-id muutos-versio] :as tiedot}]
   (oikeudet/vaadi-lukuoikeus oikeudet/urakat-suunnittelu-kustannussuunnittelu kayttaja urakka-id)
 
   (let [toimenpiteiden-tiedot (mapv
@@ -395,8 +409,7 @@
                                 ;; pysyvän muutoksen tietoja voi olla usealla hoitovuodella. Kysely ja palvelu palauttavat kaikkien hoitovuosien tiedot, toimenpiteittäin ryhmiteltynä.
                                 (muutos-kyselyt/hae-pysyvan-muutoksen-kustannustiedot db {:id muutos-id
                                                                                           :versio muutos-versio
-                                                                                          :urakka urakka-id
-                                                                                          :hoitokauden_alkuvuosi hoitokauden-alkuvuosi}))
+                                                                                          :urakka urakka-id}))
         toimenpiteiden-tehtavat (hae-toimenpiteiden-tehtavat db urakka-id)]
     {:toimenpiteiden-tiedot toimenpiteiden-tiedot
      :toimenpiteiden-tehtavat toimenpiteiden-tehtavat}))
@@ -406,7 +419,7 @@
 ;;       Olemassaolevaa muutosta muokatessa on myös tarpeen hakea muutoksen id:n perusteella lisää tietoja
 (defn hae-muutoksen-tiedot
   "Palauttaa yksittäisen muutoksen tarkat tiedot lomaketta varten."
-  [db kayttaja {:keys [urakka-id hoitokauden-alkuvuosi muutos] :as tiedot}]
+  [db kayttaja {:keys [urakka-id muutos] :as tiedot}]
   (oikeudet/vaadi-lukuoikeus oikeudet/urakat-suunnittelu-kustannussuunnittelu kayttaja urakka-id)
 
   (let [tyyppikohtaiset-tiedot (case (:tyyppi muutos)
@@ -435,7 +448,6 @@
                          (first tyyppikohtaiset-tiedot)
                          (when (= (:tyyppi muutos) "pysyva")
                            (hae-pysyvan-muutoksen-pohjatiedot db kayttaja {:urakka-id urakka-id
-                                                                           :hoitokauden-alkuvuosi hoitokauden-alkuvuosi
                                                                            :muutos-id (:id muutos)
                                                                            :muutos-versio (:versio muutos)})))
                   :liitteet liitteet)]

--- a/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
@@ -331,7 +331,11 @@
                                                (remove nil?
                                                  (concat
                                                    [(:tavoitehinnan-muutos (last rahavaraukset))]
-                                                   (map :tavoitehinnan_muutos tehtava-ja-maaramuutokset))))]
+                                                   (map :tavoitehinnan_muutos tehtava-ja-maaramuutokset))))
+        muutosten-vaikutus-yht (+
+                                 (or (:tavoitehinta-indeksikorjattu budjettitavoiteet) 0)
+                                 kirjatut-muutokset-yht
+                                 toteumiin-perustuvat-muutokset-yht)]
 
     {;; kirjatut muutokset jos hoitokausi 2025-2026 tai jälkeen
      :kirjatut-muutokset kirjatut-muutokset
@@ -345,7 +349,8 @@
      :budjettitavoitteet {:indeksikorjaus-vahvistettu? (:indeksikorjaus-vahvistettu budjettitavoiteet)
                           :hoitovuoden-alun-indeksikorjattu-tavoitehinta (:tavoitehinta-indeksikorjattu budjettitavoiteet)
                           :kirjatut-muutokset-yht kirjatut-muutokset-yht
-                          :toteumiin-perustuvat-muutokset-yht toteumiin-perustuvat-muutokset-yht}}))
+                          :toteumiin-perustuvat-muutokset-yht toteumiin-perustuvat-muutokset-yht
+                          :muutosten-vaikutus-yht muutosten-vaikutus-yht}}))
 
 
 

--- a/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
@@ -15,6 +15,7 @@
             [harja.kyselyt.kulut :as kulu-kyselyt]
             [harja.kyselyt.liitteet :as liite-kyselyt]
             [harja.domain.muutos-domain :as muutos-domain]
+            [harja.kyselyt.indeksit :as indeksi-kyselyt]
             [harja.kyselyt.toimenpideinstanssit :as tpi-q]
             [harja.kyselyt.muutos-kyselyt :as muutos-kyselyt]
             [harja.kyselyt.rahavaraukset :as rahavaraus-kyselyt]
@@ -22,22 +23,6 @@
             [harja.palvelin.asetukset :refer [ominaisuus-kaytossa?]]
             [harja.kyselyt.budjettisuunnittelu :as budjettisuunnittelu-q]
             [harja.palvelin.komponentit.http-palvelin :refer [julkaise-palvelut poista-palvelut]]))
-
-
-(defn tavoitehinnan-muutos
-  "Laskee rivin tavoitehinnan muutoksen. Sen sijainti vaihtelee tyyppikohtaisesti."
-  ;; on hyvä saada tavoitehinnan muutos samaan avaimeen, niin summauslaskennat jne. toimivat myöhemmin suoraan
-  [muutokset]
-  (mapv (fn [rivi]
-          (let [total (if (= (:tyyppi rivi)
-                            "johto-ja-hallintokorvaus")
-                        (or (:jjh-muutosten-summa rivi) 0)
-                        (some->>
-                          (:kustannusvaikutukset rivi)
-                          (map :summa)
-                          (reduce + 0)))]
-            (assoc rivi :tavoitehinnan-muutos total)))
-    muutokset))
 
 (defn- rahavarausten-summarivi [rahavaraukset]
   (let [{:keys [summa-indeksikorjattu toteumat]}
@@ -292,6 +277,42 @@
                 [hoitokauden-alkuvuosi vahvistettu?]))
         hoitokaudet))))
 
+(defn- laske-indeksikorjattu-summa
+  "Indeksikorjattu summa lasketaan summasta ja urakan voimassaolevista indekseistä.
+  Jos summaa ei ole annettu tai indeksiä hoitovuodelle ei löydy, palautetaan nil."
+  [summa urakan-indeksit hoitovuosi-nro]
+  (when summa
+    (indeksi-kyselyt/indeksikorjaa
+      (indeksi-kyselyt/indeksikerroin urakan-indeksit hoitovuosi-nro) summa)))
+
+(defn tavoitehinnan-muutos
+  "Laskee rivin tavoitehinnan muutoksen. Sen sijainti vaihtelee tyyppikohtaisesti."
+  ;; on hyvä saada tavoitehinnan muutos samaan avaimeen, niin summauslaskennat jne. toimivat myöhemmin suoraan
+  [muutokset]
+  (mapv (fn [rivi]
+          (let [total (if (= (:tyyppi rivi)
+                            "johto-ja-hallintokorvaus")
+                        (or (:jjh-muutosten-summa rivi) 0)
+                        (some->>
+                          (:kustannusvaikutukset rivi)
+                          (map :summa)
+                          (reduce + 0)))]
+            (assoc rivi :tavoitehinnan-muutos total)))
+    muutokset))
+
+(defn indeksikorjaa-tavoitehinnan-muutokset [db urakka-id hoitokauden-alkuvuosi muutokset]
+  (if (seq muutokset)
+    (let [urakka (first (q-urakat/hae-urakka db urakka-id))
+          hoitokauden-nro (pvm/hoitokausivuosi->mhu-hoitovuosi-nro (:alkupvm urakka) hoitokauden-alkuvuosi)
+          urakan-indeksit (indeksi-kyselyt/hae-urakan-indeksikertoimet db urakka-id)]
+      (map (fn [rivi]
+             (assoc rivi :tavoitehinnan-muutos-indeksikorjattu
+               (or
+                 (laske-indeksikorjattu-summa (:tavoitehinnan-muutos rivi) urakan-indeksit hoitokauden-nro)
+                 0)))
+        muutokset))
+    muutokset))
+
 (defn- parsi-kirjatut-muutokset-vastaus [vastaus]
   (->> vastaus
     (mapv (fn [rivi]
@@ -317,6 +338,9 @@
                                                   :hoitokauden_alkuvuosi hoitokauden-alkuvuosi
                                                   :hae-vain-aiemmat-pysyvat-muutokset? true})
                                              (parsi-kirjatut-muutokset-vastaus))
+        ;; Indeksikorjataan ainoastaan aiemmat pysyvät muutokset
+        aiempien-vuosien-pysyvat-muutokset (indeksikorjaa-tavoitehinnan-muutokset db
+                                             urakka-id hoitokauden-alkuvuosi aiempien-vuosien-pysyvat-muutokset)
         rahavarausten-suunnitelmat (map
                                      #(select-keys % [:id :nimi :summa-indeksikorjattu])
                                      (rahavaraus-kyselyt/hae-urakan-suunnitellut-rahavarausten-kustannukset db {:urakka_id urakka-id
@@ -349,8 +373,11 @@
                                                                            :valittu-hoitokausi valittu-hoitokausi})
 
         kirjatut-muutokset-yht (reduce + (map :tavoitehinnan-muutos kirjatut-muutokset))
-        ;; TODO: Luo indeksikorjattu summa aiempien vuosien pysyville muutoksille
-        aiemmat-pysyvat-muutokset-indeksikorjattu-yht (reduce + (map :tavoitehinnan-muutos aiempien-vuosien-pysyvat-muutokset))
+        aiemmat-pysyvat-muutokset-indeksikorjattu-yht (reduce +
+                                                        ;; Arvot voivat periaatteessa olla nil, jos indeksikorjausta ei ole
+                                                        ;; tehty, joten poistetaan nillit ennen summauksen laskemista
+                                                        (remove nil?
+                                                          (map :tavoitehinnan-muutos-indeksikorjattu aiempien-vuosien-pysyvat-muutokset)))
         toteumiin-perustuvat-muutokset-yht (reduce + 0
                                                (remove nil?
                                                  (concat

--- a/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
@@ -323,12 +323,15 @@
                                                                            :hoitokaudet hoitokaudet
                                                                            :valittu-hoitokausi valittu-hoitokausi})
 
-        muutosten-vaikutus-yhteensa (reduce + 0
+        kirjatut-muutokset-yht (reduce + 0
                                       (remove nil?
                                         (concat
-                                          (map :tavoitehinnan-muutos kirjatut-muutokset)
-                                          [(:tavoitehinnan-muutos (last rahavaraukset))]
-                                          (map :tavoitehinnan_muutos tehtava-ja-maaramuutokset))))]
+                                          (map :tavoitehinnan-muutos kirjatut-muutokset))))
+        toteumiin-perustuvat-muutokset-yht (reduce + 0
+                                               (remove nil?
+                                                 (concat
+                                                   [(:tavoitehinnan-muutos (last rahavaraukset))]
+                                                   (map :tavoitehinnan_muutos tehtava-ja-maaramuutokset))))]
 
     {;; kirjatut muutokset jos hoitokausi 2025-2026 tai jälkeen
      :kirjatut-muutokset kirjatut-muutokset
@@ -341,12 +344,8 @@
      :suunniteltujen-maarien-muutokset []
      :budjettitavoitteet {:indeksikorjaus-vahvistettu? (:indeksikorjaus-vahvistettu budjettitavoiteet)
                           :hoitovuoden-alun-indeksikorjattu-tavoitehinta (:tavoitehinta-indeksikorjattu budjettitavoiteet)
-                          :muutosten-vaikutus-yhteensa muutosten-vaikutus-yhteensa
-                          :hoitovuoden-lopun-tavoitehinta (when (:tavoitehinta-indeksikorjattu budjettitavoiteet)
-                                                            (+
-                                                              (:tavoitehinta-indeksikorjattu budjettitavoiteet)
-                                                             ;; TODO: tässä huomioitava kaikkien muutosten vaikutus, työversiossa vasta kirjatut muutokset mukana
-                                                              muutosten-vaikutus-yhteensa))}}))
+                          :kirjatut-muutokset-yht kirjatut-muutokset-yht
+                          :toteumiin-perustuvat-muutokset-yht toteumiin-perustuvat-muutokset-yht}}))
 
 
 

--- a/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
@@ -291,8 +291,8 @@
                                          (update :kustannusvaikutukset #(konv/jsonb->clojuremap %))
                                          (update :tehtavat_ja_maarat #(konv/jsonb->clojuremap %))
                                          (update :liitteet #(konv/jsonb->clojuremap %))))
-                                     (muutos-kyselyt/hae-urakan-hoitovuoden-muutostiedot db {:urakka urakka-id
-                                                                                             :hoitokauden_alkuvuosi hoitokauden-alkuvuosi}))
+                                     (muutos-kyselyt/hae-urakan-hoitovuoden-kirjatut-muutokset db {:urakka urakka-id
+                                                                                                   :hoitokauden_alkuvuosi hoitokauden-alkuvuosi}))
         kirjatut-muutokset (tavoitehinnan-muutos kirjatut-muutokset-vastaus)
         rahavarausten-suunnitelmat (map
                                      #(select-keys % [:id :nimi :summa-indeksikorjattu])

--- a/src/cljc/harja/domain/muutos_domain.cljc
+++ b/src/cljc/harja/domain/muutos_domain.cljc
@@ -15,20 +15,10 @@
 (def +muutostyo-valinnat+ {:erillisrahoitus "Erillisrahoituksella tehtävä muutostyö"
                            :poikkeama "Poikkeaminen tehtävä- ja määräluettelon määrästä"})
 
-;; TODO: Figma-speksissä muutostyypit ovat lomaketasolla nykyisin:
-;;       Muutostyö: Sisältää erillisrahoitettu ja maarapoikkeama tyypit
-;;                  erillisrahoitettu = Erillisrahoituksella tehtävä muutostyö
-;;                  maarapoikkeama = Poikkeaminen tehtävä- ja määräluettelon määrästä
-;;       Toteutuneet määrät taitaa olla oma asiansa nykyisin, ja se ei noudata mhu_muutos-taulun mallia kuten muut muutokset
-;;       Lomakkeen muutostyypit ja niiden nimet pitää tarkistaa ja päivittää
-
 (def +muutostyypit-lomakkeella+
   "MHU muutosten mahdolliset tyypit. Näiden tulee matchata tietokannassa olevaan custom typeen MHU_MUUTOSTYYPPI"
-  ["erillisrahoitettu"
+  ["pysyva"
    "johto-ja-hallintokorvaus"
-   "maarapoikkeama"
-   "pysyva"
-   "toteutuneet-maarat"
    "muutostyo"])
 
 

--- a/src/cljc/harja/domain/muutos_domain.cljc
+++ b/src/cljc/harja/domain/muutos_domain.cljc
@@ -52,3 +52,8 @@
   (if (pvm/ennen? urakan-alkupvm (pvm/->pvm "5.10.2024"))
     :muutos
     :vahennys))
+
+(defn muutos-voimassa-kesken-hoitokauden?
+  "Muutoksen voimassaolo alkaa kesken hoitovuoden?"
+  [voimassa-alkaen hoitovuosi]
+  (pvm/valissa? voimassa-alkaen (first hoitovuosi) (second hoitovuosi)))

--- a/src/cljs-dev/harja/loki.cljs
+++ b/src/cljs-dev/harja/loki.cljs
@@ -1,6 +1,19 @@
 (ns harja.loki
   "Apufunktioita lokittamiseen."
-  (:require [clojure.string :refer [join]]))
+  (:require
+    [clojure.string :refer [join]]
+    [taoensso.timbre :as log]))
+
+;; -- Konfiguroi Timbre-lokitus dev-ympäristöihin--
+;; Timbre käyttää js/console appenderia CLJS:ssa, konfiguroidaan min-level sopivalle tasolle, jotta selaimen
+;; konsoli ei täyty turhista lokituksista
+
+(log/merge-config!
+  {:appenders
+   {:console
+    {:min-level :debug}}})
+
+;; ---
 
 (def +mittaa-aika+ false)
 
@@ -33,3 +46,4 @@
   [nimi atomi]
   (add-watch atomi :tarkkailija (fn [_ _ vanha uusi]
                                   (log nimi ": " (pr-str vanha) " => " (pr-str uusi)))))
+

--- a/src/cljs-prod/harja/loki.cljs
+++ b/src/cljs-prod/harja/loki.cljs
@@ -1,5 +1,20 @@
 (ns harja.loki
-  "Tuotantomoodin lokitus. Lokita, jos erikseen laitettu päälle.")
+  "Tuotantomoodin lokitus. Lokita, jos erikseen laitettu päälle."
+  (:require
+    [taoensso.timbre :as log]))
+
+;; -- Konfiguroi Timbre-lokitus tuotantoon --
+;; Timbre käyttää js/console appenderia CLJS:ssa, konfiguroidaan min-level sopivalle tasolle, jotta selaimen
+;; konsoli ei täyty turhista lokituksista
+
+(log/merge-config!
+  {:appenders
+   {:console
+    {:min-level :info}}})
+
+;; ---
+
+;; TODO: Näitä apufunktioita ei juurikaan käytetä, poista jos ei tarvetta
 
 (def +lokitetaan+ false)
 

--- a/src/cljs/harja/tiedot/urakka/muutokset/kirjatut_muutokset_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/muutokset/kirjatut_muutokset_tiedot.cljs
@@ -169,7 +169,6 @@
     (let [valittu-hoitokausi (:valittu-hoitokausi app)]
       (tuck-apurit/post! :hae-pysyvan-muutoksen-pohjatiedot
         {:urakka-id @nav/valittu-urakka-id
-         :hoitokauden-alkuvuosi (get-in app [:muokattava-muutos :hoitovuosi])
          ;; TODO: Tällä hetkellä uudelleenkäyttää olemassaolevan pysyvän muutoksen tietojen hakuun tehtyä
          ;;       SQL-kyselyä, joka palauttaa mukana myös suunniteltuja määriä yms.
          ;;       Jos tarvetta, voidaan tehdä erillinen kysely pelkkiä pohjatietoja varten.

--- a/src/cljs/harja/tiedot/urakka/muutokset/kirjatut_muutokset_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/muutokset/kirjatut_muutokset_tiedot.cljs
@@ -25,6 +25,9 @@
 (defrecord PaivitaToimenpiteenTavoitehinnanMuutos [toimenpideinstanssi hk-alkuvuosi muutos-summa])
 (defrecord MerkitseTehtavanMaaramuutosPoistetuksi [toimenpideinstanssi tehtava-id hk-alkuvuosi poistettu?])
 (defrecord KopioiHoitovuodenMuutoksetTulevilleHoitovuosille [hk-alkuvuosi urakan-hoitovuodet])
+(defrecord PeruutaTavoiteJaKattohinta [hk-alkuvuosi])
+(defrecord PeruutaTavoiteJaKattohintaOnnistui [vastaus hk-alkuvuosi])
+(defrecord PeruutaTavoiteJaKattohintaEpaonnistui [virhe])
 
 (defn muokkaa-toimenpiteen-rivit-pysyva-muutos
   "Palauttaa app-tilan, jossa yhden toimenpideinstanssin vetolaatikon rivejä on muokattu muokkaus-fn avulla."
@@ -264,6 +267,7 @@
                    toimenpideinstanssi :toimenpideinstanssi
                    hk-alkuvuosi :hk-alkuvuosi} app]
     (log/debug "PaivitaToimenpiteenTavoitehinnanMuutos, summa" muutos-summa " tpi " toimenpideinstanssi "hk-alkuvuosi " hk-alkuvuosi)
+    (assert (int? hk-alkuvuosi))
 
     (-> app
       ;; Nämä pitävät gridin tilan synkassa app-tilan kanssa
@@ -291,6 +295,8 @@
   KopioiHoitovuodenMuutoksetTulevilleHoitovuosille
   (process-event [{hk-alkuvuosi :hk-alkuvuosi urakan-hoitovuodet :urakan-hoitovuodet} app]
     (log/debug "KopioiHoitovuodenMuutoksetTulevilleHoitovuosille, hoitovuosi: " hk-alkuvuosi)
+    (assert (int? hk-alkuvuosi))
+
     ;; TODO: Tässä on tarkoituksena on kopioida valitun hoitokauden muutokset urakan kaikille tuleville hoitovuosille
     ;;       Eli, valitun hoitovuoden tiedot ensin etsitään [:muokattava-muutos :toimenpiteiden-tiedot] polusta
     ;;       Sieltä otetaan talteen :tehtavat_ja_maarat ja :kustannusvaikutukset
@@ -308,7 +314,45 @@
 
         ;; Yhdistä tehtavat ja määrät, sekä kustannusvaikutukset kaikista vetolaatikoista tallennusta varten
         (koosta-tehtavat-ja-maarat-pysyvaan-muutokseen)
-        (koosta-kustannusvaikutukset-pysyvaan-muutokseen)))))
+        (koosta-kustannusvaikutukset-pysyvaan-muutokseen))))
+
+  PeruutaTavoiteJaKattohinta
+  (process-event [{hk-alkuvuosi :hk-alkuvuosi} app]
+    (log/debug "PeruUrakanTavoitehinnanVahvistus, hoitovuosi: " hk-alkuvuosi)
+    (assert (int? hk-alkuvuosi))
+
+    (tuck-apurit/post! :vahvista-tavoite-ja-kattohinta
+      {:urakka-id @nav/valittu-urakka-id
+       :hoitovuoden-alkuvuosi hk-alkuvuosi
+       :vahvista? false}
+      {:onnistui ->PeruutaTavoiteJaKattohintaOnnistui
+       :onnistui-parametrit [hk-alkuvuosi]
+       :epaonnistui ->PeruutaTavoiteJaKattohintaEpaonnistui
+       :paasta-virhe-lapi? true})
+    app)
+
+    PeruutaTavoiteJaKattohintaOnnistui
+    (process-event [{hk-alkuvuosi :hk-alkuvuosi vastaus :vastaus } app]
+      (assert (int? hk-alkuvuosi))
+
+      (if (get-in vastaus [:kustannussuunnitelma :vahvistus-virhe])
+        (viesti/nayta-toast!
+          "Tavoite- ja kattohinnan peruminen epäonnistui!"
+          :varoitus
+          viesti/viestin-nayttoaika-keskipitka)
+        (viesti/nayta-toast! "Tavoite- ja kattohinnan vahvistus peruttu."))
+
+      ;; Päivitä app-tilaan tieto, että hoitovuoden vahvistukset on purettu
+      (-> app
+        (assoc-in [:budjettitavoitteet :tavoitehinta-indeksikorjattu-per-hoitovuosi hk-alkuvuosi] false)))
+
+    PeruutaTavoiteJaKattohintaEpaonnistui
+    (process-event [_ app]
+      (viesti/nayta-toast!
+        "Tavoite- ja kattohinnan vahvistuksen peruminen epäonnistui!"
+        :varoitus
+        viesti/viestin-nayttoaika-keskipitka)
+      app))
 
 ;; -- Pysyvät muutokset -- LOPPUU
 

--- a/src/cljs/harja/tiedot/urakka/muutokset/kirjatut_muutokset_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/muutokset/kirjatut_muutokset_tiedot.cljs
@@ -165,8 +165,7 @@
     (log/debug "HaePysyvanMuutoksenPohjatiedotLomakkeelleOnnistui")
 
     ;; Pysyviä muutoksia voi kirjata vain 2025 alkaen
-    (let [mahdolliset-hoitovuodet (->> (:urakan-hoitokaudet app)
-                                    (filter #(>= (-> % first pvm/vuosi) 2025)))]
+    (let [mahdolliset-hoitovuodet (:urakan-hoitokaudet app)]
       (-> app
         (assoc-in [:muokattava-muutos :toimenpiteiden-tiedot] (:toimenpiteiden-tiedot vastaus))
         (assoc-in [:muokattava-muutos :toimenpiteiden-tehtavat] (:toimenpiteiden-tehtavat vastaus))
@@ -174,8 +173,9 @@
         (assoc-in [:muokattava-muutos :liitteet] [])
         (assoc-in [:muokattava-muutos :tehtavat_ja_maarat] [])
         (assoc-in [:muokattava-muutos :kustannusvaikutukset] [])
-        ;; Ei valita mitään hoitovuotta ennakkoon, vaan ensin valitaan voimassa alkaen pvm, jotta mahdolliset hoitovuodet
-        ;; tulevat hoitovuosi-valintaan saataville oikein
+        ;; TODO: Tarkista halutaanko valita jokin hoitovuosi ennakkoon, vai annetaanko käyttäjän päättää
+        ;;       Esimerkiksi yksi hyvä valinta voisi olla muutokset näkymässä valittu hoitokausi, jolloin käyttäjä
+        ;;       voisi helposti alkaa täyttämään kyseisen hoitokauden tietoja suoraan.
         (assoc-in [:muokattava-muutos :hoitovuosi] nil))))
 
   HaePysyvanMuutoksenPohjatiedotLomakkeelleEpaonnistui

--- a/src/cljs/harja/tiedot/urakka/muutokset/kirjatut_muutokset_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/muutokset/kirjatut_muutokset_tiedot.cljs
@@ -64,23 +64,48 @@
       (flatten)
       (vec))))
 
-;; Apureita tehtävien määrämuutosten ja kustannusvaikutusten kopiointiin hoitovuodelle
-(defn- muunna-tehtava-ja-maara-rivit-kohdevuodelle
-  "Tekee muunnoksia tehtävät-ja-määrät riveihin, jotta ne sopivat kopioitavaksi toiselle hoitovuodelle."
-  [lahderivit kohdevuosi]
-  (mapv (fn [rivi]
-          (-> rivi
-            (assoc :hoitokauden_alkuvuosi kohdevuosi)))
-    lahderivit))
+;; -- Apureita tehtävien määrämuutosten ja kustannusvaikutusten kopiointiin hoitovuodelle
+(defn- korvaa-rivi-tai-merkitse-poistetuksi
+  "Merkitse rivit poistetuksi tai korvaa tehtava-avainta vastaava rivi uusilla tiedoilla lähdehoitovuodelta."
+  [lahderivit kohderivi]
+  ;; Etsitään korvaava rivi lähderivien joukosta tehtava-avaimen perusteella
+  (let [korvaava-rivi (some #(when (= (:tehtava kohderivi) (:tehtava %)) %) lahderivit)]
+    (cond
+      korvaava-rivi
+      (assoc korvaava-rivi :korvattu? true)
+      ;; Jos rivi on täysin uusi (eli vain UI:n tilassa), niin ei merkitä poistetuksi, vaan poistetaan kokonaan UI:sta
+      ;; Muutoin, ohjeistetaan backendiä poistamaan rivi tietokannasta
+      (not (:uusi? kohderivi))
+      (assoc kohderivi :poistettu true)
+      ;; Vain UI:n tilassa olevat rivit (eli :uusi? true) rivit suodatetaan pois
+      :else nil)))
 
-(defn- merkitse-rivit-poistetuksi
-  "Merkitse rivit poistetuksi."
-  [lahderivit]
-  (mapv (fn [rivi]
-          ;; Jos rivi on uusi (eli vain UI:ssa olemassaoleva), niin ei merkitä poistetuksi, vaan poistetaan kokonaan UI:sta
-          (when (not (:uusi? rivi))
-            (assoc rivi :poistettu true)))
-    lahderivit))
+(defn- muunna-tehtava-ja-maara-rivit-kohdevuodelle
+  "Muuntaa lahde- ja kohderivejä siten, että kopiointi kohdehoitovuodelle onnistuu ja vanhat rivit kohdevuodelta poistetaan."
+  [lahderivit kohderivit kohdevuosi]
+  (let [
+        ;; Käydään kohdevuoden rivit läpi. Rivit joko korvataan vastaavien lähderivien tiedoilla tai poistetaan
+        kohderivit (remove nil?
+                     (mapv
+                       (fn [rivi]
+                         (korvaa-rivi-tai-merkitse-poistetuksi lahderivit rivi))
+                       kohderivit))
+        ;; Lahderiveistä poistetaan ne rivit, jotka on jo korvattu kohderiveihin
+        ;; Myöskään lähderiveissä poistetuksi merkittyjä rivejä ei saa kopioida kohdevuodelle
+        lahderivit (remove #(some (fn [kohderivi]
+                                    (or
+                                      (= (:tehtava kohderivi) (:tehtava %))
+                                      (:poistettu %)))
+                              kohderivit)
+                     lahderivit)
+        ;; Yhdistetään rivien joukot. Näistä tulee lopullinen rivijoukko, joka kopioidaan kohdehoitovuodelle.
+        uudet-rivit (concat kohderivit lahderivit)]
+
+    ;; Lisätään vielä riveihin oikea kohdevuotta vastaava hoitovuosi
+    (mapv (fn [rivi]
+            (-> rivi
+              (assoc :hoitokauden_alkuvuosi kohdevuosi)))
+      uudet-rivit)))
 
 (defn- korvaa-vuosien-tehtavat-ja-maara-rivit
   "Korvaa kohdevuosien tehtävä- ja määrärivit kopiolla lähdevuoden riveistä.
@@ -93,13 +118,9 @@
       (->> (reduce (fn [m vuosi]
                      ;; Korvaa vuoden tehtävä- ja määrärivit lähderiveillä, aseta uusi alkuvuosi
                      (assoc m vuosi (concat
-                                      ;; Merkitse vanhat rivit poistetuksi ennen korvaavien rivien lisäämistä
-                                      ;; FIXME: Grid-komponentissa on ongelmia säilöä samanaikaisesti poistettu- ja ei-poistettuja rivejä
-                                      ;;       joilla on sama tunniste (eli tässä tapauksessa :tehtävä id)
-                                      ;;       Eli, jos kopioidaan toiselle hoitovuodelle rivi, jolla on sama tehtävä id kuin lähderivillä,
-                                      ;;       poistamisen sijaan pitäisi korvatakin kyseisen rivin tiedot lähderivin tiedoilla.
-                                      (remove nil? (merkitse-rivit-poistetuksi (get m vuosi)))
-                                      (muunna-tehtava-ja-maara-rivit-kohdevuodelle lahderivit vuosi))))
+                                      ;; Korvataan kohdevuoden rivit lähderiveillä tai poistetaan sellaisia
+                                      ;; kohdevuoden rivejä, joita ei löydy lähderivien joukosta.
+                                      (muunna-tehtava-ja-maara-rivit-kohdevuodelle lahderivit (get m vuosi) vuosi))))
              tjm-per-vuosi-map
              vuodet)
         (sort-by first)

--- a/src/cljs/harja/tiedot/urakka/muutokset/kirjatut_muutokset_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/muutokset/kirjatut_muutokset_tiedot.cljs
@@ -19,7 +19,7 @@
 
 ;; -- Pysyvät muutokset -- ALKAA
 (defrecord HaePysyvanMuutoksenPohjatiedotLomakkeelle [])
-(defrecord HaePysyvanMuutoksenPohjatiedotLomakkeelleOnnistui [vastaus])
+(defrecord HaePysyvanMuutoksenPohjatiedotLomakkeelleOnnistui [vastaus valittu-hoitokausi])
 (defrecord HaePysyvanMuutoksenPohjatiedotLomakkeelleEpaonnistui [virhe])
 (defrecord PaivitaToimenpiteenTehtavamaarat [toimenpideinstanssi hk-alkuvuosi taulukon-rivit])
 (defrecord PaivitaToimenpiteenTavoitehinnanMuutos [toimenpideinstanssi hk-alkuvuosi muutos-summa])
@@ -145,23 +145,25 @@
   (process-event [_ app]
     (log/debug "HaePysyvanMuutoksenPohjatiedotLomakkeelle")
 
-    (tuck-apurit/post! :hae-pysyvan-muutoksen-pohjatiedot
-      {:urakka-id @nav/valittu-urakka-id
-       :hoitokauden-alkuvuosi (get-in app [:muokattava-muutos :hoitovuosi])
-       ;; TODO: Tällä hetkellä uudelleenkäyttää olemassaolevan pysyvän muutoksen tietojen hakuun tehtyä
-       ;;       SQL-kyselyä, joka palauttaa mukana myös suunniteltuja määriä yms.
-       ;;       Jos tarvetta, voidaan tehdä erillinen kysely pelkkiä pohjatietoja varten.
-       ;;       Nyt annetaan vain mhu_muutos tietojen hakua varten nil-arvot, jotta kysely toimii ja haetaankin
-       ;;       vain pelkät pohjatiedot.
-       :muutos {:id nil
-                :versio nil
-                :tyyppi "pysyva"}}
-      {:onnistui ->HaePysyvanMuutoksenPohjatiedotLomakkeelleOnnistui
-       :epaonnistui ->HaePysyvanMuutoksenPohjatiedotLomakkeelleEpaonnistui})
+    (let [valittu-hoitokausi (:valittu-hoitokausi app)]
+      (tuck-apurit/post! :hae-pysyvan-muutoksen-pohjatiedot
+        {:urakka-id @nav/valittu-urakka-id
+         :hoitokauden-alkuvuosi (get-in app [:muokattava-muutos :hoitovuosi])
+         ;; TODO: Tällä hetkellä uudelleenkäyttää olemassaolevan pysyvän muutoksen tietojen hakuun tehtyä
+         ;;       SQL-kyselyä, joka palauttaa mukana myös suunniteltuja määriä yms.
+         ;;       Jos tarvetta, voidaan tehdä erillinen kysely pelkkiä pohjatietoja varten.
+         ;;       Nyt annetaan vain mhu_muutos tietojen hakua varten nil-arvot, jotta kysely toimii ja haetaankin
+         ;;       vain pelkät pohjatiedot.
+         :muutos {:id nil
+                  :versio nil
+                  :tyyppi "pysyva"}}
+        {:onnistui ->HaePysyvanMuutoksenPohjatiedotLomakkeelleOnnistui
+         :onnistui-parametrit [valittu-hoitokausi]
+         :epaonnistui ->HaePysyvanMuutoksenPohjatiedotLomakkeelleEpaonnistui}))
     app)
 
   HaePysyvanMuutoksenPohjatiedotLomakkeelleOnnistui
-  (process-event [{vastaus :vastaus} app]
+  (process-event [{valittu-hoitokausi :valittu-hoitokausi vastaus :vastaus} app]
     (log/debug "HaePysyvanMuutoksenPohjatiedotLomakkeelleOnnistui")
 
     ;; Pysyviä muutoksia voi kirjata vain 2025 alkaen
@@ -173,10 +175,8 @@
         (assoc-in [:muokattava-muutos :liitteet] [])
         (assoc-in [:muokattava-muutos :tehtavat_ja_maarat] [])
         (assoc-in [:muokattava-muutos :kustannusvaikutukset] [])
-        ;; TODO: Tarkista halutaanko valita jokin hoitovuosi ennakkoon, vai annetaanko käyttäjän päättää
-        ;;       Esimerkiksi yksi hyvä valinta voisi olla muutokset näkymässä valittu hoitokausi, jolloin käyttäjä
-        ;;       voisi helposti alkaa täyttämään kyseisen hoitokauden tietoja suoraan.
-        (assoc-in [:muokattava-muutos :hoitovuosi] nil))))
+        ;; Asetetaan suoraan Muutos-näkymässä valittu hoitokausi pysyvän muutoksen hoitovuodeksi
+        (assoc-in [:muokattava-muutos :hoitovuosi] valittu-hoitokausi))))
 
   HaePysyvanMuutoksenPohjatiedotLomakkeelleEpaonnistui
   (process-event [_ app]

--- a/src/cljs/harja/tiedot/urakka/muutokset/kirjatut_muutokset_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/muutokset/kirjatut_muutokset_tiedot.cljs
@@ -290,8 +290,9 @@
   (process-event [{hk-alkuvuosi :hk-alkuvuosi urakan-hoitovuodet :urakan-hoitovuodet} app]
     (log/debug "KopioiHoitovuodenMuutoksetTulevilleHoitovuosille, hoitovuosi: " hk-alkuvuosi)
     (assert (int? hk-alkuvuosi))
+    (assert (sequential? urakan-hoitovuodet))
 
-    (let [urakan-hoitovuodet (map #(-> % first pvm/vuosi) urakan-hoitovuodet)]
+    (let [urakan-hoitovuodet (map #(some-> % first pvm/vuosi) urakan-hoitovuodet)]
       (-> app
         (update-in [:muokattava-muutos :toimenpiteiden-tiedot]
           (fn [rivit]

--- a/src/cljs/harja/tiedot/urakka/muutokset/kirjatut_muutokset_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/muutokset/kirjatut_muutokset_tiedot.cljs
@@ -286,20 +286,10 @@
       ;; Yhdistä kustannusvaikutukset kaikista vetolaatikoista tallennusta varten
       (koosta-kustannusvaikutukset-pysyvaan-muutokseen)))
 
-  ;; TODO: Jätetään myöhemmäksi, aluksi tallennus muokkaus ja muut tärkeämmät ominaisuudet.
   KopioiHoitovuodenMuutoksetTulevilleHoitovuosille
   (process-event [{hk-alkuvuosi :hk-alkuvuosi urakan-hoitovuodet :urakan-hoitovuodet} app]
     (log/debug "KopioiHoitovuodenMuutoksetTulevilleHoitovuosille, hoitovuosi: " hk-alkuvuosi)
     (assert (int? hk-alkuvuosi))
-
-    ;; TODO: Tässä on tarkoituksena on kopioida valitun hoitokauden muutokset urakan kaikille tuleville hoitovuosille
-    ;;       Eli, valitun hoitovuoden tiedot ensin etsitään [:muokattava-muutos :toimenpiteiden-tiedot] polusta
-    ;;       Sieltä otetaan talteen :tehtavat_ja_maarat ja :kustannusvaikutukset
-    ;;       Sitten etsitään urakan kaikki hoitokaudet, jotka ovat saatilla :toimenpiteiden-tiedot polusta
-    ;;       Ja käydään ne läpi, ja päivitetään kunkin hoitokauden :tehtavat_ja_maarat ja :kustannusvaikutukset
-    ;;       Jokaisen hoitokauden päivityksessä tulee huomioida, että vanhat rivit korvataan kopioiduilla riveillä
-    ;;       ja jokaisen rivin kohdalle päivitetään :hoitokauden_alkuvuosi vastaamaan kunkin hoitokauden alkuvuotta
-    ;;       Lopuksi päivitetään app-tila kutsumalla koosta-tehtavat-ja-maarat-pysyvaan-muutokseen ja koosta-kustannusvaikutukset-pysyvaan-muutokseen
 
     (let [urakan-hoitovuodet (map #(-> % first pvm/vuosi) urakan-hoitovuodet)]
       (-> app

--- a/src/cljs/harja/tiedot/urakka/muutokset/kirjatut_muutokset_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/muutokset/kirjatut_muutokset_tiedot.cljs
@@ -211,8 +211,6 @@
                    hk-alkuvuosi :hk-alkuvuosi
                    ;; Yhden vetolaatikon tehtävät-ja-määrät rivit valitulta hoitovuodelta
                    taulukon-rivit :taulukon-rivit} app]
-    (log/debug "PaivitaToimenpiteenTehtavamaarat taulukon-rivit: " taulukon-rivit)
-
     (-> app
       ;; Nämä pitävät gridin tilan synkassa app-tilan kanssa
       (muokkaa-toimenpiteen-rivit-pysyva-muutos toimenpideinstanssi
@@ -235,8 +233,6 @@
                    tehtava-id :tehtava-id
                    hk-alkuvuosi :hk-alkuvuosi
                    poistettu? :poistettu?} app]
-    (log/debug "MerkitseTehtavanMaaramuutosPoistetuksi, tpi " toimenpideinstanssi " tehtava-id " tehtava-id " hk-alkuvuosi " hk-alkuvuosi " poistettu? " poistettu?)
-
     (-> app
       ;; Nämä pitävät gridin tilan synkassa app-tilan kanssa
       (muokkaa-toimenpiteen-rivit-pysyva-muutos toimenpideinstanssi
@@ -266,7 +262,6 @@
   (process-event [{muutos-summa :muutos-summa
                    toimenpideinstanssi :toimenpideinstanssi
                    hk-alkuvuosi :hk-alkuvuosi} app]
-    (log/debug "PaivitaToimenpiteenTavoitehinnanMuutos, summa" muutos-summa " tpi " toimenpideinstanssi "hk-alkuvuosi " hk-alkuvuosi)
     (assert (int? hk-alkuvuosi))
 
     (-> app
@@ -318,7 +313,6 @@
 
   PeruutaTavoiteJaKattohinta
   (process-event [{hk-alkuvuosi :hk-alkuvuosi} app]
-    (log/debug "PeruUrakanTavoitehinnanVahvistus, hoitovuosi: " hk-alkuvuosi)
     (assert (int? hk-alkuvuosi))
 
     (tuck-apurit/post! :vahvista-tavoite-ja-kattohinta

--- a/src/cljs/harja/tiedot/urakka/muutokset/lasketut_muutokset_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/muutokset/lasketut_muutokset_tiedot.cljs
@@ -1,22 +1,15 @@
 (ns harja.tiedot.urakka.muutokset.lasketut-muutokset-tiedot
   "Urakan muutosten tiedot - lasketut muutokset."
   (:require
-    [harja.tiedot.urakka.muutokset.yhteiset-tiedot :as t-yhteiset]
     [taoensso.timbre :as log]
     [tuck.core :as tuck]
-    ;; Tuck efektit ja apurit
-    [harja.tyokalut.tuck]
-    [reagent.core :refer [atom]]
 
-    [harja.pvm :as pvm]
+    ;; Tuck efektit ja apurit
+    [harja.tyokalut.tuck :as tuck-apurit]
     [harja.tiedot.urakka :as u]
-    [harja.ui.lomake :as lomake]
+    [harja.tiedot.urakka.muutokset.yhteiset-tiedot :as t-yhteiset]
     [harja.ui.viesti :as viesti]
-    [harja.ui.liitteet :as liitteet]
-    [harja.tiedot.navigaatio :as nav]
-    [harja.ui.nakymasiirrin :as siirrin]
-    [harja.tiedot.urakka.urakka :as tila]
-    [harja.tyokalut.tuck :as tuck-apurit]))
+    [harja.tiedot.urakka.urakka :as tila]))
 
 ;; Muutostyypit:
 ;; - Tehtävä- ja määrämuutokset

--- a/src/cljs/harja/tiedot/urakka/muutokset/lasketut_muutokset_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/muutokset/lasketut_muutokset_tiedot.cljs
@@ -1,18 +1,22 @@
 (ns harja.tiedot.urakka.muutokset.lasketut-muutokset-tiedot
   "Urakan muutosten tiedot - lasketut muutokset."
-  (:require [taoensso.timbre :as log]
-            [tuck.core :as tuck]
-            [reagent.core :refer [atom]]
+  (:require
+    [harja.tiedot.urakka.muutokset.yhteiset-tiedot :as t-yhteiset]
+    [taoensso.timbre :as log]
+    [tuck.core :as tuck]
+    ;; Tuck efektit ja apurit
+    [harja.tyokalut.tuck]
+    [reagent.core :refer [atom]]
 
-            [harja.pvm :as pvm]
-            [harja.tiedot.urakka :as u]
-            [harja.ui.lomake :as lomake]
-            [harja.ui.viesti :as viesti]
-            [harja.ui.liitteet :as liitteet]
-            [harja.tiedot.navigaatio :as nav]
-            [harja.ui.nakymasiirrin :as siirrin]
-            [harja.tiedot.urakka.urakka :as tila]
-            [harja.tyokalut.tuck :as tuck-apurit]))
+    [harja.pvm :as pvm]
+    [harja.tiedot.urakka :as u]
+    [harja.ui.lomake :as lomake]
+    [harja.ui.viesti :as viesti]
+    [harja.ui.liitteet :as liitteet]
+    [harja.tiedot.navigaatio :as nav]
+    [harja.ui.nakymasiirrin :as siirrin]
+    [harja.tiedot.urakka.urakka :as tila]
+    [harja.tyokalut.tuck :as tuck-apurit]))
 
 ;; Muutostyypit:
 ;; - Tehtävä- ja määrämuutokset
@@ -39,6 +43,8 @@
   TallennaTehtavaMaaramuutokset
   (process-event [{:keys [rivit]}
                   {:keys [_valittu-rivi] :as app}]
+    (log/debug "TallennaTehtavaMaaramuutokset")
+
     (let [parametrit {:rivit rivit
                       :urakka-id (-> @tila/yleiset :urakka :id)
                       :hoitokaudet @u/valitun-urakan-hoitokaudet
@@ -53,10 +59,24 @@
 
   TallennaTehtavaMaaramuutoksetOnnistui
   (process-event [{:keys [vastaus]} app]
+    (log/debug "TallennaTehtavaMaaramuutoksetOnnistui")
+
     (viesti/nayta-toast! "Tallennus onnistui" :onnistui viesti/viestin-nayttoaika-lyhyt)
-    (assoc app
-      :tehtava-maaramuutokset vastaus
-      :haku-kaynnissa? false))
+
+    (let [app (assoc app
+                :tehtava-maaramuutokset vastaus
+                :haku-kaynnissa? false)]
+
+      ;; TODO: Kannattaa ehkä refaktoroida logiikkaa backend-palvelun puolelle pidemmän päälle, jotta vältämme
+      ;;       turhia raskaita kyselyitä.
+      ;;       Käyttöliittymään täytyy päivittää koosteita muutoksista, joten tallennuksen jälkeen on haettava
+      ;;       viimeisimmät tiedot. Tehdään nyt näin helpoimman kautta ja palataan asiaan.
+      ;; Laukaise lopuksi efekti, joka hakee urakan viimeisimmät muutostiedot koostenäkymään
+      ;; Antaa viimeisimmän app-tilan eventille
+      (tuck/fx app
+        {:tuck.effect/type :debounce
+         :event t-yhteiset/->HaeUrakanMuutostiedot
+         :timeout 200})))
 
 
   TallennaTehtavaMaaramuutoksetEpaonnistui
@@ -113,9 +133,23 @@
   TallennaYksikkohintaOnnistui
   (process-event [{:keys [vastaus]} app]
     (viesti/nayta-toast! "Yksikköhinta tallennettu" :onnistui viesti/viestin-nayttoaika-lyhyt)
-    (assoc app
-      :haku-kaynnissa? false
-      :tehtava-maaramuutokset vastaus))
+
+    (tuck/send-async! t-yhteiset/->HaeUrakanMuutostiedot)
+
+    (let [app (assoc app
+                :haku-kaynnissa? false
+                :tehtava-maaramuutokset vastaus)]
+
+      ;; TODO: Kannattaa ehkä refaktoroida logiikkaa backend-palvelun puolelle pidemmän päälle, jotta vältämme
+      ;;       turhia raskaita kyselyitä.
+      ;;       Käyttöliittymään täytyy päivittää koosteita muutoksista, joten tallennuksen jälkeen on haettava
+      ;;       viimeisimmät tiedot. Tehdään nyt näin helpoimman kautta ja palataan asiaan.
+      ;; Laukaise lopuksi efekti, joka hakee urakan viimeisimmät muutostiedot koostenäkymään
+      ;; Antaa viimeisimmän app-tilan eventille
+      (tuck/fx app
+        {:tuck.effect/type :debounce
+         :event t-yhteiset/->HaeUrakanMuutostiedot
+         :timeout 200})))
 
   TallennaYksikkohintaEpaonnistui
   (process-event [_ app]

--- a/src/cljs/harja/tiedot/urakka/muutokset/yhteiset_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/muutokset/yhteiset_tiedot.cljs
@@ -153,6 +153,8 @@
 (extend-protocol tuck/Event
   HaeUrakanMuutostiedot
   (process-event [_ app]
+    (log/debug "HaeUrakanMuutostiedot")
+
     (hae-urakan-muutostiedot
       (assoc
         (tuck-apurit/nollaa-tuck-tila app nollatut-valinnat)
@@ -163,6 +165,8 @@
 
   HaeUrakanMuutostiedotOnnistui
   (process-event [{:keys [vastaus]} app]
+    (log/debug "HaeUrakanMuutostiedotOnnistui")
+
     (vastaus-haku-onnistui app vastaus))
 
 

--- a/src/cljs/harja/tiedot/urakka/muutokset/yhteiset_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/muutokset/yhteiset_tiedot.cljs
@@ -217,8 +217,7 @@
           ;; jos tästä tulee jossain kohti liian hidas, voidaan tarkastelu suorittaa joko backendissä tai tietokannassakin
           aikaisin-hoitovuosi-jossa-kirjauksia (pienin-hoitokauden-alkuvuosi-jossa-kirjauksia toimenpiteiden-tiedot)
           ;; vain ne hoitovuodet mahdollisia, jotka ovat voimassa alkaen pvm:n jälkeen eli alkupvm on sen jälkeen
-          mahdolliset-hoitovuodet-lomakkeella (filter #(pvm/jalkeen? (first %) (get-in app [:muokattava-muutos :voimassa_alkaen]))
-                                                (:urakan-hoitokaudet app))
+          mahdolliset-hoitovuodet-lomakkeella (:urakan-hoitokaudet app)
           hoitovuosi-lomakkeelle (or (when (and aikaisin-hoitovuosi-jossa-kirjauksia
                                              ;; Varmista, että hoitovuosi on mahdollisissa hoitovuosissa
                                              ;; :budjetoidut_summat voi sisältää arvoja, mutta sellaista hoitovuotta ei

--- a/src/cljs/harja/tiedot/urakka/muutokset/yhteiset_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/muutokset/yhteiset_tiedot.cljs
@@ -210,19 +210,12 @@
           lomakkeen-hoitokausi (get-in app [:muokattava-muutos :hoitovuosi])
           toimenpiteiden-tiedot (:toimenpiteiden-tiedot vastaus)
           toimenpiteiden-tehtavat (:toimenpiteiden-tehtavat vastaus)
-          ;; lomakkeen on kyettävä käsittelemään usealle hoitovuodelle tehtäviä kirjauksia. Kun ländätään lomakkeelle,
+          ;; Lomakkeen on kyettävä käsittelemään usealle hoitovuodelle tehtäviä kirjauksia. Kun ländätään lomakkeelle,
           ;; halutaan defaulttina näyttää aikaisin hoitovuosi, jossa on kirjauksia.
-          ;; Jos aikaisin kirjauksia sisältävä hoitovuosi ei ole mahdollisten hoitovuosien listassa,
-          ;; valitaan ensimmäinen mahdollisista hoitovuosista.
-          ;; jos tästä tulee jossain kohti liian hidas, voidaan tarkastelu suorittaa joko backendissä tai tietokannassakin
+          ;; Jos tästä tulee jossain kohti liian hidas, voidaan tarkastelu suorittaa joko backendissä tai tietokannassakin
           aikaisin-hoitovuosi-jossa-kirjauksia (pienin-hoitokauden-alkuvuosi-jossa-kirjauksia toimenpiteiden-tiedot)
-          ;; vain ne hoitovuodet mahdollisia, jotka ovat voimassa alkaen pvm:n jälkeen eli alkupvm on sen jälkeen
           mahdolliset-hoitovuodet-lomakkeella (:urakan-hoitokaudet app)
-          hoitovuosi-lomakkeelle (or (when (and aikaisin-hoitovuosi-jossa-kirjauksia
-                                             ;; Varmista, että hoitovuosi on mahdollisissa hoitovuosissa
-                                             ;; :budjetoidut_summat voi sisältää arvoja, mutta sellaista hoitovuotta ei
-                                             ;; saa kuitenkaan valita, jos se ei ole mahdollisten hoitovuosien joukossa.
-                                             (contains? (vec mahdolliset-hoitovuodet-lomakkeella) aikaisin-hoitovuosi-jossa-kirjauksia))
+          hoitovuosi-lomakkeelle (or (when aikaisin-hoitovuosi-jossa-kirjauksia
                                        (pvm/vuodesta-hoitokausi aikaisin-hoitovuosi-jossa-kirjauksia))
                                    (first mahdolliset-hoitovuodet-lomakkeella))
           johto-ja-hallinto (johto-ja-hallintokorvausmuutoksen-rivit valittu-hoitokausi (:kulut vastaus))

--- a/src/cljs/harja/tiedot/urakka/muutokset/yhteiset_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/muutokset/yhteiset_tiedot.cljs
@@ -191,7 +191,6 @@
 
   PaivitaLomake
   (process-event [{:keys [lomake]} app]
-    (log/debug "PaivitaLomake")
     (assoc app :muokattava-muutos lomake))
 
   ;; Hakee olemassaolevan muutoksen kaikki tiedot muokkausta varten
@@ -312,19 +311,16 @@
   LisaaLiite
   (process-event
     [{:keys [liite]} app]
-    (prn "LisaaLiite")
     (-> app
       (update-in [:muokattava-muutos :liitteet] conj liite)))
 
   PoistaLisattyLiite
   (process-event [_ app]
-    (prn "PoistaLisattyLiite")
     (assoc app :uusi-liite nil))
 
   PoistaTallennettuLiite
   (process-event
     [{:keys [liite-id]} app]
-    (prn "PoistaTallennettuLiite, liite-id: " liite-id)
     (let [{urakka-id :id} @nav/valittu-urakka
           e! (tuck/current-send-function)
           ;; hanskataan tässä myös tilanne, jossa muutosta ei ole vielä tallennettu

--- a/src/cljs/harja/tiedot/urakka/muutokset/yhteiset_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/muutokset/yhteiset_tiedot.cljs
@@ -20,6 +20,7 @@
                      :haku-kaynnissa? false
                      :tallennus-kesken? false
                      :kirjatut-muutokset nil
+                     :aiempien-hoitovuosien-pysyvat-muutokset nil
                      :tehtava-maaramuutokset nil
                      :rahavarausten-muutokset nil
                      :tavoitehinnan-muutokset nil
@@ -115,6 +116,7 @@
     :haku-kaynnissa? false
     :tallennus-kesken? false
     :kirjatut-muutokset (:kirjatut-muutokset vastaus)
+    :aiempien-hoitovuosien-pysyvat-muutokset (:aiempien-hoitovuosien-pysyvat-muutokset vastaus)
     :tehtava-maaramuutokset (:lasketut-muutokset vastaus)
     :rahavarausten-muutokset (:rahavarausten-muutokset vastaus)
     :tavoitehinnan-muutokset (:tavoitehinnan-muutokset vastaus)

--- a/src/cljs/harja/tiedot/urakka/muutokset/yhteiset_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/muutokset/yhteiset_tiedot.cljs
@@ -66,6 +66,12 @@
     (< (pvm/vuosi (first valittu-hoitokausi))
       muutoksien-kayttoonoton-hoitokauden-alkuvuosi)))
 
+(defn hoitovuoden-indeksikorjaus-vahvistettu?
+  [{:keys [tavoitehinta-indeksikorjattu-per-hoitovuosi] :as budjettitavoitteet} hoitovuosi]
+  (let [hoitokauden-alkuvuosi (some-> hoitovuosi (first) (pvm/vuosi))
+        indeksikorjaus-vahvistettu? (get tavoitehinta-indeksikorjattu-per-hoitovuosi hoitokauden-alkuvuosi false)]
+    indeksikorjaus-vahvistettu?))
+
 
 ;; --- Tuck-eventit ja käsittelijät ---
 ;; Hae muutostiedot

--- a/src/cljs/harja/tiedot/urakka/muutokset/yhteiset_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/muutokset/yhteiset_tiedot.cljs
@@ -37,7 +37,8 @@
                             :syy "Muutoksen syy"
                             :voimassa_alkaen "Voimassa alkaen"})
 
-(def +indeksikorjausta-ei-vahvistettu-txt+ "Indeksikorjausta ei saatavilla")
+(def +indeksikorjausta-ei-vahvistettu-txt+ "Ei saatavilla")
+(def +muutosten-vaikutus-yhteensa-ei-saatavilla+ "Ei saatavilla")
 (def muutoksien-kayttoonoton-hoitokauden-alkuvuosi 2025)
 
 (defonce nakymassa? (atom false))

--- a/src/cljs/harja/tyokalut/tuck.cljs
+++ b/src/cljs/harja/tyokalut/tuck.cljs
@@ -2,6 +2,7 @@
   "Tuck-apureita"
   (:require [cljs.test :as t :refer-macros [is]]
             [tuck.core :as tuck]
+            [tuck.effect :as tuck-effect]
             [harja.loki :refer [log]]
             [cljs.core.async :as async :refer [<! >! chan timeout unsub pub put! close!]]
             [harja.asiakas.kommunikaatio :as k])
@@ -129,6 +130,7 @@
 (defrecord MuutaTila [polku arvo])
 (defrecord PaivitaTila [polku f])
 (defrecord AloitaViivastettyjenEventtienKuuntelu [viive kanava])
+(defrecord DebounceEffect [effect])
 
 (extend-protocol tuck/Event
   MuutaTila
@@ -155,4 +157,31 @@
                                                                (do (e! event)
                                                                    true)))})
                                       (<! kanava))))))
-    app))
+    app)
+
+  DebounceEffect
+  (process-event [{:keys [effect]} app]
+    (tuck/fx app effect)))
+
+
+;; Tuck effects apureita
+
+(defmethod tuck-effect/process-effect :laukaise-event [e! {:keys [event]}]
+  (assert event "Määrittele event")
+  (if (fn? event)
+    (e! (event))
+    (e! event)))
+
+(defonce debounce-timeouts (atom {}))
+(defmethod tuck-effect/process-effect :debounce [e! {:keys [event effect timeout id]}]
+  (let [timeout-id (or id event)
+        existing-timeout (get @debounce-timeouts timeout-id)]
+    (when existing-timeout
+      (.clearTimeout js/window existing-timeout))
+    (swap! debounce-timeouts
+      assoc timeout-id
+      (.setTimeout js/window #(do
+                                (swap! debounce-timeouts dissoc timeout-id)
+                                (if event
+                                  (e! (event))
+                                  (e! (->DebounceEffect effect)))) timeout))))

--- a/src/cljs/harja/ui/yleiset.cljs
+++ b/src/cljs/harja/ui/yleiset.cljs
@@ -569,11 +569,6 @@ joita kutsutaan kun niiden näppäimiä paineetaan."
                                          (not (jata-kaventamatta otsikko)))
                                    {:style {:margin-bottom "0.5em"}}))
                 [:span.tietokentta (merge tietokentta-attrs rivin-attribuutit) otsikko]
-                ;; Jätetään "täyttöelementti" pois, jos otsikko vie koko rivin leveyden
-                (when-not (:koko-rivin-leveys? otsikko-meta)
-                  (if otsikot-omalla-rivilla?
-                    [:div]
-                    [:span {:style {:display "inline-block" :width "1em"}}]))
                 ;; Jätetään renderöimättä arvo, jos otsikko vie koko rivin leveyden
                 (when-not (:koko-rivin-leveys? otsikko-meta)
                   [:span.tietoarvo.max-width-3 arvo])

--- a/src/cljs/harja/ui/yleiset.cljs
+++ b/src/cljs/harja/ui/yleiset.cljs
@@ -549,21 +549,23 @@ joita kutsutaan kun niiden näppäimiä paineetaan."
     [:div.tietoja {:class class}
      (keep-indexed
        (fn [i [otsikko arvo]]
-         (when arvo
-           (let [rivin-attribuutit (when (otsikot-samalla-rivilla otsikko)
-                                     {:style {:display "auto"}})]
-             ^{:key (str i otsikko)}
-             [:div.tietorivi (merge
-                                   {:class tietorivi-luokka}
-                                   (when-not piirra-viivat?
-                                     {:class (str tietorivi-luokka " tietorivi-ilman-alaviivaa")})
-                                   (when (and kavenna?
-                                           (not (jata-kaventamatta otsikko)))
-                                     {:style {:margin-bottom "0.5em"}}))
-              [:span.tietokentta (merge tietokentta-attrs rivin-attribuutit) otsikko]
-              [:span.tietoarvo.max-width-3 arvo]
-              (when (tyhja-rivi-otsikon-jalkeen otsikko)
-                [:span [:br] [:br]])])))
+         (let [otsikko-meta (meta otsikko)]
+           (prn "otsikko-meta" otsikko-meta)
+           (when arvo
+             (let [rivin-attribuutit (when (otsikot-samalla-rivilla otsikko)
+                                       {:style {:display "auto"}})]
+               ^{:key (str i otsikko)}
+               [:div.tietorivi (merge
+                                 {:class tietorivi-luokka}
+                                 (when-not (or piirra-viivat? (:viiva-rivin-alle? otsikko-meta))
+                                   {:class (str tietorivi-luokka " tietorivi-ilman-alaviivaa")})
+                                 (when (and kavenna?
+                                         (not (jata-kaventamatta otsikko)))
+                                   {:style {:margin-bottom "0.5em"}}))
+                [:span.tietokentta (merge tietokentta-attrs rivin-attribuutit) otsikko]
+                [:span.tietoarvo.max-width-3 arvo]
+                (when (tyhja-rivi-otsikon-jalkeen otsikko)
+                  [:span [:br] [:br]])]))))
        (partition 2 otsikot-ja-arvot))]))
 
 (defn taulukkotietonakyma

--- a/src/cljs/harja/ui/yleiset.cljs
+++ b/src/cljs/harja/ui/yleiset.cljs
@@ -550,7 +550,6 @@ joita kutsutaan kun niiden näppäimiä paineetaan."
      (keep-indexed
        (fn [i [otsikko arvo]]
          (let [otsikko-meta (meta otsikko)]
-           (prn "otsikko-meta" otsikko-meta)
            (when arvo
              (let [rivin-attribuutit (when (otsikot-samalla-rivilla otsikko)
                                        {:style {:display "auto"}})]

--- a/src/cljs/harja/ui/yleiset.cljs
+++ b/src/cljs/harja/ui/yleiset.cljs
@@ -534,7 +534,13 @@ joita kutsutaan kun niiden näppäimiä paineetaan."
   :otsikot-samalla-rivilla      Setti otsikoita, jotka ovat samalla rivillä
   :tyhja-rivi-otsikon-jalkeen   Setti otsikoita, joiden jälkeen tyhjä rivi
   :piirra-viivat?               Piirtää viivat otsikoiden ja arvojen alle (oletus true)
-  :tietorivi-luokka             Aseta lisäluokka tietoriville"
+  :tietorivi-luokka             Aseta lisäluokka tietoriville
+
+  Otsikon metadata:
+  - Otsikon metadata toimii keinona ujuttaa rivikohtaisia optioita otsikon tietojen yhteydessä.
+  :viiva-rivin-alle?            Hallitse yksittäisen rivin kohdalla viivan piirtämistä
+  :koko-rivin-leveys?           Jos true, tietokenttä vie koko rivin leveyden (oletus false), ja erillinen arvo jätetään pois.
+  :tietorivi-luokka             Aseta lisäluokka koko tietoriville otsikon metadatassa"
   [{:keys [class otsikot-omalla-rivilla? otsikot-samalla-rivilla piirra-viivat?
            tyhja-rivi-otsikon-jalkeen kavenna? jata-kaventamatta tietokentan-leveys tietorivi-luokka]} & otsikot-ja-arvot]
   (let [tyhja-rivi-otsikon-jalkeen (or tyhja-rivi-otsikon-jalkeen #{})
@@ -552,7 +558,8 @@ joita kutsutaan kun niiden näppäimiä paineetaan."
          (let [otsikko-meta (meta otsikko)]
            (when arvo
              (let [rivin-attribuutit (when (otsikot-samalla-rivilla otsikko)
-                                       {:style {:display "auto"}})]
+                                       {:style {:display "auto"}})
+                   tietorivi-luokka (or (:tietorivi-luokka otsikko-meta) tietorivi-luokka)]
                ^{:key (str i otsikko)}
                [:div.tietorivi (merge
                                  {:class tietorivi-luokka}
@@ -562,7 +569,14 @@ joita kutsutaan kun niiden näppäimiä paineetaan."
                                          (not (jata-kaventamatta otsikko)))
                                    {:style {:margin-bottom "0.5em"}}))
                 [:span.tietokentta (merge tietokentta-attrs rivin-attribuutit) otsikko]
-                [:span.tietoarvo.max-width-3 arvo]
+                ;; Jätetään "täyttöelementti" pois, jos otsikko vie koko rivin leveyden
+                (when-not (:koko-rivin-leveys? otsikko-meta)
+                  (if otsikot-omalla-rivilla?
+                    [:div]
+                    [:span {:style {:display "inline-block" :width "1em"}}]))
+                ;; Jätetään renderöimättä arvo, jos otsikko vie koko rivin leveyden
+                (when-not (:koko-rivin-leveys? otsikko-meta)
+                  [:span.tietoarvo.max-width-3 arvo])
                 (when (tyhja-rivi-otsikon-jalkeen otsikko)
                   [:span [:br] [:br]])]))))
        (partition 2 otsikot-ja-arvot))]))

--- a/src/cljs/harja/views/urakka/muutokset/kirjatut_muutokset.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/kirjatut_muutokset.cljs
@@ -30,7 +30,14 @@
         :rivin-luokka (fn [arvo _]
                         (let [rivin-id (:id arvo)
                               viimeksi-klikattu-id (-> app :viimeksi-valittu :id)]
-                          (when (= viimeksi-klikattu-id rivin-id) "viimeksi-valittu-tausta")))}
+                          (when (= viimeksi-klikattu-id rivin-id) "viimeksi-valittu-tausta")))
+        :rivi-jalkeen-fn (fn [rivit]
+                           (let [tavoitehinnan-muutokset (map :tavoitehinnan-muutos rivit)
+                                 tavoitehinnan-muutokset-yhteensa (apply + tavoitehinnan-muutokset)]
+                             [{:teksti "Hoitovuoden lopun tavoitehinnan muutokset yhteensä" :luokka "yhteensa" :sarakkeita 2}
+                              {:teksti "" :luokka "yhteensa" :leveys 8 :tasaa :oikea}
+                              {:teksti (fmt/euro-opt false true tavoitehinnan-muutokset-yhteensa) :luokka "yhteensa" :leveys 8 :tasaa :oikea}
+                              {:teksti "" :luokka "yhteensa" :leveys 8 :tasaa :oikea}]))}
 
        ;; Taulukon kentät
        [{:otsikko "Tyyppi"

--- a/src/cljs/harja/views/urakka/muutokset/kirjatut_muutokset.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/kirjatut_muutokset.cljs
@@ -16,7 +16,8 @@
    {:tunniste :id
     ;; Näytetään otsikko tyyliin: "2. hoitovuoden (01.10.2025 − 30.09.2026) kirjatut muutokset"
     :otsikko (str (fmt/hoitokauden-jarjestysluku-ja-alku-ja-loppupvm
-                    (pvm/vuosi (first valittu-hoitokausi)) (map (comp pvm/vuosi first) urakan-hoitokaudet) "hoitovuoden")
+                    (some-> valittu-hoitokausi (first) (pvm/vuosi))
+                    (map #(some-> % (first) (pvm/vuosi)) urakan-hoitokaudet) "hoitovuoden")
                " kirjatut muutokset")
     :luokat ["kirjatut-muutokset-grid"]
     :tyhja "Ei kirjattuja muutoksia."

--- a/src/cljs/harja/views/urakka/muutokset/kirjatut_muutokset.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/kirjatut_muutokset.cljs
@@ -88,8 +88,7 @@
                       (when (= viimeksi-klikattu-id rivin-id) "viimeksi-valittu-tausta")))
     :rivi-jalkeen-fn (fn [rivit]
                        (let [tavoitehinnan-muutokset-yhteensa (reduce + (map :tavoitehinnan-muutos rivit))
-                             ;; TODO: Tavoitehinnan muutokset indeksikorjattu yhteensä pitää toteuttaa
-                             tavoitehinnan-muutokset-indeksikorjattu-yht nil]
+                             tavoitehinnan-muutokset-indeksikorjattu-yht (reduce + (map :tavoitehinnan-muutos-indeksikorjattu rivit))]
                          [{:teksti "Hoitovuoden alun tavoitehinnan muutokset yhteensä" :luokka "yhteensa" :sarakkeita 2}
                           {:teksti (fmt/euro-opt false true tavoitehinnan-muutokset-yhteensa) :luokka "yhteensa" :leveys 8 :tasaa :oikea}
                           {:teksti (fmt/euro-opt false true tavoitehinnan-muutokset-indeksikorjattu-yht) :luokka "yhteensa" :leveys 8 :tasaa :oikea}

--- a/src/cljs/harja/views/urakka/muutokset/kirjatut_muutokset.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/kirjatut_muutokset.cljs
@@ -14,6 +14,7 @@
 (defn hoitovuoden-kirjatut-muutokset-grid [e! {:keys [kirjatut-muutokset valittu-hoitokausi urakan-hoitokaudet] :as app}]
   [grid/grid
    {:tunniste :id
+    ;; Näytetään otsikko tyyliin: "2. hoitovuoden (01.10.2025 − 30.09.2026) kirjatut muutokset"
     :otsikko (str (fmt/hoitokauden-jarjestysluku-ja-alku-ja-loppupvm
                     (pvm/vuosi (first valittu-hoitokausi)) (map (comp pvm/vuosi first) urakan-hoitokaudet) "hoitovuoden")
                " kirjatut muutokset")
@@ -70,8 +71,8 @@
                      #(e! (t-yhteiset/->MuokkaaMuutosta rivi))])}]
    kirjatut-muutokset])
 
-;; TODO: Toteuta loppuun
-(defn aiemmilta-hoitovuosilta-jatkuvat-pysyvat-muutokset-grid [e! {:keys [kirjatut-muutokset] :as app}]
+;; TODO: Toteuta loppuun ja testaa
+(defn aiemmilta-hoitovuosilta-jatkuvat-pysyvat-muutokset-grid [e! {:keys [aiempien-hoitovuosien-pysyvat-muutokset] :as app}]
   [grid/grid
    {:tunniste :id
     :otsikko "Aiemmilta hoitovuosilta jatkuvat pysyvät muutokset"
@@ -127,10 +128,9 @@
      :komponentti (fn [rivi]
                     [napit/muokkaa "Muokkaa"
                      #(e! (t-yhteiset/->MuokkaaMuutosta rivi))])}]
-   ;; TODO: Data
-   []])
+   aiempien-hoitovuosien-pysyvat-muutokset])
 
-(defn kirjatut-muutokset [e! {:keys [kirjatut-muutokset] :as app}]
+(defn kirjatut-muutokset [e! {:keys [kirjatut-muutokset aiempien-hoitovuosien-pysyvat-muutokset] :as app}]
   [yhteiset/kehystetty-avattava-grid e! app
    {:taulukon-avain :kirjatut-muutokset
     :taulukon-nakyvyys-event #(e! (t-yhteiset/->ToggleTaulukonNakyvyys :kirjatut-muutokset))

--- a/src/cljs/harja/views/urakka/muutokset/kirjatut_muutokset.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/kirjatut_muutokset.cljs
@@ -131,19 +131,17 @@
    []])
 
 (defn kirjatut-muutokset [e! {:keys [kirjatut-muutokset] :as app}]
-  [:<>
-   [debug/debug app]
-   [yhteiset/kehystetty-avattava-grid e! app
-    {:taulukon-avain :kirjatut-muutokset
-     :taulukon-nakyvyys-event #(e! (t-yhteiset/->ToggleTaulukonNakyvyys :kirjatut-muutokset))
-     :otsikko "Kirjatut muutokset"
-     :summa (reduce + 0 (map :tavoitehinnan-muutos kirjatut-muutokset))
-     :toiminnot-asetukset {:tasaa :oikea}
-     :toiminnot (fn [e! app]
-                  [napit/uusi "Lisää uusi" #(e! (t-yhteiset/->MuokkaaMuutosta {}))])
-     :taulukko
-     (fn [e! app]
-       [:<>
-        [hoitovuoden-kirjatut-muutokset-grid e! app]
-        ;; TODO: Toteuta pysyvien muutosten haku näkymään aiemmilta vuosilta
-        [aiemmilta-hoitovuosilta-jatkuvat-pysyvat-muutokset-grid e! app]])}]])
+  [yhteiset/kehystetty-avattava-grid e! app
+   {:taulukon-avain :kirjatut-muutokset
+    :taulukon-nakyvyys-event #(e! (t-yhteiset/->ToggleTaulukonNakyvyys :kirjatut-muutokset))
+    :otsikko "Kirjatut muutokset"
+    :summa (reduce + 0 (map :tavoitehinnan-muutos kirjatut-muutokset))
+    :toiminnot-asetukset {:tasaa :oikea}
+    :toiminnot (fn [e! app]
+                 [napit/uusi "Lisää uusi" #(e! (t-yhteiset/->MuokkaaMuutosta {}))])
+    :taulukko
+    (fn [e! app]
+      [:<>
+       [hoitovuoden-kirjatut-muutokset-grid e! app]
+       ;; TODO: Toteuta pysyvien muutosten haku näkymään aiemmilta vuosilta
+       [aiemmilta-hoitovuosilta-jatkuvat-pysyvat-muutokset-grid e! app]])}])

--- a/src/cljs/harja/views/urakka/muutokset/kirjatut_muutokset.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/kirjatut_muutokset.cljs
@@ -141,5 +141,4 @@
     (fn [e! app]
       [:<>
        [hoitovuoden-kirjatut-muutokset-grid e! app]
-       ;; TODO: Toteuta pysyvien muutosten haku näkymään aiemmilta vuosilta
        [aiemmilta-hoitovuosilta-jatkuvat-pysyvat-muutokset-grid e! app]])}])

--- a/src/cljs/harja/views/urakka/muutokset/kirjatut_muutokset.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/kirjatut_muutokset.cljs
@@ -56,7 +56,7 @@
     {:otsikko "Tavoitehinnan muutos (€)"
      :nimi :tavoitehinnan-muutos
      :tyyppi :numero
-     :fmt fmt/euro-opt
+     :fmt (partial fmt/euro-opt false true)
      :tasaa :oikea
      :leveys 15}
 
@@ -107,14 +107,14 @@
     {:otsikko "Tavoitehinnan muutos (€)"
      :nimi :tavoitehinnan-muutos
      :tyyppi :numero
-     :fmt fmt/euro-opt
+     :fmt (partial fmt/euro-opt false true)
      :tasaa :oikea
      :leveys 15}
 
     {:otsikko "Indeksikorjattu"
      :nimi :tavoitehinnan-muutos-indeksikorjattu
      :tyyppi :numero
-     :fmt fmt/euro-opt
+     :fmt (partial fmt/euro-opt false true)
      :tasaa :oikea
      :leveys 15}
 

--- a/src/cljs/harja/views/urakka/muutokset/kirjatut_muutokset.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/kirjatut_muutokset.cljs
@@ -1,6 +1,8 @@
 (ns harja.views.urakka.muutokset.kirjatut-muutokset
   "Muutokset välilehden 'Kirjatut muutokset' -osio"
   (:require [harja.fmt :as fmt]
+            [harja.pvm :as pvm]
+            [harja.ui.debug :as debug]
             [harja.ui.grid :as grid]
             [harja.ui.napit :as napit]
             [harja.tiedot.navigaatio :as nav]
@@ -9,67 +11,139 @@
             [harja.tiedot.urakka.muutokset.yhteiset-tiedot :as t-yhteiset]))
 
 
+(defn hoitovuoden-kirjatut-muutokset-grid [e! {:keys [kirjatut-muutokset valittu-hoitokausi urakan-hoitokaudet] :as app}]
+  [grid/grid
+   {:tunniste :id
+    :otsikko (str (fmt/hoitokauden-jarjestysluku-ja-alku-ja-loppupvm
+                    (pvm/vuosi (first valittu-hoitokausi)) (map (comp pvm/vuosi first) urakan-hoitokaudet) "hoitovuoden")
+               " kirjatut muutokset")
+    :luokat ["kirjatut-muutokset-grid"]
+    :tyhja "Ei kirjattuja muutoksia."
+    :voi-lisata? false
+    :voi-kumota? false
+    :voi-poistaa? (constantly false)
+    :voi-muokata? false
+    :rivin-luokka (fn [arvo _]
+                    (let [rivin-id (:id arvo)
+                          viimeksi-klikattu-id (-> app :viimeksi-valittu :id)]
+                      (when (= viimeksi-klikattu-id rivin-id) "viimeksi-valittu-tausta")))
+    :rivi-jalkeen-fn (fn [rivit]
+                       (let [tavoitehinnan-muutokset (map :tavoitehinnan-muutos rivit)
+                             tavoitehinnan-muutokset-yhteensa (apply + tavoitehinnan-muutokset)]
+                         [{:teksti "Hoitovuoden lopun tavoitehinnan muutokset yhteensä" :luokka "yhteensa" :sarakkeita 2}
+                          {:teksti "" :luokka "yhteensa" :leveys 8 :tasaa :oikea}
+                          {:teksti (fmt/euro-opt false true tavoitehinnan-muutokset-yhteensa) :luokka "yhteensa" :leveys 8 :tasaa :oikea}
+                          {:teksti "" :luokka "yhteensa" :leveys 8 :tasaa :oikea}]))}
+
+   ;; Taulukon kentät
+   [{:otsikko "Tyyppi"
+     :nimi :tyyppi
+     :tyyppi :string
+     :leveys 15
+     :fmt (fn [arvo]
+            (muutos-domain/tyyppi-fmt arvo (:sopimustyyppi @nav/valittu-urakka)))}
+
+    {:otsikko "Muutoksen syy"
+     :nimi :syy
+     :tyyppi :string
+     :leveys 35}
+
+    {:otsikko "Voimassa alkaen"
+     :nimi :voimassa_alkaen
+     :tyyppi :pvm
+     :leveys 15}
+
+    {:otsikko "Tavoitehinnan muutos (€)"
+     :nimi :tavoitehinnan-muutos
+     :tyyppi :numero
+     :fmt fmt/euro-opt
+     :tasaa :oikea
+     :leveys 15}
+
+    {:otsikko ""
+     :nimi :toiminnot
+     :tyyppi :komponentti
+     :leveys 10
+     :tasaa :oikea
+     :komponentti (fn [rivi]
+                    [napit/muokkaa "Muokkaa"
+                     #(e! (t-yhteiset/->MuokkaaMuutosta rivi))])}]
+   kirjatut-muutokset])
+
+;; TODO: Toteuta loppuun
+(defn aiemmilta-hoitovuosilta-jatkuvat-pysyvat-muutokset-grid [e! {:keys [kirjatut-muutokset] :as app}]
+  [grid/grid
+   {:tunniste :id
+    :otsikko "Aiemmilta hoitovuosilta jatkuvat pysyvät muutokset"
+    :luokat ["kirjatut-muutokset-grid"]
+    :tyhja "Ei muutoksia aiemmilta hoitovuosilta."
+    :voi-lisata? false
+    :voi-kumota? false
+    :voi-poistaa? (constantly false)
+    :voi-muokata? false
+    :rivin-luokka (fn [arvo _]
+                    (let [rivin-id (:id arvo)
+                          viimeksi-klikattu-id (-> app :viimeksi-valittu :id)]
+                      (when (= viimeksi-klikattu-id rivin-id) "viimeksi-valittu-tausta")))
+    :rivi-jalkeen-fn (fn [rivit]
+                       (let [tavoitehinnan-muutokset (map :tavoitehinnan-muutos rivit)
+                             tavoitehinnan-muutokset-yhteensa (apply + tavoitehinnan-muutokset)]
+                         [{:teksti "Hoitovuoden alun tavoitehinnan muutokset yhteensä" :luokka "yhteensa" :sarakkeita 2}
+                          ;; TODO:
+                          {:teksti (fmt/euro-opt false true tavoitehinnan-muutokset-yhteensa) :luokka "yhteensa" :leveys 8 :tasaa :oikea}
+                          {:teksti (fmt/euro-opt false true tavoitehinnan-muutokset-yhteensa) :luokka "yhteensa" :leveys 8 :tasaa :oikea}
+                          {:teksti "" :luokka "yhteensa" :leveys 8 :tasaa :oikea}]))}
+
+   ;; Taulukon kentät
+   [{:otsikko "Muutoksen syy"
+     :nimi :syy
+     :tyyppi :string
+     :leveys 40}
+
+    {:otsikko "Voimassa alkaen"
+     :nimi :voimassa_alkaen
+     :tyyppi :pvm
+     :leveys 15}
+
+    {:otsikko "Tavoitehinnan muutos (€)"
+     :nimi :tavoitehinnan-muutos
+     :tyyppi :numero
+     :fmt fmt/euro-opt
+     :tasaa :oikea
+     :leveys 15}
+
+    {:otsikko "Indeksikorjattu"
+     :nimi :tavoitehinnan-muutos-indeksikorjattu
+     :tyyppi :numero
+     :fmt fmt/euro-opt
+     :tasaa :oikea
+     :leveys 15}
+
+    {:otsikko ""
+     :nimi :toiminnot
+     :tyyppi :komponentti
+     :leveys 10
+     :tasaa :oikea
+     :komponentti (fn [rivi]
+                    [napit/muokkaa "Muokkaa"
+                     #(e! (t-yhteiset/->MuokkaaMuutosta rivi))])}]
+   ;; TODO: Data
+   []])
+
 (defn kirjatut-muutokset [e! {:keys [kirjatut-muutokset] :as app}]
-  [yhteiset/kehystetty-avattava-grid e! app
-   {:taulukon-avain :kirjatut-muutokset
-    :taulukon-nakyvyys-event #(e! (t-yhteiset/->ToggleTaulukonNakyvyys :kirjatut-muutokset))
-    :otsikko "Kirjatut muutokset"
-    :summa (reduce + 0 (map :tavoitehinnan-muutos kirjatut-muutokset))
-    :toiminnot (fn [e! app]
-                 [napit/uusi "Lisää uusi" #(e! (t-yhteiset/->MuokkaaMuutosta {}))])
-    :taulukko
-    (fn [e! app]
-      [grid/grid
-       {:tunniste :id
-        :luokat ["kirjatut-muutokset-grid"]
-        :tyhja "Ei kirjattuja muutoksia."
-        :voi-lisata? false
-        :voi-kumota? false
-        :voi-poistaa? (constantly false)
-        :voi-muokata? false
-        :rivin-luokka (fn [arvo _]
-                        (let [rivin-id (:id arvo)
-                              viimeksi-klikattu-id (-> app :viimeksi-valittu :id)]
-                          (when (= viimeksi-klikattu-id rivin-id) "viimeksi-valittu-tausta")))
-        :rivi-jalkeen-fn (fn [rivit]
-                           (let [tavoitehinnan-muutokset (map :tavoitehinnan-muutos rivit)
-                                 tavoitehinnan-muutokset-yhteensa (apply + tavoitehinnan-muutokset)]
-                             [{:teksti "Hoitovuoden lopun tavoitehinnan muutokset yhteensä" :luokka "yhteensa" :sarakkeita 2}
-                              {:teksti "" :luokka "yhteensa" :leveys 8 :tasaa :oikea}
-                              {:teksti (fmt/euro-opt false true tavoitehinnan-muutokset-yhteensa) :luokka "yhteensa" :leveys 8 :tasaa :oikea}
-                              {:teksti "" :luokka "yhteensa" :leveys 8 :tasaa :oikea}]))}
-
-       ;; Taulukon kentät
-       [{:otsikko "Tyyppi"
-         :nimi :tyyppi
-         :tyyppi :string
-         :leveys 15
-         :fmt (fn [arvo]
-                (muutos-domain/tyyppi-fmt arvo (:sopimustyyppi @nav/valittu-urakka)))}
-
-        {:otsikko "Muutoksen syy"
-         :nimi :syy
-         :tyyppi :string
-         :leveys 35}
-
-        {:otsikko "Voimassa alkaen"
-         :nimi :voimassa_alkaen
-         :tyyppi :pvm
-         :leveys 15}
-
-        {:otsikko "Tavoitehinnan muutos (€)"
-         :nimi :tavoitehinnan-muutos
-         :tyyppi :numero
-         :fmt fmt/euro-opt
-         :tasaa :oikea
-         :leveys 15}
-
-        {:otsikko ""
-         :nimi :toiminnot
-         :tyyppi :komponentti
-         :leveys 10
-         :tasaa :oikea
-         :komponentti (fn [rivi]
-                        [napit/muokkaa "Muokkaa"
-                         #(e! (t-yhteiset/->MuokkaaMuutosta rivi))])}]
-       kirjatut-muutokset])}])
+  [:<>
+   [debug/debug app]
+   [yhteiset/kehystetty-avattava-grid e! app
+    {:taulukon-avain :kirjatut-muutokset
+     :taulukon-nakyvyys-event #(e! (t-yhteiset/->ToggleTaulukonNakyvyys :kirjatut-muutokset))
+     :otsikko "Kirjatut muutokset"
+     :summa (reduce + 0 (map :tavoitehinnan-muutos kirjatut-muutokset))
+     :toiminnot-asetukset {:tasaa :oikea}
+     :toiminnot (fn [e! app]
+                  [napit/uusi "Lisää uusi" #(e! (t-yhteiset/->MuokkaaMuutosta {}))])
+     :taulukko
+     (fn [e! app]
+       [:<>
+        [hoitovuoden-kirjatut-muutokset-grid e! app]
+        ;; TODO: Toteuta pysyvien muutosten haku näkymään aiemmilta vuosilta
+        [aiemmilta-hoitovuosilta-jatkuvat-pysyvat-muutokset-grid e! app]])}]])

--- a/src/cljs/harja/views/urakka/muutokset/kirjatut_muutokset.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/kirjatut_muutokset.cljs
@@ -29,8 +29,7 @@
                           viimeksi-klikattu-id (-> app :viimeksi-valittu :id)]
                       (when (= viimeksi-klikattu-id rivin-id) "viimeksi-valittu-tausta")))
     :rivi-jalkeen-fn (fn [rivit]
-                       (let [tavoitehinnan-muutokset (map :tavoitehinnan-muutos rivit)
-                             tavoitehinnan-muutokset-yhteensa (apply + tavoitehinnan-muutokset)]
+                       (let [tavoitehinnan-muutokset-yhteensa (reduce + (map :tavoitehinnan-muutos rivit))]
                          [{:teksti "Hoitovuoden lopun tavoitehinnan muutokset yhteensä" :luokka "yhteensa" :sarakkeita 2}
                           {:teksti "" :luokka "yhteensa" :leveys 8 :tasaa :oikea}
                           {:teksti (fmt/euro-opt false true tavoitehinnan-muutokset-yhteensa) :luokka "yhteensa" :leveys 8 :tasaa :oikea}
@@ -87,8 +86,7 @@
                           viimeksi-klikattu-id (-> app :viimeksi-valittu :id)]
                       (when (= viimeksi-klikattu-id rivin-id) "viimeksi-valittu-tausta")))
     :rivi-jalkeen-fn (fn [rivit]
-                       (let [tavoitehinnan-muutokset (map :tavoitehinnan-muutos rivit)
-                             tavoitehinnan-muutokset-yhteensa (apply + tavoitehinnan-muutokset)]
+                       (let [tavoitehinnan-muutokset-yhteensa (reduce + (map :tavoitehinnan-muutos rivit))]
                          [{:teksti "Hoitovuoden alun tavoitehinnan muutokset yhteensä" :luokka "yhteensa" :sarakkeita 2}
                           ;; TODO:
                           {:teksti (fmt/euro-opt false true tavoitehinnan-muutokset-yhteensa) :luokka "yhteensa" :leveys 8 :tasaa :oikea}

--- a/src/cljs/harja/views/urakka/muutokset/kirjatut_muutokset.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/kirjatut_muutokset.cljs
@@ -86,11 +86,12 @@
                           viimeksi-klikattu-id (-> app :viimeksi-valittu :id)]
                       (when (= viimeksi-klikattu-id rivin-id) "viimeksi-valittu-tausta")))
     :rivi-jalkeen-fn (fn [rivit]
-                       (let [tavoitehinnan-muutokset-yhteensa (reduce + (map :tavoitehinnan-muutos rivit))]
+                       (let [tavoitehinnan-muutokset-yhteensa (reduce + (map :tavoitehinnan-muutos rivit))
+                             ;; TODO: Tavoitehinnan muutokset indeksikorjattu yhteensä pitää toteuttaa
+                             tavoitehinnan-muutokset-indeksikorjattu-yht nil]
                          [{:teksti "Hoitovuoden alun tavoitehinnan muutokset yhteensä" :luokka "yhteensa" :sarakkeita 2}
-                          ;; TODO:
                           {:teksti (fmt/euro-opt false true tavoitehinnan-muutokset-yhteensa) :luokka "yhteensa" :leveys 8 :tasaa :oikea}
-                          {:teksti (fmt/euro-opt false true tavoitehinnan-muutokset-yhteensa) :luokka "yhteensa" :leveys 8 :tasaa :oikea}
+                          {:teksti (fmt/euro-opt false true tavoitehinnan-muutokset-indeksikorjattu-yht) :luokka "yhteensa" :leveys 8 :tasaa :oikea}
                           {:teksti "" :luokka "yhteensa" :leveys 8 :tasaa :oikea}]))}
 
    ;; Taulukon kentät

--- a/src/cljs/harja/views/urakka/muutokset/lasketut_muutokset.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lasketut_muutokset.cljs
@@ -124,7 +124,14 @@
                     [ajax-loader-pieni "Haku käynnissä..."]
                     "Aikavälille ei löytynyt tuloksia.")
            :tallenna (fn [sisalto]
-                       (tuck-apurit/e-kanavalla! e! t-lasketut/->TallennaTehtavaMaaramuutokset sisalto))}
+                       (tuck-apurit/e-kanavalla! e! t-lasketut/->TallennaTehtavaMaaramuutokset sisalto))
+           :rivi-jalkeen-fn (fn [rivit]
+                              (let [tavoitehinnan-muutokset (map :tavoitehinnan_muutos rivit)
+                                    tavoitehinnan-muutokset-yhteensa (apply + tavoitehinnan-muutokset)]
+                                [{:teksti "Tavoitehinnan muutokset yhteensä" :luokka "yhteensa" :sarakkeita 7}
+                                 {:teksti "" :luokka "yhteensa" :leveys 8 :tasaa :oikea}
+                                 {:teksti (fmt/euro-opt false true tavoitehinnan-muutokset-yhteensa) :luokka "yhteensa" :leveys 8 :tasaa :oikea}
+                                 {:teksti "" :luokka "yhteensa" :leveys 8 :tasaa :oikea}]))}
 
           [{:otsikko "Tehtävä"
             :nimi :tehtava

--- a/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
@@ -71,7 +71,8 @@
          ^{:key (str valittu-hoitovuoden-alkuvuosi "_"
                   ;; Älä seuraa koko vektorin sisältöä, vaan counttia, jotta ei jatkuvasti renderöidä uudelleen
                   ;; input-kenttien muuttuessa
-                  (count tehtavat-ja-maarat-valittuna-hoitovuonna))}
+                  (count tehtavat-ja-maarat-valittuna-hoitovuonna) "_"
+                  voi-muokata?)}
          [grid/grid
           {:luokat ["vaikutus-tehtaviin-grid"]
            :tunniste :tehtava
@@ -104,6 +105,7 @@
           [{:otsikko "Tehtävä"
             :nimi :tehtava
             :tyyppi :valinta
+            :muokattava? (constantly voi-muokata?)
             ;; Varmistetaan, että useammalle riville ei voi valita samaa tehtävää
             :valinnat-fn (fn [rivi]
                            (let [valittu-tehtava (:tehtava rivi)
@@ -148,6 +150,7 @@
            {:otsikko "Määrämuutos (+/-)"
             :nimi :maaramuutos
             :tyyppi :numero
+            :muokattava? (constantly voi-muokata?)
             :leveys 20}
 
            {:otsikko "Muuttunut määrä"
@@ -171,7 +174,8 @@
                                    valittu-hoitovuoden-alkuvuosi
                                    true))
                             {:ikoni (ikonit/livicon-trash)
-                             :luokka "nappi-toissijainen"}])}]
+                             :luokka "nappi-toissijainen"
+                             :disabled (not voi-muokata?)}])}]
           tehtavat-ja-maarat-valittuna-hoitovuonna]
 
          [:h4 "Vaikutus tavoitehintaan"]

--- a/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
@@ -306,29 +306,20 @@
                        "Pysyvä muutos vaikuttaa kaikkiin tuleviin hoitovuosiin."]])}
 
      (lomake/ryhma {:otsikko "Perustiedot"}
-       {:nimi :nimi
-        :otsikko "Nimi"
-        :tyyppi :string
-        :uusi-rivi? true
-        :pakollinen? true
-        :validoi [#(when (nil? (seq %)) "Kirjoita nimi")]
-        ::lomake/col-luokka "perustiedot col-sm-6"}
+       ;; TODO: Tarkista täytyykö nimi olla pakollinen pysyvälle muutokselle.
+       ;;       Speksissä muutokselle on vain syy ja voimassa alkaen.
+       #_{:nimi :nimi
+          :otsikko "Nimi"
+          :tyyppi :string
+          :uusi-rivi? true
+          :pakollinen? true
+          :validoi [#(when (nil? (seq %)) "Kirjoita nimi")]
+          ::lomake/col-luokka "perustiedot col-sm-6"}
 
        (yhteiset/+rivi-muutoksen-syy+)
-       (yhteiset/+rivi-muutos-voimassa+ urakan-hoitokaudet))
+       (yhteiset/+rivi-muutos-voimassa+ urakan-hoitokaudet)
 
-     (lomake/ryhma {:otsikko "Vaikutus tavoitehintaan ja suunniteltuihin tehtäviin"}
-
-       {:otsikko "Hoitovuosi"
-        :nimi :hoitovuosi
-        :kaariva-luokka "hoitovuosi-valinta"
-        :tyyppi :valinta
-        :valinnat (or (:mahdolliset-hoitovuodet-lomakkeella muokattava-muutos) [])
-        :valinta-nayta #(if %
-                          (fmt/hoitokauden-jarjestysluku-ja-vuodet % urakan-hoitokaudet "Hoitovuosi")
-                          "Valitse")
-        :valinta-arvo identity}
-
+       ;; -- Info-laatikot --
        (when (muutos-domain/muutos-voimassa-kesken-hoitokauden? voimassa-alkaen hoitovuosi)
          {:tyyppi :komponentti
           :uusi-rivi? true
@@ -341,6 +332,32 @@
                             [:ul
                              [:li "Ensimmäisen hoitovuoden tavoitehinnan muutos lisätään hoitovuoden lopun tavoitehintaan ilman indeksikorjausta."]
                              [:li "Seuraavien hoitovuosien osalta tavoitehinnan muutokset siirtyvät automaattisesti Hoitovuoden alun tavoitehinta -välilehdelle indeksikorjattavaksi."]]]]])})
+
+
+       ;; -- Liitekenttä --
+       (first (yhteiset/liite-kentta e! app)))
+
+     ;; --
+
+     ;; Jakaja
+     {:tyyppi :komponentti
+      :uusi-rivi? true
+      :komponentti (fn [_rivi]
+                     [:hr])}
+
+     ;; --
+
+     ;; -- Vaikutukset tavoitehintaan ja suunniteltuihin tehtäviin --
+     (lomake/ryhma {:otsikko "Vaikutus tavoitehintaan ja suunniteltuihin tehtäviin"}
+       {:otsikko "Hoitovuosi"
+        :nimi :hoitovuosi
+        :kaariva-luokka "hoitovuosi-valinta"
+        :tyyppi :valinta
+        :valinnat (or (:mahdolliset-hoitovuodet-lomakkeella muokattava-muutos) [])
+        :valinta-nayta #(if %
+                          (fmt/hoitokauden-jarjestysluku-ja-vuodet % urakan-hoitokaudet "Hoitovuosi")
+                          "Valitse")
+        :valinta-arvo identity}
 
        ;; Taulukko jossa vaikutuksia voidaan syöttää
        (if hoitovuosi
@@ -355,6 +372,4 @@
           :komponentti (fn [_rivi]
                          [:div.perustiedot
                           [yleiset/info-laatikko :neutraali
-                           "Valitse hoitovuosi, jotta voit tehdä pysyvän muutoksen."]])}))
-
-     (first (yhteiset/liite-kentta e! app))]))
+                           "Valitse hoitovuosi, jotta voit tehdä pysyvän muutoksen."]])}))]))

--- a/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
@@ -1,19 +1,21 @@
 (ns harja.views.urakka.muutokset.lomake.lomake-pysyva
   "Muutokset välilehden lomakkeet - Pysyvä muutos"
-  (:require [harja.domain.muutos-domain :as muutos-domain]
-            [reagent.core :as r]
+  (:require
+    [reagent.core :as r]
+    [harja.fmt :as fmt]
+    [harja.pvm :as pvm]
+    [harja.ui.grid :as grid]
+    [harja.ui.napit :as napit]
+    [harja.ui.lomake :as lomake]
+    [harja.ui.ikonit :as ikonit]
+    [harja.ui.kentat :as kentat]
 
-            [harja.fmt :as fmt]
-            [harja.pvm :as pvm]
-            [harja.ui.grid :as grid]
-            [harja.ui.napit :as napit]
-            [harja.ui.lomake :as lomake]
-            [harja.ui.ikonit :as ikonit]
-            [harja.ui.kentat :as kentat]
-            [harja.ui.debug :refer [debug]]
-            [harja.views.urakka.muutokset.yhteiset :as yhteiset]
-            [harja.tiedot.urakka.muutokset.kirjatut-muutokset-tiedot :as t-kirjatut]
-            [harja.ui.yleiset :as yleiset]))
+    [harja.ui.debug :refer [debug]]
+    [harja.domain.muutos-domain :as muutos-domain]
+    [harja.views.urakka.muutokset.yhteiset :as yhteiset]
+    [harja.tiedot.urakka.muutokset.yhteiset-tiedot :as t-yhteiset]
+    [harja.tiedot.urakka.muutokset.kirjatut-muutokset-tiedot :as t-kirjatut]
+    [harja.ui.yleiset :as yleiset]))
 
 (defn- uusi-tehtava-id [tehtavat-ja-maarat-valittuna-hoitovuonna]
   (dec (apply min
@@ -313,9 +315,7 @@
 
   (let [voimassa-alkaen (:voimassa_alkaen muokattava-muutos)
         hoitovuosi (:hoitovuosi muokattava-muutos)
-        indeksikorjatut-hoitovuodet (:urakan-tavoitehinnat-indeksikorjattu budjettitavoitteet)
-        hoitokauden-alkuvuosi (some-> hoitovuosi (first) (pvm/vuosi))
-        indeksikorjaus-vahvistettu? (get indeksikorjatut-hoitovuodet hoitokauden-alkuvuosi false)]
+        indeksikorjaus-vahvistettu? (t-yhteiset/hoitovuoden-indeksikorjaus-vahvistettu? budjettitavoitteet hoitovuosi)]
     [{:tyyppi :komponentti
       :uusi-rivi? true
       :komponentti (fn [_rivi]
@@ -374,7 +374,13 @@
                          [:div.perustiedot
                           [yleiset/info-laatikko :vahva-ilmoitus
                            "Hoitovuoden alun tavoitehinta on vahvistettu"
-                           "Pysyvän muutoksen tallentaminen peruu vahvistuksen. Vahvista tiedot uudelleen tallentamisen jälkeen."
+                           [:<>
+                            [:div "Voit perua vahvistuksen lisätäksesi hoitovuodelle pysyvän muutoksen." [:br]
+                             "Muista vahvistaa hoitovuoden tavoitehinta muutoksen tallentamisen jälkeen."]
+                            [:br]
+                            [:div [napit/yleinen-toissijainen "Peru vahvistus"
+                                   #(e! (t-kirjatut/->PeruutaTavoiteJaKattohinta
+                                          (pvm/vuosi (first (:hoitovuosi muokattava-muutos)))))]]]
                            nil
                            {:ikoni-fn #(ikonit/harja-icon-status-alert)}]])})
 

--- a/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
@@ -312,7 +312,10 @@
   [e! {:keys [urakan-hoitokaudet muokattava-muutos budjettitavoitteet] :as app}]
 
   (let [voimassa-alkaen (:voimassa_alkaen muokattava-muutos)
-        hoitovuosi (:hoitovuosi muokattava-muutos)]
+        hoitovuosi (:hoitovuosi muokattava-muutos)
+        indeksikorjatut-hoitovuodet (:urakan-tavoitehinnat-indeksikorjattu budjettitavoitteet)
+        hoitokauden-alkuvuosi (some-> hoitovuosi (first) (pvm/vuosi))
+        indeksikorjaus-vahvistettu? (get indeksikorjatut-hoitovuodet hoitokauden-alkuvuosi false)]
     [{:tyyppi :komponentti
       :uusi-rivi? true
       :komponentti (fn [_rivi]
@@ -364,7 +367,7 @@
                           "Valitse")
         :valinta-arvo identity}
 
-       (when (:indeksikorjaus-vahvistettu? budjettitavoitteet)
+       (when indeksikorjaus-vahvistettu?
          {:uusi-rivi? true
           :tyyppi :komponentti
           :komponentti (fn [_]

--- a/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
@@ -290,7 +290,9 @@
 
      ;; Header vihje sekä nappi
      [:div.pysyvan-muutoksen-grid-header
-      [yleiset/vihje "Valitse toimenpiteet, joita muutos koskee."]
+      (if voi-muokata?
+        [yleiset/vihje "Valitse toimenpiteet, joita muutos koskee."]
+        [yleiset/vihje "Hoitovuoden tietoja ei voi muokata. Voimassa alkaen-päivämäärä ei ole valitulla hoitovuodella."])
 
       [napit/nappi "Kopioi tiedot tuleville hoitovuosille"
        #(e! (t-kirjatut/->KopioiHoitovuodenMuutoksetTulevilleHoitovuosille

--- a/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
@@ -23,7 +23,7 @@
 
 (defn- hae-elementti-hoitokauden-alkuvuodella
   [hoitovuosi sekvenssi]
-  (let [alkuvuosi (when hoitovuosi (pvm/vuosi (first hoitovuosi)))]
+  (let [alkuvuosi (some-> hoitovuosi (first) (pvm/vuosi))]
     (some #(when (= alkuvuosi (:hoitokauden_alkuvuosi %)) %) sekvenssi)))
 
 (defn- hae-tehtavan-suunniteltu-maara
@@ -44,7 +44,7 @@
   (let [g (grid/grid-ohjaus)]
     (fn [e! urakan-hoitokaudet {:keys [toimenpideinstanssi kustannusvaikutukset tehtavat_ja_maarat toimenpidekoodi] :as rivi}
          {:keys [hoitovuosi toimenpiteiden-tehtavat] :as muokattava-muutos} voi-muokata?]
-      (let [valittu-hoitovuoden-alkuvuosi (pvm/vuosi (first (:hoitovuosi muokattava-muutos)))
+      (let [valittu-hoitovuoden-alkuvuosi (some-> (:hoitovuosi muokattava-muutos) (first) (pvm/vuosi))
             tehtavat-ja-maarat-valittuna-hoitovuonna (filter #(= valittu-hoitovuoden-alkuvuosi
                                                                 (:hoitokauden_alkuvuosi %))
                                                        (:tehtavat_ja_maarat rivi))
@@ -188,7 +188,7 @@
             (fn [summa]
               (e! (t-kirjatut/->PaivitaToimenpiteenTavoitehinnanMuutos
                     (:toimenpideinstanssi rivi)
-                    (pvm/vuosi (first (:hoitovuosi muokattava-muutos)))
+                    (some-> (:hoitovuosi muokattava-muutos) (first) (pvm/vuosi))
                     summa))))]]))))
 
 (defn- grid-pysyvan-muutoksen-vaikutukset*
@@ -305,7 +305,7 @@
 
       [napit/nappi "Kopioi tiedot tuleville hoitovuosille"
        #(e! (t-kirjatut/->KopioiHoitovuodenMuutoksetTulevilleHoitovuosille
-              (pvm/vuosi (first (:hoitovuosi muokattava-muutos)))
+              (some-> (:hoitovuosi muokattava-muutos) (first) (pvm/vuosi))
               (:mahdolliset-hoitovuodet-lomakkeella muokattava-muutos)))
        {:ikoni (ikonit/action-copy)
         ;; Disabloi nappi, koska toiminnallisuus ei ole vielä toteutettu
@@ -391,7 +391,7 @@
                             [:br]
                             [:div [napit/yleinen-toissijainen "Peru vahvistus"
                                    #(e! (t-kirjatut/->PeruutaTavoiteJaKattohinta
-                                          (pvm/vuosi (first (:hoitovuosi muokattava-muutos)))))]]]
+                                          (some-> (:hoitovuosi muokattava-muutos) (first) (pvm/vuosi))))]]]
                            nil
                            {:ikoni-fn #(ikonit/harja-icon-status-alert)}]])})
 

--- a/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
@@ -273,7 +273,7 @@
                               (:toimenpiteiden-tiedot muokattava-muutos)))]
     [:div.toimenpiteiden-tiedot
      ;; Näytä debug-info kehittäjille
-     [debug muokattava-muutos]
+     #_[debug muokattava-muutos]
 
      ;; Header vihje sekä nappi
      [:div.pysyvan-muutoksen-grid-header

--- a/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
@@ -251,7 +251,7 @@
        :nimi :muuttunut-kustannus
        :vaadi-ei-negatiivinen? true
        :tyyppi :numero
-       :fmt fmt/euro-opt
+       :fmt (partial fmt/euro-opt false false)
        :tasaa :oikea
        :leveys 8
        :hae (fn [rivi]
@@ -309,7 +309,7 @@
 
 (defn lomake-pysyva
   "Pysyvän muutoksen lomakekomponentti"
-  [e! {:keys [urakan-hoitokaudet muokattava-muutos] :as app}]
+  [e! {:keys [urakan-hoitokaudet muokattava-muutos budjettitavoitteet] :as app}]
 
   (let [voimassa-alkaen (:voimassa_alkaen muokattava-muutos)
         hoitovuosi (:hoitovuosi muokattava-muutos)]
@@ -363,6 +363,17 @@
                           (fmt/hoitokauden-jarjestysluku-ja-vuodet % urakan-hoitokaudet "Hoitovuosi")
                           "Valitse")
         :valinta-arvo identity}
+
+       (when (:indeksikorjaus-vahvistettu? budjettitavoitteet)
+         {:uusi-rivi? true
+          :tyyppi :komponentti
+          :komponentti (fn [_]
+                         [:div.perustiedot
+                          [yleiset/info-laatikko :vahva-ilmoitus
+                           "Hoitovuoden alun tavoitehinta on vahvistettu"
+                           "Pysyvän muutoksen tallentaminen peruu vahvistuksen. Vahvista tiedot uudelleen tallentamisen jälkeen."
+                           nil
+                           {:ikoni-fn #(ikonit/harja-icon-status-alert)}]])})
 
        ;; Taulukko jossa vaikutuksia voidaan syöttää
        (if hoitovuosi

--- a/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
@@ -321,16 +321,6 @@
                        "Pysyvä muutos vaikuttaa kaikkiin tuleviin hoitovuosiin."]])}
 
      (lomake/ryhma {:otsikko "Perustiedot"}
-       ;; TODO: Tarkista täytyykö nimi olla pakollinen pysyvälle muutokselle.
-       ;;       Speksissä muutokselle on vain syy ja voimassa alkaen.
-       #_{:nimi :nimi
-          :otsikko "Nimi"
-          :tyyppi :string
-          :uusi-rivi? true
-          :pakollinen? true
-          :validoi [#(when (nil? (seq %)) "Kirjoita nimi")]
-          ::lomake/col-luokka "perustiedot col-sm-6"}
-
        (yhteiset/+rivi-muutoksen-syy+)
        (yhteiset/+rivi-muutos-voimassa+ urakan-hoitokaudet)
 

--- a/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
@@ -264,13 +264,17 @@
      toimenpiteiden-tiedot]))
 
 (defn taulukko-pysyvan-muutoksen-vaikutukset
-  [e! {:keys [urakan-hoitokaudet muokattava-muutos] :as app}]
+  [e! {:keys [urakan-hoitokaudet muokattava-muutos budjettitavoitteet] :as app}]
   (let [hoitovuosi (:hoitovuosi muokattava-muutos)
         voimassa-alkaen (:voimassa_alkaen muokattava-muutos)
-        ;; Voi muokata, jos "voimassa alkaen" osuu johonkin hoitovuoteen tai hoitovuosi on sen jälkeen
-        voi-muokata? (or
-                       (muutos-domain/muutos-voimassa-kesken-hoitokauden? voimassa-alkaen hoitovuosi)
-                       (pvm/jalkeen? (second hoitovuosi) voimassa-alkaen))
+        indeksikorjaus-vahvistettu? (t-yhteiset/hoitovuoden-indeksikorjaus-vahvistettu? budjettitavoitteet hoitovuosi)
+        voi-muokata? (and
+                       ;; Voi muokata, jos "voimassa alkaen" osuu johonkin hoitovuoteen tai hoitovuosi on sen jälkeen
+                       (or
+                         (muutos-domain/muutos-voimassa-kesken-hoitokauden? voimassa-alkaen hoitovuosi)
+                         (pvm/jalkeen? (second hoitovuosi) voimassa-alkaen))
+                       ;; Voi muokata, jos tavoitehinnan indeksikorjaus ei ole vielä vahvistettu hoitovuodelle
+                       (not indeksikorjaus-vahvistettu?))
         vetolaatikkorivit (into {}
                             (map (juxt :toimenpideinstanssi
                                    (fn [rivi]
@@ -294,7 +298,10 @@
      [:div.pysyvan-muutoksen-grid-header
       (if voi-muokata?
         [yleiset/vihje "Valitse toimenpiteet, joita muutos koskee."]
-        [yleiset/vihje "Hoitovuoden tietoja ei voi muokata. Voimassa alkaen-päivämäärä ei ole valitulla hoitovuodella."])
+        [yleiset/vihje (str "Hoitovuoden tietoja ei voi muokata. "
+                         (if indeksikorjaus-vahvistettu?
+                           "Hoitovuoden alun tavoitehinta on jo vahvistettu."
+                           "Voimassa alkaen-päivämäärä ei ole valitulla hoitovuodella."))])
 
       [napit/nappi "Kopioi tiedot tuleville hoitovuosille"
        #(e! (t-kirjatut/->KopioiHoitovuodenMuutoksetTulevilleHoitovuosille

--- a/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
@@ -345,8 +345,12 @@
                             [:p [:b "Muutoksen voimassaolo alkaa kesken hoitovuoden"]]
                             [:div "Kun tallennat tiedot, ne käsitellään seuraavasti:"]
                             [:ul
-                             [:li "Ensimmäisen hoitovuoden tavoitehinnan muutos lisätään hoitovuoden lopun tavoitehintaan ilman indeksikorjausta."]
-                             [:li "Seuraavien hoitovuosien osalta tavoitehinnan muutokset siirtyvät automaattisesti Hoitovuoden alun tavoitehinta -välilehdelle indeksikorjattavaksi."]]]]])})
+                             [:li
+                              "Ensimmäisen hoitovuoden tavoitehinnan muutos lisätään hoitovuoden lopun "
+                              "tavoitehintaan ilman indeksikorjausta."]
+                             [:li
+                              "Seuraavien hoitovuosien osalta tavoitehinnan muutokset siirtyvät automaattisesti "
+                              "Hoitovuoden alun tavoitehinta -välilehdelle indeksikorjattavaksi."]]]]])})
 
 
        ;; -- Liitekenttä --

--- a/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
@@ -1,6 +1,7 @@
 (ns harja.views.urakka.muutokset.lomake.lomake-pysyva
   "Muutokset välilehden lomakkeet - Pysyvä muutos"
-  (:require [reagent.core :as r]
+  (:require [harja.domain.muutos-domain :as muutos-domain]
+            [reagent.core :as r]
 
             [harja.fmt :as fmt]
             [harja.pvm :as pvm]
@@ -21,10 +22,10 @@
 (defn- pysyvan-muutoksen-vetolaatikko
   "Piirtää jatkuvan muutoksen taulukkoon vetolaatikon, jolla hallitaan kustannus- ja tehtävämuutoksia."
   [e! urakan-hoitokaudet {:keys [toimenpideinstanssi kustannusvaikutukset tehtavat_ja_maarat toimenpidekoodi] :as rivi}
-   {:keys [hoitovuosi toimenpiteiden-tehtavat] :as muokattava-muutos}]
+   {:keys [hoitovuosi toimenpiteiden-tehtavat] :as muokattava-muutos} voi-muokata?]
   (let [g (grid/grid-ohjaus)]
     (fn [e! urakan-hoitokaudet {:keys [toimenpideinstanssi kustannusvaikutukset tehtavat_ja_maarat toimenpidekoodi] :as rivi}
-         {:keys [hoitovuosi toimenpiteiden-tehtavat] :as muokattava-muutos}]
+         {:keys [hoitovuosi toimenpiteiden-tehtavat] :as muokattava-muutos} voi-muokata?]
       (let [valittu-hoitovuoden-alkuvuosi (pvm/vuosi (first (:hoitovuosi muokattava-muutos)))
             tehtavat-ja-maarat-valittuna-hoitovuonna (filter #(= valittu-hoitovuoden-alkuvuosi
                                                                 (:hoitokauden_alkuvuosi %))
@@ -58,9 +59,9 @@
            :tunniste :tehtava
            :tyhja "Ei tietoja"
            :muokkaa-aina true
-           :voi-lisata? true
+           :voi-lisata? voi-muokata?
            :voi-kumota? false
-           :voi-muokata? true
+           :voi-muokata? voi-muokata?
            ;; Otetaan gridin oma poisto-toiminto käytöstä, koska tehdään se erikseen kustomoidulla napilla
            :voi-poistaa? (constantly false)
            :ohjaus g
@@ -158,7 +159,9 @@
           "Tavoitehinnan muutos euroina (+/-)"]
          [kentat/tee-kentta {:elementin-id (str "tavoitehintainput-" (:toimenpideinstanssi rivi))
                              :tyyppi :numero :fmt fmt/euro-opt
-                             :pakollinen? true :input-luokka "tavoitehinnan-muutos-input"
+                             :disabled? (not voi-muokata?)
+                             :pakollinen? true
+                             :input-luokka "tavoitehinnan-muutos-input"
                              :placeholder "Syötä hintavaikutus"}
           (r/wrap muutos-valittuna-hoitovuonna
             (fn [summa]
@@ -239,7 +242,13 @@
 
 (defn taulukko-pysyvan-muutoksen-vaikutukset
   [e! {:keys [urakan-hoitokaudet muokattava-muutos] :as app}]
-  (let [vetolaatikkorivit (into {}
+  (let [hoitovuosi (:hoitovuosi muokattava-muutos)
+        voimassa-alkaen (:voimassa_alkaen muokattava-muutos)
+        ;; Voi muokata, jos "voimassa alkaen" osuu johonkin hoitovuoteen tai hoitovuosi on sen jälkeen
+        voi-muokata? (or
+                       (muutos-domain/muutos-voimassa-kesken-hoitokauden? voimassa-alkaen hoitovuosi)
+                       (pvm/jalkeen? (second hoitovuosi) voimassa-alkaen))
+        vetolaatikkorivit (into {}
                             (map (juxt :toimenpideinstanssi
                                    (fn [rivi]
                                      [pysyvan-muutoksen-vetolaatikko e!
@@ -249,7 +258,8 @@
                                                          :toimenpidekoodi
                                                          :kustannusvaikutukset
                                                          :tehtavat_ja_maarat])
-                                      (select-keys muokattava-muutos [:hoitovuosi :toimenpiteiden-tehtavat :tehtavat_ja_maarat])]
+                                      (select-keys muokattava-muutos [:hoitovuosi :toimenpiteiden-tehtavat :tehtavat_ja_maarat])
+                                      voi-muokata?]
 
                                      #_[pysyvan-muutoksen-vetolaatikko-old e! app rivi]))
                               (:toimenpiteiden-tiedot muokattava-muutos)))]
@@ -267,7 +277,7 @@
               (:mahdolliset-hoitovuodet-lomakkeella muokattava-muutos)))
        {:ikoni (ikonit/action-copy)
         ;; Disabloi nappi, koska toiminnallisuus ei ole vielä toteutettu
-        :disabled false
+        :disabled (not voi-muokata?)
         :luokka "nappi-toissijainen pysyvan-muutoksen-kopiointinappi"}]]
 
      [grid-pysyvan-muutoksen-vaikutukset*
@@ -278,53 +288,65 @@
   "Pysyvän muutoksen lomakekomponentti"
   [e! {:keys [urakan-hoitokaudet muokattava-muutos] :as app}]
 
-  [{:tyyppi :komponentti
-    :uusi-rivi? true
-    :komponentti (fn [_rivi]
-                   [:div.perustiedot
-                    [yleiset/info-laatikko :neutraali
-                     "Pysyvä muutos vaikuttaa kaikkiin tuleviin hoitovuosiin."]])}
-
-   (lomake/ryhma {:otsikko "Perustiedot"}
-     {:nimi :nimi
-      :otsikko "Nimi"
-      :tyyppi :string
+  (let [voimassa-alkaen (:voimassa_alkaen muokattava-muutos)
+        hoitovuosi (:hoitovuosi muokattava-muutos)]
+    [{:tyyppi :komponentti
       :uusi-rivi? true
-      :pakollinen? true
-      :validoi [#(when (nil? (seq %)) "Kirjoita nimi")]
-      ::lomake/col-luokka "perustiedot col-sm-6"}
+      :komponentti (fn [_rivi]
+                     [:div.perustiedot
+                      [yleiset/info-laatikko :neutraali
+                       "Pysyvä muutos vaikuttaa kaikkiin tuleviin hoitovuosiin."]])}
 
-     (yhteiset/+rivi-muutoksen-syy+)
-     (yhteiset/+rivi-muutos-voimassa+ urakan-hoitokaudet true))
-
-   (lomake/ryhma {:otsikko "Vaikutus tavoitehintaan ja suunniteltuihin tehtäviin"}
-
-     {:otsikko "Hoitovuosi"
-      :nimi :hoitovuosi
-      :kaariva-luokka "hoitovuosi-valinta"
-      :tarkenne #(str
-                   "Oltava lomakkeelle asetetun "
-                   "'Voimassa alkaen' -pvm:n jälkeen")
-      :tyyppi :valinta
-      :valinnat (or (:mahdolliset-hoitovuodet-lomakkeella muokattava-muutos) [])
-      :valinta-nayta #(if %
-                        (fmt/hoitokauden-jarjestysluku-ja-vuodet % urakan-hoitokaudet "Hoitovuosi")
-                        "Valitse")
-      :valinta-arvo identity}
-
-     ;; Taulukko jossa vaikutuksia voidaan syöttää
-     (if (:hoitovuosi muokattava-muutos)
-       {:otsikko ""
+     (lomake/ryhma {:otsikko "Perustiedot"}
+       {:nimi :nimi
+        :otsikko "Nimi"
+        :tyyppi :string
         :uusi-rivi? true
-        :nimi :taulukko-pysyvan-muutoksen-vaikutukset
-        :tyyppi :komponentti
-        :komponentti (fn [rivi]
-                       [taulukko-pysyvan-muutoksen-vaikutukset e! app])}
-       {:tyyppi :komponentti
-        :uusi-rivi? true
-        :komponentti (fn [_rivi]
-                       [:div.perustiedot
-                        [yleiset/info-laatikko :neutraali
-                         "Valitse hoitokausi, jotta voit tehdä pysyvän muutoksen."]])}))
+        :pakollinen? true
+        :validoi [#(when (nil? (seq %)) "Kirjoita nimi")]
+        ::lomake/col-luokka "perustiedot col-sm-6"}
 
-   (first (yhteiset/liite-kentta e! app))])
+       (yhteiset/+rivi-muutoksen-syy+)
+       (yhteiset/+rivi-muutos-voimassa+ urakan-hoitokaudet))
+
+     (lomake/ryhma {:otsikko "Vaikutus tavoitehintaan ja suunniteltuihin tehtäviin"}
+
+       {:otsikko "Hoitovuosi"
+        :nimi :hoitovuosi
+        :kaariva-luokka "hoitovuosi-valinta"
+        :tyyppi :valinta
+        :valinnat (or (:mahdolliset-hoitovuodet-lomakkeella muokattava-muutos) [])
+        :valinta-nayta #(if %
+                          (fmt/hoitokauden-jarjestysluku-ja-vuodet % urakan-hoitokaudet "Hoitovuosi")
+                          "Valitse")
+        :valinta-arvo identity}
+
+       (when (muutos-domain/muutos-voimassa-kesken-hoitokauden? voimassa-alkaen hoitovuosi)
+         {:tyyppi :komponentti
+          :uusi-rivi? true
+          :komponentti (fn [_rivi]
+                         [:div.perustiedot
+                          [yleiset/info-laatikko :neutraali
+                           [:<>
+                            [:p [:b "Muutoksen voimassaolo alkaa kesken hoitovuoden"]]
+                            [:div "Kun tallennat tiedot, ne käsitellään seuraavasti:"]
+                            [:ul
+                             [:li "Ensimmäisen hoitovuoden tavoitehinnan muutos lisätään hoitovuoden lopun tavoitehintaan ilman indeksikorjausta."]
+                             [:li "Seuraavien hoitovuosien osalta tavoitehinnan muutokset siirtyvät automaattisesti Hoitovuoden alun tavoitehinta -välilehdelle indeksikorjattavaksi."]]]]])})
+
+       ;; Taulukko jossa vaikutuksia voidaan syöttää
+       (if hoitovuosi
+         {:otsikko ""
+          :uusi-rivi? true
+          :nimi :taulukko-pysyvan-muutoksen-vaikutukset
+          :tyyppi :komponentti
+          :komponentti (fn [rivi]
+                         [taulukko-pysyvan-muutoksen-vaikutukset e! app])}
+         {:tyyppi :komponentti
+          :uusi-rivi? true
+          :komponentti (fn [_rivi]
+                         [:div.perustiedot
+                          [yleiset/info-laatikko :neutraali
+                           "Valitse hoitovuosi, jotta voit tehdä pysyvän muutoksen."]])}))
+
+     (first (yhteiset/liite-kentta e! app))]))

--- a/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
@@ -189,7 +189,6 @@
       :voi-poistaa? (constantly false)
       :voi-muokata? true
       :rivi-jalkeen-fn (fn [rivit]
-                         (prn rivit)
                          (let [tavoitehinnan-muutokset (map (fn [rivi]
                                                               (or (some->
                                                                     (hae-elementti-hoitokauden-alkuvuodella

--- a/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
@@ -125,7 +125,7 @@
             :muokattava? (constantly false)}
 
            {:otsikko "Suunniteltu määrä"
-            :nimi :edellinen_maara
+            :nimi :suunniteltu_maara
             :tyyppi :positiivinen-numero
             :leveys 10
             :muokattava? (constantly false)}
@@ -140,7 +140,7 @@
             :tyyppi :numero
             :leveys 20
             :muokattava? (constantly false)
-            :hae (fn [rivi] (+ (:suunniteltu-maara rivi) (:maaramuutos rivi)))}
+            :hae (fn [rivi] (+ (or (:suunniteltu_maara rivi) 0) (:maaramuutos rivi)))}
 
            ;; Kustomoitu poisto-nappi, joka korvaa gridin oman poisto-toiminnon
            {:otsikko ""

--- a/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
@@ -19,6 +19,11 @@
   (dec (apply min
          (conj (map :tehtava tehtavat-ja-maarat-valittuna-hoitovuonna) -1))))
 
+(defn- hae-elementti-hoitokauden-alkuvuodella
+  [hoitovuosi sekvenssi]
+  (let [alkuvuosi (when hoitovuosi (pvm/vuosi (first hoitovuosi)))]
+    (some #(when (= alkuvuosi (:hoitokauden_alkuvuosi %)) %) sekvenssi)))
+
 (defn- pysyvan-muutoksen-vetolaatikko
   "Piirtää jatkuvan muutoksen taulukkoon vetolaatikon, jolla hallitaan kustannus- ja tehtävämuutoksia."
   [e! urakan-hoitokaudet {:keys [toimenpideinstanssi kustannusvaikutukset tehtavat_ja_maarat toimenpidekoodi] :as rivi}
@@ -182,7 +187,22 @@
       :voi-lisata? false
       :voi-kumota? false
       :voi-poistaa? (constantly false)
-      :voi-muokata? true}
+      :voi-muokata? true
+      :rivi-jalkeen-fn (fn [rivit]
+                         (prn rivit)
+                         (let [tavoitehinnan-muutokset (map (fn [rivi]
+                                                              (or (some->
+                                                                    (hae-elementti-hoitokauden-alkuvuodella
+                                                                      hoitovuosi
+                                                                      (get rivi :kustannusvaikutukset))
+                                                                    :summa) 0))
+                                                         rivit)
+                               tavoitehinnan-muutokset-yhteensa (apply + tavoitehinnan-muutokset)]
+                           [{:teksti "" :luokka "yhteensa" :leveys 5 :sarakkeita 1}
+                            {:teksti "Yhteensä" :luokka "yhteensa" :leveys 15 :sarakkeita 1}
+                            {:teksti "" :luokka "yhteensa" :leveys 8 :tasaa :oikea}
+                            {:teksti (fmt/euro-opt false true tavoitehinnan-muutokset-yhteensa) :luokka "yhteensa" :leveys 8 :tasaa :oikea}
+                            {:teksti "" :luokka "yhteensa" :leveys 8 :tasaa :oikea}]))}
 
      [{:tyyppi :vetolaatikon-tila :leveys 2}
       {:otsikko "Toimenpide"
@@ -200,24 +220,18 @@
        :tasaa :oikea
        :leveys 8
        :hae (fn [rivi]
-              (:budjetoitu_summa (first (filter #(when hoitovuosi
-                                                   (= (pvm/vuosi (first hoitovuosi))
-                                                     (:hoitokauden_alkuvuosi %)))
-                                          (get rivi :budjetoidut_summat)))))}
+              (:budjetoitu_summa (hae-elementti-hoitokauden-alkuvuodella hoitovuosi (get rivi :budjetoidut_summat))))}
 
       {:otsikko "Tavoitehinnan muutos (€)"
        :muokattava? (constantly false)
        :nimi :tavoitehinnan-muutos
        :tyyppi :numero
-       :fmt fmt/euro-opt
+       :fmt (partial fmt/euro-opt false true)
        :tasaa :oikea
        :leveys 8
        :solun-luokka #(str "tavoitehinnan-muutos-sarake")
        :hae (fn [rivi]
-              (:summa (first (filter #(when hoitovuosi
-                                        (= (pvm/vuosi (first hoitovuosi))
-                                          (:hoitokauden_alkuvuosi %)))
-                               (get rivi :kustannusvaikutukset)))))}
+              (:summa (hae-elementti-hoitokauden-alkuvuodella hoitovuosi (get rivi :kustannusvaikutukset))))}
 
       {:otsikko "Muuttunut kustannus (€)"
        :muokattava? (constantly false)
@@ -228,14 +242,8 @@
        :tasaa :oikea
        :leveys 8
        :hae (fn [rivi]
-              (let [budjetoitu (:budjetoitu_summa (first (filter #(when hoitovuosi
-                                                                    (= (pvm/vuosi (first hoitovuosi))
-                                                                      (:hoitokauden_alkuvuosi %)))
-                                                           (get rivi :budjetoidut_summat))))
-                    muutos (:summa (first (filter #(when hoitovuosi
-                                                     (= (pvm/vuosi (first hoitovuosi))
-                                                       (:hoitokauden_alkuvuosi %)))
-                                            (get rivi :kustannusvaikutukset))))]
+              (let [budjetoitu (:budjetoitu_summa (hae-elementti-hoitokauden-alkuvuodella hoitovuosi (get rivi :budjetoidut_summat)))
+                    muutos (:summa (hae-elementti-hoitokauden-alkuvuodella hoitovuosi (get rivi :kustannusvaikutukset)))]
                 (when (and budjetoitu (number? budjetoitu) muutos (number? muutos))
                   (+ budjetoitu muutos))))}]
      toimenpiteiden-tiedot]))

--- a/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
@@ -24,6 +24,17 @@
   (let [alkuvuosi (when hoitovuosi (pvm/vuosi (first hoitovuosi)))]
     (some #(when (= alkuvuosi (:hoitokauden_alkuvuosi %)) %) sekvenssi)))
 
+(defn- hae-tehtavan-suunniteltu-maara
+  [muokattava-muutos rivi]
+  ;; Suunniteltu määrä haetaan riville suoraan tietokantakyselyllä olemassa olevalle pysyvälle muutokselle
+  ;; = Nopeampi
+  (or (:suunniteltu_maara rivi)
+    ;; Kun tehdään uutta pysyvää muutosta, etsitään suunniteltu määrä toimenpiteiden tehtävien joukosta
+    (some #(when (= (:tehtava-id %)
+                   (:tehtava rivi))
+             (:suunniteltu-maara %))
+      (:toimenpiteiden-tehtavat muokattava-muutos))))
+
 (defn- pysyvan-muutoksen-vetolaatikko
   "Piirtää jatkuvan muutoksen taulukkoon vetolaatikon, jolla hallitaan kustannus- ja tehtävämuutoksia."
   [e! urakan-hoitokaudet {:keys [toimenpideinstanssi kustannusvaikutukset tehtavat_ja_maarat toimenpidekoodi] :as rivi}
@@ -128,7 +139,9 @@
             :nimi :suunniteltu_maara
             :tyyppi :positiivinen-numero
             :leveys 10
-            :muokattava? (constantly false)}
+            :muokattava? (constantly false)
+            :hae (fn [rivi]
+                   (hae-tehtavan-suunniteltu-maara muokattava-muutos rivi))}
 
            {:otsikko "Määrämuutos (+/-)"
             :nimi :maaramuutos
@@ -140,7 +153,8 @@
             :tyyppi :numero
             :leveys 20
             :muokattava? (constantly false)
-            :hae (fn [rivi] (+ (or (:suunniteltu_maara rivi) 0) (:maaramuutos rivi)))}
+            :hae (fn [rivi]
+                   (+ (or (hae-tehtavan-suunniteltu-maara muokattava-muutos rivi) 0) (:maaramuutos rivi)))}
 
            ;; Kustomoitu poisto-nappi, joka korvaa gridin oman poisto-toiminnon
            {:otsikko ""

--- a/src/cljs/harja/views/urakka/muutokset/rahavarausten_muutokset.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/rahavarausten_muutokset.cljs
@@ -45,9 +45,9 @@
           :rivi-jalkeen-fn (fn []
                              [{:teksti "Tavoitehinnan muutokset yhteensä" :luokka "yhteensa" :yhteenveto-vayla true}
                               {:teksti "" :sarakkeita 1 :luokka "yhteensa"}
-                              {:teksti (fmt/euro-opt (:summa-indeksikorjattu yhteenveto)) :tasaa :oikea :luokka "yhteensa"}
-                              {:teksti (fmt/euro-opt (:toteumat yhteenveto)) :tasaa :oikea :luokka "yhteensa"}
-                              {:teksti (fmt/euro-opt (:tavoitehinnan-muutos yhteenveto)) :tasaa :oikea :luokka "yhteensa"}])}
+                              {:teksti "" :tasaa :oikea :luokka "yhteensa"}
+                              {:teksti "" :tasaa :oikea :luokka "yhteensa"}
+                              {:teksti (fmt/euro-opt false true (:tavoitehinnan-muutos yhteenveto)) :tasaa :oikea :luokka "yhteensa"}])}
 
          ;; Taulukon kentät
          [{:otsikko "Rahavaraus" 

--- a/src/cljs/harja/views/urakka/muutokset/rahavarausten_muutokset.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/rahavarausten_muutokset.cljs
@@ -90,6 +90,8 @@
            :tasaa :oikea 
            :leveys 10
            :muokattava? (constantly false)}
+          ;; Tyhjä sarake, jotta "Tavoitehinnan muutos (€)" -sarake asettuun samaan kohtaan kuin muissa muutostauluissa
+          ;; Muissa tauluissa tässä sarakkeessa on toimintopainikkeet, mutta tässä ei ole toimintoja
           {:otsikko ""
            :nimi :filleri
            :tyyppi :komponentti

--- a/src/cljs/harja/views/urakka/muutokset/rahavarausten_muutokset.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/rahavarausten_muutokset.cljs
@@ -47,7 +47,8 @@
                               {:teksti "" :sarakkeita 1 :luokka "yhteensa"}
                               {:teksti "" :tasaa :oikea :luokka "yhteensa"}
                               {:teksti "" :tasaa :oikea :luokka "yhteensa"}
-                              {:teksti (fmt/euro-opt false true (:tavoitehinnan-muutos yhteenveto)) :tasaa :oikea :luokka "yhteensa"}])}
+                              {:teksti (fmt/euro-opt false true (:tavoitehinnan-muutos yhteenveto)) :tasaa :oikea :luokka "yhteensa"}
+                              {:teksti "" :luokka "yhteensa" :leveys 8 :tasaa :oikea}])}
 
          ;; Taulukon kentät
          [{:otsikko "Rahavaraus" 
@@ -88,5 +89,11 @@
            :fmt fmt/euro-opt 
            :tasaa :oikea 
            :leveys 10
-           :muokattava? (constantly false)}]
+           :muokattava? (constantly false)}
+          {:otsikko ""
+           :nimi :filleri
+           :tyyppi :komponentti
+           :komponentti (constantly nil)
+           :tasaa :oikea
+           :leveys 10}]
          rivit])}]))

--- a/src/cljs/harja/views/urakka/muutokset/yhteiset.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/yhteiset.cljs
@@ -40,9 +40,12 @@
   "Piirtää yhtenäisesti Muutoksien taulukot collapsoitaviksi.
    summan saa piiloon antamalla sille arvon :ei-summaa"
   [e! app {:keys [taulukon-avain taulukon-nakyvyys-event
-                  otsikko summa toiminnot taulukko] :as _tiedot}]
+                  otsikko summa toiminnot toiminnot-asetukset taulukko] :as _tiedot}]
 
-  (let [sisalto-nakyvissa? (get-in app [:taulukko-nakyvissa? taulukon-avain])]
+  (let [sisalto-nakyvissa? (get-in app [:taulukko-nakyvissa? taulukon-avain])
+        toiminnot-asetukset (merge
+                              {:tasaa :vasen}
+                              (when (map? toiminnot-asetukset) toiminnot-asetukset))]
     [:div.collapsoitava-osio
      [:div.otsikkorivi.klikattava {:on-click taulukon-nakyvyys-event}
       [:span
@@ -57,7 +60,9 @@
 
      (when sisalto-nakyvissa?
        [:span
-        [:div.toiminnot
+        [:div.toiminnot {:style (merge {}
+                                  (when (= :oikea (:tasaa toiminnot-asetukset))
+                                    {:float "right"}))}
          [toiminnot e! app]]
         [:div.taulukko
          [taulukko e! app]]])]))

--- a/src/cljs/harja/views/urakka/muutokset/yhteiset.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/yhteiset.cljs
@@ -97,9 +97,7 @@
                                             %)]
                (-> rivi
                  (assoc :voimassa_alkaen arvo)
-                 (assoc :mahdolliset-hoitovuodet-lomakkeella
-                   (filter #(pvm/jalkeen? (first %) arvo)
-                     urakan-hoitokaudet))
+                 (assoc :mahdolliset-hoitovuodet-lomakkeella urakan-hoitokaudet)
                  (resetoi-hoitovuosi-fn))))}))
 
 

--- a/src/cljs/harja/views/urakka/muutos_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/muutos_nakyma.cljs
@@ -128,16 +128,23 @@
   [_e! {:keys [budjettitavoitteet] :as _app}]
   (let [indeksikorjaus-vahvistettu? (:indeksikorjaus-vahvistettu? budjettitavoitteet)]
     [:div.muutosten-vaikutus
-    [:h2 "Muutosten vaikutus"]
-    [yleiset/tietoja {:class "muutosten-vaikutus-container body-text"
-                      :tietorivi-luokka "padding-8"}
-     "Hoitovuoden alun indeksikorjattu tavoitehinta" (if-not indeksikorjaus-vahvistettu?
-                                                       t-yhteiset/+indeksikorjausta-ei-vahvistettu-txt+
-                                                       (fmt/euro-opt (:hoitovuoden-alun-indeksikorjattu-tavoitehinta budjettitavoitteet)))
-     "Tavoitehinnan muutokset" (fmt/euro-opt (:muutosten-vaikutus-yhteensa budjettitavoitteet))
-     "Hoitovuoden lopun tavoitehinta" (if-not indeksikorjaus-vahvistettu?
-                                        t-yhteiset/+indeksikorjausta-ei-vahvistettu-txt+
-                                        (fmt/euro-opt (:hoitovuoden-lopun-tavoitehinta budjettitavoitteet)))]
+     [:h2 "Muutosten vaikutus"]
+
+     [yleiset/tietoja {:class "muutosten-vaikutus-container body-text"
+                       :tietorivi-luokka "padding-8"}
+      "Hoitovuoden alun indeksikorjattu tavoitehinta"
+      (if-not indeksikorjaus-vahvistettu?
+        t-yhteiset/+indeksikorjausta-ei-vahvistettu-txt+
+        (fmt/euro-opt (:hoitovuoden-alun-indeksikorjattu-tavoitehinta budjettitavoitteet)))
+
+      "Kirjatut muutokset"
+      (fmt/euro-opt (:kirjatut-muutokset-yht budjettitavoitteet))
+
+      [:div "Toteumiin perustuvat muutokset" [:br]
+       "(vahvistetaan välikatselmuksessa)"]
+      (fmt/euro-opt (:toteumiin-perustuvat-muutokset-yht budjettitavoitteet))
+
+      "Yhteensä" "foobar"]
      (when-not indeksikorjaus-vahvistettu? [yleiset/vihje "Indeksikorjaus vahvistetaan kustannussuunnitelmassa."])]))
 
 

--- a/src/cljs/harja/views/urakka/muutos_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/muutos_nakyma.cljs
@@ -113,7 +113,7 @@
 
 
 (defn muutoslistaus [e! app]
-  [:span.muutoslistaus
+  [:div.muutoslistaus
    (when (:valittu-hoitokausi app)
      (if (t-yhteiset/ennen-muutoksien-kayttoonotto? (:valittu-hoitokausi app))
        ;; Tähän 1.10.2024 tai sitä aiemmiun alkaneiden hoitokausien " legacy " muutostoiminnot

--- a/src/cljs/harja/views/urakka/muutos_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/muutos_nakyma.cljs
@@ -25,7 +25,7 @@
   [kehystetty-avattava-grid e! app
    {:taulukon-avain :tavoitehinnan-muutokset
     :taulukon-nakyvyys-event #(e! (t-yhteiset/->ToggleTaulukonNakyvyys :tavoitehinnan-muutokset))
-    :otsikko "Kirjatut muutokset"
+    :otsikko "Tavoitehinnan muutokset"
     :summa (reduce + 0 (map :tavoitehinnan-muutos tavoitehinnan-muutokset)) ;; todo
     :toiminnot (fn [e! app]
                  [::span

--- a/src/cljs/harja/views/urakka/muutos_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/muutos_nakyma.cljs
@@ -1,27 +1,28 @@
 (ns harja.views.urakka.muutos-nakyma
   "MHU-urakoiden muutosten välilehti. Hallinnoi ja näyttää tarjouksen pohjatietoihin ja tavoitehintaan tehtäviä muutoksia."
-  (:require [harja.pvm :as pvm]
-            [harja.tiedot.navigaatio :as nav]
-            [harja.tiedot.urakka.siirtymat :as siirtymat]
-            [harja.ui.debug :as debug]
-            [tuck.core :as tuck]
+  (:require
+    [tuck.core :as tuck]
+    [harja.pvm :as pvm]
+    [harja.tiedot.navigaatio :as nav]
+    [harja.tiedot.urakka.siirtymat :as siirtymat]
 
-            [harja.fmt :as fmt]
-            [harja.ui.grid :as grid]
-            [harja.ui.napit :as napit]
-            [harja.tiedot.urakka :as u]
-            [harja.ui.komponentti :as komp]
-            [harja.tiedot.urakka.urakka :as tila]
-            [harja.views.urakka.valinnat :as urakka-valinnat]
-            [harja.tiedot.urakka.muutokset.yhteiset-tiedot :as t-yhteiset]
-            [harja.ui.yleiset :as yleiset]
+
+    [harja.fmt :as fmt]
+    [harja.ui.grid :as grid]
+    [harja.ui.napit :as napit]
+    [harja.tiedot.urakka :as u]
+    [harja.ui.komponentti :as komp]
+    [harja.tiedot.urakka.urakka :as tila]
+    [harja.views.urakka.valinnat :as urakka-valinnat]
+    [harja.tiedot.urakka.muutokset.yhteiset-tiedot :as t-yhteiset]
+    [harja.ui.yleiset :as yleiset]
 
     ;; Osiot / lomake
-            [harja.views.urakka.muutokset.yhteiset :as yhteiset :refer [kehystetty-avattava-grid]]
-            [harja.views.urakka.muutokset.kirjatut-muutokset :as kirjatut-muutokset]
-            [harja.views.urakka.muutokset.lasketut-muutokset :as lasketut-muutokset]
-            [harja.views.urakka.muutokset.rahavarausten-muutokset :as rahavarausten-muutokset]
-            [harja.views.urakka.muutokset.lomake.muutoslomake :as muutoslomake]))
+    [harja.views.urakka.muutokset.yhteiset :as yhteiset :refer [kehystetty-avattava-grid]]
+    [harja.views.urakka.muutokset.kirjatut-muutokset :as kirjatut-muutokset]
+    [harja.views.urakka.muutokset.lasketut-muutokset :as lasketut-muutokset]
+    [harja.views.urakka.muutokset.rahavarausten-muutokset :as rahavarausten-muutokset]
+    [harja.views.urakka.muutokset.lomake.muutoslomake :as muutoslomake]))
 
 
 (defn- tavoitehinnan-muutokset [e! {:keys [tavoitehinnan-muutokset] :as app}]

--- a/src/cljs/harja/views/urakka/muutos_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/muutos_nakyma.cljs
@@ -130,9 +130,8 @@
 (defn- muutosten-vaikutus
   "Yhteenveto muutosten vaikutuksista."
   [_e! {:keys [budjettitavoitteet valittu-hoitokausi] :as _app}]
-  (let [indeksikorjatut-hoitovuodet (:urakan-tavoitehinnat-indeksikorjattu budjettitavoitteet)
-        hoitokauden-alkuvuosi (some-> valittu-hoitokausi (first) (pvm/vuosi))
-        indeksikorjaus-vahvistettu? (get indeksikorjatut-hoitovuodet hoitokauden-alkuvuosi false)]
+  (let [indeksikorjaus-vahvistettu? (t-yhteiset/hoitovuoden-indeksikorjaus-vahvistettu?
+                                      budjettitavoitteet valittu-hoitokausi)]
     [:div.muutosten-vaikutus
      [yleiset/tietoja {:class "muutosten-vaikutus-container body-text"
                        :tietorivi-luokka "padding-8"}

--- a/src/cljs/harja/views/urakka/muutos_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/muutos_nakyma.cljs
@@ -1,6 +1,8 @@
 (ns harja.views.urakka.muutos-nakyma
   "MHU-urakoiden muutosten välilehti. Hallinnoi ja näyttää tarjouksen pohjatietoihin ja tavoitehintaan tehtäviä muutoksia."
-  (:require [harja.ui.debug :as debug]
+  (:require [harja.tiedot.navigaatio :as nav]
+            [harja.tiedot.urakka.siirtymat :as siirtymat]
+            [harja.ui.debug :as debug]
             [tuck.core :as tuck]
 
             [harja.fmt :as fmt]
@@ -163,7 +165,15 @@
       ^{:koko-rivin-leveys? true :tietorivi-luokka (str "keskita-rivin-sisalto"
                                                      (when indeksikorjaus-vahvistettu?
                                                        " piilota-rivin-sisalto"))}
-      [yleiset/vihje "Indeksikorjaus vahvistetaan kustannussuunnitelmassa." "vihje-indeksikorjaus"] ""]]))
+      [yleiset/vihje [:span "Indeksikorjaus vahvistetaan "
+                      [:a.klikattava.alleviivaa {:href "#"
+                                                 :on-click #(siirtymat/siirry-annettuun-valilehteen
+                                                              @nav/valittu-hallintayksikko-id (:id @nav/valittu-urakka)
+                                                              {:taso1 :urakat
+                                                               :taso2 :suunnittelu
+                                                               :taso3 :uusi-kustannussuunnitelma})}
+                       "kustannussuunnitelmassa."]]
+       "vihje-indeksikorjaus"] ""]]))
 
 
 (defn muutosten-hallinta-sisalto [e! {:keys [haku-kaynnissa?] :as app}]

--- a/src/cljs/harja/views/urakka/muutos_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/muutos_nakyma.cljs
@@ -158,8 +158,12 @@
       [:b "Yhteensä"]
       [:b (if (not indeksikorjaus-vahvistettu?)
             t-yhteiset/+muutosten-vaikutus-yhteensa-ei-saatavilla+
-            (fmt/euro-opt (:muutosten-vaikutus-yht budjettitavoitteet)))]]
-     (when-not indeksikorjaus-vahvistettu? [yleiset/vihje "Indeksikorjaus vahvistetaan kustannussuunnitelmassa."])]))
+            (fmt/euro-opt (:muutosten-vaikutus-yht budjettitavoitteet)))]
+
+      ^{:koko-rivin-leveys? true :tietorivi-luokka (str "keskita-rivin-sisalto"
+                                                     (when indeksikorjaus-vahvistettu?
+                                                       " piilota-rivin-sisalto"))}
+      [yleiset/vihje "Indeksikorjaus vahvistetaan kustannussuunnitelmassa." "vihje-indeksikorjaus"] ""]]))
 
 
 (defn muutosten-hallinta-sisalto [e! {:keys [haku-kaynnissa?] :as app}]

--- a/src/cljs/harja/views/urakka/muutos_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/muutos_nakyma.cljs
@@ -168,15 +168,17 @@
       ^{:koko-rivin-leveys? true :tietorivi-luokka (str "keskita-rivin-sisalto"
                                                      (when indeksikorjaus-vahvistettu?
                                                        " piilota-rivin-sisalto"))}
-      [yleiset/vihje [:span "Indeksikorjaus vahvistetaan "
-                      [:a.klikattava.alleviivaa {:href "#"
-                                                 :on-click #(siirtymat/siirry-annettuun-valilehteen
-                                                              @nav/valittu-hallintayksikko-id (:id @nav/valittu-urakka)
-                                                              {:taso1 :urakat
-                                                               :taso2 :suunnittelu
-                                                               :taso3 :uusi-kustannussuunnitelma})}
-                       "kustannussuunnitelmassa."]]
-       "vihje-indeksikorjaus"] ""]]))
+      [yleiset/info-laatikko :neutraali
+       [:span "Indeksikorjaus vahvistetaan "
+        [:a.klikattava.alleviivaa {:href "#"
+                                   :on-click #(siirtymat/siirry-annettuun-valilehteen
+                                                @nav/valittu-hallintayksikko-id (:id @nav/valittu-urakka)
+                                                {:taso1 :urakat
+                                                 :taso2 :suunnittelu
+                                                 :taso3 :uusi-kustannussuunnitelma})}
+         "kustannussuunnitelmassa."]]
+       nil
+       {:luokka "vihje-indeksikorjaus"}] ""]]))
 
 
 (defn muutosten-hallinta-sisalto [e! {:keys [haku-kaynnissa?] :as app}]

--- a/src/cljs/harja/views/urakka/muutos_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/muutos_nakyma.cljs
@@ -139,6 +139,14 @@
         t-yhteiset/+indeksikorjausta-ei-vahvistettu-txt+
         (fmt/euro-opt (:hoitovuoden-alun-indeksikorjattu-tavoitehinta budjettitavoitteet)))
 
+      (when (:aiemmat-pysyvat-muutokset-indeksikorjattu-yht budjettitavoitteet)
+        [:ul
+         [:li.harmaa-tumma-teksti "Edellisten hoitovuosien pysyvien muutosten osuus (indeksikorjattu)"]])
+      (when (:aiemmat-pysyvat-muutokset-indeksikorjattu-yht budjettitavoitteet)
+        (if-not indeksikorjaus-vahvistettu?
+          t-yhteiset/+indeksikorjausta-ei-vahvistettu-txt+
+          (fmt/euro-opt true true (:aiemmat-pysyvat-muutokset-indeksikorjattu-yht budjettitavoitteet))))
+
       "Kirjatut muutokset"
       (fmt/euro-opt true true (:kirjatut-muutokset-yht budjettitavoitteet))
 
@@ -148,7 +156,9 @@
       (fmt/euro-opt true true (:toteumiin-perustuvat-muutokset-yht budjettitavoitteet))
 
       [:b "Yhteensä"]
-      [:b (fmt/euro-opt (:muutosten-vaikutus-yht budjettitavoitteet))]]
+      [:b (if (not indeksikorjaus-vahvistettu?)
+            t-yhteiset/+muutosten-vaikutus-yhteensa-ei-saatavilla+
+            (fmt/euro-opt (:muutosten-vaikutus-yht budjettitavoitteet)))]]
      (when-not indeksikorjaus-vahvistettu? [yleiset/vihje "Indeksikorjaus vahvistetaan kustannussuunnitelmassa."])]))
 
 

--- a/src/cljs/harja/views/urakka/muutos_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/muutos_nakyma.cljs
@@ -128,23 +128,26 @@
   [_e! {:keys [budjettitavoitteet] :as _app}]
   (let [indeksikorjaus-vahvistettu? (:indeksikorjaus-vahvistettu? budjettitavoitteet)]
     [:div.muutosten-vaikutus
-     [:h2 "Muutosten vaikutus"]
-
      [yleiset/tietoja {:class "muutosten-vaikutus-container body-text"
                        :tietorivi-luokka "padding-8"}
+
+      [:h2 "Muutosten vaikutus"] ""
+
       "Hoitovuoden alun indeksikorjattu tavoitehinta"
       (if-not indeksikorjaus-vahvistettu?
         t-yhteiset/+indeksikorjausta-ei-vahvistettu-txt+
         (fmt/euro-opt (:hoitovuoden-alun-indeksikorjattu-tavoitehinta budjettitavoitteet)))
 
       "Kirjatut muutokset"
-      (fmt/euro-opt (:kirjatut-muutokset-yht budjettitavoitteet))
+      (fmt/euro-opt true true(:kirjatut-muutokset-yht budjettitavoitteet))
 
+      ^{:viiva-rivin-alle? true}
       [:div "Toteumiin perustuvat muutokset" [:br]
        "(vahvistetaan välikatselmuksessa)"]
-      (fmt/euro-opt (:toteumiin-perustuvat-muutokset-yht budjettitavoitteet))
+      (fmt/euro-opt true true(:toteumiin-perustuvat-muutokset-yht budjettitavoitteet))
 
-      "Yhteensä" "foobar"]
+      [:b "Yhteensä"]
+      [:b (fmt/euro-opt (:muutosten-vaikutus-yht budjettitavoitteet))]]
      (when-not indeksikorjaus-vahvistettu? [yleiset/vihje "Indeksikorjaus vahvistetaan kustannussuunnitelmassa."])]))
 
 

--- a/src/cljs/harja/views/urakka/muutos_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/muutos_nakyma.cljs
@@ -157,7 +157,14 @@
 
       ^{:viiva-rivin-alle? true}
       [:div "Toteumiin perustuvat muutokset" [:br]
-       "(vahvistetaan välikatselmuksessa)"]
+       "(vahvistetaan "
+       [:a.klikattava.alleviivaa {:href "#"
+                                  :on-click
+                                  #(siirtymat/avaa-valikatselmus
+                                     @nav/valittu-hallintayksikko-id (:id @nav/valittu-urakka)
+                                     [(first valittu-hoitokausi)
+                                      (second valittu-hoitokausi)])}
+        "välikatselmuksessa."] ")"]
       (fmt/euro-opt true true (:toteumiin-perustuvat-muutokset-yht budjettitavoitteet))
 
       [:b "Yhteensä"]

--- a/src/cljs/harja/views/urakka/muutos_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/muutos_nakyma.cljs
@@ -1,6 +1,7 @@
 (ns harja.views.urakka.muutos-nakyma
   "MHU-urakoiden muutosten välilehti. Hallinnoi ja näyttää tarjouksen pohjatietoihin ja tavoitehintaan tehtäviä muutoksia."
-  (:require [tuck.core :as tuck]
+  (:require [harja.ui.debug :as debug]
+            [tuck.core :as tuck]
 
             [harja.fmt :as fmt]
             [harja.ui.grid :as grid]
@@ -12,7 +13,7 @@
             [harja.tiedot.urakka.muutokset.yhteiset-tiedot :as t-yhteiset]
             [harja.ui.yleiset :as yleiset]
 
-            ;; Osiot / lomake 
+    ;; Osiot / lomake
             [harja.views.urakka.muutokset.yhteiset :as yhteiset :refer [kehystetty-avattava-grid]]
             [harja.views.urakka.muutokset.kirjatut-muutokset :as kirjatut-muutokset]
             [harja.views.urakka.muutokset.lasketut-muutokset :as lasketut-muutokset]
@@ -41,21 +42,21 @@
         :voi-muokata? true}
 
        ;; Taulukon kentät
-       [{:otsikko "Muutos" 
-         :nimi :muutos 
-         :tyyppi :string 
+       [{:otsikko "Muutos"
+         :nimi :muutos
+         :tyyppi :string
          :leveys 15}
-        
-        {:otsikko "Perustelu" 
-         :nimi :perustelu 
-         :tyyppi :string 
+
+        {:otsikko "Perustelu"
+         :nimi :perustelu
+         :tyyppi :string
          :leveys 35}
 
-        {:otsikko "Vaikutus € (+/-)" 
-         :nimi :tavoitehinnan-muutos 
+        {:otsikko "Vaikutus € (+/-)"
+         :nimi :tavoitehinnan-muutos
          :tyyppi :numero
-         :fmt fmt/euro-opt 
-         :tasaa :oikea 
+         :fmt fmt/euro-opt
+         :tasaa :oikea
          :leveys 15}]
        tavoitehinnan-muutokset])}])
 
@@ -81,25 +82,25 @@
         :voi-muokata? true}
 
        ;; Taulukon kentät
-       [{:otsikko "Muutoksen syy" 
-         :nimi :syy 
-         :tyyppi :string 
+       [{:otsikko "Muutoksen syy"
+         :nimi :syy
+         :tyyppi :string
          :leveys 15}
-        
-        {:otsikko "Muutokset" 
-         :nimi :muutokset 
-         :tyyppi :string 
+
+        {:otsikko "Muutokset"
+         :nimi :muutokset
+         :tyyppi :string
          :leveys 35}
 
-        {:otsikko "Lisätieto" 
-         :nimi :lisatieto 
-         :tyyppi :string 
+        {:otsikko "Lisätieto"
+         :nimi :lisatieto
+         :tyyppi :string
          :leveys 15}
 
-        {:otsikko "" :nimi 
-         :toiminnot :tyyppi 
-         :komponentti 
-         :leveys 10 
+        {:otsikko "" :nimi
+         :toiminnot :tyyppi
+         :komponentti
+         :leveys 10
          :tasaa :oikea
          :komponentti (fn [rivi]
                         [napit/muokkaa "Muokkaa"
@@ -139,12 +140,12 @@
         (fmt/euro-opt (:hoitovuoden-alun-indeksikorjattu-tavoitehinta budjettitavoitteet)))
 
       "Kirjatut muutokset"
-      (fmt/euro-opt true true(:kirjatut-muutokset-yht budjettitavoitteet))
+      (fmt/euro-opt true true (:kirjatut-muutokset-yht budjettitavoitteet))
 
       ^{:viiva-rivin-alle? true}
       [:div "Toteumiin perustuvat muutokset" [:br]
        "(vahvistetaan välikatselmuksessa)"]
-      (fmt/euro-opt true true(:toteumiin-perustuvat-muutokset-yht budjettitavoitteet))
+      (fmt/euro-opt true true (:toteumiin-perustuvat-muutokset-yht budjettitavoitteet))
 
       [:b "Yhteensä"]
       [:b (fmt/euro-opt (:muutosten-vaikutus-yht budjettitavoitteet))]]
@@ -155,7 +156,7 @@
   [:valinnat-ja-listaus
    [:h1 "Muutosten hallinta"]
    [:div.otsikko-ja-hoitokausi
-    
+
     [urakka-valinnat/paivittava-urakkavuosi-tuck
      @u/valittu-aikavali
      #(e! (t-yhteiset/->HaeUrakanMuutostiedot)) haku-kaynnissa? false]]
@@ -169,7 +170,7 @@
   (komp/luo
     (komp/lippu t-yhteiset/nakymassa?)
     (komp/sisaan #(e! (t-yhteiset/->HaeUrakanMuutostiedot)))
-    (fn [e! 
+    (fn [e!
          {:keys [muokattava-muutos] :as app}]
       [:span.muutokset-sivu
        (if muokattava-muutos

--- a/src/cljs/harja/views/urakka/muutos_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/muutos_nakyma.cljs
@@ -1,6 +1,7 @@
 (ns harja.views.urakka.muutos-nakyma
   "MHU-urakoiden muutosten välilehti. Hallinnoi ja näyttää tarjouksen pohjatietoihin ja tavoitehintaan tehtäviä muutoksia."
-  (:require [harja.tiedot.navigaatio :as nav]
+  (:require [harja.pvm :as pvm]
+            [harja.tiedot.navigaatio :as nav]
             [harja.tiedot.urakka.siirtymat :as siirtymat]
             [harja.ui.debug :as debug]
             [tuck.core :as tuck]
@@ -128,8 +129,10 @@
 
 (defn- muutosten-vaikutus
   "Yhteenveto muutosten vaikutuksista."
-  [_e! {:keys [budjettitavoitteet] :as _app}]
-  (let [indeksikorjaus-vahvistettu? (:indeksikorjaus-vahvistettu? budjettitavoitteet)]
+  [_e! {:keys [budjettitavoitteet valittu-hoitokausi] :as _app}]
+  (let [indeksikorjatut-hoitovuodet (:urakan-tavoitehinnat-indeksikorjattu budjettitavoitteet)
+        hoitokauden-alkuvuosi (some-> valittu-hoitokausi (first) (pvm/vuosi))
+        indeksikorjaus-vahvistettu? (get indeksikorjatut-hoitovuodet hoitokauden-alkuvuosi false)]
     [:div.muutosten-vaikutus
      [yleiset/tietoja {:class "muutosten-vaikutus-container body-text"
                        :tietorivi-luokka "padding-8"}

--- a/src/cljs/harja/views/urakka/muutos_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/muutos_nakyma.cljs
@@ -24,7 +24,7 @@
   [kehystetty-avattava-grid e! app
    {:taulukon-avain :tavoitehinnan-muutokset
     :taulukon-nakyvyys-event #(e! (t-yhteiset/->ToggleTaulukonNakyvyys :tavoitehinnan-muutokset))
-    :otsikko "Tavoitehinnan muutokset"
+    :otsikko "Kirjatut muutokset"
     :summa (reduce + 0 (map :tavoitehinnan-muutos tavoitehinnan-muutokset)) ;; todo
     :toiminnot (fn [e! app]
                  [::span

--- a/test/clj/harja/palvelin/palvelut/muutos_palvelu_test.clj
+++ b/test/clj/harja/palvelin/palvelut/muutos_palvelu_test.clj
@@ -184,11 +184,26 @@
         valittu-hoitokausi-24-25 [(pvm/->pvm "1.10.2024") (pvm/->pvm "30.09.2025")]
         vastaus-24-25 (hae-urakan-muutostiedot +kayttaja-jvh+ {:urakka-id urakka-id
                                                                :valittu-hoitokausi valittu-hoitokausi-24-25})
-        odotetut-rivit []]
+        odotetut-rivit-24-25 [{:alityyppi nil
+                               :id 5
+                               :jjh-muutosten-summa nil
+                               :kulu_kohdistus nil
+                               :kustannusvaikutukset ()
+                               :liitteet nil
+                               :luonnos false
+                               :nimi "Lisää paikkausta"
+                               :syy "Jonkin verran pitäisi paikkailla lisää tänä vuonna"
+                               :tavoitehinnan-muutos 0
+                               :tehtavat_ja_maarat ()
+                               :tyyppi "pysyva"
+                               :urakka 36
+                               :versio 1
+                               :voimassa_alkaen #inst"2024-09-30T21:00:00.000-00:00"}]]
     (is (= (count (:kirjatut-muutokset vastaus-22-23)) 0) "oikea määrä muutoksia 22-23")
     (is (= (count (:kirjatut-muutokset vastaus-23-24)) 0) "oikea määrä muutoksia 23-24")
-    (is (= (count (:kirjatut-muutokset vastaus-24-25)) 0) "oikea määrä muutoksia 24-25")
-    (is (= odotetut-rivit (:kirjatut-muutokset vastaus-22-23) (:kirjatut-muutokset vastaus-23-24) (:kirjatut-muutokset vastaus-24-25)))))
+    (is (= (count (:kirjatut-muutokset vastaus-24-25)) 1) "oikea määrä muutoksia 24-25")
+    (is (= [] (:kirjatut-muutokset vastaus-22-23) (:kirjatut-muutokset vastaus-23-24)))
+    (is (= odotetut-rivit-24-25 (:kirjatut-muutokset vastaus-24-25)))))
 
 
 (deftest tallenna-rahavarausmuutosten-syyt-ii

--- a/test/clj/harja/palvelin/palvelut/muutos_palvelu_test.clj
+++ b/test/clj/harja/palvelin/palvelut/muutos_palvelu_test.clj
@@ -174,8 +174,9 @@
 
     ;; Indeksikorjattu tavoitehinta on nil, koska urakalle ei ole vahvistettu indeksikorjausta hoitovuodelle 2025
     (is (= nil (:tavoitehinta-indeksikorjattu budjettitavoitteet)) "Hoitovuoden alun indeksikorjattu tavoitehinta")
+    (is (= {} (:tavoitehinta-indeksikorjattu-per-hoitovuosi budjettitavoitteet)))
 
-    (is (= 1000 (:aiemmat-pysyvat-muutokset-indeksikorjattu-yht budjettitavoitteet))
+    (is (= 1374.0 (:aiemmat-pysyvat-muutokset-indeksikorjattu-yht budjettitavoitteet))
       "Aiemmat pysyvät muutokset indeksikorjattuna")
 
     (is (= 6230M (:kirjatut-muutokset-yht budjettitavoitteet)) "Kirjatut muutokset yhteensä")
@@ -190,7 +191,7 @@
     ;; * Aiemmat pysyvät muutokset (indeksikorjattuna)
     ;; * Kirjatut muutokset (tavoitehinnan muutokset) yhteensä
     ;; * Toteutumiin perustuvat muutokset (tavoitehinnan muutokset) yhteensä
-    (is (= (some->> (:muutosten-vaikutus-yht budjettitavoitteet) (round2 2)) 293712.26) "Muutosten vaikutus yhteensä")))
+    (is (= 294086.26 (some->> (:muutosten-vaikutus-yht budjettitavoitteet) (round2 2))) "Muutosten vaikutus yhteensä")))
 
 (deftest hae-urakan-tavoitehinta-muutosten-kokonaissumma-suomussalmi
   (let [urakka-id (hae-urakan-id-nimella "POP MHU Suomussalmi 2024-2029")
@@ -204,8 +205,9 @@
     ;; TODO: Hoidetaan testidataan Iin tai Suomussalmen urakalle vahvistettu tavoitehinta, jotta saadaan tämäkin
     ;;       testattua kunnolla (toinen urakka riittää, ei tarvi molempiin), ja UI:ssa näkyisi jotain järkevää suoraan
     (is (= nil (:tavoitehinta-indeksikorjattu budjettitavoitteet)) "Hoitovuoden alun indeksikorjattu tavoitehinta")
-
-    (is (= 2000 (:aiemmat-pysyvat-muutokset-indeksikorjattu-yht budjettitavoitteet))
+    (is (= {} (:tavoitehinta-indeksikorjattu-per-hoitovuosi budjettitavoitteet)))
+    ;; TODO: Eikä urakalla ole myöskään indeksiä vuodelle 2026, joten ei voida laskea indeksikorjauksia
+    (is (= 0 (:aiemmat-pysyvat-muutokset-indeksikorjattu-yht budjettitavoitteet))
       "Aiemmat pysyvät muutokset indeksikorjattuna")
 
     ;; Urakalle ei ole kirjattu muutoksia hoitovuodelle 2026-2027, ainoastaan aiemman vuoden pysyvät muutokset pitäisi näkyä
@@ -221,7 +223,7 @@
     ;; * Aiemmat pysyvät muutokset (indeksikorjattuna)
     ;; * Kirjatut muutokset (tavoitehinnan muutokset) yhteensä
     ;; * Toteutumiin perustuvat muutokset (tavoitehinnan muutokset) yhteensä
-    (is (= (some->> (:muutosten-vaikutus-yht budjettitavoitteet) (round2 2)) 2000.00) "Muutosten vaikutus yhteensä")))
+    (is (= 0.0 (some->> (:muutosten-vaikutus-yht budjettitavoitteet) (round2 2))) "Muutosten vaikutus yhteensä")))
 
 (deftest hae-urakan-muutostiedot-ii-kun-annetuilla-ehdoilla-ei-loydy
   (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")

--- a/test/clj/harja/palvelin/palvelut/muutos_palvelu_test.clj
+++ b/test/clj/harja/palvelin/palvelut/muutos_palvelu_test.clj
@@ -52,23 +52,99 @@
         valittu-hoitokausi [(pvm/->pvm "1.10.2025") (pvm/->pvm "30.09.2026")]
         vastaus (hae-urakan-muutostiedot +kayttaja-jvh+ {:urakka-id urakka-id
                                                          :valittu-hoitokausi valittu-hoitokausi})
-        odotetut-kirjatut-muutokset [{:kulu_kohdistus nil, :kustannusvaikutukset (list {:hoitokauden_alkuvuosi 2025 :summa 1000, :kustannuslaji "hankintakustannukset", :toimenpideinstanssi 90 :versio 1}),
-                                      :voimassa_alkaen #inst"2025-09-30T21:00:00.000-00:00", :syy "Täytyykin tehdä enemmän päällysteiden paikkausta, koska pahat kelirikot.",
-                                      :tehtavat_ja_maarat (list {:hoitokauden_alkuvuosi 2025 :tehtava 3117, :uusi_maara 1100, :maaramuutos 100, :edellinen_maara 1000 :versio 1}),
-                                      :urakka urakka-id, :nimi "Päällysteen paikkausmuutos", :id 1, :jjh-muutosten-summa nil, :liitteet nil, :versio 1, :luonnos false, :tavoitehinnan-muutos 1000, :tyyppi "pysyva"}
-                                     {:kulu_kohdistus nil, :kustannusvaikutukset (list {:hoitokauden_alkuvuosi 2025 :summa 3000, :kustannuslaji "hankintakustannukset", :toimenpideinstanssi 89 :versio 1}),
-                                      :voimassa_alkaen #inst"2025-09-30T21:00:00.000-00:00", :syy "Tehdään lisäksi tämä isohko sorastus, ei ollut tiedossa ennen urakan alkua.",
-                                      :tehtavat_ja_maarat (list),
-                                      :urakka urakka-id, :nimi "Erillisrahoitettu sorastusmuutos", :id 2, :jjh-muutosten-summa nil, :liitteet nil, :versio 1, :luonnos false, :tavoitehinnan-muutos 3000, :tyyppi "erillisrahoitettu"}
-                                     {:kulu_kohdistus nil, :kustannusvaikutukset (list {:hoitokauden_alkuvuosi 2025 :summa 1000, :kustannuslaji "hankintakustannukset", :toimenpideinstanssi 91 :versio 1}),
-                                      :voimassa_alkaen #inst"2025-09-30T21:00:00.000-00:00", :syy "Ei tehdä tänä kesänä rumpuja, ovat vielä kunnossa.",
+        odotetut-kirjatut-muutokset [{:id 1
+                                      :jjh-muutosten-summa nil
+                                      :kulu_kohdistus nil
+                                      :kustannusvaikutukset (list
+                                                              {:hoitokauden_alkuvuosi 2025
+                                                              :kustannuslaji "hankintakustannukset"
+                                                              :summa 1000
+                                                              :toimenpideinstanssi 90
+                                                              :versio 1})
+                                      :liitteet nil
+                                      :luonnos false
+                                      :nimi "Päällysteen paikkausmuutos"
+                                      :syy "Täytyykin tehdä enemmän päällysteiden paikkausta, koska pahat kelirikot."
+                                      :tavoitehinnan-muutos 1000
                                       :tehtavat_ja_maarat (list
-                                                            {:hoitokauden_alkuvuosi 2025 :tehtava 1406, :uusi_maara 0, :maaramuutos -40, :edellinen_maara 40 :versio 1}
-                                                            {:hoitokauden_alkuvuosi 2025 :tehtava 3029, :uusi_maara 0, :maaramuutos -30, :edellinen_maara 30 :versio 1}),
-                                      :urakka urakka-id, :nimi "Tämän hoitovuoden määräpoikkeamamuutos", :id 3, :jjh-muutosten-summa nil,
-                                      :liitteet (list {:id 11, :muutos 3}), :versio 1, :luonnos false, :tavoitehinnan-muutos 1000, :tyyppi "maarapoikkeama"}
-                                     {:kulu_kohdistus nil, :kustannusvaikutukset (list), :voimassa_alkaen #inst "2025-06-24T21:00:00.000-00:00", :syy "Työmääräarviot ylittyivät",
-                                      :tehtavat_ja_maarat (list), :urakka urakka-id, :nimi nil, :id 4, :jjh-muutosten-summa 1230M, :liitteet nil, :versio 1, :luonnos false, :tavoitehinnan-muutos 1230M, :tyyppi "johto-ja-hallintokorvaus"}]]
+                                                            {:edellinen_maara 1000
+                                                             :hoitokauden_alkuvuosi 2025
+                                                             :maaramuutos 100
+                                                             :suunniteltu_maara 0
+                                                             :tehtava 3117
+                                                             :uusi_maara 1100
+                                                             :versio 1})
+                                      :tyyppi "pysyva"
+                                      :urakka 36
+                                      :versio 1
+                                      :voimassa_alkaen #inst"2025-09-30T21:00:00.000-00:00"}
+                                     {:id 2
+                                      :jjh-muutosten-summa nil
+                                      :kulu_kohdistus nil
+                                      :kustannusvaikutukset (list
+                                                              {:hoitokauden_alkuvuosi 2025
+                                                               :kustannuslaji "hankintakustannukset"
+                                                               :summa 3000
+                                                               :toimenpideinstanssi 89
+                                                               :versio 1})
+                                      :liitteet nil
+                                      :luonnos false
+                                      :nimi "Erillisrahoitettu sorastusmuutos"
+                                      :syy "Tehdään lisäksi tämä isohko sorastus, ei ollut tiedossa ennen urakan alkua."
+                                      :tavoitehinnan-muutos 3000
+                                      :tehtavat_ja_maarat ()
+                                      :tyyppi "erillisrahoitettu"
+                                      :urakka 36
+                                      :versio 1
+                                      :voimassa_alkaen #inst"2025-09-30T21:00:00.000-00:00"}
+                                     {:id 3
+                                      :jjh-muutosten-summa nil
+                                      :kulu_kohdistus nil
+                                      :kustannusvaikutukset (list
+                                                              {:hoitokauden_alkuvuosi 2025
+                                                              :kustannuslaji "hankintakustannukset"
+                                                              :summa 1000
+                                                              :toimenpideinstanssi 91
+                                                              :versio 1})
+                                      :liitteet (list {:id 11
+                                                  :muutos 3})
+                                      :luonnos false
+                                      :nimi "Tämän hoitovuoden määräpoikkeamamuutos"
+                                      :syy "Ei tehdä tänä kesänä rumpuja, ovat vielä kunnossa."
+                                      :tavoitehinnan-muutos 1000
+                                      :tehtavat_ja_maarat (list
+                                                            {:edellinen_maara 40
+                                                            :hoitokauden_alkuvuosi 2025
+                                                            :maaramuutos -40
+                                                            :suunniteltu_maara nil
+                                                            :tehtava 1406
+                                                            :uusi_maara 0
+                                                            :versio 1}
+                                                           {:edellinen_maara 30
+                                                            :hoitokauden_alkuvuosi 2025
+                                                            :maaramuutos -30
+                                                            :suunniteltu_maara 8
+                                                            :tehtava 3029
+                                                            :uusi_maara 0
+                                                            :versio 1})
+                                      :tyyppi "maarapoikkeama"
+                                      :urakka 36
+                                      :versio 1
+                                      :voimassa_alkaen #inst"2025-09-30T21:00:00.000-00:00"}
+                                     {:id 4
+                                      :jjh-muutosten-summa 1230M
+                                      :kulu_kohdistus nil
+                                      :kustannusvaikutukset ()
+                                      :liitteet nil
+                                      :luonnos false
+                                      :nimi nil
+                                      :syy "Työmääräarviot ylittyivät"
+                                      :tavoitehinnan-muutos 1230M
+                                      :tehtavat_ja_maarat ()
+                                      :tyyppi "johto-ja-hallintokorvaus"
+                                      :urakka 36
+                                      :versio 1
+                                      :voimassa_alkaen #inst"2025-06-24T21:00:00.000-00:00"}]]
     (is (= (count (:kirjatut-muutokset vastaus)) 4) "oikea määrä muutoksia")
     (is (= (:kirjatut-muutokset vastaus) odotetut-kirjatut-muutokset))))
 
@@ -422,15 +498,15 @@
                                      {:tehtava 3117 :maaramuutos 100, :hoitokauden_alkuvuosi 2028}]
         odotettu-vastaus (list
                            ;; TODO: Edellinen maara ja uusi maara laskematta vielä palvelussa, siksi 0-arvot
-                           {:edellinen_maara 0 :hoitokauden_alkuvuosi 2025 :maaramuutos 111 :tehtava 2988 :uusi_maara 0 :versio 2}
-                           {:edellinen_maara 0 :hoitokauden_alkuvuosi 2026 :maaramuutos 222 :tehtava 2989 :uusi_maara 0 :versio 2}
-                           {:edellinen_maara 0 :hoitokauden_alkuvuosi 2027 :maaramuutos 333 :tehtava 2991 :uusi_maara 0 :versio 2}
+                           {:tehtava 2988 :hoitokauden_alkuvuosi 2025 :suunniteltu_maara 0 :maaramuutos 111 :uusi_maara nil :edellinen_maara nil :versio 2}
+                           {:tehtava 2989 :hoitokauden_alkuvuosi 2026 :suunniteltu_maara 0 :maaramuutos 222 :uusi_maara nil :edellinen_maara nil :versio 2}
+                           {:tehtava 2991 :hoitokauden_alkuvuosi 2027 :suunniteltu_maara 0 :maaramuutos 333 :uusi_maara nil :edellinen_maara nil :versio 2}
                            ;; Tämä rivi on poistettu, joten sitä ei pitäisi enää löytyä muualta kuin historiasta versiolla 1
-                           #_{:edellinen_maara 0 :hoitokauden_alkuvuosi 2025 :maaramuutos 111 :tehtava 3117 :uusi_maara 0 :versio 2}
-                           {:edellinen_maara 0 :hoitokauden_alkuvuosi 2026 :maaramuutos 222 :tehtava 3117 :uusi_maara 0 :versio 2}
-                           {:edellinen_maara 0 :hoitokauden_alkuvuosi 2027 :maaramuutos 333 :tehtava 3117 :uusi_maara 0 :versio 2}
+                           #_{:tehtava 3117 :hoitokauden_alkuvuosi 2025 :suunniteltu_maara 0 :maaramuutos 111 :uusi_maara nil :edellinen_maara nil :versio 2}
+                           {:tehtava 3117 :hoitokauden_alkuvuosi 2026 :suunniteltu_maara 0 :maaramuutos 222 :uusi_maara nil :edellinen_maara nil :versio 2}
+                           {:tehtava 3117 :hoitokauden_alkuvuosi 2027 :suunniteltu_maara 0 :maaramuutos 333 :uusi_maara nil :edellinen_maara nil :versio 2}
                            ;; Tämän rivin pitäisi jäädä alkuperäiseen versioon 1, koska rivi jätettiin tarkoituksella ennalleen
-                           {:edellinen_maara 1000 :hoitokauden_alkuvuosi 2028 :maaramuutos 100 :tehtava 3117 :uusi_maara 1100 :versio 1})
+                           {:tehtava 3117 :hoitokauden_alkuvuosi 2028 :suunniteltu_maara 0 :maaramuutos 100 :uusi_maara 1100 :edellinen_maara 1000 :versio 1})
         _ (muutos-palvelu/tallenna-muutoksen-tehtavien-maaramuutokset (:db jarjestelma) muutos tehtava-maaramuutos-payload)
 
         vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
@@ -539,24 +615,27 @@
                                         :syy "Esko tehdä pyöräytti uutta tietä 500 kilometria, täytyy vähän justeerata määriä"
                                         :tavoitehinnan-muutos 2222
                                         :tehtavat_ja_maarat (list
-                                                              {:hoitokauden_alkuvuosi 2025
-                                                               :edellinen_maara 0
+                                                              {:edellinen_maara nil
+                                                               :hoitokauden_alkuvuosi 2025
                                                                :maaramuutos 10
+                                                               :suunniteltu_maara 0
                                                                :tehtava 1448
-                                                               :uusi_maara 0
+                                                               :uusi_maara nil
                                                                :versio 1}
-                                                              {:hoitokauden_alkuvuosi 2025
-                                                               :edellinen_maara 0
-                                                              :maaramuutos 111
-                                                              :tehtava 2988
-                                                              :uusi_maara 0
+                                                              {:edellinen_maara nil
+                                                               :hoitokauden_alkuvuosi 2025
+                                                               :maaramuutos 111
+                                                               :suunniteltu_maara 0
+                                                               :tehtava 2988
+                                                               :uusi_maara nil
                                                                :versio 1}
-                                                             {:hoitokauden_alkuvuosi 2025
-                                                              :edellinen_maara 0
-                                                              :maaramuutos 111
-                                                              :tehtava 3117
-                                                              :uusi_maara 0
-                                                              :versio 1})
+                                                              {:edellinen_maara 1000
+                                                               :hoitokauden_alkuvuosi 2025
+                                                               :maaramuutos 111
+                                                               :suunniteltu_maara 0
+                                                               :tehtava 3117
+                                                               :uusi_maara 1100
+                                                               :versio 1})
                                         :tyyppi "pysyva"
                                         :urakka urakka-id
                                         :versio 1
@@ -605,24 +684,27 @@
                                         :syy "Esko teki 100 km lisää tietä, pitääpä justeerata määriä uudestaan"
                                         :tavoitehinnan-muutos 1113
                                         :tehtavat_ja_maarat (list
-                                                              {:edellinen_maara 0
-                                                              :hoitokauden_alkuvuosi 2025
-                                                              :maaramuutos 10
-                                                              :tehtava 1448
-                                                              :uusi_maara 0
-                                                              :versio 1}
-                                                             {:edellinen_maara 0
-                                                              :hoitokauden_alkuvuosi 2025
-                                                              :maaramuutos 2
-                                                              :tehtava 2988
-                                                              :uusi_maara 0
-                                                              :versio 2}
-                                                             {:edellinen_maara 0
-                                                              :hoitokauden_alkuvuosi 2025
-                                                              :maaramuutos 111
-                                                              :tehtava 3117
-                                                              :uusi_maara 0
-                                                              :versio 1})
+                                                              {:edellinen_maara nil
+                                                               :hoitokauden_alkuvuosi 2025
+                                                               :maaramuutos 10
+                                                               :suunniteltu_maara 0
+                                                               :tehtava 1448
+                                                               :uusi_maara nil
+                                                               :versio 1}
+                                                              {:edellinen_maara nil
+                                                               :hoitokauden_alkuvuosi 2025
+                                                               :maaramuutos 2
+                                                               :suunniteltu_maara 0
+                                                               :tehtava 2988
+                                                               :uusi_maara nil
+                                                               :versio 2}
+                                                              {:edellinen_maara 1000
+                                                               :hoitokauden_alkuvuosi 2025
+                                                               :maaramuutos 111
+                                                               :suunniteltu_maara 0
+                                                               :tehtava 3117
+                                                               :uusi_maara 1100
+                                                               :versio 1})
                                         :tyyppi "pysyva"
                                         :urakka 45
                                         :versio 2
@@ -778,24 +860,28 @@
                                                                              {:edellinen_maara 1000
                                                                               :hoitokauden_alkuvuosi 2025
                                                                               :maaramuutos 100
+                                                                              :suunniteltu_maara 0
                                                                               :tehtava 3117
                                                                               :uusi_maara 1100
                                                                               :versio 1}
                                                                              {:edellinen_maara 1000
                                                                               :hoitokauden_alkuvuosi 2026
                                                                               :maaramuutos 100
+                                                                              :suunniteltu_maara 0
                                                                               :tehtava 3117
                                                                               :uusi_maara 1100
                                                                               :versio 1}
                                                                              {:edellinen_maara 1000
                                                                               :hoitokauden_alkuvuosi 2027
                                                                               :maaramuutos 100
+                                                                              :suunniteltu_maara 0
                                                                               :tehtava 3117
                                                                               :uusi_maara 1100
                                                                               :versio 1}
                                                                              {:edellinen_maara 1000
                                                                               :hoitokauden_alkuvuosi 2028
                                                                               :maaramuutos 100
+                                                                              :suunniteltu_maara 0
                                                                               :tehtava 3117
                                                                               :uusi_maara 1100
                                                                               :versio 1})

--- a/test/clj/harja/palvelin/palvelut/muutos_palvelu_test.clj
+++ b/test/clj/harja/palvelin/palvelut/muutos_palvelu_test.clj
@@ -203,6 +203,8 @@
     (is (= (count (:kirjatut-muutokset vastaus-23-24)) 0) "oikea määrä muutoksia 23-24")
     (is (= (count (:kirjatut-muutokset vastaus-24-25)) 1) "oikea määrä muutoksia 24-25")
     (is (= [] (:kirjatut-muutokset vastaus-22-23) (:kirjatut-muutokset vastaus-23-24)))
+
+    ;; Pitäisi löytyä "aiemman vuoden pysyvä muutos" joka on voimassa 1.10.2024 alkaen
     (is (= odotetut-rivit-24-25 (:kirjatut-muutokset vastaus-24-25)))))
 
 

--- a/test/clj/harja/palvelin/palvelut/muutos_palvelu_test.clj
+++ b/test/clj/harja/palvelin/palvelut/muutos_palvelu_test.clj
@@ -52,86 +52,85 @@
         valittu-hoitokausi [(pvm/->pvm "1.10.2025") (pvm/->pvm "30.09.2026")]
         vastaus (hae-urakan-muutostiedot +kayttaja-jvh+ {:urakka-id urakka-id
                                                          :valittu-hoitokausi valittu-hoitokausi})
-        odotetut-kirjatut-muutokset [{:id 1
+        odotetut-kirjatut-muutokset [{:alityyppi nil
+                                      :id 1
                                       :jjh-muutosten-summa nil
                                       :kulu_kohdistus nil
-                                      :kustannusvaikutukset (list
-                                                              {:hoitokauden_alkuvuosi 2025
-                                                              :kustannuslaji "hankintakustannukset"
-                                                              :summa 1000
-                                                              :toimenpideinstanssi 90
-                                                              :versio 1})
+                                      :kustannusvaikutukset (list {:hoitokauden_alkuvuosi 2025
+                                                                   :kustannuslaji "hankintakustannukset"
+                                                                   :summa 1000
+                                                                   :toimenpideinstanssi 90
+                                                                   :versio 1})
                                       :liitteet nil
                                       :luonnos false
                                       :nimi "Päällysteen paikkausmuutos"
                                       :syy "Täytyykin tehdä enemmän päällysteiden paikkausta, koska pahat kelirikot."
                                       :tavoitehinnan-muutos 1000
-                                      :tehtavat_ja_maarat (list
-                                                            {:edellinen_maara 1000
-                                                             :hoitokauden_alkuvuosi 2025
-                                                             :maaramuutos 100
-                                                             :suunniteltu_maara 0
-                                                             :tehtava 3117
-                                                             :uusi_maara 1100
-                                                             :versio 1})
+                                      :tehtavat_ja_maarat (list {:edellinen_maara 1000
+                                                                 :hoitokauden_alkuvuosi 2025
+                                                                 :maaramuutos 100
+                                                                 :suunniteltu_maara 0
+                                                                 :tehtava 3117
+                                                                 :uusi_maara 1100
+                                                                 :versio 1})
                                       :tyyppi "pysyva"
                                       :urakka 36
                                       :versio 1
                                       :voimassa_alkaen #inst"2025-09-30T21:00:00.000-00:00"}
-                                     {:id 2
+                                     {:alityyppi "erillisrahoitus"
+                                      :id 2
                                       :jjh-muutosten-summa nil
                                       :kulu_kohdistus nil
-                                      :kustannusvaikutukset (list
-                                                              {:hoitokauden_alkuvuosi 2025
-                                                               :kustannuslaji "hankintakustannukset"
-                                                               :summa 3000
-                                                               :toimenpideinstanssi 89
-                                                               :versio 1})
+                                      :kustannusvaikutukset (list {:hoitokauden_alkuvuosi 2025
+                                                                   :kustannuslaji "hankintakustannukset"
+                                                                   :summa 3000
+                                                                   :toimenpideinstanssi 89
+                                                                   :versio 1})
                                       :liitteet nil
                                       :luonnos false
                                       :nimi "Erillisrahoitettu sorastusmuutos"
                                       :syy "Tehdään lisäksi tämä isohko sorastus, ei ollut tiedossa ennen urakan alkua."
                                       :tavoitehinnan-muutos 3000
                                       :tehtavat_ja_maarat ()
-                                      :tyyppi "erillisrahoitettu"
+                                      :tyyppi "muutostyo"
                                       :urakka 36
                                       :versio 1
                                       :voimassa_alkaen #inst"2025-09-30T21:00:00.000-00:00"}
-                                     {:id 3
+                                     {:alityyppi "poikkeama"
+                                      :id 3
                                       :jjh-muutosten-summa nil
                                       :kulu_kohdistus nil
-                                      :kustannusvaikutukset (list
-                                                              {:hoitokauden_alkuvuosi 2025
-                                                              :kustannuslaji "hankintakustannukset"
-                                                              :summa 1000
-                                                              :toimenpideinstanssi 91
-                                                              :versio 1})
+                                      :kustannusvaikutukset (list {:hoitokauden_alkuvuosi 2025
+                                                                   :kustannuslaji "hankintakustannukset"
+                                                                   :summa 1000
+                                                                   :toimenpideinstanssi 91
+                                                                   :versio 1})
                                       :liitteet (list {:id 11
-                                                  :muutos 3})
+                                                       :muutos 3})
                                       :luonnos false
                                       :nimi "Tämän hoitovuoden määräpoikkeamamuutos"
                                       :syy "Ei tehdä tänä kesänä rumpuja, ovat vielä kunnossa."
                                       :tavoitehinnan-muutos 1000
-                                      :tehtavat_ja_maarat (list
-                                                            {:edellinen_maara 40
-                                                            :hoitokauden_alkuvuosi 2025
-                                                            :maaramuutos -40
-                                                            :suunniteltu_maara nil
-                                                            :tehtava 1406
-                                                            :uusi_maara 0
-                                                            :versio 1}
-                                                           {:edellinen_maara 30
-                                                            :hoitokauden_alkuvuosi 2025
-                                                            :maaramuutos -30
-                                                            :suunniteltu_maara 8
-                                                            :tehtava 3029
-                                                            :uusi_maara 0
-                                                            :versio 1})
-                                      :tyyppi "maarapoikkeama"
+                                      :tehtavat_ja_maarat (list {:edellinen_maara 40
+                                                                 :hoitokauden_alkuvuosi 2025
+                                                                 :maaramuutos -40
+                                                                 :suunniteltu_maara nil
+                                                                 :tehtava 1406
+                                                                 :uusi_maara 0
+                                                                 :versio 1}
+                                                            {:edellinen_maara 30
+                                                             :hoitokauden_alkuvuosi 2025
+                                                             :maaramuutos -30
+                                                             :suunniteltu_maara 8
+                                                             :tehtava 3029
+                                                             :uusi_maara 0
+                                                             :versio 1})
+                                      :tyyppi "muutostyo"
                                       :urakka 36
                                       :versio 1
                                       :voimassa_alkaen #inst"2025-09-30T21:00:00.000-00:00"}
-                                     {:id 4
+                                     {:alityyppi nil
+                                      :id 4
                                       :jjh-muutosten-summa 1230M
                                       :kulu_kohdistus nil
                                       :kustannusvaikutukset ()
@@ -144,7 +143,7 @@
                                       :tyyppi "johto-ja-hallintokorvaus"
                                       :urakka 36
                                       :versio 1
-                                      :voimassa_alkaen #inst"2025-06-24T21:00:00.000-00:00"}]]
+                                      :voimassa_alkaen #inst"2025-10-19T21:00:00.000-00:00"}]]
     (is (= (count (:kirjatut-muutokset vastaus)) 4) "oikea määrä muutoksia")
     (is (= (:kirjatut-muutokset vastaus) odotetut-kirjatut-muutokset))))
 
@@ -323,7 +322,7 @@
 (deftest tallenna-johto-ja-hallintokorvausmuutos-ii
   (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
         valittu-hoitokausi [(pvm/->pvm "1.10.2025") (pvm/->pvm "30.09.2026")]
-        muutos-payload {:voimassa_alkaen #inst "2025-06-25T10:07:32.000-00:00",
+        muutos-payload {:voimassa_alkaen #inst "2025-10-20T10:07:32.000-00:00",
                         :syy "Johtamisen tarve muuttui",
                         :kulut (list {:pvm #inst "2025-10-14T21:00:00.000-00:00", :tavoitehinnan-muutos 10}
                                  {:pvm #inst "2025-11-14T22:00:00.000-00:00", :tavoitehinnan-muutos 20}
@@ -360,9 +359,10 @@
                                         :tavoitehinnan-muutos 780M
                                         :tehtavat_ja_maarat (list)
                                         :tyyppi "johto-ja-hallintokorvaus"
+                                        :alityyppi nil
                                         :urakka urakka-id
                                         :versio 1
-                                        :voimassa_alkaen #inst"2025-06-24T21:00:00.000-00:00"})
+                                        :voimassa_alkaen #inst"2025-10-19T21:00:00.000-00:00"})
         ;; sitten päivitetään samaa muutosta, jolloin tulee rivi historiatietoon...
         vastaus-updaten-jalkeen (filter
                                   #(= "Johtamisen tarve muuttui taas" (:syy %))
@@ -386,9 +386,10 @@
                                         :tavoitehinnan-muutos 780M
                                         :tehtavat_ja_maarat (list)
                                         :tyyppi "johto-ja-hallintokorvaus"
+                                        :alityyppi nil
                                         :urakka urakka-id
                                         :versio 2
-                                        :voimassa_alkaen #inst"2025-06-24T21:00:00.000-00:00"})
+                                        :voimassa_alkaen #inst"2025-10-19T21:00:00.000-00:00"})
         odotettu-historiarivi {:id (inc max-id-ennen-tallennusta)
                                :kulu_kohdistus nil
                                :luoja (:id +kayttaja-jvh+)
@@ -399,7 +400,7 @@
                                :tyyppi "johto-ja-hallintokorvaus"
                                :urakka 36
                                :versio 1
-                               :voimassa_alkaen #inst"2025-06-24T21:00:00.000-00:00"}
+                               :voimassa_alkaen #inst"2025-10-19T21:00:00.000-00:00"}
 
         historiassa-rivi-updaten-jalkeen-count (ffirst (q (format "SELECT count(*) FROM mhu_muutos_historia WHERE id = %s;" (inc max-id-ennen-tallennusta))))
         historiassa-rivi-updaten-jalkeen (first (q-map (format "SELECT id, kulu_kohdistus, luoja, luonnos, nimi, poistettu, syy, tyyppi,
@@ -566,7 +567,7 @@
         valittu-hoitokausi [(pvm/->pvm "1.10.2025") (pvm/->pvm "30.09.2026")]
         muutos-syy-insert "Esko tehdä pyöräytti uutta tietä 500 kilometria, täytyy vähän justeerata määriä"
         muutos-payload {:tyyppi "pysyva"
-                        :voimassa_alkaen #inst "2025-06-25T10:07:32.000-00:00",
+                        :voimassa_alkaen #inst "2025-10-01T10:07:32.000-00:00",
                         :syy muutos-syy-insert,
                         :nimi "Eskon muutos"
                         :tehtavat_ja_maarat [{:tehtava 1448, :uusi? true, :maaramuutos 10, :hoitokauden_alkuvuosi 2025}
@@ -637,9 +638,10 @@
                                                                :uusi_maara 1100
                                                                :versio 1})
                                         :tyyppi "pysyva"
+                                        :alityyppi nil
                                         :urakka urakka-id
                                         :versio 1
-                                        :voimassa_alkaen #inst"2025-06-24T21:00:00.000-00:00"})
+                                        :voimassa_alkaen #inst"2025-09-30T21:00:00.000-00:00"})
 
 
         ;; sitten päivitetään samaa muutosta, jolloin tulee rivi historiatietoon...
@@ -706,9 +708,10 @@
                                                                :uusi_maara 1100
                                                                :versio 1})
                                         :tyyppi "pysyva"
+                                        :alityyppi nil
                                         :urakka 45
                                         :versio 2
-                                        :voimassa_alkaen #inst"2025-06-24T21:00:00.000-00:00"})
+                                        :voimassa_alkaen #inst"2025-09-30T21:00:00.000-00:00"})
         odotettu-historiarivi {:id (inc max-id-ennen-tallennusta)
                                :kulu_kohdistus nil
                                :luoja (:id +kayttaja-jvh+)
@@ -719,7 +722,7 @@
                                :tyyppi "pysyva"
                                :urakka urakka-id
                                :versio 1
-                               :voimassa_alkaen #inst"2025-06-24T21:00:00.000-00:00"}
+                               :voimassa_alkaen #inst"2025-09-30T21:00:00.000-00:00"}
 
         historiassa-rivi-updaten-jalkeen-count (ffirst (q (format "SELECT count(*) FROM mhu_muutos_historia WHERE id = %s;" (inc max-id-ennen-tallennusta))))
         historiassa-rivi-updaten-jalkeen (first (q-map (format "SELECT id, kulu_kohdistus, luoja, luonnos, nimi, poistettu, syy, tyyppi,
@@ -759,7 +762,7 @@
     (is (pvm/ennen? historiarivi-validi-aikana-alku historiarivi-validi-aikana-loppu) "validi_aikana on ts-range, jossa alku < loppu")
     (is (pvm/ennen? muutosrivi-validi-aikana-alku muutosrivi-validi-aikana-loppu) "validi_aikana on ts-range, jossa alku < loppu")
 
-    (is (= vastaus-luonnin-jalkeen odotetut-luonnin-jalkeen) "PYsyvä muutos luonnin jälkeen")
+    (is (= vastaus-luonnin-jalkeen odotetut-luonnin-jalkeen) "Pysyvä muutos luonnin jälkeen")
     (is (nil? historia-tyhja-insertin-jalkeen) "Ei vielä historiatietoa, koska vain INSERT tehtiin")
 
     (is (= vastaus-updaten-jalkeen odotetut-updaten-jalkeen) "Pysyvä muutos updaten jälkeen")
@@ -941,7 +944,8 @@
    :luonnos false,
    :kulut nil,
    :tavoitehinnan-muutos 1000,
-   :tyyppi "maarapoikkeama"})
+   :tyyppi "muutostyo"
+   :alityyppi "poikkeama"})
 
 (deftest testaa-muutoksen-liitteiden-lisays-ja-poisto
   (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
@@ -967,6 +971,7 @@
                    :muutos muutos-payload})
         liitelinkkien-maara-tallennuksen-jalkeen (ffirst (q (format "SELECT COUNT(*) FROM mhu_muutos_liite WHERE muutos = %s;" muutos-id)))
         kirjatut (:kirjatut-muutokset vastaus)
+        _ (prn "toni" vastaus)
         paivitetty (first (filter #(= (:id %) muutos-id) kirjatut))
         odotetut-liite-linkit (list {:id olemassaoleva-liite-id, :muutos muutos-id} {:id luotu-liite-id, :muutos muutos-id})
         liitteet-poistava-payload (muutospayload-liitteilla muutos-id urakka-id [])

--- a/test/clj/harja/palvelin/palvelut/muutos_palvelu_test.clj
+++ b/test/clj/harja/palvelin/palvelut/muutos_palvelu_test.clj
@@ -4,6 +4,7 @@
             [clojure.walk :as walk]
             [com.stuartsierra.component :as component]
 
+            [harja.tyokalut.yleiset :refer [round2]]
             [harja.pvm :as pvm]
             [harja.testi :refer :all]
             [harja.palvelin.komponentit.tietokanta :as tietokanta]
@@ -167,11 +168,60 @@
   (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
         valittu-hoitokausi [(pvm/->pvm "1.10.2025") (pvm/->pvm "30.09.2026")]
 
-        vastaus (get-in
-                  (hae-urakan-muutostiedot +kayttaja-jvh+ {:urakka-id urakka-id
-                                                           :valittu-hoitokausi valittu-hoitokausi})
-                  [:budjettitavoitteet :muutosten-vaikutus-yht])]
-    (is (= (some-> vastaus Math/round) 292712) "Muutosten vaikutus yhteensä")))
+        vastaus (hae-urakan-muutostiedot +kayttaja-jvh+ {:urakka-id urakka-id
+                                                         :valittu-hoitokausi valittu-hoitokausi})
+        budjettitavoitteet (:budjettitavoitteet vastaus)]
+
+    ;; Indeksikorjattu tavoitehinta on nil, koska urakalle ei ole vahvistettu indeksikorjausta hoitovuodelle 2025
+    (is (= nil (:tavoitehinta-indeksikorjattu budjettitavoitteet)) "Hoitovuoden alun indeksikorjattu tavoitehinta")
+
+    (is (= 1000 (:aiemmat-pysyvat-muutokset-indeksikorjattu-yht budjettitavoitteet))
+      "Aiemmat pysyvät muutokset indeksikorjattuna")
+
+    (is (= 6230M (:kirjatut-muutokset-yht budjettitavoitteet)) "Kirjatut muutokset yhteensä")
+
+    (is (= -43277.74 (some->>
+                       (:toteumiin-perustuvat-muutokset-yht budjettitavoitteet)
+                       (round2 2))) "Toteutumiin perustuvat muutokset yhteensä")
+
+
+    ;; Muutosten vaikutus yhteensä sisältää:
+    ;; * Indeksikorjatun tavoitehinnan
+    ;; * Aiemmat pysyvät muutokset (indeksikorjattuna)
+    ;; * Kirjatut muutokset (tavoitehinnan muutokset) yhteensä
+    ;; * Toteutumiin perustuvat muutokset (tavoitehinnan muutokset) yhteensä
+    (is (= (some->> (:muutosten-vaikutus-yht budjettitavoitteet) (round2 2)) 293712.26) "Muutosten vaikutus yhteensä")))
+
+(deftest hae-urakan-tavoitehinta-muutosten-kokonaissumma-suomussalmi
+  (let [urakka-id (hae-urakan-id-nimella "POP MHU Suomussalmi 2024-2029")
+        valittu-hoitokausi [(pvm/->pvm "1.10.2026") (pvm/->pvm "30.09.2027")]
+
+        vastaus (hae-urakan-muutostiedot +kayttaja-jvh+ {:urakka-id urakka-id
+                                                         :valittu-hoitokausi valittu-hoitokausi})
+        budjettitavoitteet (:budjettitavoitteet vastaus)]
+
+    ;; Indeksikorjattu tavoitehinta on nil, koska urakalle ei ole vahvistettu indeksikorjausta hoitovuodelle 2025
+    ;; TODO: Hoidetaan testidataan Iin tai Suomussalmen urakalle vahvistettu tavoitehinta, jotta saadaan tämäkin
+    ;;       testattua kunnolla (toinen urakka riittää, ei tarvi molempiin), ja UI:ssa näkyisi jotain järkevää suoraan
+    (is (= nil (:tavoitehinta-indeksikorjattu budjettitavoitteet)) "Hoitovuoden alun indeksikorjattu tavoitehinta")
+
+    (is (= 2000 (:aiemmat-pysyvat-muutokset-indeksikorjattu-yht budjettitavoitteet))
+      "Aiemmat pysyvät muutokset indeksikorjattuna")
+
+    ;; Urakalle ei ole kirjattu muutoksia hoitovuodelle 2026-2027, ainoastaan aiemman vuoden pysyvät muutokset pitäisi näkyä
+    (is (= 0 (:kirjatut-muutokset-yht budjettitavoitteet)) "Kirjatut muutokset yhteensä")
+
+    ;; Urakalle ei ole lainkaan kirjattu toteutumiin perustuvia muutoksia
+    (is (= 0.0 (some->>
+                 (:toteumiin-perustuvat-muutokset-yht budjettitavoitteet)
+                 (round2 2))) "Toteutumiin perustuvat muutokset yhteensä")
+
+    ;; Muutosten vaikutus yhteensä sisältää:
+    ;; * Indeksikorjatun tavoitehinnan
+    ;; * Aiemmat pysyvät muutokset (indeksikorjattuna)
+    ;; * Kirjatut muutokset (tavoitehinnan muutokset) yhteensä
+    ;; * Toteutumiin perustuvat muutokset (tavoitehinnan muutokset) yhteensä
+    (is (= (some->> (:muutosten-vaikutus-yht budjettitavoitteet) (round2 2)) 2000.00) "Muutosten vaikutus yhteensä")))
 
 (deftest hae-urakan-muutostiedot-ii-kun-annetuilla-ehdoilla-ei-loydy
   (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
@@ -619,14 +669,14 @@
                                         :kustannusvaikutukset (list
                                                                 {:hoitokauden_alkuvuosi 2025
                                                                  :kustannuslaji "hankintakustannukset"
-                                                                :summa 1111
-                                                                :toimenpideinstanssi 129
+                                                                 :summa 1111
+                                                                 :toimenpideinstanssi 129
                                                                  :versio 1}
-                                                               {:hoitokauden_alkuvuosi 2025
-                                                                :kustannuslaji "hankintakustannukset"
-                                                                :summa 1111
-                                                                :toimenpideinstanssi 132
-                                                                :versio 1})
+                                                                {:hoitokauden_alkuvuosi 2025
+                                                                 :kustannuslaji "hankintakustannukset"
+                                                                 :summa 1111
+                                                                 :toimenpideinstanssi 132
+                                                                 :versio 1})
                                         :liitteet nil
                                         :luonnos nil
                                         :nimi "Eskon muutos"
@@ -694,9 +744,9 @@
                                                                  :versio 1}
                                                                 {:hoitokauden_alkuvuosi 2025
                                                                  :kustannuslaji "hankintakustannukset"
-                                                                :summa 2
-                                                                :toimenpideinstanssi 132
-                                                                :versio 2})
+                                                                 :summa 2
+                                                                 :toimenpideinstanssi 132
+                                                                 :versio 2})
                                         :liitteet nil
                                         :luonnos nil
                                         :nimi "Eskon muutos"

--- a/test/clj/harja/palvelin/palvelut/muutos_palvelu_test.clj
+++ b/test/clj/harja/palvelin/palvelut/muutos_palvelu_test.clj
@@ -53,15 +53,15 @@
         vastaus (hae-urakan-muutostiedot +kayttaja-jvh+ {:urakka-id urakka-id
                                                          :valittu-hoitokausi valittu-hoitokausi})
         odotetut-kirjatut-muutokset [{:kulu_kohdistus nil, :kustannusvaikutukset (list {:hoitokauden_alkuvuosi 2025 :summa 1000, :kustannuslaji "hankintakustannukset", :toimenpideinstanssi 90 :versio 1}),
-                                      :voimassa_alkaen #inst "2025-05-06T21:00:00.000-00:00", :syy "Täytyykin tehdä enemmän päällysteiden paikkausta, koska pahat kelirikot.",
+                                      :voimassa_alkaen #inst"2025-09-30T21:00:00.000-00:00", :syy "Täytyykin tehdä enemmän päällysteiden paikkausta, koska pahat kelirikot.",
                                       :tehtavat_ja_maarat (list {:hoitokauden_alkuvuosi 2025 :tehtava 3117, :uusi_maara 1100, :maaramuutos 100, :edellinen_maara 1000 :versio 1}),
                                       :urakka urakka-id, :nimi "Päällysteen paikkausmuutos", :id 1, :jjh-muutosten-summa nil, :liitteet nil, :versio 1, :luonnos false, :tavoitehinnan-muutos 1000, :tyyppi "pysyva"}
                                      {:kulu_kohdistus nil, :kustannusvaikutukset (list {:hoitokauden_alkuvuosi 2025 :summa 3000, :kustannuslaji "hankintakustannukset", :toimenpideinstanssi 89 :versio 1}),
-                                      :voimassa_alkaen #inst "2025-05-06T21:00:00.000-00:00", :syy "Tehdään lisäksi tämä isohko sorastus, ei ollut tiedossa ennen urakan alkua.",
+                                      :voimassa_alkaen #inst"2025-09-30T21:00:00.000-00:00", :syy "Tehdään lisäksi tämä isohko sorastus, ei ollut tiedossa ennen urakan alkua.",
                                       :tehtavat_ja_maarat (list),
                                       :urakka urakka-id, :nimi "Erillisrahoitettu sorastusmuutos", :id 2, :jjh-muutosten-summa nil, :liitteet nil, :versio 1, :luonnos false, :tavoitehinnan-muutos 3000, :tyyppi "erillisrahoitettu"}
                                      {:kulu_kohdistus nil, :kustannusvaikutukset (list {:hoitokauden_alkuvuosi 2025 :summa 1000, :kustannuslaji "hankintakustannukset", :toimenpideinstanssi 91 :versio 1}),
-                                      :voimassa_alkaen #inst "2025-05-06T21:00:00.000-00:00", :syy "Ei tehdä tänä kesänä rumpuja, ovat vielä kunnossa.",
+                                      :voimassa_alkaen #inst"2025-09-30T21:00:00.000-00:00", :syy "Ei tehdä tänä kesänä rumpuja, ovat vielä kunnossa.",
                                       :tehtavat_ja_maarat (list
                                                             {:hoitokauden_alkuvuosi 2025 :tehtava 1406, :uusi_maara 0, :maaramuutos -40, :edellinen_maara 40 :versio 1}
                                                             {:hoitokauden_alkuvuosi 2025 :tehtava 3029, :uusi_maara 0, :maaramuutos -30, :edellinen_maara 30 :versio 1}),
@@ -842,7 +842,7 @@
   {:kulu_kohdistus nil,
    :kustannusvaikutukset (list
                            {:summa 1000, :toimenpide 700, :kustannuslaji "hankintakustannukset" :hoitokauden_alkuvuosi 2025}),
-   :voimassa_alkaen #inst "2025-05-06T21:00:00.000-00:00",
+   :voimassa_alkaen #inst"2025-09-30T21:00:00.000-00:00",
    :syy "Ei tehdä tänä kesänä rumpuja, ovat vielä kunnossa.",
    :tehtavat_ja_maarat (list
                          {:tehtava 1406, :uusi_maara 0, :maaramuutos -40, :edellinen_maara 40 :hoitokauden_alkuvuosi 2025}

--- a/test/clj/harja/palvelin/palvelut/muutos_palvelu_test.clj
+++ b/test/clj/harja/palvelin/palvelut/muutos_palvelu_test.clj
@@ -171,8 +171,8 @@
         vastaus (get-in
                   (hae-urakan-muutostiedot +kayttaja-jvh+ {:urakka-id urakka-id
                                                            :valittu-hoitokausi valittu-hoitokausi})
-                  [:budjettitavoitteet :muutosten-vaikutus-yhteensa])]
-    (is (= (Math/round vastaus) -37048) "Muutosten vaikutus yhteensä")))
+                  [:budjettitavoitteet :muutosten-vaikutus-yht])]
+    (is (= (some-> vastaus Math/round) 292712) "Muutosten vaikutus yhteensä")))
 
 (deftest hae-urakan-muutostiedot-ii-kun-annetuilla-ehdoilla-ei-loydy
   (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")

--- a/tietokanta/src/main/resources/db/migration/R__Mhu_muutokset.sql
+++ b/tietokanta/src/main/resources/db/migration/R__Mhu_muutokset.sql
@@ -20,7 +20,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER mhu_muutos_historia_trigger
+DROP TRIGGER IF EXISTS mhu_muutos_historia_trigger ON mhu_muutos;
+CREATE TRIGGER mhu_muutos_historia_trigger
     -- mhu_muutos-taulun sisällöstä ei koskaan poisteta rivejä
     BEFORE UPDATE
     ON mhu_muutos
@@ -50,7 +51,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER mhu_muutos_liite_historia_trigger
+DROP TRIGGER IF EXISTS mhu_muutos_liite_historia_trigger ON mhu_muutos_liite;
+CREATE TRIGGER mhu_muutos_liite_historia_trigger
     BEFORE UPDATE OR DELETE
     ON mhu_muutos_liite
     FOR EACH ROW
@@ -78,7 +80,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER paivita_mhu_muutos_kustannusvaikutus_historia_trigger
+DROP TRIGGER IF EXISTS paivita_mhu_muutos_kustannusvaikutus_historia_trigger ON mhu_muutos_kustannusvaikutus;
+CREATE TRIGGER paivita_mhu_muutos_kustannusvaikutus_historia_trigger
     BEFORE UPDATE OR DELETE
     ON mhu_muutos_kustannusvaikutus
     FOR EACH ROW
@@ -106,7 +109,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER mhu_muutos_tehtava_ja_maaraluettelo_historia_trigger
+DROP TRIGGER IF EXISTS mhu_muutos_tehtava_ja_maaraluettelo_historia_trigger ON mhu_muutos_tehtava_ja_maaraluettelo;
+CREATE TRIGGER mhu_muutos_tehtava_ja_maaraluettelo_historia_trigger
     BEFORE UPDATE OR DELETE
     ON mhu_muutos_tehtava_ja_maaraluettelo
     FOR EACH ROW

--- a/tietokanta/testidata/muutos_testidata.sql
+++ b/tietokanta/testidata/muutos_testidata.sql
@@ -29,17 +29,19 @@ declare
     muutos_id_4 INTEGER := NULL;
     muutos_id_4_kulu_1 INTEGER := NULL;
 
+    muutos_id_5 INTEGER := NULL;
+
 BEGIN
 -- itse muutoksia on vain yksi, ja siitä tallennetaan kaikille tuleville hoitokausille kustannus- ja määrävaikutus
 
--- Muutos 1: päällysteiden paikkausta enemmän
+-- Muutos 1: [Pysyvä muutos] Päällysteiden paikkausta enemmän
    INSERT INTO mhu_muutos(versio, urakka, voimassa_alkaen, tyyppi, nimi, syy, luoja, luotu)
    VALUES (_versio, urakka_id, alkaen_pvm, 'pysyva', 'Päällysteen paikkausmuutos',
            'Täytyykin tehdä enemmän päällysteiden paikkausta, koska pahat kelirikot.', kayttaja_id_tero,
            NOW())
 RETURNING id INTO muutos_id_1;
 
--- Muutos 2: erillisrahoitettu sorastus
+-- Muutos 2: [Muutostyö: Erillisrahoitus] Erillisrahoitettu sorastus
 INSERT INTO mhu_muutos(versio, urakka, voimassa_alkaen, tyyppi, alityyppi, nimi, syy, luoja, luotu)
 VALUES (_versio,urakka_id, alkaen_pvm, 'muutostyo', 'erillisrahoitus', 'Erillisrahoitettu sorastusmuutos',
         'Tehdään lisäksi tämä isohko sorastus, ei ollut tiedossa ennen urakan alkua.', kayttaja_id_tero,
@@ -50,7 +52,7 @@ INSERT INTO mhu_muutos_kustannusvaikutus(versio, muutos, kustannuslaji, toimenpi
 VALUES (_versio, muutos_id_2, 'hankintakustannukset',
         _toimenpideinstanssi_id_sorateiden_hoito, ensimmainen_tayden_hkn_alkuvuosi, 3000);
 
--- Muutos 3: poikkeama tehtävä- ja määräluettelon määrästä yksittäisen hoitovuoden osalta, ei tehdäkään sorateiden rumpuja
+-- Muutos 3: [Muutostyö: Poikkeama] Poikkeama tehtävä- ja määräluettelon määrästä yksittäisen hoitovuoden osalta, ei tehdäkään sorateiden rumpuja
 INSERT INTO mhu_muutos(versio, urakka, voimassa_alkaen, tyyppi, alityyppi, nimi, syy, luoja, luotu)
 VALUES (_versio,urakka_id, alkaen_pvm, 'muutostyo', 'poikkeama','Tämän hoitovuoden määräpoikkeamamuutos',
         'Ei tehdä tänä kesänä rumpuja, ovat vielä kunnossa.', kayttaja_id_tero,
@@ -76,28 +78,16 @@ RETURNING id INTO muutos_id_3_liite_1;
 INSERT INTO mhu_muutos_liite (muutos, liite)
 VALUES (muutos_id_3,muutos_id_3_liite_1);
 
--- Usean hoitokauden muutokset
-FOR vuosi IN ensimmainen_tayden_hkn_alkuvuosi..viimeinen_tayden_hkn_alkuvuosi LOOP
-            -- muutos 1: päällysteiden paikkausta enemmän - kustannusvaikutus
-            INSERT INTO mhu_muutos_kustannusvaikutus(versio, muutos, kustannuslaji, toimenpideinstanssi, hoitokauden_alkuvuosi, summa)
-            VALUES (_versio, muutos_id_1, 'hankintakustannukset',
-                    _toimenpideinstanssi_id_paall_paikk, vuosi, 1000);
-            -- muutos 1: päällysteiden paikkausta enemmän - tehtävä- ja määräluettelon muutokset
-            INSERT INTO mhu_muutos_tehtava_ja_maaraluettelo(versio, muutos, tehtava, hoitokauden_alkuvuosi, edellinen_maara, maaramuutos, uusi_maara)
-            VALUES (_versio, muutos_id_1, _tehtava_id_ab_paikkaus, vuosi,
-                    1000, 100, 1100);
-
-        END LOOP;
 
 -- Muutos 4: Johto- ja hallintokorvauksen muutos
-INSERT INTO mhu_muutos (versio, urakka, voimassa_alkaen, tyyppi, nimi, syy, luoja)
-VALUES  (1, urakka_id, '2025-10-20', 'johto-ja-hallintokorvaus', null, 'Työmääräarviot ylittyivät',
-         kayttaja_id_tero)
+   INSERT INTO mhu_muutos (versio, urakka, voimassa_alkaen, tyyppi, nimi, syy, luoja)
+   VALUES  (1, urakka_id, '2025-10-20', 'johto-ja-hallintokorvaus', null, 'Työmääräarviot ylittyivät',
+            kayttaja_id_tero)
 RETURNING id INTO muutos_id_4;
 
-INSERT INTO kulu (kokonaissumma, erapaiva, urakka, luoja,  lisatieto, koontilaskun_kuukausi)
-VALUES  (1230, '2025-10-15', urakka_id, kayttaja_id_tero,
-         'Muutoksesta automaattisesti luotu kulu 1', 'lokakuu/5-hoitovuosi')
+   INSERT INTO kulu (kokonaissumma, erapaiva, urakka, luoja,  lisatieto, koontilaskun_kuukausi)
+   VALUES  (1230, '2025-10-15', urakka_id, kayttaja_id_tero,
+            'Muutoksesta automaattisesti luotu kulu 1', 'lokakuu/5-hoitovuosi')
 RETURNING id INTO muutos_id_4_kulu_1;
 
 INSERT INTO kulu_kohdistus (rivi, kulu, summa, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, luoja, tyyppi, tavoitehintainen)
@@ -105,6 +95,49 @@ VALUES  ( 0, muutos_id_4_kulu_1, 1230, _toimenpideinstassi_id_hoidon_johto, _joh
           kayttaja_id_tero, 'jjh-muutos', true);
 INSERT INTO mhu_muutos_kulu (versio, muutos, kulu)
 VALUES  (1, muutos_id_4,muutos_id_4_kulu_1);
+
+
+-- Muutos 5: [Pysyvä muutos] Edellisen hoitokauden pysyvä muutos
+--           Tämän pitäisi tulla näkyviin "Aiemmilta hoitovuosilta jatkuvat pysyvät muutokset"-taulukkoon Muutos-näkymässä
+INSERT INTO mhu_muutos(versio, urakka, voimassa_alkaen, tyyppi, nimi, syy, luoja, luotu)
+   VALUES (_versio, urakka_id, (SELECT alkaen_pvm - INTERVAL '1 year'), 'pysyva', 'Lisää paikkausta',
+           'Jonkin verran pitäisi paikkailla lisää tänä vuonna', kayttaja_id_tero,
+           NOW())
+RETURNING id INTO muutos_id_5;
+
+
+-- Usean hoitokauden muutoksia varten loopataan hoitokaudet läpi ja lisätään data tässä
+FOR vuosi IN ensimmainen_tayden_hkn_alkuvuosi..viimeinen_tayden_hkn_alkuvuosi
+    LOOP
+        -- Muutos 1: Päällysteiden paikkausta enemmän - kustannusvaikutus
+        INSERT INTO mhu_muutos_kustannusvaikutus(versio, muutos, kustannuslaji, toimenpideinstanssi,
+                                                 hoitokauden_alkuvuosi, summa)
+        VALUES (_versio, muutos_id_1, 'hankintakustannukset',
+                _toimenpideinstanssi_id_paall_paikk, vuosi, 1000);
+        -- Muutos 1: Päällysteiden paikkausta enemmän - tehtävä- ja määräluettelon muutokset
+        INSERT INTO mhu_muutos_tehtava_ja_maaraluettelo(versio, muutos, tehtava, hoitokauden_alkuvuosi, edellinen_maara,
+                                                        maaramuutos, uusi_maara)
+        VALUES (_versio, muutos_id_1, _tehtava_id_ab_paikkaus, vuosi,
+                1000, 100, 1100);
+
+        -- Muutos 5: Lisää paikkausta (aiemman hoitovuoden pysyvä muutos) - kustannusvaikutus
+        --           HOX: Muutos on voimassa alkaen edellisen hoitokauden alusta, mutta kustannusvaikutusta lisätään
+        --                seuraaville kokonaisille hoitovuosille
+        INSERT INTO mhu_muutos_kustannusvaikutus(versio, muutos, kustannuslaji, toimenpideinstanssi,
+                                                 hoitokauden_alkuvuosi, summa)
+        VALUES (_versio, muutos_id_5, 'hankintakustannukset',
+                _toimenpideinstanssi_id_paall_paikk, vuosi, 1000);
+        -- Muutos 5: Lisää paikkausta (aiemman hoitovuoden pysyvä muutos) - tehtävä- ja määräluettelon muutokset
+        --           HOX: Muutos on voimassa alkaen edellisen hoitokauden alusta, mutta määrämuutoksia lisätään
+        --           seuraaville kokonaisille hoitovuosille
+        INSERT INTO mhu_muutos_tehtava_ja_maaraluettelo(versio, muutos, tehtava, hoitokauden_alkuvuosi, edellinen_maara,
+                                                        maaramuutos, uusi_maara)
+        VALUES (_versio, muutos_id_5, _tehtava_id_ab_paikkaus, vuosi,
+                1000, 100, 1100);
+
+    END LOOP;
+
+--
 
 -- Iihin vähän kiinteähintaista työtä, jotta nähdään että nousee oikein pysyävän muutoksen lomakkeelle
 -- TODO: Tämä ei välttämättä ole tarpeeksi geneerinen eri urakoihin, mutta toimii ainakin Iissä

--- a/tietokanta/testidata/muutos_testidata.sql
+++ b/tietokanta/testidata/muutos_testidata.sql
@@ -166,10 +166,10 @@ $$ language plpgsql;
 
 
 SELECT * FROM luo_mhu_muutoksia((SELECT id FROM harja.public.urakka WHERE nimi = 'Iin MHU 2021-2026'),
-              '2025-05-07');
+              '2025-10-01');
 
 SELECT * FROM luo_mhu_muutoksia((SELECT id FROM harja.public.urakka WHERE nimi = 'POP MHU Suomussalmi 2024-2029'),
-                                '2025-05-07');
+                                '2025-10-01');
 
 
 

--- a/tietokanta/testidata/muutos_testidata.sql
+++ b/tietokanta/testidata/muutos_testidata.sql
@@ -40,8 +40,8 @@ BEGIN
 RETURNING id INTO muutos_id_1;
 
 -- Muutos 2: erillisrahoitettu sorastus
-INSERT INTO mhu_muutos(versio, urakka, voimassa_alkaen, tyyppi, nimi, syy, luoja, luotu)
-VALUES (_versio,urakka_id, alkaen_pvm, 'erillisrahoitettu', 'Erillisrahoitettu sorastusmuutos',
+INSERT INTO mhu_muutos(versio, urakka, voimassa_alkaen, tyyppi, alityyppi, nimi, syy, luoja, luotu)
+VALUES (_versio,urakka_id, alkaen_pvm, 'muutostyo', 'erillisrahoitus', 'Erillisrahoitettu sorastusmuutos',
         'Tehdään lisäksi tämä isohko sorastus, ei ollut tiedossa ennen urakan alkua.', kayttaja_id_tero,
         NOW())
 RETURNING id INTO muutos_id_2;
@@ -51,8 +51,8 @@ VALUES (_versio, muutos_id_2, 'hankintakustannukset',
         _toimenpideinstanssi_id_sorateiden_hoito, ensimmainen_tayden_hkn_alkuvuosi, 3000);
 
 -- Muutos 3: poikkeama tehtävä- ja määräluettelon määrästä yksittäisen hoitovuoden osalta, ei tehdäkään sorateiden rumpuja
-INSERT INTO mhu_muutos(versio, urakka, voimassa_alkaen, tyyppi, nimi, syy, luoja, luotu)
-VALUES (_versio,urakka_id, alkaen_pvm, 'maarapoikkeama', 'Tämän hoitovuoden määräpoikkeamamuutos',
+INSERT INTO mhu_muutos(versio, urakka, voimassa_alkaen, tyyppi, alityyppi, nimi, syy, luoja, luotu)
+VALUES (_versio,urakka_id, alkaen_pvm, 'muutostyo', 'poikkeama','Tämän hoitovuoden määräpoikkeamamuutos',
         'Ei tehdä tänä kesänä rumpuja, ovat vielä kunnossa.', kayttaja_id_tero,
         NOW())
 RETURNING id INTO muutos_id_3;
@@ -91,7 +91,7 @@ FOR vuosi IN ensimmainen_tayden_hkn_alkuvuosi..viimeinen_tayden_hkn_alkuvuosi LO
 
 -- Muutos 4: Johto- ja hallintokorvauksen muutos
 INSERT INTO mhu_muutos (versio, urakka, voimassa_alkaen, tyyppi, nimi, syy, luoja)
-VALUES  (1, urakka_id, '2025-06-25', 'johto-ja-hallintokorvaus', null, 'Työmääräarviot ylittyivät',
+VALUES  (1, urakka_id, '2025-10-20', 'johto-ja-hallintokorvaus', null, 'Työmääräarviot ylittyivät',
          kayttaja_id_tero)
 RETURNING id INTO muutos_id_4;
 


### PR DESCRIPTION
### :wrench: Lisäyksiä/parannuksia muutoksiin
* **Muutos-näkymän parannuksia**, yhteenvetorivejä, yhteenveto-elementti
* Hahmoteltu **aiempien vuosien pysyvien muutosten** taulukkoa ja tiedonhakua Muutos-näkymään
   * Lisätty testidataan yksi "aiemman hoitovuoden pysyvä muutos" 
   * Indeksikorjatut aiempien pysyvien muutosten vaikutukset
*  **Yleisempiä korjauksia** pysyvien muutosten lomakkeelle, yhteinäistämistä speksien kanssa 
* Hoitovuoden alun tavoitehinnan vahvistuksen purku pysyvän muutoksen lomakkeella manuaalisesti, mikäli vahvistettu.
* Linkit kustannussuunnitelmaan ja välikatselmukseen

### :lady_beetle: Bugikorjauksia:
* Korjaus pysyvien muutosten kopiointiin tuleville hoitovuosille.
* Triggeröidään muutostietojen haku yhteenvetoa varten Tehtävä- ja määrätoteumiin perustuvat tavoitehintamuutokset tallennuksen yhteydessä
* Korjattu testidataa ja testejä muutostöiden tyyppien ja alityyppien osalta.
* Korjattu testidataa ja testejä muutosten voimassa_alkaen päivämäärien suhteen

### :new: Uutta:
* **Tuck-efektit** eventtien turvallisempaan ja monipuolisempaan laukaisuun muista eventeistä. Lisätty pari yleishyödyllistä efektiä
* Yleiset/tietoja UI-komponenttiin parannuksia ja parempaa rivikohtaista hallintaa komponenttiin