### PR TITLE
Harja 1221 lupaus 7 tavoitehinnan ennustaminen

### DIFF
--- a/dev-resources/less/pages/lupaus_tyylit.less
+++ b/dev-resources/less/pages/lupaus_tyylit.less
@@ -442,3 +442,28 @@ input.kuukausipisteet {
 .sivupalkki-footer-otsikko {
     font-size: 0.74375rem;
 }
+
+/* Kustannusennuste-taulukon tyylit */
+
+.kustannusennuste-taulukko thead th {
+  background-color: @harmaa13;
+  padding: 8px 12px;
+  font-weight: bold;
+  border-bottom: none;
+}
+
+.kustannusennuste-taulukko tbody td {
+  background-color: @white-default;
+}
+
+.kustannusennuste-taulukko thead tr.aliotsikko th:nth-child(2n) {
+  border-right: 1px solid @harmaa9; /* jakaja tuplakolumnien välillä */
+}
+
+.kustannusennuste-taulukko thead tr.paivamaara th {
+  border-right: 1px solid @harmaa9; 
+}
+
+.kustannusennuste-taulukko tbody td:nth-child(2n) {
+  border-right: 1px solid @harmaa9; /* jakaja tuplakolumnien välillä */
+}

--- a/dev-resources/less/yleiset.less
+++ b/dev-resources/less/yleiset.less
@@ -265,6 +265,14 @@ button > .ajax-loader {
   .livi-alasveto(215px);
 }
 
+.lukutila-kentta {
+  .kentan-otsikko {}
+
+  .lukutila-arvo {
+    padding: @valistys-12 0px;
+  }
+}
+
 //vain "demo-koodia"
 .harjan-ikonit {
   -webkit-column-count: 4; /* Chrome, Safari, Opera */

--- a/dev-resources/less/yleiset.less
+++ b/dev-resources/less/yleiset.less
@@ -266,10 +266,8 @@ button > .ajax-loader {
 }
 
 .lukutila-kentta {
-  .kentan-otsikko {}
-
   .lukutila-arvo {
-    padding: @valistys-12 0px;
+    padding: @valistys-8 0px;
   }
 }
 

--- a/src/clj/harja/kyselyt/lupaus_kyselyt.sql
+++ b/src/clj/harja/kyselyt/lupaus_kyselyt.sql
@@ -439,8 +439,29 @@ WHERE "urakka-id" = :urakka-id
 -- name: paivita-kustannusennuste-lopulliset-pisteet!
 -- Päivittää kustannusennusteen lopulliset pisteet
 UPDATE lupaus_kustannusennuste
-SET lasketut_pisteet = :lopulliset-pisteet,
+SET ennustettu_tavoitehinta = :ennustettu-tavoitehinta,
+    ennustetut_kustannukset = :ennustetut-kustannukset,
+    lasketut_pisteet = :lasketut-pisteet,
     tarkkuus_prosentti = :tarkkuus-prosentti,
+    laskentakaava_versio = :laskentakaava-versio,
+    laskentakaava_teksti = :laskentakaava-teksti,
+    laskentakaava_parametrit = :laskentakaava-parametrit::jsonb,
+    laskentakaava_vaiheet = :laskentakaava-vaiheet::jsonb,
     muokkaaja = :muokkaaja,
     muokattu = NOW()
 WHERE id = :kustannusennuste-id;
+
+-- name: onko-kustannusennuste-pisteet-laskettu
+SELECT 
+  COUNT(*) as yhteensa,
+  COUNT(ke.lasketut_pisteet) as laskettu_pisteet,
+  CASE 
+    WHEN COUNT(*) = 0 THEN false
+    WHEN COUNT(ke.lasketut_pisteet) = COUNT(*) THEN true 
+    ELSE false 
+  END as kaikki_laskettu
+FROM lupaus_kustannusennuste ke
+INNER JOIN lupaus l ON l.id = ke."lupaus-id"  
+WHERE ke."urakka-id" = :urakka-id
+  AND ke.hoitovuosi_alkuvuosi = :hoitokauden-alkuvuosi
+  AND l.lupaustyyppi = 'kustannusennuste';

--- a/src/clj/harja/kyselyt/lupaus_kyselyt.sql
+++ b/src/clj/harja/kyselyt/lupaus_kyselyt.sql
@@ -297,3 +297,81 @@ SELECT id,
   FROM lupaus_hoitovuoden_kirjauskuukaudet
  WHERE "lupaus-id" = :lupaus-id
    AND "hoitovuosi-nro" = :hoitovuosi-nro;
+
+-- name: hae-kustannusennuste-id
+-- single?: true
+SELECT id 
+FROM lupaus_kustannusennuste ke
+WHERE ke."lupaus-id" = :lupaus-id
+  AND ke."urakka-id" = :urakka-id
+  AND ke.maarapaiva = :maarapaiva;
+
+-- name: hae-kustannusennuste
+-- single?: true  
+SELECT ke.id,
+       ke."lupaus-id",
+       ke."urakka-id", 
+       ke.hoitovuosi_alkuvuosi,
+       ke.maarapaiva,
+       ke.ennustettu_tavoitehinta AS tavoitehinta,
+       ke.ennustetut_kustannukset AS "toteutuneet-kustannukset",
+       ke.syotetty_pvm,
+       ke.lasketut_pisteet as pisteet,
+       ke.luoja,
+       ke.muokkaaja,
+       ke.luotu,
+       ke.muokattu
+FROM lupaus_kustannusennuste ke
+WHERE ke."lupaus-id" = :lupaus-id
+  AND ke."urakka-id" = :urakka-id  
+  AND ke.maarapaiva = :maarapaiva;
+
+-- name: lisaa-kustannusennuste<!
+INSERT INTO lupaus_kustannusennuste 
+  ("lupaus-id", "urakka-id", hoitovuosi_alkuvuosi, maarapaiva, 
+   ennustettu_tavoitehinta, ennustetut_kustannukset, syotetty_pvm, 
+   lasketut_pisteet, luoja)
+VALUES (:lupaus-id, :urakka-id, :hoitovuosi-alkuvuosi, :maarapaiva,
+        :tavoitehinta, :toteutuneet-kustannukset, :syotetty-pvm,
+        :pisteet, :kayttaja);
+
+-- name: paivita-kustannusennuste<!
+UPDATE lupaus_kustannusennuste
+SET ennustettu_tavoitehinta = :tavoitehinta,
+    ennustetut_kustannukset = :toteutuneet-kustannukset,
+    syotetty_pvm = :syotetty-pvm,
+    lasketut_pisteet = :pisteet,
+    muokkaaja = :kayttaja,
+    muokattu = NOW()
+WHERE id = :id;
+
+-- name: hae-lupauksen-kaikki-kustannusennusteet
+SELECT ke.id,
+       ke."lupaus-id",
+       ke."urakka-id", 
+       ke.hoitovuosi_alkuvuosi,
+       ke.maarapaiva,
+       ke.ennustettu_tavoitehinta AS tavoitehinta,
+       ke.ennustetut_kustannukset AS "toteutuneet-kustannukset",
+       ke.syotetty_pvm,
+       ke.lasketut_pisteet as pisteet,
+       ke.luoja,
+       ke.muokkaaja,
+       ke.luotu,
+       ke.muokattu,
+       EXTRACT(MONTH FROM ke.maarapaiva) as maarapaiva_kk
+FROM lupaus_kustannusennuste ke
+WHERE ke."lupaus-id" = :lupaus-id
+  AND ke."urakka-id" = :urakka-id
+  AND ke.hoitovuosi_alkuvuosi = :hoitokauden-alkuvuosi
+ORDER BY ke.maarapaiva;
+
+-- name: hae-kustannusennusteen-pisterajat
+SELECT pr.id,
+       pr."lupaus-id",
+       pr.maarapaiva_kk,
+       pr.tarkkuus_prosentti,
+       pr.pisteet
+FROM lupaus_kustannusennuste_pisteraja pr  
+WHERE pr."lupaus-id" = :lupaus-id
+ORDER BY pr.maarapaiva_kk, pr.tarkkuus_prosentti;

--- a/src/clj/harja/kyselyt/lupaus_kyselyt.sql
+++ b/src/clj/harja/kyselyt/lupaus_kyselyt.sql
@@ -464,3 +464,13 @@ INNER JOIN lupaus l ON l.id = ke."lupaus-id"
 WHERE ke."urakka-id" = :urakka-id
   AND ke.hoitovuosi_alkuvuosi = :hoitokauden-alkuvuosi
   AND l.lupaustyyppi = 'kustannusennuste';
+
+-- name: hae-kustannusennuste-maarapaivat
+-- Hakee kustannusennusteen määräpäivätiedot urakan alkuvuoden perusteella
+SELECT kuukausi, 
+       paiva, 
+       kuvaus,
+       MAKE_DATE(:hoitokauden-alkuvuosi + CASE WHEN kuukausi >= 10 THEN 0 ELSE 1 END, kuukausi, paiva) AS maarapaiva_pvm
+FROM lupaus_kustannusennuste_kuukausi_pisteet 
+WHERE "urakan-alkuvuosi" = :urakan-alkuvuosi
+ORDER BY kuukausi;

--- a/src/clj/harja/kyselyt/lupaus_kyselyt.sql
+++ b/src/clj/harja/kyselyt/lupaus_kyselyt.sql
@@ -375,3 +375,71 @@ SELECT pr.id,
 FROM lupaus_kustannusennuste_pisteraja pr  
 WHERE pr."lupaus-id" = :lupaus-id
 ORDER BY pr.maarapaiva_kk, pr.tarkkuus_prosentti;
+
+-- name: hae-valikatselmuksen-vahvistetut-kustannusennusteet
+SELECT pty.tavoitehinta AS "vahvistettu-tavoitehinta",
+       pty.toteutuneet_kustannukset AS "vahvistetut-toteutuneet-kustannukset",
+       pty.hoitokauden_alkuvuosi,
+       pta.hoitokauden_lopun_tavoitehinta AS "alitus-tavoitehinta", 
+       pta.toteutuneet_kustannukset AS "alitus-toteutuneet-kustannukset",
+       pta.hoitokauden_alkuvuosi AS "alitus-hoitokauden-alkuvuosi"
+FROM paatos_tavoitehinta_ylitys pty
+FULL OUTER JOIN paatos_tavoitehinta_alitus pta ON (
+    pty.urakkaid = pta.urakkaid 
+    AND pty.hoitokauden_alkuvuosi = pta.hoitokauden_alkuvuosi
+)
+WHERE (pty.urakkaid = :urakka-id OR pta.urakkaid = :urakka-id)
+  AND (pty.hoitokauden_alkuvuosi = :hoitokauden-alkuvuosi OR pta.hoitokauden_alkuvuosi = :hoitokauden-alkuvuosi)
+  AND (pty.poistettu = FALSE OR pty.poistettu IS NULL)
+  AND (pta.poistettu = FALSE OR pta.poistettu IS NULL);
+
+-- name: hae-urakan-kustannusennuste-lupaukset
+-- Hakee urakan kustannusennuste-lupaukset hoitokaudelle
+SELECT l.id AS "lupaus-id",
+       l.kuvaus,
+       l.sisalto,
+       l.jarjestys,
+       ke.id AS "kustannusennuste-id",
+       ke.ennustettu_tavoitehinta,
+       ke.ennustetut_kustannukset,
+       ke.maarapaiva,
+       ke.lasketut_pisteet
+FROM lupaus l
+JOIN lupaus_kustannusennuste ke ON l.id = ke."lupaus-id"
+WHERE l.lupaustyyppi = 'kustannusennuste'::lupaustyyppi
+  AND ke."urakka-id" = :urakka-id
+  AND ke.hoitovuosi_alkuvuosi = :hoitokauden-alkuvuosi;
+
+-- name: tallenna-lopputilanne!
+-- Tallentaa hoitovuoden lopputilanteen
+INSERT INTO lupaus_hoitovuosi_lopputilanne
+       ("urakka-id", hoitovuosi_alkuvuosi, lopullinen_tavoitehinta, 
+        lopulliset_kustannukset, valikatselmus_pvm, vahvistaja, vahvistettu)
+VALUES (:urakka-id, :hoitovuosi-alkuvuosi, :lopullinen-tavoitehinta,
+        :lopulliset-kustannukset, :valikatselmus-pvm, :vahvistaja, NOW())
+    ON CONFLICT ("urakka-id", hoitovuosi_alkuvuosi)
+    DO UPDATE SET
+        lopullinen_tavoitehinta = EXCLUDED.lopullinen_tavoitehinta,
+        lopulliset_kustannukset = EXCLUDED.lopulliset_kustannukset,
+        valikatselmus_pvm = EXCLUDED.valikatselmus_pvm,
+        vahvistaja = EXCLUDED.vahvistaja,
+        vahvistettu = NOW();
+
+-- name: hae-hoitovuoden-lopputilanne
+-- Hakee hoitovuoden lopputilanteen
+SELECT lopullinen_tavoitehinta,
+       lopulliset_kustannukset,
+       valikatselmus_pvm,
+       vahvistaja,
+       vahvistettu
+FROM lupaus_hoitovuosi_lopputilanne
+WHERE "urakka-id" = :urakka-id
+  AND hoitovuosi_alkuvuosi = :hoitovuosi-alkuvuosi;
+
+-- name: paivita-kustannusennuste-lopulliset-pisteet!
+-- Päivittää kustannusennusteen lopulliset pisteet
+UPDATE lupaus_kustannusennuste
+SET lasketut_pisteet = :lopulliset-pisteet,
+    muokkaaja = :muokkaaja,
+    muokattu = NOW()
+WHERE id = :kustannusennuste-id;

--- a/src/clj/harja/kyselyt/lupaus_kyselyt.sql
+++ b/src/clj/harja/kyselyt/lupaus_kyselyt.sql
@@ -440,6 +440,7 @@ WHERE "urakka-id" = :urakka-id
 -- Päivittää kustannusennusteen lopulliset pisteet
 UPDATE lupaus_kustannusennuste
 SET lasketut_pisteet = :lopulliset-pisteet,
+    tarkkuus_prosentti = :tarkkuus-prosentti,
     muokkaaja = :muokkaaja,
     muokattu = NOW()
 WHERE id = :kustannusennuste-id;

--- a/src/clj/harja/kyselyt/lupaus_kyselyt.sql
+++ b/src/clj/harja/kyselyt/lupaus_kyselyt.sql
@@ -311,7 +311,7 @@ WHERE ke."lupaus-id" = :lupaus-id
 SELECT ke.id,
        ke."lupaus-id",
        ke."urakka-id", 
-       ke.hoitovuosi_alkuvuosi,
+       ke.hoitovuosi,
        ke.maarapaiva,
        ke.ennustettu_tavoitehinta AS tavoitehinta,
        ke.ennustetut_kustannukset AS "toteutuneet-kustannukset",
@@ -328,7 +328,7 @@ WHERE ke."lupaus-id" = :lupaus-id
 
 -- name: lisaa-kustannusennuste<!
 INSERT INTO lupaus_kustannusennuste 
-  ("lupaus-id", "urakka-id", hoitovuosi_alkuvuosi, maarapaiva, 
+  ("lupaus-id", "urakka-id", hoitovuosi, maarapaiva, 
    ennustettu_tavoitehinta, ennustetut_kustannukset, syotetty_pvm, 
    lasketut_pisteet, luoja)
 VALUES (:lupaus-id, :urakka-id, :hoitovuosi-alkuvuosi, :maarapaiva,
@@ -349,7 +349,7 @@ WHERE id = :id;
 SELECT ke.id,
        ke."lupaus-id",
        ke."urakka-id", 
-       ke.hoitovuosi_alkuvuosi,
+       ke.hoitovuosi,
        ke.maarapaiva,
        ke.ennustettu_tavoitehinta AS tavoitehinta,
        ke.ennustetut_kustannukset AS "toteutuneet-kustannukset",
@@ -363,7 +363,7 @@ SELECT ke.id,
 FROM lupaus_kustannusennuste ke
 WHERE ke."lupaus-id" = :lupaus-id
   AND ke."urakka-id" = :urakka-id
-  AND ke.hoitovuosi_alkuvuosi = :hoitokauden-alkuvuosi
+  AND ke.hoitovuosi = :hoitokauden-alkuvuosi
 ORDER BY ke.maarapaiva;
 
 -- name: hae-kustannusennuste-kuukausi-pisterajat  
@@ -407,16 +407,16 @@ FROM lupaus l
 JOIN lupaus_kustannusennuste ke ON l.id = ke."lupaus-id"
 WHERE l.lupaustyyppi = 'kustannusennuste'::lupaustyyppi
   AND ke."urakka-id" = :urakka-id
-  AND ke.hoitovuosi_alkuvuosi = :hoitokauden-alkuvuosi;
+  AND ke.hoitovuosi = :hoitokauden-alkuvuosi;
 
 -- name: tallenna-lopputilanne!
 -- Tallentaa hoitovuoden lopputilanteen
 INSERT INTO lupaus_hoitovuosi_lopputilanne
-       ("urakka-id", hoitovuosi_alkuvuosi, lopullinen_tavoitehinta, 
+       ("urakka-id", hoitovuosi, lopullinen_tavoitehinta, 
         lopulliset_kustannukset, valikatselmus_pvm, vahvistaja, vahvistettu)
 VALUES (:urakka-id, :hoitovuosi-alkuvuosi, :lopullinen-tavoitehinta,
         :lopulliset-kustannukset, :valikatselmus-pvm, :vahvistaja, NOW())
-    ON CONFLICT ("urakka-id", hoitovuosi_alkuvuosi)
+    ON CONFLICT ("urakka-id", hoitovuosi)
     DO UPDATE SET
         lopullinen_tavoitehinta = EXCLUDED.lopullinen_tavoitehinta,
         lopulliset_kustannukset = EXCLUDED.lopulliset_kustannukset,
@@ -433,7 +433,7 @@ SELECT lopullinen_tavoitehinta,
        vahvistettu
 FROM lupaus_hoitovuosi_lopputilanne
 WHERE "urakka-id" = :urakka-id
-  AND hoitovuosi_alkuvuosi = :hoitovuosi-alkuvuosi;
+  AND hoitovuosi = :hoitovuosi-alkuvuosi;
 
 -- name: paivita-kustannusennuste-lopulliset-pisteet!
 -- Päivittää kustannusennusteen lopulliset pisteet
@@ -462,7 +462,7 @@ SELECT
 FROM lupaus_kustannusennuste ke
 INNER JOIN lupaus l ON l.id = ke."lupaus-id"  
 WHERE ke."urakka-id" = :urakka-id
-  AND ke.hoitovuosi_alkuvuosi = :hoitokauden-alkuvuosi
+  AND ke.hoitovuosi = :hoitokauden-alkuvuosi
   AND l.lupaustyyppi = 'kustannusennuste';
 
 -- name: hae-kustannusennuste-maarapaivat

--- a/src/clj/harja/kyselyt/lupaus_kyselyt.sql
+++ b/src/clj/harja/kyselyt/lupaus_kyselyt.sql
@@ -285,3 +285,31 @@ JOIN lupausryhma_urakka lu ON
 WHERE
 	lu."urakka_id" = :urakka-id
 ORDER BY r.jarjestys, l.jarjestys;
+
+-- name: hae-lupauksen-hoitovuoden-kirjauskuukaudet
+SELECT id,
+       "lupaus-id",
+       "hoitovuosi-nro",
+       "kirjaus-kkt",
+       "paatos-kk",
+       "joustovara-kkta"
+  FROM lupaus_hoitovuoden_kirjauskuukaudet
+ WHERE "lupaus-id" = :lupaus-id
+   AND "hoitovuosi-nro" = :hoitovuosi-nro;
+
+-- name: lisaa-lupauksen-hoitovuoden-kirjauskuukaudet<!
+INSERT INTO lupaus_hoitovuoden_kirjauskuukaudet ("lupaus-id", "hoitovuosi-nro", "kirjaus-kkt", "paatos-kk", "joustovara-kkta", luoja)
+VALUES (:lupaus-id, :hoitovuosi-nro, :kirjaus-kkt, :paatos-kk, :joustovara-kkta, :luoja);
+
+-- name: paivita-lupauksen-hoitovuoden-kirjauskuukaudet<!
+UPDATE lupaus_hoitovuoden_kirjauskuukaudet
+   SET "kirjaus-kkt" = :kirjaus-kkt,
+       "paatos-kk" = :paatos-kk,
+       "joustovara-kkta" = :joustovara-kkta
+ WHERE "lupaus-id" = :lupaus-id
+   AND "hoitovuosi-nro" = :hoitovuosi-nro;
+
+-- name: poista-lupauksen-hoitovuoden-kirjauskuukaudet<!
+DELETE FROM lupaus_hoitovuoden_kirjauskuukaudet
+ WHERE "lupaus-id" = :lupaus-id
+   AND "hoitovuosi-nro" = :hoitovuosi-nro;

--- a/src/clj/harja/kyselyt/lupaus_kyselyt.sql
+++ b/src/clj/harja/kyselyt/lupaus_kyselyt.sql
@@ -366,15 +366,14 @@ WHERE ke."lupaus-id" = :lupaus-id
   AND ke.hoitovuosi_alkuvuosi = :hoitokauden-alkuvuosi
 ORDER BY ke.maarapaiva;
 
--- name: hae-kustannusennusteen-pisterajat
-SELECT pr.id,
-       pr."lupaus-id",
-       pr.maarapaiva_kk,
-       pr.tarkkuus_prosentti,
-       pr.pisteet
-FROM lupaus_kustannusennuste_pisteraja pr  
-WHERE pr."lupaus-id" = :lupaus-id
-ORDER BY pr.maarapaiva_kk, pr.tarkkuus_prosentti;
+-- name: hae-kustannusennuste-kuukausi-pisterajat  
+-- single?: true
+-- Hakee kuukauden pisterajat JSON-muodossa uudesta taulusta
+SELECT kp.pisterajat
+FROM lupaus_kustannusennuste_kuukausi_pisteet kp
+WHERE kp."urakan-alkuvuosi" = :urakan-alkuvuosi
+  AND kp.kuukausi = :kuukausi  
+ORDER BY kp.paiva;
 
 -- name: hae-valikatselmuksen-vahvistetut-kustannusennusteet
 SELECT pty.tavoitehinta AS "vahvistettu-tavoitehinta",

--- a/src/clj/harja/kyselyt/lupaus_kyselyt.sql
+++ b/src/clj/harja/kyselyt/lupaus_kyselyt.sql
@@ -287,6 +287,7 @@ WHERE
 ORDER BY r.jarjestys, l.jarjestys;
 
 -- name: hae-lupauksen-hoitovuoden-kirjauskuukaudet
+-- row-fn: muunna-lupaus
 SELECT id,
        "lupaus-id",
        "hoitovuosi-nro",
@@ -294,22 +295,5 @@ SELECT id,
        "paatos-kk",
        "joustovara-kkta"
   FROM lupaus_hoitovuoden_kirjauskuukaudet
- WHERE "lupaus-id" = :lupaus-id
-   AND "hoitovuosi-nro" = :hoitovuosi-nro;
-
--- name: lisaa-lupauksen-hoitovuoden-kirjauskuukaudet<!
-INSERT INTO lupaus_hoitovuoden_kirjauskuukaudet ("lupaus-id", "hoitovuosi-nro", "kirjaus-kkt", "paatos-kk", "joustovara-kkta", luoja)
-VALUES (:lupaus-id, :hoitovuosi-nro, :kirjaus-kkt, :paatos-kk, :joustovara-kkta, :luoja);
-
--- name: paivita-lupauksen-hoitovuoden-kirjauskuukaudet<!
-UPDATE lupaus_hoitovuoden_kirjauskuukaudet
-   SET "kirjaus-kkt" = :kirjaus-kkt,
-       "paatos-kk" = :paatos-kk,
-       "joustovara-kkta" = :joustovara-kkta
- WHERE "lupaus-id" = :lupaus-id
-   AND "hoitovuosi-nro" = :hoitovuosi-nro;
-
--- name: poista-lupauksen-hoitovuoden-kirjauskuukaudet<!
-DELETE FROM lupaus_hoitovuoden_kirjauskuukaudet
  WHERE "lupaus-id" = :lupaus-id
    AND "hoitovuosi-nro" = :hoitovuosi-nro;

--- a/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
@@ -692,6 +692,7 @@
                             :ennustettu-tavoitehinta ennustettu-tavoitehinta
                             :ennustetut-kustannukset ennustetut-kustannukset
                             :lopulliset-pisteet (:pisteet lopulliset-pisteet)
+                            :tarkkuus-prosentti (:tarkkuus-prosentti lopulliset-pisteet)
                             :muokkaaja user-id})
                 
                       (log/info (format "Päivitettiin kustannusennuste %s lopulliset pisteet: %s"

--- a/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
@@ -111,6 +111,32 @@
                       (lupaus-kyselyt/hae-urakan-lupaustiedot db {:urakka urakka-id
                                                                    :alkupvm hk-alkupvm
                                                                    :loppupvm hk-loppupvm}))
+        ;; Selvitä hoitovuosi-nro suhteessa urakan alkuvuoteen erikoisarvoja varten
+        urakan-tiedot (first (urakat-q/hae-urakka db {:id urakka-id}))
+        urakan-alkuvuosi (some-> (:alkupvm urakan-tiedot) pvm/vuosi)
+        hoitovuosi-nro (when (and urakan-alkuvuosi hk-alkupvm)
+                         (pvm/hoitokausivuosi->mhu-hoitovuosi-nro (:alkupvm urakan-tiedot) (pvm/vuosi hk-alkupvm)))
+        lupaus-idt (mapv :lupaus-id vastaus)
+        erikoisarvot (if (seq lupaus-idt)
+                               ;; Hae erikoisarvot yksi kerrallaan ja ryhmittele
+                       (->> lupaus-idt
+                         (map #(lupaus-kyselyt/hae-lupauksen-hoitovuoden-kirjauskuukaudet db {:lupaus-id %
+                                                                                              :hoitovuosi-nro hoitovuosi-nro}))
+                         (filter seq)
+                         (map first)
+                         (group-by :lupaus-id))
+                       {})
+        ;; Sovelletaan erikoisarvot perusarvoihin ennen domain-muunnoksia  
+        vastaus (mapv (fn [r]
+                        (if-let [erikoisarvo (first (get erikoisarvot (:lupaus-id r)))]
+                          (-> r
+                              (assoc :hoitovuosi-nro hoitovuosi-nro)
+                              (assoc :hoitovuoden-erikoisarvot erikoisarvo)
+                              (assoc :kirjaus-kkt (:kirjaus-kkt erikoisarvo))
+                              (cond-> (not (nil? (:paatos-kk erikoisarvo))) (assoc :paatos-kk (:paatos-kk erikoisarvo)))
+                              (cond-> (not (nil? (:joustovara-kkta erikoisarvo))) (assoc :joustovara-kkta (:joustovara-kkta erikoisarvo))))
+                          r))
+                      vastaus)
         vastaus (->> vastaus
                      (mapv #(update % :vastaukset konversio/jsonb->clojuremap))
                      (mapv #(update % :vastaukset
@@ -291,7 +317,13 @@
                                                        (first (lupaus-kyselyt/hae-lupaus-vastaus db {:id id}))
                                                        tiedot)
         _ (assert lupaus-id)
-        lupaus (first (lupaus-kyselyt/hae-lupaus db {:id lupaus-id}))]
+  lupaus (first (lupaus-kyselyt/hae-lupaus db {:id lupaus-id}))
+  urakan-tiedot (first (urakat-q/hae-urakka db {:id urakka-id}))
+  urakan-alkupvm (:alkupvm urakan-tiedot)
+  ;; Hoitovuoden järjestysnumero (1 = ensimmäinen) perustuen kuukausi/vuosi -parametreihin
+  paivamaara (pvm/luo-pvm vuosi (dec kuukausi) 1)
+  hoitovuosi-nro (pvm/paivamaara->mhu-hoitovuosi-nro urakan-alkupvm paivamaara)
+  hoitovuoden-erikoisarvot nil #_(first (lupaus-kyselyt/hae-lupauksen-hoitovuoden-kirjauskuukaudet db {:lupaus-id lupaus-id :hoitovuosi-nro hoitovuosi-nro}))]
     (assert (false? (valikatselmus-tehty-urakalle? db urakka-id (pvm/hoitokauden-alkuvuosi vuosi kuukausi)))
             "Vastauksia ei voi enää muuttaa välikatselmuksen jälkeen")
     ;; Tarkista, että "yksittainen"-tyyppiselle lupaukselle on annettu boolean "vastaus",
@@ -299,7 +331,8 @@
     (tarkista-vastaus-ja-vaihtoehto db lupaus vastaus lupaus-vaihtoehto-id)
     (when-not id
       ;; Tarkista, että kirjaus/päätös tulee sallitulle kuukaudelle.
-      (assert (lupaus-domain/sallittu-kuukausi? lupaus kuukausi paatos)))))
+  (assert (lupaus-domain/sallittu-kuukausi-hoitovuodelle? lupaus kuukausi paatos hoitovuosi-nro hoitovuoden-erikoisarvot)
+      (str "Kuukausi " kuukausi " ei ole sallittu (paatos=" paatos ") hoitovuodelle " hoitovuosi-nro ".")))))
 
 (defn- nykyhetki
   "Mahdollistaa nykyhetken lähettämisen parametrina kehitysympäristössä.

--- a/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
@@ -151,7 +151,7 @@
                                         tulos))))
                      (mapv lupaus-domain/liita-ennuste-tai-toteuma)
                      (mapv #(lupaus-domain/liita-odottaa-kannanottoa % nykyhetki valittu-hoitokausi))
-                     (mapv #(lupaus-domain/liita-lupaus-kuukaudet % nykyhetki valittu-hoitokausi))
+                     (mapv #(lupaus-domain/liita-lupaus-kuukaudet % nykyhetki valittu-hoitokausi hoitovuosi-nro (get erikoisarvot (:lupaus-id %))))
                      (mapv #(liita-lupaus-vaihtoehdot db %)))
         lupaus-sitoutuminen (sitoutumistiedot vastaus)
         lupausryhmat (lupausryhman-tiedot vastaus)

--- a/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
@@ -726,14 +726,13 @@
     (let [hk-alkupvm (pvm/hoitokauden-alkupvm hoitokauden-alkuvuosi)
           hoitovuoden-alun-tavoitehinta (maarita-urakan-tavoitehinta db urakka-id hk-alkupvm)]
       
-      ;; Tallenna ensin lopputilanne
-      (when (resolve 'lupaus-kyselyt/tallenna-lopputilanne!)
+        ;; Tallenna ensin lopputilanne 
         (lupaus-kyselyt/tallenna-lopputilanne! db {:urakka-id urakka-id
                                                    :hoitovuosi-alkuvuosi hoitokauden-alkuvuosi
                                                    :lopullinen-tavoitehinta toteutunut-tavoitehinta
                                                    :lopulliset-kustannukset toteutunut-kustannus
                                                    :valikatselmus-pvm valikatselmus-pvm
-                                                   :vahvistaja user-id}))
+                                                   :vahvistaja user-id})
 
       ;; Hae kaikki kustannusennusteet lupausten kautta
       (let [lupaukset (lupaus-kyselyt/hae-urakan-lupaukset db {:urakka-id urakka-id})

--- a/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
@@ -103,6 +103,16 @@
   (let [lupauspaatos (first (paatos-kyselyt/hae-lupauspaatokset db {:urakkaid urakka-id :hoitokauden_alkuvuosi hoitokauden-alkuvuosi}))]
     (boolean lupauspaatos)))
 
+(defn hae-lupauksen-kustannusennusteet
+  "Hakee lupauksen kaikki kustannusennusteet hoitokaudelle"
+  [db lupaus-id urakka-id hoitokauden-alkuvuosi]
+  (when (and lupaus-id urakka-id hoitokauden-alkuvuosi)
+    ;; Haetaan kaikki kustannusennusteet kerralla
+    (lupaus-kyselyt/hae-lupauksen-kaikki-kustannusennusteet 
+      db {:lupaus-id lupaus-id
+          :urakka-id urakka-id
+          :hoitokauden-alkuvuosi hoitokauden-alkuvuosi})))
+
 (defn hae-urakan-lupaustiedot-hoitokaudelle [db {:keys [urakka-id nykyhetki
                                                         valittu-hoitokausi] :as tiedot}]
   (let [[hk-alkupvm hk-loppupvm] valittu-hoitokausi
@@ -151,7 +161,9 @@
                                         tulos))))
                      (mapv lupaus-domain/liita-ennuste-tai-toteuma)
                      (mapv #(lupaus-domain/liita-odottaa-kannanottoa % nykyhetki valittu-hoitokausi))
-                     (mapv #(lupaus-domain/liita-lupaus-kuukaudet % nykyhetki valittu-hoitokausi hoitovuosi-nro (get erikoisarvot (:lupaus-id %))))
+                     (mapv #(let [kustannusennusteet (when (= "kustannusennuste" (:lupaustyyppi %))
+                                                       (hae-lupauksen-kustannusennusteet db (:lupaus-id %) urakka-id hoitokauden-alkuvuosi))]
+                              (lupaus-domain/liita-lupaus-kuukaudet % nykyhetki valittu-hoitokausi hoitovuosi-nro (get erikoisarvot (:lupaus-id %)) kustannusennusteet)))
                      (mapv #(liita-lupaus-vaihtoehdot db %)))
         lupaus-sitoutuminen (sitoutumistiedot vastaus)
         lupausryhmat (lupausryhman-tiedot vastaus)
@@ -292,21 +304,96 @@
     ;; Sallitaan nil-arvon asettaminen.
     true))
 
-(defn- tarkista-vastaus-ja-vaihtoehto
-  "Tarkista, että 'yksittainen'-tyyppiselle lupaukselle on annettu boolean 'vastaus',
-  ja muun tyyppiselle sallittu 'lupaus-vaihtoehto-id'.
-  vastaus / lupaus-vaihtoehto-id voidaan asettaa nil-arvoon."
-  [db lupaus vastaus lupaus-vaihtoehto-id]
-  (cond (= "yksittainen" (:lupaustyyppi lupaus))
-        (assert (nil? lupaus-vaihtoehto-id))
+(defn laske-kustannusennuste-pisteet
+  "Laskee pisteet poikkeamaprosentin ja määräpäivän perusteella"
+  [db lupaus-id poikkeama-prosentti maarapaiva-kk]
+  (let [pisterajat (lupaus-kyselyt/hae-kustannusennusteen-pisterajat
+                     db {:lupaus-id lupaus-id})]
+    ;; Etsi sopiva pisteraja kuukauden ja poikkeaman perusteella
+    (->> pisterajat
+      (filter #(= (:maarapaiva-kk %) maarapaiva-kk))
+      (filter #(<= poikkeama-prosentti (:tarkkuus-prosentti %)))
+      (sort-by :tarkkuus-prosentti)
+      first
+      :pisteet
+      (or 1)))) ; Oletuspisteet jos ei löydy sopivaa rajaa
 
-        (or (= "monivalinta" (:lupaustyyppi lupaus))
-            (= "kysely" (:lupaustyyppi lupaus)))
-        (do (assert (nil? vastaus))
-            (assert (sallittu-vaihtoehto? db (:id lupaus) lupaus-vaihtoehto-id)))))
+(defn- kustannusennuste-poikkeama
+  "Laskee kustannusennusteen poikkeama-prosentin"
+  [{:keys [tavoitehinta toteutuneet-kustannukset]}]
+  (when (and tavoitehinta toteutuneet-kustannukset (pos? tavoitehinta))
+    (Math/abs (double (/ (* 100 (- toteutuneet-kustannukset tavoitehinta))
+                         tavoitehinta)))))
+
+(defn- tallenna-kustannusennuste-vastaus [db user {:keys [lupaus-id urakka-id kuukausi vuosi
+                                                          kustannusennuste] :as tiedot}]
+  ;; Laske pisteet automaattisesti
+  (let [poikkeama-prosentti (kustannusennuste-poikkeama kustannusennuste)
+        pisteet (laske-kustannusennuste-pisteet db lupaus-id poikkeama-prosentti kuukausi)
+        maarapaiva (pvm/luo-pvm vuosi (dec kuukausi) 15) ; 15. päivä
+        syotetty-pvm (pvm/nyt)
+        
+        ;; Laske hoitovuosi-alkuvuosi
+        urakan-tiedot (first (urakat-q/hae-urakka db {:id urakka-id}))
+        urakan-alkupvm (:alkupvm urakan-tiedot)
+        paivamaara (pvm/luo-pvm vuosi (dec kuukausi) 1)
+        hoitovuosi-nro (pvm/paivamaara->mhu-hoitovuosi-nro urakan-alkupvm paivamaara)
+        hoitovuosi-alkuvuosi (pvm/hoitokauden-alkuvuosi vuosi kuukausi)
+
+        ;; Tarkista onko kustannusennuste jo olemassa
+        olemassa-oleva-id (lupaus-kyselyt/hae-kustannusennuste-id
+                            db {:lupaus-id lupaus-id
+                                :urakka-id urakka-id
+                                :maarapaiva maarapaiva})]
+
+    (if olemassa-oleva-id
+      ;; Päivitä olemassa oleva
+      (lupaus-kyselyt/paivita-kustannusennuste<!
+        db (merge kustannusennuste
+             {:id olemassa-oleva-id
+              :pisteet pisteet
+              :syotetty-pvm syotetty-pvm
+              :hoitovuosi-alkuvuosi hoitovuosi-alkuvuosi
+              :kayttaja (:id user)}))
+      ;; Luo uusi
+      (lupaus-kyselyt/lisaa-kustannusennuste<!
+        db (merge kustannusennuste
+             {:lupaus-id lupaus-id
+              :urakka-id urakka-id
+              :maarapaiva maarapaiva
+              :pisteet pisteet
+              :syotetty-pvm syotetty-pvm
+              :hoitovuosi-alkuvuosi hoitovuosi-alkuvuosi
+              :kayttaja (:id user)})))
+
+    ;; Palauta kustannusennusteen tiedot
+    (lupaus-kyselyt/hae-kustannusennuste db
+      {:lupaus-id lupaus-id
+       :urakka-id urakka-id
+       :maarapaiva maarapaiva})))
+
+(defn- tarkista-vastaus-ja-vaihtoehto
+  "Tarkista vastaustyyppi lupauksen tyypin mukaan"
+  [db lupaus vastaus lupaus-vaihtoehto-id kustannusennuste]
+  (cond
+    (= "yksittainen" (:lupaustyyppi lupaus))
+    (assert (nil? lupaus-vaihtoehto-id))
+
+    (= "kustannusennuste" (:lupaustyyppi lupaus))
+    (do
+      (assert (nil? vastaus))
+      (assert (nil? lupaus-vaihtoehto-id))
+      (assert kustannusennuste "Kustannusennuste on pakollinen")
+      (assert (:tavoitehinta kustannusennuste) "Tavoitehinta on pakollinen")
+      (assert (:toteutuneet-kustannukset kustannusennuste) "Toteutuneet kustannukset pakolliset"))
+
+    (or (= "monivalinta" (:lupaustyyppi lupaus))
+      (= "kysely" (:lupaustyyppi lupaus)))
+    (do (assert (nil? vastaus))
+      (assert (sallittu-vaihtoehto? db (:id lupaus) lupaus-vaihtoehto-id)))))
 
 (defn- tarkista-lupaus-vastaus
-  [db user {:keys [id lupaus-id urakka-id kuukausi vuosi paatos vastaus lupaus-vaihtoehto-id] :as tiedot}]
+  [db user {:keys [id lupaus-id urakka-id kuukausi vuosi paatos vastaus lupaus-vaihtoehto-id kustannusennuste] :as tiedot}]
   {:pre [db user tiedot]}
   (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-valitavoitteet user urakka-id)
   (when (and paatos (not (roolit/tilaajan-kayttaja? user)))
@@ -328,7 +415,7 @@
             "Vastauksia ei voi enää muuttaa välikatselmuksen jälkeen")
     ;; Tarkista, että "yksittainen"-tyyppiselle lupaukselle on annettu boolean "vastaus",
     ;; ja muun tyyppiselle sallittu "lupaus-vaihtoehto-id".
-    (tarkista-vastaus-ja-vaihtoehto db lupaus vastaus lupaus-vaihtoehto-id)
+    (tarkista-vastaus-ja-vaihtoehto db lupaus vastaus lupaus-vaihtoehto-id kustannusennuste)
     (when-not id
       ;; Tarkista, että kirjaus/päätös tulee sallitulle kuukaudelle.
   (assert (lupaus-domain/sallittu-kuukausi-hoitovuodelle? lupaus kuukausi paatos hoitovuosi-nro hoitovuoden-erikoisarvot)
@@ -346,14 +433,19 @@
   (assoc tiedot :nykyhetki (nykyhetki tiedot asetukset)))
 
 (defn- vastaa-lupaukseen
-  [db user {:keys [id lupaus-id urakka-id kuukausi vuosi paatos vastaus lupaus-vaihtoehto-id] :as tiedot}]
+  [db user {:keys [id lupaus-id] :as tiedot}]
   {:pre [db user tiedot]}
   (log/debug "vastaa-lupaukseen " tiedot)
   (tarkista-lupaus-vastaus db user tiedot)
+
   (jdbc/with-db-transaction [db db]
-                            (if id
-                              (paivita-lupaus-vastaus db (:id user) tiedot)
-                              (lisaa-lupaus-vastaus db (:id user) tiedot))))
+    (if (= "kustannusennuste" (:lupaustyyppi (first (lupaus-kyselyt/hae-lupaus db {:id lupaus-id}))))
+      ;; Kustannusennustelogiikka
+      (tallenna-kustannusennuste-vastaus db user tiedot)
+      ;; Tavallinen lupausvastaus
+      (if id
+        (paivita-lupaus-vastaus db (:id user) tiedot)
+        (lisaa-lupaus-vastaus db (:id user) tiedot)))))
 
 (defn- kommentit
   [db user {:keys [lupaus-id urakka-id aikavali] :as tiedot}]

--- a/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
@@ -140,10 +140,12 @@
                                                         valittu-hoitokausi] :as tiedot}]
   (let [[hk-alkupvm hk-loppupvm] valittu-hoitokausi
         hoitokauden-alkuvuosi (pvm/vuosi hk-alkupvm)
+        kustannusennuste-pisteet-tila (onko-kustannusennuste-pisteet-laskettu?
+                                        db urakka-id hoitokauden-alkuvuosi)
         vastaus (into []
-                      (lupaus-kyselyt/hae-urakan-lupaustiedot db {:urakka urakka-id
-                                                                   :alkupvm hk-alkupvm
-                                                                   :loppupvm hk-loppupvm}))
+                  (lupaus-kyselyt/hae-urakan-lupaustiedot db {:urakka urakka-id
+                                                              :alkupvm hk-alkupvm
+                                                              :loppupvm hk-loppupvm}))
         ;; Selvitä hoitovuosi-nro suhteessa urakan alkuvuoteen erikoisarvoja varten
         urakan-tiedot (first (urakat-q/hae-urakka db {:id urakka-id}))
         urakan-alkuvuosi (some-> (:alkupvm urakan-tiedot) pvm/vuosi)
@@ -163,31 +165,34 @@
         vastaus (mapv (fn [r]
                         (if-let [erikoisarvo (first (get erikoisarvot (:lupaus-id r)))]
                           (-> r
-                              (assoc :hoitovuosi-nro hoitovuosi-nro)
-                              (assoc :hoitovuoden-erikoisarvot erikoisarvo)
-                              (assoc :kirjaus-kkt (:kirjaus-kkt erikoisarvo))
-                              (cond-> (not (nil? (:paatos-kk erikoisarvo))) (assoc :paatos-kk (:paatos-kk erikoisarvo)))
-                              (cond-> (not (nil? (:joustovara-kkta erikoisarvo))) (assoc :joustovara-kkta (:joustovara-kkta erikoisarvo))))
+                            (assoc :hoitovuosi-nro hoitovuosi-nro)
+                            (assoc :hoitovuoden-erikoisarvot erikoisarvo)
+                            (assoc :kirjaus-kkt (:kirjaus-kkt erikoisarvo))
+                            (cond-> (not (nil? (:paatos-kk erikoisarvo))) (assoc :paatos-kk (:paatos-kk erikoisarvo)))
+                            (cond-> (not (nil? (:joustovara-kkta erikoisarvo))) (assoc :joustovara-kkta (:joustovara-kkta erikoisarvo))))
                           r))
-                      vastaus)
+                  vastaus)
         vastaus (->> vastaus
-                     (mapv #(update % :vastaukset konversio/jsonb->clojuremap))
-                     (mapv #(update % :vastaukset
-                                    (fn [rivit]
-                                      (let [tulos (keep
-                                                    (fn [r]
+                  (mapv #(update % :vastaukset konversio/jsonb->clojuremap))
+                  (mapv #(update % :vastaukset
+                           (fn [rivit]
+                             (let [tulos (keep
+                                           (fn [r]
                                                       ;; Haku käyttää hakemisessa left joinia, joten on mahdollista, että taulusta
                                                       ;; löytyy nil id
-                                                      (when (not (nil? (:f1 r)))
-                                                        (clojure.set/rename-keys r db-vastaus->speqcl-avaimet)))
-                                                    rivit)]
-                                        tulos))))
-                     (mapv lupaus-domain/liita-ennuste-tai-toteuma)
-                     (mapv #(lupaus-domain/liita-odottaa-kannanottoa % nykyhetki valittu-hoitokausi))
-                     (mapv #(let [kustannusennusteet (when (= "kustannusennuste" (:lupaustyyppi %))
-                                                       (hae-lupauksen-kustannusennusteet db (:lupaus-id %) urakka-id hoitokauden-alkuvuosi))]
-                              (lupaus-domain/liita-lupaus-kuukaudet % nykyhetki valittu-hoitokausi hoitovuosi-nro (get erikoisarvot (:lupaus-id %)) kustannusennusteet)))
-                     (mapv #(liita-lupaus-vaihtoehdot db %)))
+                                             (when (not (nil? (:f1 r)))
+                                               (clojure.set/rename-keys r db-vastaus->speqcl-avaimet)))
+                                           rivit)]
+                               tulos))))
+                  (mapv #(lupaus-domain/liita-odottaa-kannanottoa % nykyhetki valittu-hoitokausi))
+                  (mapv #(let [kustannusennusteet (when (= "kustannusennuste" (:lupaustyyppi %))
+                                                    (hae-lupauksen-kustannusennusteet db (:lupaus-id %) urakka-id hoitokauden-alkuvuosi))]
+                           (lupaus-domain/liita-lupaus-kuukaudet % nykyhetki valittu-hoitokausi hoitovuosi-nro (get erikoisarvot (:lupaus-id %)) kustannusennusteet)))
+                  (mapv #(liita-lupaus-vaihtoehdot db %))
+                  (mapv #(if (= "kustannusennuste" (:lupaustyyppi %))
+                           (assoc % :hoitovuosi-paattynyt? (:kaikki-laskettu kustannusennuste-pisteet-tila))
+                           %))
+                  (mapv lupaus-domain/liita-ennuste-tai-toteuma))
         lupaus-sitoutuminen (sitoutumistiedot vastaus)
         lupausryhmat (lupausryhman-tiedot vastaus)
         piste-maksimi (lupaus-domain/rivit->maksimipisteet lupausryhmat)
@@ -197,13 +202,11 @@
         merkitsevat-odottaa-kannanottoa (lupaus-domain/lupausryhmat->merkitsevat-odottaa-kannanottoa lupausryhmat)
         odottaa-urakoitsijan-kannanottoa? (> odottaa-kannanottoa merkitsevat-odottaa-kannanottoa)
         tavoitehinta (when hk-alkupvm (maarita-urakan-tavoitehinta db urakka-id hk-alkupvm))
-        ;; Hae oikaistu tavoitehinta välikatselmuksesta vertailua varten
-        kustannusennuste-pisteet-tila (onko-kustannusennuste-pisteet-laskettu?
-                                        db urakka-id hoitokauden-alkuvuosi)
+        ;; Hae oikaistu tavoitehinta välikatselmuksesta vertailua varten 
         oikaistu-tavoitehinta-data (try
                                      (when hk-alkupvm
-                                       (valikatselmus-q/hae-oikaistu-tavoitehinta 
-                                         db {:urakka-id urakka-id 
+                                       (valikatselmus-q/hae-oikaistu-tavoitehinta
+                                         db {:urakka-id urakka-id
                                              :hoitokauden-alkuvuosi hoitokauden-alkuvuosi}))
                                      (catch Exception e
                                        (log/warn "Oikaistun tavoitehinnan haku epäonnistui:" (.getMessage e))
@@ -230,19 +233,19 @@
                                :tavoitehinta tavoitehinta}))
         ;; Ennuste voidaan tehdä, jos hoitokauden alkupäivä on menneisyydessä ja bonus-tai-sanktio != nil
         ennusteen-voi-tehda? (and (pvm/sama-tai-jalkeen? nykyhetki hk-alkupvm)
-                                  bonus-tai-sanktio)
+                               bonus-tai-sanktio)
         hoitovuosi-valmis? (boolean piste-toteuma)
         ennusteen-tila (cond tallennettu-bonus-tai-sanktio
-                             :katselmoitu-toteuma
+                         :katselmoitu-toteuma
 
-                             hoitovuosi-valmis?
-                             :alustava-toteuma
+                         hoitovuosi-valmis?
+                         :alustava-toteuma
 
-                             ennusteen-voi-tehda?
-                             :ennuste
+                         ennusteen-voi-tehda?
+                         :ennuste
 
-                             :else
-                             :ei-viela-ennustetta)]
+                         :else
+                         :ei-viela-ennustetta)]
     {:lupaus-sitoutuminen (if tallennettu-paatos
                             ;; Näytetään päätökseen tallennetut pisteet, jos saatavilla
                             {:pisteet (:luvatut_pisteet tallennettu-paatos)}
@@ -646,6 +649,42 @@
                    :luvatut-pisteet-puuttuu? luvatut-pisteet-puuttuu?
                    :vahvistetut-kustannusennusteet vahvistetut-kustannusennusteet}})))
 
+(defn- hae-kustannusennuste-pisterajat
+  "Hakee kustannusennusteen pisterajat tietokannasta ja konvertoi JSONB:n Clojure-dataksi"
+  [db urakan-alkuvuosi kuukausi]
+  (let [tulos (lupaus-kyselyt/hae-kustannusennuste-kuukausi-pisterajat
+                db
+                {:urakan-alkuvuosi urakan-alkuvuosi
+                 :kuukausi kuukausi})]
+    (when tulos
+      (konversio/jsonb->clojuremap tulos))))
+
+(defn maarita-kustannusennuste-pisteet
+  "Määrittää pisteet tarkkuuden ja kuukauden perusteella tietokannasta haettujen pisterajojen mukaan.
+   Kuukausikohtaiset raja-arvot määrittävät pistemäärän."
+  ([db tarkkuus-prosentti kuukausi urakan-alkuvuosi]
+   (maarita-kustannusennuste-pisteet db tarkkuus-prosentti kuukausi urakan-alkuvuosi nil))
+  ([db tarkkuus-prosentti kuukausi urakan-alkuvuosi pisterajat-data]
+   {:pre [(number? tarkkuus-prosentti) (number? kuukausi) (number? urakan-alkuvuosi)]}
+   (let [tarkkuus-abs (Math/abs tarkkuus-prosentti)
+         pisterajat-result (when-not pisterajat-data
+                             (hae-kustannusennuste-pisterajat db urakan-alkuvuosi kuukausi))
+  
+         ;; Käy läpi pisterajat järjestyksessä ja etsi sopiva
+         tulos (some (fn [raja]
+                       (let [operaattori (:operaattori raja)
+                             raja-arvo (:raja raja)
+                             pisteet (:pisteet raja)]
+                         (cond
+                           (and (= operaattori "≤") (<= tarkkuus-abs raja-arvo))
+                           pisteet
+
+                           (and (= operaattori ">") (> tarkkuus-abs raja-arvo))
+                           pisteet
+
+                           :else nil)))
+                 pisterajat-result)]
+     (or tulos 0))))
 (defn laske-lopullinen-kustannusennuste!
   "Laskee lopulliset pisteet kustannusennusteille kun välikatselmus on saatavilla.
    Kutsutaan välikatselmuksen päätöksestä."
@@ -698,9 +737,11 @@
                                             :toteutunut-tavoitehinta toteutunut-tavoitehinta
                                             :toteutunut-kustannus toteutunut-kustannus
                                             :hoitovuoden-alun-tavoitehinta hoitovuoden-alun-tavoitehinta})
-                          lopulliset-pisteet (lupaus-domain/maarita-kustannusennuste-pisteet
+                          lopulliset-pisteet (maarita-kustannusennuste-pisteet
+                                               db
                                                (:tarkkuus-prosentti tarkkuus-tulos)
-                                               (pvm/kuukausi maarapaiva))]
+                                               (pvm/kuukausi maarapaiva)
+                                               2021)]
                     
                       ;; Päivitä lopulliset pisteet tietokantaan
                       (lupaus-kyselyt/paivita-kustannusennuste-lopulliset-pisteet!
@@ -826,3 +867,116 @@
     {:urakka 36
      :alkupvm #inst "2023-09-30T21:00:00.000-00:00"
      :loppupvm #inst "2024-09-30T20:59:59.000-00:00"}))
+
+(comment
+  (def j harja.palvelin.main/harja-jarjestelma)
+
+  ;; Testaa maarita-kustannusennuste-pisteet funktio
+  (defn testaa-kustannusennuste-pisteet []
+    (let [db (:db j)]
+      (println "=== Testaa maarita-kustannusennuste-pisteet ===")
+
+      ;; Testaa eri tarkkuuksia lokakuulle (kuukausi 10)
+      (println "\n--- Lokakuu (kuukausi 10) testit ---")
+      (doseq [tarkkuus [1.0 3.0 5.0 8.0 15.0 25.0]]
+        (let [pisteet (maarita-kustannusennuste-pisteet db tarkkuus 10 2021)]
+          (println (format "Tarkkuus %.1f%% -> %d pistettä" tarkkuus pisteet))))
+
+      ;; Testaa eri tarkkuuksia tammikuulle (kuukausi 1)  
+      (println "\n--- Tammikuu (kuukausi 1) testit ---")
+      (doseq [tarkkuus [1.0 3.0 5.0 8.0 15.0 25.0]]
+        (let [pisteet (maarita-kustannusennuste-pisteet db tarkkuus 1 2021)]
+          (println (format "Tarkkuus %.1f%% -> %d pistettä" tarkkuus pisteet))))
+
+      ;; Testaa eri tarkkuuksia huhtikuulle (kuukausi 4)
+      (println "\n--- Huhtikuu (kuukausi 4) testit ---")
+      (doseq [tarkkuus [1.0 3.0 5.0 8.0 15.0 25.0]]
+        (let [pisteet (maarita-kustannusennuste-pisteet db tarkkuus 4 2021)]
+          (println (format "Tarkkuus %.1f%% -> %d pistettä" tarkkuus pisteet))))
+
+      ;; Testaa eri tarkkuuksia kesäkuulle (kuukausi 6)
+      (println "\n--- Kesäkuu (kuukausi 6) testit ---")
+      (doseq [tarkkuus [1.0 3.0 5.0 8.0 15.0 25.0]]
+        (let [pisteet (maarita-kustannusennuste-pisteet db tarkkuus 6 2021)]
+          (println (format "Tarkkuus %.1f%% -> %d pistettä" tarkkuus pisteet))))
+
+      ;; Testaa eri tarkkuuksia elokuulle (kuukausi 8)
+      (println "\n--- Elokuu (kuukausi 8) testit ---")
+      (doseq [tarkkuus [1.0 3.0 5.0 8.0 15.0 25.0]]
+        (let [pisteet (maarita-kustannusennuste-pisteet db tarkkuus 8 2021)]
+          (println (format "Tarkkuus %.1f%% -> %d pistettä" tarkkuus pisteet))))
+
+      ;; Testaa eri urakan alkuvuosia
+      (println "\n--- Eri urakan alkuvuodet (lokakuu) ---")
+      (doseq [alkuvuosi [2019 2020 2021 2022 2023]]
+        (let [pisteet (maarita-kustannusennuste-pisteet db 5.0 10 alkuvuosi)]
+          (println (format "Alkuvuosi %d, tarkkuus 5.0%% -> %d pistettä" alkuvuosi pisteet))))
+
+      ;; Testaa negatiivisia tarkkuuksia (absoluuttiarvo otetaan)
+      (println "\n--- Negatiiviset tarkkuudet (lokakuu 2021) ---")
+      (doseq [tarkkuus [-1.0 -3.0 -5.0 -8.0 -15.0]]
+        (let [pisteet (maarita-kustannusennuste-pisteet db tarkkuus 10 2021)]
+          (println (format "Tarkkuus %.1f%% -> %d pistettä" tarkkuus pisteet))))
+
+      ;; Testaa tietokannasta haettua pisterajat JSONia
+      (println "\n--- Tietokannasta haetut pisterajat ---")
+      (let [pisterajat (lupaus-kyselyt/hae-kustannusennuste-kuukausi-pisterajat
+                         db {:urakan-alkuvuosi 2021 :kuukausi 10 :paiva 15})]
+        (println "Lokakuu 2021, päivä 15:")
+        (clojure.pprint/pprint pisterajat)
+
+      (let [pisterajat (lupaus-kyselyt/hae-kustannusennuste-kuukausi-pisterajat
+                         db {:urakan-alkuvuosi 2021 :kuukausi 4 :paiva 30})]
+        (println "\nHuhtikuu 2021, päivä 30:")
+        (clojure.pprint/pprint (:pisterajat pisterajat)))
+
+      ;; Testaa vanhoja kyselyitä
+      (println "\n--- Vanhan kyselyn testit ---")
+      (lupaus-kyselyt/hae-urakan-lupaustiedot
+        db
+        {:urakka 36
+         :alkupvm #inst "2023-09-30T21:00:00.000-00:00"
+         :loppupvm #inst "2024-09-30T20:59:59.000-00:00"}))))
+
+  ;; Kutsu testiä
+   (testaa-kustannusennuste-pisteet)
+
+   (defn testaa-jsonb-suoraan []
+     (let [raaka-tulos (lupaus-kyselyt/hae-kustannusennuste-kuukausi-pisterajat
+                         (:db j) {:urakan-alkuvuosi 2021 :kuukausi 10 :paiva 15})
+           pisterajat-pgobject raaka-tulos]
+       (println "Raaka PGobject:")
+       (println (type pisterajat-pgobject))
+       (println pisterajat-pgobject)
+       (println "\nPGobject getValue:")
+       (println (.getValue pisterajat-pgobject))
+       (println "\nKonvertoitu cheshire/decode:")
+       (clojure.pprint/pprint (cheshire/decode (.getValue pisterajat-pgobject) true))
+       (println "\nKonvertoitu jsonb->clojuremap:")
+       (clojure.pprint/pprint (konversio/jsonb->clojuremap pisterajat-pgobject))))
+   
+   (testaa-jsonb-suoraan)
+
+
+  ;; Yksittäiset nopeat testit
+  ;; (maarita-kustannusennuste-pisteet (:db j) 5.0 10 2021)
+  ;; (maarita-kustannusennuste-pisteet (:db j) 2.0 1 2021) 
+  ;; (maarita-kustannusennuste-pisteet (:db j) 10.0 4 2021)
+
+  ;; Hae pisterajat suoraan tietokannasta
+  ;; (lupaus-kyselyt/hae-kustannusennuste-kuukausi-pisterajat 
+  ;;   (:db j) {:urakan-alkuvuosi 2021 :kuukausi 10 :paiva 15})
+
+  ;; Testaa myös testidatalla ilman tietokantakutsua
+  (defn testaa-pisterajat-testidatalla []
+    (let [testidata [{:operaattori "≤" :raja 2 :pisteet 10}
+                     {:operaattori "≤" :raja 5 :pisteet 8}
+                     {:operaattori "≤" :raja 10 :pisteet 6}
+                     {:operaattori ">" :raja 10 :pisteet 0}]]
+      (println "\n=== Testaa testidatalla ===")
+      (doseq [tarkkuus [1.0 2.0 3.0 5.0 8.0 10.0 15.0]]
+        (let [pisteet (maarita-kustannusennuste-pisteet (:db j) tarkkuus 10 2021 testidata)]
+          (println (format "Testidatalla tarkkuus %.1f%% -> %d pistettä" tarkkuus pisteet))))))
+
+  ;; (testaa-pisterajat-testidatalla)
+  )

--- a/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
@@ -218,8 +218,6 @@
         ennusteen-voi-tehda? (and (pvm/sama-tai-jalkeen? nykyhetki hk-alkupvm)
                                   bonus-tai-sanktio)
         hoitovuosi-valmis? (boolean piste-toteuma)
-        _ (prn "ennusteen-voi-tehda?" ennusteen-voi-tehda?)
-        _ (prn "bonus-tai-sanktio" bonus-tai-sanktio tallennettu-bonus-tai-sanktio)
         ennusteen-tila (cond tallennettu-bonus-tai-sanktio
                              :katselmoitu-toteuma
 
@@ -660,7 +658,7 @@
 
         ;; Käy läpi jokainen kustannusennuste-lupaus
         (doseq [lupaus kustannusennuste-lupaukset]
-          (let [lupaus-id (:id lupaus)
+          (let [lupaus-id (:lupaus-id lupaus)
                 kustannusennusteet (lupaus-kyselyt/hae-lupauksen-kaikki-kustannusennusteet
                                      db {:lupaus-id lupaus-id
                                          :urakka-id urakka-id
@@ -669,29 +667,43 @@
             (doseq [ke kustannusennusteet]
               (let [ennustettu-tavoitehinta (:tavoitehinta ke)
                     ennustetut-kustannukset (:toteutuneet-kustannukset ke)
-                    maarapaiva (:maarapaiva ke)
+                    maarapaiva (:maarapaiva ke) 
                     kustannusennuste-id (:id ke)]
 
                 ;; Laske lopulliset pisteet domain-logiikalla
-                (when (and ennustettu-tavoitehinta ennustetut-kustannukset hoitovuoden-alun-tavoitehinta)
-                  (let [lopulliset-pisteet (lupaus-domain/laske-kustannusennuste-tulos
-                                             {:ennustettu-tavoitehinta ennustettu-tavoitehinta
-                                              :ennustettu-kustannus ennustetut-kustannukset
-                                              :toteutunut-tavoitehinta toteutunut-tavoitehinta
-                                              :toteutunut-kustannus toteutunut-kustannus
-                                              :hoitovuoden-alun-tavoitehinta hoitovuoden-alun-tavoitehinta}
-                                             (pvm/kuukausi maarapaiva))]
-
-                    ;; Päivitä lopulliset pisteet tietokantaan
-                    (lupaus-kyselyt/paivita-kustannusennuste-lopulliset-pisteet!
-                      db {:kustannusennuste-id kustannusennuste-id
-                          :ennustettu-tavoitehinta ennustettu-tavoitehinta
-                          :ennustetut-kustannukset ennustetut-kustannukset
-                          :lasketut-pisteet lopulliset-pisteet
-                          :muokkaaja user-id})
-
-                    (log/info (format "Päivitettiin kustannusennuste %s lopulliset pisteet: %s"
-                                kustannusennuste-id lopulliset-pisteet)))))))))
+                (let [puuttuvat-arvot (cond-> []
+                                        (nil? ennustettu-tavoitehinta) (conj "ennustettu-tavoitehinta")
+                                        (nil? ennustetut-kustannukset) (conj "ennustetut-kustannukset")
+                                        (nil? hoitovuoden-alun-tavoitehinta) (conj "hoitovuoden-alun-tavoitehinta"))]
+                
+                  (if (empty? puuttuvat-arvot)
+                    ;; Kaikki arvot löytyvät - suorita päivitys
+                    (let [lopulliset-pisteet (lupaus-domain/laske-kustannusennuste-tulos
+                                               {:ennustettu-tavoitehinta ennustettu-tavoitehinta
+                                                :ennustettu-kustannus ennustetut-kustannukset
+                                                :toteutunut-tavoitehinta toteutunut-tavoitehinta
+                                                :toteutunut-kustannus toteutunut-kustannus
+                                                :hoitovuoden-alun-tavoitehinta hoitovuoden-alun-tavoitehinta}
+                                               (pvm/kuukausi maarapaiva))]
+                
+                      ;; Päivitä lopulliset pisteet tietokantaan
+                      (lupaus-kyselyt/paivita-kustannusennuste-lopulliset-pisteet!
+                        db {:kustannusennuste-id kustannusennuste-id
+                            :ennustettu-tavoitehinta ennustettu-tavoitehinta
+                            :ennustetut-kustannukset ennustetut-kustannukset
+                            :lopulliset-pisteet (:pisteet lopulliset-pisteet)
+                            :muokkaaja user-id})
+                
+                      (log/info (format "Päivitettiin kustannusennuste %s lopulliset pisteet: %s"
+                                  kustannusennuste-id (:pisteet lopulliset-pisteet))))
+                
+                    ;; Arvoja puuttuu - loki varoitus ja jatka seuraavaan
+                    (log/error (format "Kustannusennuste %s: Päivitys ohitettiin puuttuvien arvojen takia. Puuttuvat: %s. Arvot: ennustettu-tavoitehinta=%s, ennustetut-kustannukset=%s, hoitovuoden-alun-tavoitehinta=%s"
+                                kustannusennuste-id
+                                (clojure.string/join ", " puuttuvat-arvot)
+                                ennustettu-tavoitehinta
+                                ennustetut-kustannukset
+                                hoitovuoden-alun-tavoitehinta)))))))))
 
       (log/info (format "Lopulliset kustannusennuste pisteet laskettu urakalle %s hoitokaudelle %s"
                   urakka-id hoitokauden-alkuvuosi)))
@@ -700,42 +712,6 @@
       (log/error e (format "Virhe laskettaessa lopullisia kustannusennuste pisteitä urakalle %s: %s"
                      urakka-id (.getMessage e)))
       (throw e))))
-
-(defn laske-lopullinen-kustannusennuste
-  "Laskee hoitovuoden lopulliset kustannusennusteen pisteet kustannustietojen perusteella.
-   
-   Tätä funktiota kutsutaan välikatselmuksessa, kun hoitokauden lopun hintapäätös tehdään.
-   Funktio:
-   1. Hakee toteutuneet kustannukset hoitokaudelta
-   2. Kutsuu lupaus-palvelun kustannusennuste-logiikkaa 
-   3. Palauttaa päivitetyn päätöksen tai nil jos laskenta epäonnistuu
-   
-   Parametrit:
-   - db: Tietokantayhteys
-   - urakka-id: Urakan tunniste
-   - hoitokauden-alkuvuosi: Hoitokauden alkuvuosi (esim. 2024)
-   - paatos: Välikatselmuksen päätös (map)
-   - kayttaja: Käyttäjän tiedot"
-  [db urakka-id hoitokauden-alkuvuosi paatos kayttaja]
-  (try
-    (log/info (format "Lasketaan lopulliset kustannusennuste pisteet urakalle %s hoitokaudelle %s"
-                urakka-id hoitokauden-alkuvuosi))
-
-    ;; Haetaan toteutuneet kustannukset päätöksestä
-    (let [toteutunut-tavoitehinta (:tavoitehinta paatos)
-          toteutuneet-kustannukset (:toteutuneet_kustannukset paatos)
-          paatos-pvm (:paatosten_asettamisaika paatos)
-          user-id (:id kayttaja)]
-
-      ;; Kutsutaan aiempaa logiikkaa
-      (laske-lopullinen-kustannusennuste! db urakka-id hoitokauden-alkuvuosi
-        toteutunut-tavoitehinta toteutuneet-kustannukset
-        paatos-pvm user-id)
-      ;; Palauta päätös jossa on toteutuneet kustannukset
-      (assoc paatos :toteutuneet_kustannukset toteutuneet-kustannukset))
-    (catch Exception e
-      (log/error e "Virhe kustannusennusteen laskennassa")
-      nil)))
 
 (defn hae-kuukausittaiset-pisteet [db user {:keys [urakka-id valittu-hoitokausi nykyhetki] :as tiedot}]
   {:pre [db user tiedot (number? urakka-id) (not (nil? valittu-hoitokausi)) (number? (:id user))]}

--- a/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
@@ -127,6 +127,28 @@
           :urakka-id urakka-id
           :hoitokauden-alkuvuosi hoitokauden-alkuvuosi})))
 
+(defn laske-maarapaiva-tiedot
+  "Laskee määräpäivätiedot kustannusennusteille.
+   Palauttaa map-rakenteen: {kuukausi {:maarapaiva-mennyt-ohi? boolean :syotetty-ajoissa? boolean}}"
+  [db urakan-alkuvuosi hoitokauden-alkuvuosi nykyhetki]
+  {:pre [(number? urakan-alkuvuosi) (number? hoitokauden-alkuvuosi)]}
+  (try
+    (let [maarapaivat (lupaus-kyselyt/hae-kustannusennuste-maarapaivat 
+                        db {:urakan-alkuvuosi urakan-alkuvuosi
+                            :hoitokauden-alkuvuosi hoitokauden-alkuvuosi})]
+      (if (empty? maarapaivat)
+        (throw (ex-info (str "Määräpäivätietoja ei löytynyt urakan alkuvuodelle " urakan-alkuvuosi)
+                        {:urakan-alkuvuosi urakan-alkuvuosi}))
+        (into {}
+              (map (fn [{:keys [kuukausi maarapaiva_pvm]}]
+                     (let [maarapaiva-mennyt-ohi? (pvm/jalkeen? nykyhetki maarapaiva_pvm)]
+                       [kuukausi {:maarapaiva-mennyt-ohi? maarapaiva-mennyt-ohi?
+                                 :maarapaiva-pvm maarapaiva_pvm}]))
+                   maarapaivat))))
+    (catch Exception e
+      (log/error "Määräpäivätietojen laskenta epäonnistui:" (.getMessage e))
+      (throw e))))
+
 (defn- hae-lupaus-kustannukset-jarjestettyna [db urakkaid hoitovuosi hoitokauden-alkupvm hoitokauden-loppupvm]
   (let [kustannukset (kustannusten-seuranta-palvelu/hae-urakan-kustannusten-seuranta-paaryhmittain-ilman-validointia
                        db {:urakka-id urakkaid
@@ -151,6 +173,12 @@
         urakan-alkuvuosi (some-> (:alkupvm urakan-tiedot) pvm/vuosi)
         hoitovuosi-nro (when (and urakan-alkuvuosi hk-alkupvm)
                          (pvm/hoitokausivuosi->mhu-hoitovuosi-nro (:alkupvm urakan-tiedot) (pvm/vuosi hk-alkupvm)))
+        maarapaiva-tiedot (when urakan-alkuvuosi
+                           (try
+                             (laske-maarapaiva-tiedot db urakan-alkuvuosi hoitokauden-alkuvuosi nykyhetki)
+                             (catch Exception e
+                               (log/warn "Määräpäivätietojen haku epäonnistui, jatketaan ilman:" (.getMessage e))
+                               {})))
         lupaus-idt (mapv :lupaus-id vastaus)
         erikoisarvot (if (seq lupaus-idt)
                                ;; Hae erikoisarvot yksi kerrallaan ja ryhmittele
@@ -187,7 +215,8 @@
                   (mapv #(lupaus-domain/liita-odottaa-kannanottoa % nykyhetki valittu-hoitokausi))
                   (mapv #(let [kustannusennusteet (when (= "kustannusennuste" (:lupaustyyppi %))
                                                     (hae-lupauksen-kustannusennusteet db (:lupaus-id %) urakka-id hoitokauden-alkuvuosi))]
-                           (lupaus-domain/liita-lupaus-kuukaudet % nykyhetki valittu-hoitokausi hoitovuosi-nro (get erikoisarvot (:lupaus-id %)) kustannusennusteet)))
+                           (lupaus-domain/liita-lupaus-kuukaudet % nykyhetki valittu-hoitokausi hoitovuosi-nro 
+                                                                (get erikoisarvot (:lupaus-id %)) kustannusennusteet maarapaiva-tiedot)))
                   (mapv #(liita-lupaus-vaihtoehdot db %))
                   (mapv #(if (= "kustannusennuste" (:lupaustyyppi %))
                            (assoc % :hoitovuosi-paattynyt? (:kaikki-laskettu kustannusennuste-pisteet-tila))

--- a/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
@@ -1,26 +1,27 @@
 (ns harja.palvelin.palvelut.lupaus.lupaus-palvelu
-  (:require [com.stuartsierra.component :as component]
-            [harja.id :refer [id-olemassa?]]
-            [harja.kyselyt
+  (:require
+   [cheshire.core :as cheshire]
+   [clojure.java.jdbc :as jdbc]
+   [clojure.set :as set]
+   [com.stuartsierra.component :as component]
+   [harja.domain.kulut.kustannusten-seuranta :as kustannusten-seuranta]
+   [harja.domain.lupaus-domain :as lupaus-domain]
+   [harja.domain.oikeudet :as oikeudet]
+   [harja.domain.roolit :as roolit]
+   [harja.id :refer [id-olemassa?]]
+   [harja.kyselyt
              [lupaus-kyselyt :as lupaus-kyselyt]
              [urakat :as urakat-q]
              [budjettisuunnittelu :as budjetti-q]
              [valikatselmus :as valikatselmus-q]
              [paatos-kyselyt :as paatos-kyselyt]]
-            [harja.palvelin.komponentit.http-palvelin :refer [julkaise-palvelu poista-palvelut]]
-            [harja.domain.oikeudet :as oikeudet]
-            [harja.domain.lupaus-domain :as lupaus-domain]
-            [harja.domain.roolit :as roolit]
-            [harja.domain.urakka :as urakka]
-            [harja.domain.kulut.valikatselmus :as valikatselmus-domain]
-            [harja.domain.kulut.kustannusten-seuranta :as kustannusten-seuranta]
-            [harja.palvelin.palvelut.kulut.kustannusten-seuranta :as kustannusten-seuranta-palvelu]
-            [clojure.java.jdbc :as jdbc]
-            [clojure.set :as set]
-            [harja.kyselyt.konversio :as konversio]
-            [harja.kyselyt.kommentit :as kommentit]
-            [harja.pvm :as pvm]
-            [taoensso.timbre :as log]))
+   [harja.kyselyt.kommentit :as kommentit]
+   [harja.kyselyt.konversio :as konversio]
+   [harja.palvelin.komponentit.http-palvelin :refer [julkaise-palvelu
+                                                     poista-palvelut]]
+   [harja.palvelin.palvelut.kulut.kustannusten-seuranta :as kustannusten-seuranta-palvelu]
+   [harja.pvm :as pvm]
+   [taoensso.timbre :as log]))
 
 (defn- sitoutumistiedot [lupausrivit]
   {:pisteet (:sitoutuminen-pisteet (first lupausrivit))
@@ -99,11 +100,22 @@
                                                                     :hoitokauden_alkuvuosi hoitokauden-alkuvuosi}))]
     lupauspaatos))
 
-(defn valikatselmus-tehty-urakalle? [db urakka-id hoitokauden-alkuvuosi]
-  "Onko urakalle tehty välikatselmus minä tahansa hoitokautena."
+(defn valikatselmus-tehty-urakalle? "Onko urakalle tehty välikatselmus minä tahansa hoitokautena." 
+  [db urakka-id hoitokauden-alkuvuosi] 
   {:pre [(number? urakka-id)]}
   (let [lupauspaatos (first (paatos-kyselyt/hae-lupauspaatokset db {:urakkaid urakka-id :hoitokauden_alkuvuosi hoitokauden-alkuvuosi}))]
     (boolean lupauspaatos)))
+
+(defn- onko-kustannusennuste-pisteet-laskettu?
+  "Tarkistaa onko kaikille kustannusennusteille laskettu lopulliset pisteet"
+  [db urakka-id hoitokauden-alkuvuosi]
+  (when (and urakka-id hoitokauden-alkuvuosi)
+    (let [tulos (first (lupaus-kyselyt/onko-kustannusennuste-pisteet-laskettu
+                         db {:urakka-id urakka-id
+                             :hoitokauden-alkuvuosi hoitokauden-alkuvuosi}))]
+      {:kaikki-laskettu (:kaikki_laskettu tulos)
+       :yhteensa (:yhteensa tulos)
+       :laskettu-pisteet (:laskettu_pisteet tulos)})))
 
 (defn hae-lupauksen-kustannusennusteet
   "Hakee lupauksen kaikki kustannusennusteet hoitokaudelle"
@@ -186,6 +198,8 @@
         odottaa-urakoitsijan-kannanottoa? (> odottaa-kannanottoa merkitsevat-odottaa-kannanottoa)
         tavoitehinta (when hk-alkupvm (maarita-urakan-tavoitehinta db urakka-id hk-alkupvm))
         ;; Hae oikaistu tavoitehinta välikatselmuksesta vertailua varten
+        kustannusennuste-pisteet-tila (onko-kustannusennuste-pisteet-laskettu?
+                                        db urakka-id hoitokauden-alkuvuosi)
         oikaistu-tavoitehinta-data (try
                                      (when hk-alkupvm
                                        (valikatselmus-q/hae-oikaistu-tavoitehinta 
@@ -254,6 +268,7 @@
                   ;; Lisätään oikaistu tavoitehinta välikatselmuksesta
                   :oikaistu-tavoitehinta oikaistu-tavoitehinta
                   :oikaistu-toteutuneet-kustannukset oikaistu-toteutuneet-kustannukset
+                  :kustannusennuste-pisteet-laskettu kustannusennuste-pisteet-tila
                   :odottaa-kannanottoa odottaa-kannanottoa
                   :merkitsevat-odottaa-kannanottoa merkitsevat-odottaa-kannanottoa
                   :odottaa-urakoitsijan-kannanottoa? odottaa-urakoitsijan-kannanottoa?
@@ -668,31 +683,36 @@
               (let [ennustettu-tavoitehinta (:tavoitehinta ke)
                     ennustetut-kustannukset (:toteutuneet-kustannukset ke)
                     maarapaiva (:maarapaiva ke) 
-                    kustannusennuste-id (:id ke)]
+                    kustannusennuste-id (:id ke)
+                    puuttuvat-arvot (cond-> []
+                                              (nil? ennustettu-tavoitehinta) (conj "ennustettu-tavoitehinta")
+                                              (nil? ennustetut-kustannukset) (conj "ennustetut-kustannukset")
+                                              (nil? hoitovuoden-alun-tavoitehinta) (conj "hoitovuoden-alun-tavoitehinta"))]
 
                 ;; Laske lopulliset pisteet domain-logiikalla
-                (let [puuttuvat-arvot (cond-> []
-                                        (nil? ennustettu-tavoitehinta) (conj "ennustettu-tavoitehinta")
-                                        (nil? ennustetut-kustannukset) (conj "ennustetut-kustannukset")
-                                        (nil? hoitovuoden-alun-tavoitehinta) (conj "hoitovuoden-alun-tavoitehinta"))]
-                
-                  (if (empty? puuttuvat-arvot)
+                (if (empty? puuttuvat-arvot)
                     ;; Kaikki arvot löytyvät - suorita päivitys
-                    (let [lopulliset-pisteet (lupaus-domain/laske-kustannusennuste-tulos
-                                               {:ennustettu-tavoitehinta ennustettu-tavoitehinta
-                                                :ennustettu-kustannus ennustetut-kustannukset
-                                                :toteutunut-tavoitehinta toteutunut-tavoitehinta
-                                                :toteutunut-kustannus toteutunut-kustannus
-                                                :hoitovuoden-alun-tavoitehinta hoitovuoden-alun-tavoitehinta}
+                    (let [tarkkuus-tulos (lupaus-domain/laske-kustannusennusteen-tarkkuus
+                                           {:ennustettu-tavoitehinta ennustettu-tavoitehinta
+                                            :ennustettu-kustannus ennustetut-kustannukset
+                                            :toteutunut-tavoitehinta toteutunut-tavoitehinta
+                                            :toteutunut-kustannus toteutunut-kustannus
+                                            :hoitovuoden-alun-tavoitehinta hoitovuoden-alun-tavoitehinta})
+                          lopulliset-pisteet (lupaus-domain/maarita-kustannusennuste-pisteet
+                                               (:tarkkuus-prosentti tarkkuus-tulos)
                                                (pvm/kuukausi maarapaiva))]
-                
+                    
                       ;; Päivitä lopulliset pisteet tietokantaan
                       (lupaus-kyselyt/paivita-kustannusennuste-lopulliset-pisteet!
                         db {:kustannusennuste-id kustannusennuste-id
                             :ennustettu-tavoitehinta ennustettu-tavoitehinta
                             :ennustetut-kustannukset ennustetut-kustannukset
-                            :lopulliset-pisteet (:pisteet lopulliset-pisteet)
-                            :tarkkuus-prosentti (:tarkkuus-prosentti lopulliset-pisteet)
+                            :lasketut-pisteet lopulliset-pisteet
+                            :tarkkuus-prosentti (:tarkkuus-prosentti tarkkuus-tulos)
+                            :laskentakaava-versio (:laskentakaava-versio tarkkuus-tulos)
+                            :laskentakaava-teksti (:laskentakaava-teksti tarkkuus-tulos)
+                            :laskentakaava-parametrit (cheshire/encode (:laskentakaava-parametrit tarkkuus-tulos))
+                            :laskentakaava-vaiheet (cheshire/encode (:laskentakaava-vaiheet tarkkuus-tulos))
                             :muokkaaja user-id})
                 
                       (log/info (format "Päivitettiin kustannusennuste %s lopulliset pisteet: %s"
@@ -707,7 +727,7 @@
                                 hoitovuoden-alun-tavoitehinta)))))))))
 
       (log/info (format "Lopulliset kustannusennuste pisteet laskettu urakalle %s hoitokaudelle %s"
-                  urakka-id hoitokauden-alkuvuosi)))
+                  urakka-id hoitokauden-alkuvuosi))
 
     (catch Exception e
       (log/error e (format "Virhe laskettaessa lopullisia kustannusennuste pisteitä urakalle %s: %s"

--- a/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
@@ -13,6 +13,8 @@
             [harja.domain.roolit :as roolit]
             [harja.domain.urakka :as urakka]
             [harja.domain.kulut.valikatselmus :as valikatselmus-domain]
+            [harja.domain.kulut.kustannusten-seuranta :as kustannusten-seuranta]
+            [harja.palvelin.palvelut.kulut.kustannusten-seuranta :as kustannusten-seuranta-palvelu]
             [clojure.java.jdbc :as jdbc]
             [clojure.set :as set]
             [harja.kyselyt.konversio :as konversio]
@@ -113,6 +115,15 @@
           :urakka-id urakka-id
           :hoitokauden-alkuvuosi hoitokauden-alkuvuosi})))
 
+(defn- hae-lupaus-kustannukset-jarjestettyna [db urakkaid hoitovuosi hoitokauden-alkupvm hoitokauden-loppupvm]
+  (let [kustannukset (kustannusten-seuranta-palvelu/hae-urakan-kustannusten-seuranta-paaryhmittain-ilman-validointia
+                       db {:urakka-id urakkaid
+                           :hoitokauden-alkuvuosi hoitovuosi
+                           :alkupvm hoitokauden-alkupvm
+                           :loppupvm hoitokauden-loppupvm})
+        kustannukset-jarjestettyna (kustannusten-seuranta/jarjesta-tehtavat kustannukset)]
+    kustannukset-jarjestettyna))
+
 (defn hae-urakan-lupaustiedot-hoitokaudelle [db {:keys [urakka-id nykyhetki
                                                         valittu-hoitokausi] :as tiedot}]
   (let [[hk-alkupvm hk-loppupvm] valittu-hoitokausi
@@ -174,6 +185,24 @@
         merkitsevat-odottaa-kannanottoa (lupaus-domain/lupausryhmat->merkitsevat-odottaa-kannanottoa lupausryhmat)
         odottaa-urakoitsijan-kannanottoa? (> odottaa-kannanottoa merkitsevat-odottaa-kannanottoa)
         tavoitehinta (when hk-alkupvm (maarita-urakan-tavoitehinta db urakka-id hk-alkupvm))
+        ;; Hae oikaistu tavoitehinta välikatselmuksesta vertailua varten
+        oikaistu-tavoitehinta-data (try
+                                     (when hk-alkupvm
+                                       (valikatselmus-q/hae-oikaistu-tavoitehinta 
+                                         db {:urakka-id urakka-id 
+                                             :hoitokauden-alkuvuosi hoitokauden-alkuvuosi}))
+                                     (catch Exception e
+                                       (log/warn "Oikaistun tavoitehinnan haku epäonnistui:" (.getMessage e))
+                                       nil))
+        kustannukset-jarjestettyna (try
+                                     (when hk-alkupvm
+                                       (hae-lupaus-kustannukset-jarjestettyna
+                                         db urakka-id hoitokauden-alkuvuosi hk-alkupvm hk-loppupvm))
+                                     (catch Exception e
+                                       (log/warn "Kustannusten haku epäonnistui:" (.getMessage e))
+                                       nil))
+        oikaistu-tavoitehinta oikaistu-tavoitehinta-data
+        oikaistu-toteutuneet-kustannukset (get-in kustannukset-jarjestettyna [:yhteensa :yht-toteutunut-summa])
         tavoitehinta-puuttuu? (not (and tavoitehinta (pos? tavoitehinta)))
         luvatut-pisteet-puuttuu? (not (:pisteet lupaus-sitoutuminen))
         tallennettu-paatos (hae-lupauspaatos db urakka-id (pvm/vuosi hk-alkupvm))
@@ -189,6 +218,8 @@
         ennusteen-voi-tehda? (and (pvm/sama-tai-jalkeen? nykyhetki hk-alkupvm)
                                   bonus-tai-sanktio)
         hoitovuosi-valmis? (boolean piste-toteuma)
+        _ (prn "ennusteen-voi-tehda?" ennusteen-voi-tehda?)
+        _ (prn "bonus-tai-sanktio" bonus-tai-sanktio tallennettu-bonus-tai-sanktio)
         ennusteen-tila (cond tallennettu-bonus-tai-sanktio
                              :katselmoitu-toteuma
 
@@ -222,6 +253,9 @@
                                   ;; Näytetään päätökseen tallennettu tavoitehinta, jos saatavilla
                                   (:tavoitehinta tallennettu-paatos)
                                   tavoitehinta)
+                  ;; Lisätään oikaistu tavoitehinta välikatselmuksesta
+                  :oikaistu-tavoitehinta oikaistu-tavoitehinta
+                  :oikaistu-toteutuneet-kustannukset oikaistu-toteutuneet-kustannukset
                   :odottaa-kannanottoa odottaa-kannanottoa
                   :merkitsevat-odottaa-kannanottoa merkitsevat-odottaa-kannanottoa
                   :odottaa-urakoitsijan-kannanottoa? odottaa-urakoitsijan-kannanottoa?
@@ -304,73 +338,49 @@
     ;; Sallitaan nil-arvon asettaminen.
     true))
 
-(defn laske-kustannusennuste-pisteet
-  "Laskee pisteet poikkeamaprosentin ja määräpäivän perusteella"
-  [db lupaus-id poikkeama-prosentti maarapaiva-kk]
-  (let [pisterajat (lupaus-kyselyt/hae-kustannusennusteen-pisterajat
-                     db {:lupaus-id lupaus-id})]
-    ;; Etsi sopiva pisteraja kuukauden ja poikkeaman perusteella
-    (->> pisterajat
-      (filter #(= (:maarapaiva-kk %) maarapaiva-kk))
-      (filter #(<= poikkeama-prosentti (:tarkkuus-prosentti %)))
-      (sort-by :tarkkuus-prosentti)
-      first
-      :pisteet
-      (or 1)))) ; Oletuspisteet jos ei löydy sopivaa rajaa
-
-(defn- kustannusennuste-poikkeama
-  "Laskee kustannusennusteen poikkeama-prosentin"
-  [{:keys [tavoitehinta toteutuneet-kustannukset]}]
-  (when (and tavoitehinta toteutuneet-kustannukset (pos? tavoitehinta))
-    (Math/abs (double (/ (* 100 (- toteutuneet-kustannukset tavoitehinta))
-                         tavoitehinta)))))
 
 (defn- tallenna-kustannusennuste-vastaus [db user {:keys [lupaus-id urakka-id kuukausi vuosi
-                                                          kustannusennuste] :as tiedot}]
-  ;; Laske pisteet automaattisesti
-  (let [poikkeama-prosentti (kustannusennuste-poikkeama kustannusennuste)
-        pisteet (laske-kustannusennuste-pisteet db lupaus-id poikkeama-prosentti kuukausi)
-        maarapaiva (pvm/luo-pvm vuosi (dec kuukausi) 15) ; 15. päivä
-        syotetty-pvm (pvm/nyt)
-        
-        ;; Laske hoitovuosi-alkuvuosi
-        urakan-tiedot (first (urakat-q/hae-urakka db {:id urakka-id}))
-        urakan-alkupvm (:alkupvm urakan-tiedot)
-        paivamaara (pvm/luo-pvm vuosi (dec kuukausi) 1)
-        hoitovuosi-nro (pvm/paivamaara->mhu-hoitovuosi-nro urakan-alkupvm paivamaara)
-        hoitovuosi-alkuvuosi (pvm/hoitokauden-alkuvuosi vuosi kuukausi)
+                                                           kustannusennuste] :as tiedot}]
+  ;; EI lasketa pisteitä automaattisesti - ne lasketaan vasta välikatselmuksessa
+   (let [maarapaiva (pvm/luo-pvm vuosi (dec kuukausi) 15)
+         syotetty-pvm (pvm/nyt)
+         hoitovuosi-alkuvuosi (pvm/hoitokauden-alkuvuosi vuosi kuukausi)
 
         ;; Tarkista onko kustannusennuste jo olemassa
-        olemassa-oleva-id (lupaus-kyselyt/hae-kustannusennuste-id
-                            db {:lupaus-id lupaus-id
-                                :urakka-id urakka-id
-                                :maarapaiva maarapaiva})]
+         olemassa-oleva-id (lupaus-kyselyt/hae-kustannusennuste-id
+                             db {:lupaus-id lupaus-id
+                                 :urakka-id urakka-id
+                                 :maarapaiva maarapaiva})]
 
-    (if olemassa-oleva-id
+     (if olemassa-oleva-id
       ;; Päivitä olemassa oleva
-      (lupaus-kyselyt/paivita-kustannusennuste<!
-        db (merge kustannusennuste
-             {:id olemassa-oleva-id
-              :pisteet pisteet
-              :syotetty-pvm syotetty-pvm
-              :hoitovuosi-alkuvuosi hoitovuosi-alkuvuosi
-              :kayttaja (:id user)}))
+       (lupaus-kyselyt/paivita-kustannusennuste<! db
+         {:id olemassa-oleva-id
+          :tavoitehinta (:tavoitehinta kustannusennuste)
+          :toteutuneet-kustannukset (:toteutuneet-kustannukset kustannusennuste)
+          :syotetty-pvm syotetty-pvm
+         ;; EI tallenneta pisteitä vielä - ne lasketaan välikatselmuksessa
+          :pisteet nil
+          :kayttaja (:id user)})
+
       ;; Luo uusi
-      (lupaus-kyselyt/lisaa-kustannusennuste<!
-        db (merge kustannusennuste
-             {:lupaus-id lupaus-id
-              :urakka-id urakka-id
-              :maarapaiva maarapaiva
-              :pisteet pisteet
-              :syotetty-pvm syotetty-pvm
-              :hoitovuosi-alkuvuosi hoitovuosi-alkuvuosi
-              :kayttaja (:id user)})))
+       (lupaus-kyselyt/lisaa-kustannusennuste<! db
+         {:lupaus-id lupaus-id
+          :urakka-id urakka-id
+          :maarapaiva maarapaiva
+          :tavoitehinta (:tavoitehinta kustannusennuste)
+          :toteutuneet-kustannukset (:toteutuneet-kustannukset kustannusennuste)
+          :syotetty-pvm syotetty-pvm
+          :hoitovuosi-alkuvuosi hoitovuosi-alkuvuosi
+         ;; EI tallenneta pisteitä vielä - ne lasketaan välikatselmuksessa
+          :pisteet nil
+          :kayttaja (:id user)}))
 
     ;; Palauta kustannusennusteen tiedot
-    (lupaus-kyselyt/hae-kustannusennuste db
-      {:lupaus-id lupaus-id
-       :urakka-id urakka-id
-       :maarapaiva maarapaiva})))
+   (lupaus-kyselyt/hae-kustannusennuste db
+     {:lupaus-id lupaus-id
+      :urakka-id urakka-id
+      :maarapaiva maarapaiva})))
 
 (defn- tarkista-vastaus-ja-vaihtoehto
   "Tarkista vastaustyyppi lupauksen tyypin mukaan"
@@ -559,6 +569,9 @@
          valikatselmus-tehty-hoitokaudelle? (valikatselmus-tehty-urakalle? db urakka-id (pvm/vuosi hk-alkupvm))
          ;; Koko urakkakauden sitoutumispisteisiin vaikuttaa onko urakalle tehty yhtään välitkaselmusta
          valikatselmus-tehty-urakalle? (valikatselmus-tehty-urakalle? db urakka-id vuosi)
+         ;; Hae välikatselmuksen vahvistetut kustannusennusteet
+         vahvistetut-kustannusennusteet (lupaus-kyselyt/hae-valikatselmuksen-vahvistetut-kustannusennusteet db {:urakka-id urakka-id
+                                                                                                              :hoitokauden-alkuvuosi vuosi})
          lopulliset-pisteet (lupaus-domain/kokoa-vastauspisteet kayttaja kuukausipisteet urakka-id
                               valittu-hoitokausi valikatselmus-tehty-hoitokaudelle?
                               nykyhetki)
@@ -617,7 +630,112 @@
                    :odottaa-urakoitsijan-kannanottoa? odottaa-urakoitsijan-kannanottoa?
                    :valikatselmus-tehty-urakalle? valikatselmus-tehty-urakalle?
                    :tavoitehinta-puuttuu? tavoitehinta-puuttuu?
-                   :luvatut-pisteet-puuttuu? luvatut-pisteet-puuttuu?}})))
+                   :luvatut-pisteet-puuttuu? luvatut-pisteet-puuttuu?
+                   :vahvistetut-kustannusennusteet vahvistetut-kustannusennusteet}})))
+
+(defn laske-lopullinen-kustannusennuste!
+  "Laskee lopulliset pisteet kustannusennusteille kun välikatselmus on saatavilla.
+   Kutsutaan välikatselmuksen päätöksestä."
+  [db urakka-id hoitokauden-alkuvuosi toteutunut-tavoitehinta toteutunut-kustannus valikatselmus-pvm user-id]
+  (try
+    (log/info (format "Lasketaan lopulliset kustannusennuste pisteet urakalle %s hoitokaudelle %s"
+                urakka-id hoitokauden-alkuvuosi))
+
+    ;; Hae hoitovuoden alun tavoitehinta  
+    (let [hk-alkupvm (pvm/hoitokauden-alkupvm hoitokauden-alkuvuosi)
+          hoitovuoden-alun-tavoitehinta (maarita-urakan-tavoitehinta db urakka-id hk-alkupvm)]
+      
+      ;; Tallenna ensin lopputilanne
+      (when (resolve 'lupaus-kyselyt/tallenna-lopputilanne!)
+        (lupaus-kyselyt/tallenna-lopputilanne! db {:urakka-id urakka-id
+                                                   :hoitovuosi-alkuvuosi hoitokauden-alkuvuosi
+                                                   :lopullinen-tavoitehinta toteutunut-tavoitehinta
+                                                   :lopulliset-kustannukset toteutunut-kustannus
+                                                   :valikatselmus-pvm valikatselmus-pvm
+                                                   :vahvistaja user-id}))
+
+      ;; Hae kaikki kustannusennusteet lupausten kautta
+      (let [lupaukset (lupaus-kyselyt/hae-urakan-lupaukset db {:urakka-id urakka-id})
+            kustannusennuste-lupaukset (filter #(= "kustannusennuste" (:lupaustyyppi %)) lupaukset)]
+
+        ;; Käy läpi jokainen kustannusennuste-lupaus
+        (doseq [lupaus kustannusennuste-lupaukset]
+          (let [lupaus-id (:id lupaus)
+                kustannusennusteet (lupaus-kyselyt/hae-lupauksen-kaikki-kustannusennusteet
+                                     db {:lupaus-id lupaus-id
+                                         :urakka-id urakka-id
+                                         :hoitokauden-alkuvuosi hoitokauden-alkuvuosi})]
+
+            (doseq [ke kustannusennusteet]
+              (let [ennustettu-tavoitehinta (:tavoitehinta ke)
+                    ennustetut-kustannukset (:toteutuneet-kustannukset ke)
+                    maarapaiva (:maarapaiva ke)
+                    kustannusennuste-id (:id ke)]
+
+                ;; Laske lopulliset pisteet domain-logiikalla
+                (when (and ennustettu-tavoitehinta ennustetut-kustannukset hoitovuoden-alun-tavoitehinta)
+                  (let [lopulliset-pisteet (lupaus-domain/laske-kustannusennuste-tulos
+                                             {:ennustettu-tavoitehinta ennustettu-tavoitehinta
+                                              :ennustettu-kustannus ennustetut-kustannukset
+                                              :toteutunut-tavoitehinta toteutunut-tavoitehinta
+                                              :toteutunut-kustannus toteutunut-kustannus
+                                              :hoitovuoden-alun-tavoitehinta hoitovuoden-alun-tavoitehinta}
+                                             (pvm/kuukausi maarapaiva))]
+
+                    ;; Päivitä lopulliset pisteet tietokantaan
+                    (lupaus-kyselyt/paivita-kustannusennuste-lopulliset-pisteet!
+                      db {:kustannusennuste-id kustannusennuste-id
+                          :ennustettu-tavoitehinta ennustettu-tavoitehinta
+                          :ennustetut-kustannukset ennustetut-kustannukset
+                          :lasketut-pisteet lopulliset-pisteet
+                          :muokkaaja user-id})
+
+                    (log/info (format "Päivitettiin kustannusennuste %s lopulliset pisteet: %s"
+                                kustannusennuste-id lopulliset-pisteet)))))))))
+
+      (log/info (format "Lopulliset kustannusennuste pisteet laskettu urakalle %s hoitokaudelle %s"
+                  urakka-id hoitokauden-alkuvuosi)))
+
+    (catch Exception e
+      (log/error e (format "Virhe laskettaessa lopullisia kustannusennuste pisteitä urakalle %s: %s"
+                     urakka-id (.getMessage e)))
+      (throw e))))
+
+(defn laske-lopullinen-kustannusennuste
+  "Laskee hoitovuoden lopulliset kustannusennusteen pisteet kustannustietojen perusteella.
+   
+   Tätä funktiota kutsutaan välikatselmuksessa, kun hoitokauden lopun hintapäätös tehdään.
+   Funktio:
+   1. Hakee toteutuneet kustannukset hoitokaudelta
+   2. Kutsuu lupaus-palvelun kustannusennuste-logiikkaa 
+   3. Palauttaa päivitetyn päätöksen tai nil jos laskenta epäonnistuu
+   
+   Parametrit:
+   - db: Tietokantayhteys
+   - urakka-id: Urakan tunniste
+   - hoitokauden-alkuvuosi: Hoitokauden alkuvuosi (esim. 2024)
+   - paatos: Välikatselmuksen päätös (map)
+   - kayttaja: Käyttäjän tiedot"
+  [db urakka-id hoitokauden-alkuvuosi paatos kayttaja]
+  (try
+    (log/info (format "Lasketaan lopulliset kustannusennuste pisteet urakalle %s hoitokaudelle %s"
+                urakka-id hoitokauden-alkuvuosi))
+
+    ;; Haetaan toteutuneet kustannukset päätöksestä
+    (let [toteutunut-tavoitehinta (:tavoitehinta paatos)
+          toteutuneet-kustannukset (:toteutuneet_kustannukset paatos)
+          paatos-pvm (:paatosten_asettamisaika paatos)
+          user-id (:id kayttaja)]
+
+      ;; Kutsutaan aiempaa logiikkaa
+      (laske-lopullinen-kustannusennuste! db urakka-id hoitokauden-alkuvuosi
+        toteutunut-tavoitehinta toteutuneet-kustannukset
+        paatos-pvm user-id)
+      ;; Palauta päätös jossa on toteutuneet kustannukset
+      (assoc paatos :toteutuneet_kustannukset toteutuneet-kustannukset))
+    (catch Exception e
+      (log/error e "Virhe kustannusennusteen laskennassa")
+      nil)))
 
 (defn hae-kuukausittaiset-pisteet [db user {:keys [urakka-id valittu-hoitokausi nykyhetki] :as tiedot}]
   {:pre [db user tiedot (number? urakka-id) (not (nil? valittu-hoitokausi)) (number? (:id user))]}

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
@@ -606,7 +606,20 @@
 
           _ (if (seq validaatio)
               (heita-virhe (str "Virheellinen päätös: " (string/join ", " validaatio)))
-              (paatos-kyselyt/tee-hoitokauden-lopun-hintapaatos db paatos))]
+              (paatos-kyselyt/tee-hoitokauden-lopun-hintapaatos db paatos))
+        
+          ;; Laske lopullinen lupausten kustannusennuste kun välikatselmus on tehty
+          _ (let [toteutunut-tavoitehinta (:tavoitehinta_jalkeen paatos)
+                  kustannukset-jarjestettyna (hae-kustannukset-jarjestettyna
+                                               db urakka-id hoitokauden-alkuvuosi
+                                               (pvm/hoitokauden-alkupvm hoitokauden-alkuvuosi)
+                                               (pvm/hoitokauden-loppupvm (inc hoitokauden-alkuvuosi)))
+                  toteutuneet-kustannukset (get-in kustannukset-jarjestettyna [:yhteensa :yht-toteutunut-summa])
+                  paatos-pvm (pvm/nyt)
+                  user-id (:id kayttaja)]
+              (lupaus-palvelu/laske-lopullinen-kustannusennuste!
+                db urakka-id hoitokauden-alkuvuosi toteutunut-tavoitehinta
+                toteutuneet-kustannukset paatos-pvm user-id))]
       ;; Hae välikatselmuksen tiedot
       (hae-valikatselmuksen-tiedot-hoitovuodelle db kayttaja {:urakkaid (:urakkaid paatos) :hoitovuosi (:hoitokauden_alkuvuosi paatos)}))))
 

--- a/src/cljc/harja/domain/lupaus_domain.cljc
+++ b/src/cljc/harja/domain/lupaus_domain.cljc
@@ -102,13 +102,15 @@
   (case lupaustyyppi
     "yksittainen" (yksittainen->ennuste lupaus)
     "kysely" (kysely->ennuste lupaus)
-    "monivalinta" (monivalinta->ennuste lupaus)))
+    "monivalinta" (monivalinta->ennuste lupaus)
+    "kustannusennuste" (yksittainen->ennuste lupaus)))
 
 (defn lupaus->toteuma [{:keys [lupaustyyppi] :as lupaus}]
   (case lupaustyyppi
     "yksittainen" (yksittainen->toteuma lupaus)
     "kysely" (monivalinta->toteuma lupaus)
-    "monivalinta" (monivalinta->toteuma lupaus)))
+    "monivalinta" (monivalinta->toteuma lupaus)
+    "kustannusennuste" (yksittainen->toteuma lupaus)))
 
 (defn lupaus->ennuste-tai-toteuma [lupaus]
   (or (when-let [toteuma (lupaus->toteuma lupaus)]
@@ -320,14 +322,30 @@
 (defn lupausryhmat->merkitsevat-odottaa-kannanottoa [lupausryhmat]
   (rivit->summa lupausryhmat :merkitsevat-odottaa-kannanottoa))
 
-(defn sallittu-kuukausi? [{:keys [kirjaus-kkt paatos-kk] :as lupaus} kuukausi paatos]
+(defn hoitovuoden-kirjauskuukaudet [lupaus _hoitovuosi-nro hoitovuoden-erikoisarvot]
+  (or (:kirjaus-kkt hoitovuoden-erikoisarvot)
+      (:kirjaus-kkt lupaus)))
+
+(defn hoitovuoden-paatos-kk [lupaus _hoitovuosi-nro hoitovuoden-erikoisarvot]
+  (or (:paatos-kk hoitovuoden-erikoisarvot)
+      (:paatos-kk lupaus)))
+
+(defn hoitovuoden-joustovara [lupaus _hoitovuosi-nro hoitovuoden-erikoisarvot]
+  (or (:joustovara-kkta hoitovuoden-erikoisarvot)
+      (:joustovara-kkta lupaus)))
+
+(defn sallittu-kuukausi-hoitovuodelle? [lupaus kuukausi paatos hoitovuosi-nro hoitovuoden-erikoisarvot]
   {:pre [lupaus kuukausi (boolean? paatos)]}
-  (let [sallittu? (if paatos
-                    (or (= paatos-kk kuukausi)
-                        ;; 0 = kaikki
-                        (= paatos-kk 0))
-                    (contains? (set kirjaus-kkt) kuukausi))]
-    sallittu?))
+  (let [kirjaus-kkt (hoitovuoden-kirjauskuukaudet lupaus hoitovuosi-nro hoitovuoden-erikoisarvot)
+        paatos-kk (hoitovuoden-paatos-kk lupaus hoitovuosi-nro hoitovuoden-erikoisarvot)]
+    (if paatos
+      (or (= paatos-kk kuukausi)
+          (= paatos-kk 0))
+      (contains? (set kirjaus-kkt) kuukausi))))
+
+;; Taaksepäinyhteensopivuus: jos ei annettu hoitovuositietoja, käytetään perusarvoja
+(defn sallittu-kuukausi? [lupaus kuukausi paatos]
+  (sallittu-kuukausi-hoitovuodelle? lupaus kuukausi paatos nil nil))
 
 (defn bonus-tai-sanktio
   "Bonuksia tulee kun toteutuneet pisteet ylittää lupauspisteet.

--- a/src/cljc/harja/domain/lupaus_domain.cljc
+++ b/src/cljc/harja/domain/lupaus_domain.cljc
@@ -645,44 +645,62 @@
        :cljs (/ a b))))
 
 (defn laske-kustannusennusteen-tarkkuus
-  "Laskee kustannusennusteen tarkkuuden kaavan mukaan.
-   
-   Kaava: x = [(Te - Tt)/Th × 0,05 + (Ke - Kt)/Th × 0,05 + [(Ke - Te) - (Kt - Tt)]/Th × 0,9]
-   
-   Parametrit mapissa:
-   - ennustettu-tavoitehinta (Te): Ennustettu tavoitehinta
-   - toteutunut-tavoitehinta (Tt): Toteutunut tavoitehinta  
-   - ennustettu-kustannus (Ke): Ennustettu kustannus
-   - toteutunut-kustannus (Kt): Toteutunut kustannus
-   - hoitovuoden-tavoitehinta (Th): Hoitovuoden alun tavoitehinta
-   
-   Palauttaa: {:tarkkuus-prosentti x} tai {:virhe 'virheviesti'}"
+  "Laskee kustannusennusteen tarkkuuden ja palauttaa tietokantaan tallennettavan muodon."
   [{:keys [ennustettu-tavoitehinta toteutunut-tavoitehinta
            ennustettu-kustannus toteutunut-kustannus
            hoitovuoden-alun-tavoitehinta] :as syotteet}]
   (let [validointi (validoi-kustannusennuste-syotteet syotteet)]
     (if (:virhe validointi)
       validointi
-      (let [te (double ennustettu-tavoitehinta)           ;; Muunnetaan doubleiksi
+      (let [te (double ennustettu-tavoitehinta)
             tt (double toteutunut-tavoitehinta)
             ke (double ennustettu-kustannus)
             kt (double toteutunut-kustannus)
             th (double hoitovuoden-alun-tavoitehinta)
 
-            ;; Kaavan osat turvallisella jaolla
+            ;; Laskentavaiheet
             tavoitehinta-ero (turvallinen-jako (- te tt) th)
             kustannus-ero (turvallinen-jako (- ke kt) th)
             riski-ero (turvallinen-jako (- (- ke te) (- kt tt)) th)
 
-            ;; Lopullinen kaava
+            ;; Lopputulos
             tarkkuus (+ (* tavoitehinta-ero 0.05)
                         (* kustannus-ero 0.05)
                         (* riski-ero 0.9))
+            tarkkuus-prosentti (/ (Math/round (* tarkkuus 1000.0)) 10.0)
 
-            ;; Muutetaan prosenteiksi ja pyöristetään yhteen desimaaliin
-            tarkkuus-prosentti (/ (Math/round (* tarkkuus 1000.0)) 10.0)]
+            ;; Tallennettava data
+            kaava-versio "v1.0"
+            kaava-teksti "x = [(Te - Tt)/Th × 0.05 + (Ke - Kt)/Th × 0.05 + [(Ke - Te) - (Kt - Tt)]/Th × 0.9]"
 
-        {:tarkkuus-prosentti tarkkuus-prosentti}))))
+            parametrit {:Te te :Tt tt :Ke ke :Kt kt :Th th
+                        :kertoimet {:tavoitehinta-kerroin 0.05
+                                    :kustannus-kerroin 0.05
+                                    :riski-kerroin 0.9}}
+
+            vaiheet {:vaihe-1 {:kuvaus "Tavoitehinnan ero"
+                               :kaava "(Te - Tt) / Th"
+                               :laskenta (str "(" te " - " tt ") / " th)
+                               :tulos tavoitehinta-ero}
+                     :vaihe-2 {:kuvaus "Kustannuksen ero"
+                               :kaava "(Ke - Kt) / Th"
+                               :laskenta (str "(" ke " - " kt ") / " th)
+                               :tulos kustannus-ero}
+                     :vaihe-3 {:kuvaus "Riskin ero"
+                               :kaava "[(Ke - Te) - (Kt - Tt)] / Th"
+                               :laskenta (str "[(" ke " - " te ") - (" kt " - " tt ")] / " th)
+                               :tulos riski-ero}
+                     :vaihe-4 {:kuvaus "Lopputulos"
+                               :kaava "vaihe-1 × 0.05 + vaihe-2 × 0.05 + vaihe-3 × 0.9"
+                               :laskenta (str tavoitehinta-ero " × 0.05 + " kustannus-ero " × 0.05 + " riski-ero " × 0.9")
+                               :tulos tarkkuus}
+                     :lopputulos-prosentti tarkkuus-prosentti}]
+
+        {:tarkkuus-prosentti tarkkuus-prosentti
+         :laskentakaava-versio kaava-versio
+         :laskentakaava-teksti kaava-teksti
+         :laskentakaava-parametrit parametrit
+         :laskentakaava-vaiheet vaiheet}))))
 
 (defn maarita-kustannusennuste-pisteet
   "Määrittää pisteet tarkkuuden ja kuukauden perusteella.

--- a/src/cljc/harja/domain/lupaus_domain.cljc
+++ b/src/cljc/harja/domain/lupaus_domain.cljc
@@ -171,25 +171,92 @@
     (set kaikki-kuukaudet)
     #{paatos-kk}))
 
-(defn vaaditut-vastauskuukaudet [{:keys [kirjaus-kkt paatos-kk] :as lupaus} kuluva-kuukausi]
-  (->>
-    ;; Vaaditut vastauskuukaudet koko vuoden ajalta
-    (set/union (set kirjaus-kkt)
-               (paatos-kk-joukko paatos-kk))
-    ;; Vaaditaan vain kuluvaa kuukautta ennen olevat kuukaudet
-    (filter #(or
-               (nil? kuluva-kuukausi)                       ; Ei määritelty, ei suodateta
-               (hoitokuukausi-ennen? % kuluva-kuukausi)))
-    set))
+(defn hoitovuoden-kirjauskuukaudet [lupaus _hoitovuosi-nro hoitovuoden-erikoisarvot]
+  (or (:kirjaus-kkt hoitovuoden-erikoisarvot)
+    (:kirjaus-kkt lupaus)))
 
+(defn hoitovuoden-paatos-kk [lupaus _hoitovuosi-nro hoitovuoden-erikoisarvot]
+  (or (:paatos-kk hoitovuoden-erikoisarvot)
+    (:paatos-kk lupaus)))
+
+(defn hoitovuoden-joustovara [lupaus _hoitovuosi-nro hoitovuoden-erikoisarvot]
+  (or (:joustovara-kkta hoitovuoden-erikoisarvot)
+    (:joustovara-kkta lupaus)))
+
+(defn vaaditut-vastauskuukaudet-hoitovuodelle 
+  [lupaus kuluva-kuukausi hoitovuosi-nro hoitovuoden-erikoisarvot]
+  (let [kaytettavat-kirjaus-kkt (hoitovuoden-kirjauskuukaudet lupaus hoitovuosi-nro hoitovuoden-erikoisarvot)
+        kaytettava-paatos-kk (hoitovuoden-paatos-kk lupaus hoitovuosi-nro hoitovuoden-erikoisarvot)]
+    (->>
+      ;; Yhdistä kirjaus- ja päätöskuukaudet
+      (set/union (set kaytettavat-kirjaus-kkt)
+                 (paatos-kk-joukko kaytettava-paatos-kk))
+      ;; Suodata vain kuluvan kuukauden sisään
+      (filter #(or
+                 (nil? kuluva-kuukausi)
+                 (hoitokuukausi-ennen? % kuluva-kuukausi)))
+      set)))
+
+
+;; Säilytä vanha funktio taaksepäinyhteensopivuudelle:
+(defn vaaditut-vastauskuukaudet [{:keys [kirjaus-kkt paatos-kk] :as lupaus} kuluva-kuukausi]
+  (vaaditut-vastauskuukaudet-hoitovuodelle lupaus kuluva-kuukausi nil nil))
+
+(defn puuttuvat-vastauskuukaudet-hoitovuodelle
+  [lupaus kuluva-kuukausi hoitovuosi-nro hoitovuoden-erikoisarvot]
+  (let [vastaus-kkt (->> (:vastaukset lupaus)
+                      (filter vastattu?)
+                      (map :kuukausi)
+                      set)
+        vaaditut-kkt (vaaditut-vastauskuukaudet-hoitovuodelle
+                       lupaus kuluva-kuukausi hoitovuosi-nro hoitovuoden-erikoisarvot)]
+    (set/difference vaaditut-kkt vastaus-kkt)))
+
+;; Päivitä vanha funktio käyttämään uutta:
 (defn puuttuvat-vastauskuukaudet [{:keys [lupaustyyppi joustovara-kkta kirjaus-kkt paatos-kk vastaukset] :as lupaus}
                                   kuluva-kuukausi]
-  (let [vastaus-kkt (->> vastaukset
-                         (filter vastattu?)
-                         (map :kuukausi)
-                         set)
-        vaaditut-kkt (vaaditut-vastauskuukaudet lupaus kuluva-kuukausi)]
-    (set/difference vaaditut-kkt vastaus-kkt)))
+  (puuttuvat-vastauskuukaudet-hoitovuodelle lupaus kuluva-kuukausi nil nil))
+
+(defn maarita-kuluva-kuukausi-hoitokaudelle
+  "Määrittää mikä kuluva-kuukausi parametri pitää antaa 
+   odottaa-kannanottoa-kkt-hoitovuodelle funktiolle hoitokauden 
+   aikatilan perusteella."
+  [nykyhetki valittu-hoitokausi]
+  (let [[hk-alkupvm hk-loppupvm] valittu-hoitokausi]
+    (cond
+      ;; Tuleviin hoitokausiin ei oteta kantaa
+      (pvm/ennen? nykyhetki hk-alkupvm)
+      :tuleva-hoitokausi
+
+      ;; Menneet hoitokaudet: ei määritetä kuluvaa kuukautta
+      (pvm/jalkeen? nykyhetki hk-loppupvm)
+      nil
+
+      ;; Kuluva hoitokausi lasketaan kuluvan kuukauden perusteella
+      :else
+      (pvm/kuukausi nykyhetki))))
+
+(defn odottaa-kannanottoa-kkt-hoitovuodelle
+  [lupaus kuluva-kuukausi hoitovuosi-nro hoitovuoden-erikoisarvot]
+  (cond
+    ;; Tuleviin hoitokausiin ei oteta kantaa
+    (= kuluva-kuukausi :tuleva-hoitokausi)
+    []
+
+    ;; Jos toteuma voidaan laskea, ei tarvitse ottaa kantaa
+    (lupaus->toteuma lupaus)
+    []
+
+    ;; Muuten laske puuttuvat kuukaudet
+    :else
+    (puuttuvat-vastauskuukaudet-hoitovuodelle
+      lupaus kuluva-kuukausi hoitovuosi-nro hoitovuoden-erikoisarvot)))
+
+(defn odottaa-kannanottoa-kkt-hoitokaudelle
+  "Laskee puuttuvat kannanottokuukaudet ottaen huomioon hoitokauden aikatilan."
+  [lupaus nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot]
+  (let [kuluva-kuukausi (maarita-kuluva-kuukausi-hoitokaudelle nykyhetki valittu-hoitokausi)]
+    (odottaa-kannanottoa-kkt-hoitovuodelle lupaus kuluva-kuukausi hoitovuosi-nro hoitovuoden-erikoisarvot)))
 
 (defn odottaa-kannanottoa-kkt
   ([lupaus nykyhetki valittu-hoitokausi]
@@ -237,18 +304,21 @@
    :paattava-kuukausi? true,
    :nykyhetkeen-verrattuna :mennyt-kuukausi,
    :vastaus true}"
-  [{:keys [paatos-kk vastaukset kirjaus-kkt joustovara-kkta] :as lupaus}
-   nykyhetki valittu-hoitokausi]
+  [{:keys [vastaukset] :as lupaus}
+   nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot]
   (let [[hk-alkupvm hk-loppupvm] valittu-hoitokausi
         kuluva-vuosi (pvm/vuosi nykyhetki)
         kuluva-kuukausi (pvm/kuukausi nykyhetki)
         kk->vastaus (into {}
                           (map (fn [vastaus] [(:kuukausi vastaus) vastaus]))
-                          vastaukset)
-        puuttuvat-kkt (odottaa-kannanottoa-kkt lupaus nykyhetki valittu-hoitokausi)
-        paatos-kkt (paatos-kk-joukko paatos-kk)
-        kirjaus-kkt (set kirjaus-kkt)
-        paatos-hylatty? (paatos-hylatty? vastaukset joustovara-kkta)]
+                          vastaukset) 
+        kaytettavat-kirjaus-kkt (set (hoitovuoden-kirjauskuukaudet lupaus hoitovuosi-nro hoitovuoden-erikoisarvot))
+        kaytettava-paatos-kk (hoitovuoden-paatos-kk lupaus hoitovuosi-nro hoitovuoden-erikoisarvot)
+        puuttuvat-kkt (odottaa-kannanottoa-kkt-hoitokaudelle lupaus nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot)
+        kaytettava-joustovara (hoitovuoden-joustovara lupaus hoitovuosi-nro hoitovuoden-erikoisarvot)
+        paatos-kkt (paatos-kk-joukko kaytettava-paatos-kk)
+        kirjaus-kkt kaytettavat-kirjaus-kkt
+        paatos-hylatty? (paatos-hylatty? vastaukset kaytettava-joustovara)]
     (for [{:keys [vuosi kuukausi]} (hoitokuukaudet (pvm/vuosi hk-alkupvm))]
       (let [vastaus (kk->vastaus kuukausi)]
         (merge
@@ -265,9 +335,11 @@
           (when vastaus
             {:vastaus vastaus}))))))
 
-(defn liita-lupaus-kuukaudet [lupaus nykyhetki valittu-hoitokausi]
+(defn liita-lupaus-kuukaudet [lupaus nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot]
   (assoc lupaus :lupaus-kuukaudet
-                (lupaus->kuukaudet lupaus nykyhetki valittu-hoitokausi)))
+                (lupaus->kuukaudet lupaus nykyhetki valittu-hoitokausi
+                  hoitovuosi-nro
+                  hoitovuoden-erikoisarvot)))
 
 (defn liita-odottaa-kannanottoa [lupaus nykyhetki valittu-hoitokausi]
   (assoc lupaus :odottaa-kannanottoa?
@@ -322,17 +394,6 @@
 (defn lupausryhmat->merkitsevat-odottaa-kannanottoa [lupausryhmat]
   (rivit->summa lupausryhmat :merkitsevat-odottaa-kannanottoa))
 
-(defn hoitovuoden-kirjauskuukaudet [lupaus _hoitovuosi-nro hoitovuoden-erikoisarvot]
-  (or (:kirjaus-kkt hoitovuoden-erikoisarvot)
-      (:kirjaus-kkt lupaus)))
-
-(defn hoitovuoden-paatos-kk [lupaus _hoitovuosi-nro hoitovuoden-erikoisarvot]
-  (or (:paatos-kk hoitovuoden-erikoisarvot)
-      (:paatos-kk lupaus)))
-
-(defn hoitovuoden-joustovara [lupaus _hoitovuosi-nro hoitovuoden-erikoisarvot]
-  (or (:joustovara-kkta hoitovuoden-erikoisarvot)
-      (:joustovara-kkta lupaus)))
 
 (defn sallittu-kuukausi-hoitovuodelle? [lupaus kuukausi paatos hoitovuosi-nro hoitovuoden-erikoisarvot]
   {:pre [lupaus kuukausi (boolean? paatos)]}

--- a/src/cljc/harja/domain/lupaus_domain.cljc
+++ b/src/cljc/harja/domain/lupaus_domain.cljc
@@ -303,15 +303,21 @@
    :odottaa-kannanottoa? false,
    :paattava-kuukausi? true,
    :nykyhetkeen-verrattuna :mennyt-kuukausi,
-   :vastaus true}"
-  [{:keys [vastaukset] :as lupaus}
+   :vastaus true,
+   :kustannusennuste {...}}"
+  [{:keys [vastaukset kustannusennusteet] :as lupaus}
    nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot]
   (let [[hk-alkupvm hk-loppupvm] valittu-hoitokausi
         kuluva-vuosi (pvm/vuosi nykyhetki)
         kuluva-kuukausi (pvm/kuukausi nykyhetki)
         kk->vastaus (into {}
                           (map (fn [vastaus] [(:kuukausi vastaus) vastaus]))
-                          vastaukset) 
+                          vastaukset)
+        ;; Lisätään kustannusennusteiden map kuukauden mukaan
+        kk->kustannusennuste (when kustannusennusteet
+                               (into {}
+                                     (map (fn [ke] [(pvm/kuukausi (:maarapaiva ke)) ke]))
+                                     kustannusennusteet)) 
         kaytettavat-kirjaus-kkt (set (hoitovuoden-kirjauskuukaudet lupaus hoitovuosi-nro hoitovuoden-erikoisarvot))
         kaytettava-paatos-kk (hoitovuoden-paatos-kk lupaus hoitovuosi-nro hoitovuoden-erikoisarvot)
         puuttuvat-kkt (odottaa-kannanottoa-kkt-hoitokaudelle lupaus nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot)
@@ -320,7 +326,9 @@
         kirjaus-kkt kaytettavat-kirjaus-kkt
         paatos-hylatty? (paatos-hylatty? vastaukset kaytettava-joustovara)]
     (for [{:keys [vuosi kuukausi]} (hoitokuukaudet (pvm/vuosi hk-alkupvm))]
-      (let [vastaus (kk->vastaus kuukausi)]
+      (let [vastaus (kk->vastaus kuukausi)
+            kustannusennuste (when kk->kustannusennuste
+                               (kk->kustannusennuste kuukausi))]
         (merge
           {:vuosi vuosi
            :kuukausi kuukausi
@@ -333,13 +341,23 @@
                                                        {:vuosi vuosi
                                                         :kuukausi kuukausi})}
           (when vastaus
-            {:vastaus vastaus}))))))
+            {:vastaus vastaus})
+          ;; Lisätään kustannusennuste jos löytyy
+          (when kustannusennuste
+            {:kustannusennuste kustannusennuste}))))))
 
-(defn liita-lupaus-kuukaudet [lupaus nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot]
-  (assoc lupaus :lupaus-kuukaudet
-                (lupaus->kuukaudet lupaus nykyhetki valittu-hoitokausi
-                  hoitovuosi-nro
-                  hoitovuoden-erikoisarvot)))
+(defn liita-lupaus-kuukaudet 
+  ([lupaus nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot]
+   ;; Perus signature ilman kustannusennusteita (nil-käsittely)
+   (liita-lupaus-kuukaudet lupaus nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot nil))
+  ([lupaus nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot kustannusennusteet]
+   ;; Täysi signature kustannusennusteilla - nil käsitellään automaattisesti
+   (let [lupaus-kustannusennusteilla (if kustannusennusteet
+                                       (assoc lupaus :kustannusennusteet kustannusennusteet)
+                                       lupaus)]
+     (assoc lupaus-kustannusennusteilla :lupaus-kuukaudet
+                                        (lupaus->kuukaudet lupaus-kustannusennusteilla nykyhetki valittu-hoitokausi
+                                          hoitovuosi-nro hoitovuoden-erikoisarvot)))))
 
 (defn liita-odottaa-kannanottoa [lupaus nykyhetki valittu-hoitokausi]
   (assoc lupaus :odottaa-kannanottoa?

--- a/src/cljc/harja/domain/lupaus_domain.cljc
+++ b/src/cljc/harja/domain/lupaus_domain.cljc
@@ -636,6 +636,14 @@
     :else
     {:ok true}))
 
+(defn turvallinen-jako
+  "Turvallinen jakolasku joka välttää BigDecimal-ongelmat ja toimii sekä CLJ että CLJS:ssä"
+  [a b]
+  (if (zero? b)
+    0.0
+    #?(:clj (double (/ (double a) (double b)))
+       :cljs (/ a b))))
+
 (defn laske-kustannusennusteen-tarkkuus
   "Laskee kustannusennusteen tarkkuuden kaavan mukaan.
    
@@ -649,31 +657,31 @@
    - hoitovuoden-tavoitehinta (Th): Hoitovuoden alun tavoitehinta
    
    Palauttaa: {:tarkkuus-prosentti x} tai {:virhe 'virheviesti'}"
-  [{:keys [ennustettu-tavoitehinta toteutunut-tavoitehinta 
+  [{:keys [ennustettu-tavoitehinta toteutunut-tavoitehinta
            ennustettu-kustannus toteutunut-kustannus
            hoitovuoden-alun-tavoitehinta] :as syotteet}]
   (let [validointi (validoi-kustannusennuste-syotteet syotteet)]
     (if (:virhe validointi)
       validointi
-      (let [te ennustettu-tavoitehinta
-            tt toteutunut-tavoitehinta
-            ke ennustettu-kustannus
-            kt toteutunut-kustannus
-            th hoitovuoden-alun-tavoitehinta
-            
-            ;; Kaavan osat
-            tavoitehinta-ero (/ (- te tt) th)
-            kustannus-ero (/ (- ke kt) th)
-            riski-ero (/ (- (- ke te) (- kt tt)) th)
-            
+      (let [te (double ennustettu-tavoitehinta)           ;; Muunnetaan doubleiksi
+            tt (double toteutunut-tavoitehinta)
+            ke (double ennustettu-kustannus)
+            kt (double toteutunut-kustannus)
+            th (double hoitovuoden-alun-tavoitehinta)
+
+            ;; Kaavan osat turvallisella jaolla
+            tavoitehinta-ero (turvallinen-jako (- te tt) th)
+            kustannus-ero (turvallinen-jako (- ke kt) th)
+            riski-ero (turvallinen-jako (- (- ke te) (- kt tt)) th)
+
             ;; Lopullinen kaava
             tarkkuus (+ (* tavoitehinta-ero 0.05)
                         (* kustannus-ero 0.05)
                         (* riski-ero 0.9))
-            
+
             ;; Muutetaan prosenteiksi ja pyöristetään yhteen desimaaliin
             tarkkuus-prosentti (/ (Math/round (* tarkkuus 1000.0)) 10.0)]
-        
+
         {:tarkkuus-prosentti tarkkuus-prosentti}))))
 
 (defn maarita-kustannusennuste-pisteet

--- a/src/cljc/harja/domain/lupaus_domain.cljc
+++ b/src/cljc/harja/domain/lupaus_domain.cljc
@@ -115,25 +115,24 @@
 
 (defn kustannusennuste->toteuma
   "Laskee kustannusennusteen toteuman kun se on mahdollista.
-   Toteuma = keskiarvo kaikista 4 ennustekuukaudesta (10,1,4,6).
-   Puuttuvat ennusteet = 0 pistettä keskiarvossa.
+   Toteuma = keskiarvo kaikista kustannusennustekuukausista joissa on pisteitä.
+   Jos ei ole pisteitä ollenkaan, palauttaa 0.
    
    HUOM: Toteuma lasketaan vain kun kaikki ennustekuukaudet on ohitettu ajallisesti.
    Tämän tarkistuksen tulee tapahtua kutsuvassa koodissa hoitovuoden tilan perusteella."
-  [{:keys [lupaus-kuukaudet hoitovuosi-paattynyt?]}]
-  (when hoitovuosi-paattynyt?
-    ;; Vaaditut ennustekuukaudet (lokakuu, tammikuu, huhtikuu, kesäkuu)
-    (let [vaaditut-kuukaudet #{10 1 4 6}
-          ;; Hae pisteet kaikille vaadituille kuukausille
-          kuukauden-pisteet (reduce (fn [pisteet kk]
-                                      (let [kuukausi-data (first (filter #(= (:kuukausi %) kk) lupaus-kuukaudet))
-                                            pisteet-kuukaudelle (get-in kuukausi-data [:kustannusennuste :pisteet] 0)]
-                                        (conj pisteet pisteet-kuukaudelle)))
-                                    []
-                                    vaaditut-kuukaudet)
-          ;; Laske keskiarvo (puuttuvat = 0 pistettä)
-          keskiarvo (/ (reduce + kuukauden-pisteet) (count kuukauden-pisteet))]
-      (Math/round keskiarvo))))
+  [{:keys [lupaus-kuukaudet hoitovuosi-paattynyt?]}] 
+    (when hoitovuosi-paattynyt?
+      ;; Hae kaikki kuukaudet joissa on kustannusennusteita ja pisteitä
+      (let [kuukaudet-pisteilla (->> lupaus-kuukaudet
+                                  (filter #(get-in % [:kustannusennuste :pisteet]))
+                                  (map #(get-in % [:kustannusennuste :pisteet])))]
+        (if (seq kuukaudet-pisteilla)
+          ;; Laske keskiarvo vain niistä kuukausista joissa on pisteitä
+          (let [keskiarvo (/ (reduce + kuukaudet-pisteilla) (count kuukaudet-pisteilla))]
+            #?(:clj (Math/round (double keskiarvo))
+               :cljs (js/Math.round keskiarvo)))
+          ;; Jos ei ole pisteitä ollenkaan, palauta 0
+          0))))
 
 (defn lupaus->ennuste [{:keys [lupaustyyppi] :as lupaus}]
   (case lupaustyyppi
@@ -702,58 +701,45 @@
          :laskentakaava-parametrit parametrit
          :laskentakaava-vaiheet vaiheet}))))
 
-(defn maarita-kustannusennuste-pisteet
+(defn maarita-kustannusennuste-pisteet-kovakoodattu
   "Määrittää pisteet tarkkuuden ja kuukauden perusteella.
    Kuukausikohtaiset raja-arvot määrittävät pistemäärän."
   [tarkkuus-prosentti kuukausi]
   {:pre [(number? tarkkuus-prosentti) (number? kuukausi)]}
   (let [tarkkuus-itseisarvo (Math/abs tarkkuus-prosentti)]
-    (cond
-      ;; Lokakuu - tammikuu (ensimmäiset 4 kuukautta)
-      (#{10 11 12 1} kuukausi)
-      (cond
-        (<= tarkkuus-itseisarvo 15.0) 5
-        (<= tarkkuus-itseisarvo 25.0) 3
-        (<= tarkkuus-itseisarvo 35.0) 1
-        :else 0)
+    (case kuukausi
+      ;; Lokakuu: ≤ 7,0% = 8p, ≤ 9,0% = 4p, > 9,0% = 1p
+      10 (cond
+           (<= tarkkuus-itseisarvo 7.0) 8
+           (<= tarkkuus-itseisarvo 9.0) 4
+           :else 1)
 
-      ;; Helmikuu - huhtikuu (kuukaudet 5-7)
-      (#{2 3 4} kuukausi)
-      (cond
-        (<= tarkkuus-itseisarvo 10.0) 5
-        (<= tarkkuus-itseisarvo 20.0) 3
-        (<= tarkkuus-itseisarvo 30.0) 1
-        :else 0)
+      ;; Tammikuu: ≤ 4,0% = 8p, ≤ 6,0% = 4p, > 6,0% = 1p
+      1 (cond
+          (<= tarkkuus-itseisarvo 4.0) 8
+          (<= tarkkuus-itseisarvo 6.0) 4
+          :else 1)
 
-      ;; Toukokuu - heinäkuu (kuukaudet 8-10)
-      (#{5 6 7} kuukausi)
-      (cond
-        (<= tarkkuus-itseisarvo 7.5) 5
-        (<= tarkkuus-itseisarvo 15.0) 3
-        (<= tarkkuus-itseisarvo 22.5) 1
-        :else 0)
+      ;; Huhtikuu: ≤ 2,0% = 8p, ≤ 3,0% = 4p, > 3,0% = 1p
+      4 (cond
+          (<= tarkkuus-itseisarvo 2.0) 8
+          (<= tarkkuus-itseisarvo 3.0) 4
+          :else 1)
 
-      ;; Elokuu - syyskuu (kuukaudet 11-12)
-      (#{8 9} kuukausi)
-      (cond
-        (<= tarkkuus-itseisarvo 5.0) 5
-        (<= tarkkuus-itseisarvo 10.0) 3
-        (<= tarkkuus-itseisarvo 15.0) 1
-        :else 0)
+      ;; Kesäkuu: ≤ 1,0% = 8p, ≤ 2,0% = 4p, > 2,0% = 1p
+      6 (cond
+          (<= tarkkuus-itseisarvo 1.0) 8
+          (<= tarkkuus-itseisarvo 2.0) 4
+          :else 1)
 
-      :else 0)))
+      ;; Elokuu: samat arvot kuin lokakuu
+      8 (cond
+          (<= tarkkuus-itseisarvo 7.0) 8
+          (<= tarkkuus-itseisarvo 9.0) 4
+          :else 1)
 
-(defn laske-kustannusennuste-tulos
-  "Laskee kustannusennusteen kokonaistulon (tarkkuus + pisteet).
-   Yhdistää tarkkuuslaskennan ja pisteiden määrityksen."
-  [syotteet kuukausi]
-  {:pre [(map? syotteet) (number? kuukausi)]}
-  (let [tarkkuus-tulos (laske-kustannusennusteen-tarkkuus syotteet)]
-    (if (:virhe tarkkuus-tulos)
-      tarkkuus-tulos
-      (let [tarkkuus (:tarkkuus-prosentti tarkkuus-tulos)
-            pisteet (maarita-kustannusennuste-pisteet tarkkuus kuukausi)]
-        (assoc tarkkuus-tulos :pisteet pisteet)))))
+      ;; Muut kuukaudet - oletusarvo
+      0)))
 
 (defn odottaa-urakoitsijan-kannanottoa?
   "Odottaako 19/20 alkanut urakka urakoitsijan kannanottoa."
@@ -771,29 +757,3 @@
         (filter :odottaa-vastausta?)
         first
         boolean))))
-
-(comment
-  (laske-kustannusennuste-tulos
-    {:ennustettu-tavoitehinta 1000000
-     :ennustettu-kustannus 800000
-     :toteutunut-tavoitehinta 950000
-     :toteutunut-kustannus 780000
-     :hoitovuoden-alun-tavoitehinta 1200000}
-    3)
-  
-  ;; Testaa kustannusennuste-integrointi
-  (let [kustannusennuste-lupaus {:lupaustyyppi "kustannusennuste"
-                                 :hoitovuosi-paattynyt? true
-                                 :lupaus-kuukaudet [{:kuukausi 10 :kustannusennuste {:pisteet 5}}
-                                                   {:kuukausi 1 :kustannusennuste {:pisteet 3}}
-                                                   {:kuukausi 4 :kustannusennuste {:pisteet 4}}
-                                                   ;; Kesäkuu puuttuu = 0 pistettä
-                                                   {:kuukausi 6}]}]
-    ;; Ennuste: 4 (viimeisin annettu)
-    (kustannusennuste->ennuste kustannusennuste-lupaus)
-    ;; Toteuma: (5+3+4+0)/4 = 3 (keskiarvo, puuttuva kesäkuu = 0)
-    (kustannusennuste->toteuma kustannusennuste-lupaus)
-    ;; Integrointi:
-    (lupaus->ennuste kustannusennuste-lupaus)
-    (lupaus->toteuma kustannusennuste-lupaus))
-  )

--- a/src/cljc/harja/domain/lupaus_domain.cljc
+++ b/src/cljc/harja/domain/lupaus_domain.cljc
@@ -148,6 +148,27 @@
     "monivalinta" (monivalinta->toteuma lupaus)
     "kustannusennuste" (kustannusennuste->toteuma lupaus)))
 
+(defn lupaus->maksimipisteet
+  "Palauttaa lupauksen maksimipisteet lupaustyypistä riippumatta.
+   Backend palauttaa :kyselypisteet arvoksi vähintään 0 jos muuta arvoa ei ole."
+  [{:keys [lupaustyyppi pisteet kyselypisteet]}]
+  (case lupaustyyppi
+    "yksittainen" pisteet
+    "kustannusennuste" pisteet
+    ; kysely ja monivalinta käyttävät kyselypisteitä, defaulttaa 0:aan
+    (or kyselypisteet 0)))
+
+(defn lupaus->pistenakyma
+  "Palauttaa lupauksen pistenäytön merkkijonona UI:ta varten.
+   Yksittäinen: näyttää vain pisteet
+   Kustannusennuste ja muut: näyttää 'Pisteet 0 - X'"
+  [{:keys [lupaustyyppi pisteet kyselypisteet] :as lupaus}]
+  (case lupaustyyppi
+    "yksittainen" (str pisteet)
+    "kustannusennuste" (str "Pisteet 0 - " pisteet)
+    ; kysely ja monivalinta
+    (str "Pisteet 0 - " (or kyselypisteet 0))))
+
 (defn lupaus->ennuste-tai-toteuma [lupaus]
   (or (when-let [toteuma (lupaus->toteuma lupaus)]
         {:pisteet-toteuma toteuma
@@ -341,8 +362,8 @@
    :nykyhetkeen-verrattuna :mennyt-kuukausi,
    :vastaus true,
    :kustannusennuste {...}}"
-  [{:keys [vastaukset kustannusennusteet] :as lupaus}
-   nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot]
+  [{:keys [vastaukset kustannusennusteet lupaustyyppi] :as lupaus}
+   nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot maarapaiva-tiedot]
   (let [[hk-alkupvm hk-loppupvm] valittu-hoitokausi
         kuluva-vuosi (pvm/vuosi nykyhetki)
         kuluva-kuukausi (pvm/kuukausi nykyhetki)
@@ -360,11 +381,23 @@
         kaytettava-joustovara (hoitovuoden-joustovara lupaus hoitovuosi-nro hoitovuoden-erikoisarvot)
         paatos-kkt (paatos-kk-joukko kaytettava-paatos-kk)
         kirjaus-kkt kaytettavat-kirjaus-kkt
-        paatos-hylatty? (paatos-hylatty? vastaukset kaytettava-joustovara)]
+        paatos-hylatty? (paatos-hylatty? vastaukset kaytettava-joustovara)
+         ;; Kustannusennustelupaukselle karsitaan määräpäivätiedot vain kirjauskuukausille
+        karsitut-maarapaiva-tiedot (when (and (= "kustannusennuste" lupaustyyppi) maarapaiva-tiedot)
+                                     (select-keys maarapaiva-tiedot kaytettavat-kirjaus-kkt))
+        ;; Käytetään karsittuja määräpäivätietoja kustannusennusteille, muille alkuperäisiä
+        kaytettavat-maarapaiva-tiedot (if (= "kustannusennuste" lupaustyyppi)
+                                        karsitut-maarapaiva-tiedot
+                                        maarapaiva-tiedot)]
     (for [{:keys [vuosi kuukausi]} (hoitokuukaudet (pvm/vuosi hk-alkupvm))]
       (let [vastaus (kk->vastaus kuukausi)
             kustannusennuste (when kk->kustannusennuste
-                               (kk->kustannusennuste kuukausi))]
+                               (kk->kustannusennuste kuukausi))
+            maarapaiva-tieto (when kaytettavat-maarapaiva-tiedot 
+                               (get kaytettavat-maarapaiva-tiedot kuukausi))
+            syotetty-ajoissa? (when (and kustannusennuste maarapaiva-tieto)
+                                (pvm/ennen? (:syotetty_pvm kustannusennuste) 
+                                  (:maarapaiva-pvm maarapaiva-tieto)))]
         (merge
           {:vuosi vuosi
            :kuukausi kuukausi
@@ -374,26 +407,32 @@
            :kirjauskuukausi? (contains? kirjaus-kkt kuukausi)
            :nykyhetkeen-verrattuna (vertaa-nykyhetkeen {:vuosi kuluva-vuosi
                                                         :kuukausi kuluva-kuukausi}
-                                                       {:vuosi vuosi
-                                                        :kuukausi kuukausi})}
+                                     {:vuosi vuosi
+                                      :kuukausi kuukausi})}
           (when vastaus
             {:vastaus vastaus})
-          ;; Lisätään kustannusennuste jos löytyy
           (when kustannusennuste
-            {:kustannusennuste kustannusennuste}))))))
+            {:kustannusennuste kustannusennuste})
+          (when maarapaiva-tieto
+            {:maarapaiva-mennyt-ohi? (:maarapaiva-mennyt-ohi? maarapaiva-tieto)
+             :maarapaiva-pvm (:maarapaiva-pvm maarapaiva-tieto)
+             :syotetty-ajoissa? syotetty-ajoissa?}))))))
 
-(defn liita-lupaus-kuukaudet 
+(defn liita-lupaus-kuukaudet
   ([lupaus nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot]
    ;; Perus signature ilman kustannusennusteita (nil-käsittely)
-   (liita-lupaus-kuukaudet lupaus nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot nil))
+   (liita-lupaus-kuukaudet lupaus nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot nil nil))
   ([lupaus nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot kustannusennusteet]
-   ;; Täysi signature kustannusennusteilla - nil käsitellään automaattisesti
+   ;; Signature kustannusennusteilla mutta ilman määräpäivätietoja
+   (liita-lupaus-kuukaudet lupaus nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot kustannusennusteet nil))
+  ([lupaus nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot kustannusennusteet maarapaiva-tiedot]
+   ;; Täysi signature kustannusennusteilla ja määräpäivätiedoilla
    (let [lupaus-kustannusennusteilla (if kustannusennusteet
                                        (assoc lupaus :kustannusennusteet kustannusennusteet)
                                        lupaus)]
      (assoc lupaus-kustannusennusteilla :lupaus-kuukaudet
-                                        (lupaus->kuukaudet lupaus-kustannusennusteilla nykyhetki valittu-hoitokausi
-                                          hoitovuosi-nro hoitovuoden-erikoisarvot)))))
+       (lupaus->kuukaudet lupaus-kustannusennusteilla nykyhetki valittu-hoitokausi
+         hoitovuosi-nro hoitovuoden-erikoisarvot maarapaiva-tiedot)))))
 
 (defn liita-odottaa-kannanottoa [lupaus nykyhetki valittu-hoitokausi]
   (assoc lupaus :odottaa-kannanottoa?

--- a/src/cljc/harja/domain/lupaus_domain.cljc
+++ b/src/cljc/harja/domain/lupaus_domain.cljc
@@ -14,7 +14,7 @@
 
 (def ennusteiden-tilat
   #{;; "Ei vielä ennustetta"
-    ;; Ensimmäiset ennusteet annetaan lokakuun alussa, kun tiedot on syötetty ensimmäiseltä  kuukaudelta.
+    ;; Ensimmäiset ennusteet annetaan lokakuun alussa, kun pidetty ensimmäiseltä kuukaudelta.
     :ei-viela-ennustetta
 
     ;; "Huhtikuun ennusteen mukaan urakalle on tulossa Bonusta 5200 €"
@@ -98,19 +98,56 @@
   (or (:pisteet (viimeisin-vastaus vastaukset))
       kyselypisteet))
 
+(defn kustannusennuste->ennuste
+  "Laskee kustannusennusteen ennusteen kuukausittaisten kustannusennusteiden perusteella.
+   Jos kaikki kuukaudet eivät ole täytetty, palauttaa viimeisimmän annetun ennusteen.
+   Jos dataa ei löydy, palauttaa 0."
+  [{:keys [lupaus-kuukaudet]}]
+  (let [;; Hae kaikki kuukaudet, joissa on kustannusennusteita
+        kuukaudet-pisteilla (->> lupaus-kuukaudet
+                              (filter #(get-in % [:kustannusennuste :pisteet]))
+                              (sort-by :kuukausi))
+        ;; Jos on annettu kustannusennusteita, käytä viimeisintä
+        viimeisin-pisteet (when (seq kuukaudet-pisteilla)
+                            (get-in (last kuukaudet-pisteilla) [:kustannusennuste :pisteet]))]
+    ;; Palauta 0 jos ei ole dataa, muuten viimeisin pistemäärä
+    (or viimeisin-pisteet 0)))
+
+(defn kustannusennuste->toteuma
+  "Laskee kustannusennusteen toteuman kun se on mahdollista.
+   Toteuma = keskiarvo kaikista 4 ennustekuukaudesta (10,1,4,6).
+   Puuttuvat ennusteet = 0 pistettä keskiarvossa.
+   
+   HUOM: Toteuma lasketaan vain kun kaikki ennustekuukaudet on ohitettu ajallisesti.
+   Tämän tarkistuksen tulee tapahtua kutsuvassa koodissa hoitovuoden tilan perusteella."
+  [{:keys [lupaus-kuukaudet hoitovuosi-paattynyt?]}]
+  (when hoitovuosi-paattynyt?
+    ;; Vaaditut ennustekuukaudet (lokakuu, tammikuu, huhtikuu, kesäkuu)
+    (let [vaaditut-kuukaudet #{10 1 4 6}
+          ;; Hae pisteet kaikille vaadituille kuukausille
+          kuukauden-pisteet (reduce (fn [pisteet kk]
+                                      (let [kuukausi-data (first (filter #(= (:kuukausi %) kk) lupaus-kuukaudet))
+                                            pisteet-kuukaudelle (get-in kuukausi-data [:kustannusennuste :pisteet] 0)]
+                                        (conj pisteet pisteet-kuukaudelle)))
+                                    []
+                                    vaaditut-kuukaudet)
+          ;; Laske keskiarvo (puuttuvat = 0 pistettä)
+          keskiarvo (/ (reduce + kuukauden-pisteet) (count kuukauden-pisteet))]
+      (Math/round keskiarvo))))
+
 (defn lupaus->ennuste [{:keys [lupaustyyppi] :as lupaus}]
   (case lupaustyyppi
     "yksittainen" (yksittainen->ennuste lupaus)
     "kysely" (kysely->ennuste lupaus)
     "monivalinta" (monivalinta->ennuste lupaus)
-    "kustannusennuste" (yksittainen->ennuste lupaus)))
+    "kustannusennuste" (kustannusennuste->ennuste lupaus)))
 
 (defn lupaus->toteuma [{:keys [lupaustyyppi] :as lupaus}]
   (case lupaustyyppi
     "yksittainen" (yksittainen->toteuma lupaus)
     "kysely" (monivalinta->toteuma lupaus)
     "monivalinta" (monivalinta->toteuma lupaus)
-    "kustannusennuste" (yksittainen->toteuma lupaus)))
+    "kustannusennuste" (kustannusennuste->toteuma lupaus)))
 
 (defn lupaus->ennuste-tai-toteuma [lupaus]
   (or (when-let [toteuma (lupaus->toteuma lupaus)]
@@ -578,6 +615,120 @@
   [urakka]
   (-> urakka :alkupvm pvm/vuosi vuosi-19-20?))
 
+(defn validoi-kustannusennuste-syotteet
+  "Validoi että kaikki syötteet ovat valideja laskentaa varten"
+  [{:keys [ennustettu-tavoitehinta toteutunut-tavoitehinta 
+           ennustettu-kustannus toteutunut-kustannus
+           hoitovuoden-alun-tavoitehinta] :as syotteet}]
+  {:pre [syotteet]}
+  (cond
+    (not (every? number? [ennustettu-tavoitehinta toteutunut-tavoitehinta 
+                          ennustettu-kustannus toteutunut-kustannus
+                          hoitovuoden-alun-tavoitehinta]))
+    {:virhe "Kaikki arvot on oltava numeroita"}
+
+    (zero? hoitovuoden-alun-tavoitehinta)
+    {:virhe "Hoitovuoden tavoitehinta ei voi olla nolla (nollajako)"}
+
+    (neg? hoitovuoden-alun-tavoitehinta)
+    {:virhe "Hoitovuoden tavoitehinta ei voi olla negatiivinen"}
+
+    :else
+    {:ok true}))
+
+(defn laske-kustannusennusteen-tarkkuus
+  "Laskee kustannusennusteen tarkkuuden kaavan mukaan.
+   
+   Kaava: x = [(Te - Tt)/Th × 0,05 + (Ke - Kt)/Th × 0,05 + [(Ke - Te) - (Kt - Tt)]/Th × 0,9]
+   
+   Parametrit mapissa:
+   - ennustettu-tavoitehinta (Te): Ennustettu tavoitehinta
+   - toteutunut-tavoitehinta (Tt): Toteutunut tavoitehinta  
+   - ennustettu-kustannus (Ke): Ennustettu kustannus
+   - toteutunut-kustannus (Kt): Toteutunut kustannus
+   - hoitovuoden-tavoitehinta (Th): Hoitovuoden alun tavoitehinta
+   
+   Palauttaa: {:tarkkuus-prosentti x} tai {:virhe 'virheviesti'}"
+  [{:keys [ennustettu-tavoitehinta toteutunut-tavoitehinta 
+           ennustettu-kustannus toteutunut-kustannus
+           hoitovuoden-alun-tavoitehinta] :as syotteet}]
+  (let [validointi (validoi-kustannusennuste-syotteet syotteet)]
+    (if (:virhe validointi)
+      validointi
+      (let [te ennustettu-tavoitehinta
+            tt toteutunut-tavoitehinta
+            ke ennustettu-kustannus
+            kt toteutunut-kustannus
+            th hoitovuoden-alun-tavoitehinta
+            
+            ;; Kaavan osat
+            tavoitehinta-ero (/ (- te tt) th)
+            kustannus-ero (/ (- ke kt) th)
+            riski-ero (/ (- (- ke te) (- kt tt)) th)
+            
+            ;; Lopullinen kaava
+            tarkkuus (+ (* tavoitehinta-ero 0.05)
+                        (* kustannus-ero 0.05)
+                        (* riski-ero 0.9))
+            
+            ;; Muutetaan prosenteiksi ja pyöristetään yhteen desimaaliin
+            tarkkuus-prosentti (/ (Math/round (* tarkkuus 1000.0)) 10.0)]
+        
+        {:tarkkuus-prosentti tarkkuus-prosentti}))))
+
+(defn maarita-kustannusennuste-pisteet
+  "Määrittää pisteet tarkkuuden ja kuukauden perusteella.
+   Kuukausikohtaiset raja-arvot määrittävät pistemäärän."
+  [tarkkuus-prosentti kuukausi]
+  {:pre [(number? tarkkuus-prosentti) (number? kuukausi)]}
+  (let [tarkkuus-itseisarvo (Math/abs tarkkuus-prosentti)]
+    (cond
+      ;; Lokakuu - tammikuu (ensimmäiset 4 kuukautta)
+      (#{10 11 12 1} kuukausi)
+      (cond
+        (<= tarkkuus-itseisarvo 15.0) 5
+        (<= tarkkuus-itseisarvo 25.0) 3
+        (<= tarkkuus-itseisarvo 35.0) 1
+        :else 0)
+
+      ;; Helmikuu - huhtikuu (kuukaudet 5-7)
+      (#{2 3 4} kuukausi)
+      (cond
+        (<= tarkkuus-itseisarvo 10.0) 5
+        (<= tarkkuus-itseisarvo 20.0) 3
+        (<= tarkkuus-itseisarvo 30.0) 1
+        :else 0)
+
+      ;; Toukokuu - heinäkuu (kuukaudet 8-10)
+      (#{5 6 7} kuukausi)
+      (cond
+        (<= tarkkuus-itseisarvo 7.5) 5
+        (<= tarkkuus-itseisarvo 15.0) 3
+        (<= tarkkuus-itseisarvo 22.5) 1
+        :else 0)
+
+      ;; Elokuu - syyskuu (kuukaudet 11-12)
+      (#{8 9} kuukausi)
+      (cond
+        (<= tarkkuus-itseisarvo 5.0) 5
+        (<= tarkkuus-itseisarvo 10.0) 3
+        (<= tarkkuus-itseisarvo 15.0) 1
+        :else 0)
+
+      :else 0)))
+
+(defn laske-kustannusennuste-tulos
+  "Laskee kustannusennusteen kokonaistulon (tarkkuus + pisteet).
+   Yhdistää tarkkuuslaskennan ja pisteiden määrityksen."
+  [syotteet kuukausi]
+  {:pre [(map? syotteet) (number? kuukausi)]}
+  (let [tarkkuus-tulos (laske-kustannusennusteen-tarkkuus syotteet)]
+    (if (:virhe tarkkuus-tulos)
+      tarkkuus-tulos
+      (let [tarkkuus (:tarkkuus-prosentti tarkkuus-tulos)
+            pisteet (maarita-kustannusennuste-pisteet tarkkuus kuukausi)]
+        (assoc tarkkuus-tulos :pisteet pisteet)))))
+
 (defn odottaa-urakoitsijan-kannanottoa?
   "Odottaako 19/20 alkanut urakka urakoitsijan kannanottoa."
   [kuukausipisteet]
@@ -594,3 +745,29 @@
         (filter :odottaa-vastausta?)
         first
         boolean))))
+
+(comment
+  (laske-kustannusennuste-tulos
+    {:ennustettu-tavoitehinta 1000000
+     :ennustettu-kustannus 800000
+     :toteutunut-tavoitehinta 950000
+     :toteutunut-kustannus 780000
+     :hoitovuoden-alun-tavoitehinta 1200000}
+    3)
+  
+  ;; Testaa kustannusennuste-integrointi
+  (let [kustannusennuste-lupaus {:lupaustyyppi "kustannusennuste"
+                                 :hoitovuosi-paattynyt? true
+                                 :lupaus-kuukaudet [{:kuukausi 10 :kustannusennuste {:pisteet 5}}
+                                                   {:kuukausi 1 :kustannusennuste {:pisteet 3}}
+                                                   {:kuukausi 4 :kustannusennuste {:pisteet 4}}
+                                                   ;; Kesäkuu puuttuu = 0 pistettä
+                                                   {:kuukausi 6}]}]
+    ;; Ennuste: 4 (viimeisin annettu)
+    (kustannusennuste->ennuste kustannusennuste-lupaus)
+    ;; Toteuma: (5+3+4+0)/4 = 3 (keskiarvo, puuttuva kesäkuu = 0)
+    (kustannusennuste->toteuma kustannusennuste-lupaus)
+    ;; Integrointi:
+    (lupaus->ennuste kustannusennuste-lupaus)
+    (lupaus->toteuma kustannusennuste-lupaus))
+  )

--- a/src/cljs/harja/tiedot/urakka/lupaus_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/lupaus_tiedot.cljs
@@ -77,6 +77,11 @@
 (defrecord AsetaKustannusennusteTavoitehinta [arvo])
 (defrecord AsetaKustannusennusteToteutuneet [arvo])
 
+;; Kustannusennusteen tallentaminen
+(defrecord TallennaKustannusennuste [])
+(defrecord TallennaKustannusennusteOnnistui [vastaus])
+(defrecord TallennaKustannusennusteEpaonnistui [vastaus])
+
 (defn valitse-urakka [app urakka]
   (let [hoitokaudet (u/hoito-tai-sopimuskaudet urakka)
         vanha-hoitokausi (:valittu-hoitokausi app)
@@ -151,8 +156,9 @@
           (tulos!))))
     app))
 
-(defn laske-pisteet-poikkeaman-perusteella [poikkeama-prosentti kuukausi]
-  "Laskee pisteet pisteytystaulukon mukaan"
+(defn laske-pisteet-poikkeaman-perusteella
+  "Laskee pisteet pisteytystaulukon mukaan" 
+  [poikkeama-prosentti kuukausi] 
   (case kuukausi
     10 (cond
          (> poikkeama-prosentti 9.0) 1
@@ -176,24 +182,36 @@
         :else 1)
     1))
 
-(defn laske-kustannusennuste-automaattiset-arvot [app]
+(defn paivita-kuukauden-kustannusennuste
+  "Päivittää kuukauden kustannusennusteen kentän lupaus-kuukaudet rakenteessa"
+  [app kuukausi kentta arvo]
+  (update-in app [:vastaus-lomake :lupaus-kuukaudet]
+    (fn [kuukaudet]
+      (mapv #(if (= (:kuukausi %) kuukausi)
+               (assoc-in % [:kustannusennuste kentta] arvo)
+               %)
+        kuukaudet))))
+(defn laske-kustannusennuste-automaattiset-arvot
   "Laskee poikkeama-prosentin ja pisteet automaattisesti kun tavoitehinta tai toteutuneet kustannukset muuttuvat"
-  (let [kustannusennuste (get-in app [:vastaus-lomake :kustannusennuste])
+  [app]
+  (let [kohdekuukausi (get-in app [:vastaus-lomake :vastauskuukausi])
+        lupaus-kuukausi (lupaus-domain/etsi-lupaus-kuukausi
+                          (get-in app [:vastaus-lomake :lupaus-kuukaudet])
+                          kohdekuukausi)
+        kustannusennuste (:kustannusennuste lupaus-kuukausi)
         {:keys [tavoitehinta toteutuneet-kustannukset]} kustannusennuste]
-    (if (and tavoitehinta toteutuneet-kustannukset
-          (pos? tavoitehinta))
-      (let [poikkeama-prosentti (abs (/ (* 100 (- toteutuneet-kustannukset tavoitehinta))
-                                        tavoitehinta))
-            pisteet (laske-pisteet-poikkeaman-perusteella poikkeama-prosentti
-                      (get-in app [:vastaus-lomake :vastauskuukausi]))]
+    (if (and tavoitehinta toteutuneet-kustannukset (pos? tavoitehinta))
+      (let [poikkeama-prosentti (Math/abs (/ (* 100 (- toteutuneet-kustannukset tavoitehinta))
+                                             tavoitehinta))
+            pisteet (laske-pisteet-poikkeaman-perusteella poikkeama-prosentti kohdekuukausi)]
+        ;; Päivitä lupaus-kuukaudet rakenteeseen
         (-> app
-          (assoc-in [:vastaus-lomake :kustannusennuste :poikkeama-prosentti] poikkeama-prosentti)
-          (assoc-in [:vastaus-lomake :kustannusennuste :pisteet] pisteet)))
-      ;; Jos arvot puuttuvat, nollaa lasketut kentät
+          (paivita-kuukauden-kustannusennuste kohdekuukausi :poikkeama-prosentti poikkeama-prosentti)
+          (paivita-kuukauden-kustannusennuste kohdekuukausi :pisteet pisteet)))
+      ;; Jos arvot puuttuvat, nollaa lasketut kentät 
       (-> app
-        (assoc-in [:vastaus-lomake :kustannusennuste :poikkeama-prosentti] nil)
-        (assoc-in [:vastaus-lomake :kustannusennuste :pisteet] nil)))))
-
+        (paivita-kuukauden-kustannusennuste kohdekuukausi :poikkeama-prosentti nil)
+        (paivita-kuukauden-kustannusennuste kohdekuukausi :pisteet nil)))))
 
 
 (extend-protocol tuck/Event
@@ -523,10 +541,55 @@
   
   AsetaKustannusennusteTavoitehinta
   (process-event [{arvo :arvo} app]
-    (let [uusi-app (assoc-in app [:vastaus-lomake :kustannusennuste :tavoitehinta] arvo)]
-      (laske-kustannusennuste-automaattiset-arvot uusi-app))
+    (let [kohdekuukausi (get-in app [:vastaus-lomake :vastauskuukausi])
+          uusi-app (paivita-kuukauden-kustannusennuste app kohdekuukausi :tavoitehinta arvo)]
+      (laske-kustannusennuste-automaattiset-arvot uusi-app)))
   
   AsetaKustannusennusteToteutuneet
   (process-event [{arvo :arvo} app]
-    (let [uusi-app (assoc-in app [:vastaus-lomake :kustannusennuste :toteutuneet-kustannukset] arvo)]
-      (laske-kustannusennuste-automaattiset-arvot uusi-app)))))
+    (let [kohdekuukausi (get-in app [:vastaus-lomake :vastauskuukausi])
+          uusi-app (paivita-kuukauden-kustannusennuste app kohdekuukausi :toteutuneet-kustannukset arvo)]
+      (laske-kustannusennuste-automaattiset-arvot uusi-app)))
+
+  TallennaKustannusennuste
+  (process-event [_ app]
+    (let [kohdekuukausi (get-in app [:vastaus-lomake :vastauskuukausi])
+          lupaus-kuukausi (lupaus-domain/etsi-lupaus-kuukausi
+                            (get-in app [:vastaus-lomake :lupaus-kuukaudet])
+                            kohdekuukausi)
+          kuukauden-kustannusennuste (:kustannusennuste lupaus-kuukausi)
+          lupaus-id (get-in app [:vastaus-lomake :lupaus-id])
+          kohdevuosi (get-in app [:vastaus-lomake :vastausvuosi])
+          urakka-id (-> @tila/tila :yleiset :urakka :id)
+          lupaus (get-in app [:vastaus-lomake])  ; Koko lupaus-objekti
+          vastaus-data {:lupaus-id lupaus-id
+                        :urakka-id urakka-id
+                        :kuukausi kohdekuukausi
+                        :vuosi kohdevuosi
+                        :paatos (if (or (= kohdekuukausi (:paatos-kk lupaus))
+                                      (= 0 (:paatos-kk lupaus)))
+                                  true false)
+                        :vastaus nil
+                        :lupaus-vaihtoehto-id nil
+                        :kustannusennuste kuukauden-kustannusennuste}]
+      (tuck-apurit/post! :vastaa-lupaukseen
+        vastaus-data
+        {:onnistui ->TallennaKustannusennusteOnnistui
+         :epaonnistui ->TallennaKustannusennusteEpaonnistui})
+      (-> app
+        (assoc-in [:vastaus-lomake :lahetetty-vastaus] vastaus-data)
+        (assoc :lupausta-lahetataan {:kohdekuukausi kohdekuukausi
+                                     :lupaus-id lupaus-id
+                                     :tyyppi :kustannusennuste}))))
+  
+  TallennaKustannusennusteOnnistui
+  (process-event [{vastaus :vastaus} app]
+    ;; Koska vastauksen antaminen muuttaa sekä vastauslomaketta, että vastauslistaa, niin haetaan koko setti uusiksi
+    (hae-urakan-lupaustiedot app (-> @tila/tila :yleiset :urakka))
+    (viesti/nayta! "Kustannusennuste tallennettu onnistuneesti" :success)
+    app)
+  
+  TallennaKustannusennusteEpaonnistui
+  (process-event [{vastaus :vastaus} app]
+    (viesti/nayta! "Kustannusennusteen tallentaminen epäonnistui" :danger)
+    (dissoc app :lupausta-lahetataan)))

--- a/src/cljs/harja/tiedot/urakka/lupaus_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/lupaus_tiedot.cljs
@@ -73,6 +73,10 @@
 ;; Monivalintojen naytettavat valinnat alustus
 (def naytettavat-valinnat-alustus [1])
 
+;; Kustannusennuste
+(defrecord AsetaKustannusennusteTavoitehinta [arvo])
+(defrecord AsetaKustannusennusteToteutuneet [arvo])
+
 (defn valitse-urakka [app urakka]
   (let [hoitokaudet (u/hoito-tai-sopimuskaudet urakka)
         vanha-hoitokausi (:valittu-hoitokausi app)
@@ -146,6 +150,51 @@
           (virhe!)
           (tulos!))))
     app))
+
+(defn laske-pisteet-poikkeaman-perusteella [poikkeama-prosentti kuukausi]
+  "Laskee pisteet pisteytystaulukon mukaan"
+  (case kuukausi
+    10 (cond
+         (> poikkeama-prosentti 9.0) 1
+         (<= poikkeama-prosentti 9.0) 4
+         (<= poikkeama-prosentti 7.0) 8
+         :else 1)
+    1 (cond
+        (> poikkeama-prosentti 6.0) 1
+        (<= poikkeama-prosentti 6.0) 4
+        (<= poikkeama-prosentti 4.0) 8
+        :else 1)
+    4 (cond
+        (> poikkeama-prosentti 3.0) 1
+        (<= poikkeama-prosentti 3.0) 4
+        (<= poikkeama-prosentti 2.0) 8
+        :else 1)
+    6 (cond
+        (> poikkeama-prosentti 2.0) 1
+        (<= poikkeama-prosentti 2.0) 4
+        (<= poikkeama-prosentti 1.0) 8
+        :else 1)
+    1))
+
+(defn laske-kustannusennuste-automaattiset-arvot [app]
+  "Laskee poikkeama-prosentin ja pisteet automaattisesti kun tavoitehinta tai toteutuneet kustannukset muuttuvat"
+  (let [kustannusennuste (get-in app [:vastaus-lomake :kustannusennuste])
+        {:keys [tavoitehinta toteutuneet-kustannukset]} kustannusennuste]
+    (if (and tavoitehinta toteutuneet-kustannukset
+          (pos? tavoitehinta))
+      (let [poikkeama-prosentti (abs (/ (* 100 (- toteutuneet-kustannukset tavoitehinta))
+                                        tavoitehinta))
+            pisteet (laske-pisteet-poikkeaman-perusteella poikkeama-prosentti
+                      (get-in app [:vastaus-lomake :vastauskuukausi]))]
+        (-> app
+          (assoc-in [:vastaus-lomake :kustannusennuste :poikkeama-prosentti] poikkeama-prosentti)
+          (assoc-in [:vastaus-lomake :kustannusennuste :pisteet] pisteet)))
+      ;; Jos arvot puuttuvat, nollaa lasketut kentät
+      (-> app
+        (assoc-in [:vastaus-lomake :kustannusennuste :poikkeama-prosentti] nil)
+        (assoc-in [:vastaus-lomake :kustannusennuste :pisteet] nil)))))
+
+
 
 (extend-protocol tuck/Event
   HoitokausiVaihdettu
@@ -470,4 +519,14 @@
   (process-event [{nykyhetki :nykyhetki} app]
     (-> app
         (assoc :nykyhetki nykyhetki)
-        hae-urakan-lupaustiedot)))
+        hae-urakan-lupaustiedot))
+  
+  AsetaKustannusennusteTavoitehinta
+  (process-event [{arvo :arvo} app]
+    (let [uusi-app (assoc-in app [:vastaus-lomake :kustannusennuste :tavoitehinta] arvo)]
+      (laske-kustannusennuste-automaattiset-arvot uusi-app))
+  
+  AsetaKustannusennusteToteutuneet
+  (process-event [{arvo :arvo} app]
+    (let [uusi-app (assoc-in app [:vastaus-lomake :kustannusennuste :toteutuneet-kustannukset] arvo)]
+      (laske-kustannusennuste-automaattiset-arvot uusi-app)))))

--- a/src/cljs/harja/tiedot/urakka/lupaus_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/lupaus_tiedot.cljs
@@ -157,7 +157,7 @@
     app))
 
 (defn laske-pisteet-poikkeaman-perusteella
-  "Laskee pisteet pisteytystaulukon mukaan" 
+  "Laskee pisteet pisteytystaulukon mukaan."
   [poikkeama-prosentti kuukausi] 
   (case kuukausi
     10 (cond
@@ -203,10 +203,11 @@
     (if (and tavoitehinta toteutuneet-kustannukset (pos? tavoitehinta))
       (let [poikkeama-prosentti (Math/abs (/ (* 100 (- toteutuneet-kustannukset tavoitehinta))
                                              tavoitehinta))
-            pisteet (laske-pisteet-poikkeaman-perusteella poikkeama-prosentti kohdekuukausi)]
+            pisteet (laske-pisteet-poikkeaman-perusteella poikkeama-prosentti kohdekuukausi)
+            pyoristetty-poikkeama (/ (Math/round (* poikkeama-prosentti 10)) 10)]
         ;; Päivitä lupaus-kuukaudet rakenteeseen
         (-> app
-          (paivita-kuukauden-kustannusennuste kohdekuukausi :poikkeama-prosentti poikkeama-prosentti)
+          (paivita-kuukauden-kustannusennuste kohdekuukausi :poikkeama-prosentti pyoristetty-poikkeama)
           (paivita-kuukauden-kustannusennuste kohdekuukausi :pisteet pisteet)))
       ;; Jos arvot puuttuvat, nollaa lasketut kentät 
       (-> app

--- a/src/cljs/harja/tiedot/urakka/lupaus_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/lupaus_tiedot.cljs
@@ -67,20 +67,17 @@
 (defrecord Kuukausipisteitamuokattu [pisteet kuukausi])
 (defrecord AvaaKuukausipisteetMuokattavaksi [kuukausi])
 
+;; Kustannusennuste
+(defrecord PaivitaKustannusennuste [kuukausi kentta arvo])
+(defrecord TallennaKustannusennuste [])
+(defrecord TallennaKustannusennusteOnnistui [vastaus])
+(defrecord TallennaKustannusennusteEpaonnistui [vastaus])
+
 ;; Testaus
 (defrecord AsetaNykyhetki [nykyhetki])
 
 ;; Monivalintojen naytettavat valinnat alustus
 (def naytettavat-valinnat-alustus [1])
-
-;; Kustannusennuste
-(defrecord AsetaKustannusennusteTavoitehinta [arvo])
-(defrecord AsetaKustannusennusteToteutuneet [arvo])
-
-;; Kustannusennusteen tallentaminen
-(defrecord TallennaKustannusennuste [])
-(defrecord TallennaKustannusennusteOnnistui [vastaus])
-(defrecord TallennaKustannusennusteEpaonnistui [vastaus])
 
 (defn valitse-urakka [app urakka]
   (let [hoitokaudet (u/hoito-tai-sopimuskaudet urakka)
@@ -156,32 +153,6 @@
           (tulos!))))
     app))
 
-(defn laske-pisteet-poikkeaman-perusteella
-  "Laskee pisteet pisteytystaulukon mukaan."
-  [poikkeama-prosentti kuukausi] 
-  (case kuukausi
-    10 (cond
-         (> poikkeama-prosentti 9.0) 1
-         (<= poikkeama-prosentti 9.0) 4
-         (<= poikkeama-prosentti 7.0) 8
-         :else 1)
-    1 (cond
-        (> poikkeama-prosentti 6.0) 1
-        (<= poikkeama-prosentti 6.0) 4
-        (<= poikkeama-prosentti 4.0) 8
-        :else 1)
-    4 (cond
-        (> poikkeama-prosentti 3.0) 1
-        (<= poikkeama-prosentti 3.0) 4
-        (<= poikkeama-prosentti 2.0) 8
-        :else 1)
-    6 (cond
-        (> poikkeama-prosentti 2.0) 1
-        (<= poikkeama-prosentti 2.0) 4
-        (<= poikkeama-prosentti 1.0) 8
-        :else 1)
-    1))
-
 (defn paivita-kuukauden-kustannusennuste
   "Päivittää kuukauden kustannusennusteen kentän lupaus-kuukaudet rakenteessa"
   [app kuukausi kentta arvo]
@@ -191,29 +162,6 @@
                (assoc-in % [:kustannusennuste kentta] arvo)
                %)
         kuukaudet))))
-(defn laske-kustannusennuste-automaattiset-arvot
-  "Laskee poikkeama-prosentin ja pisteet automaattisesti kun tavoitehinta tai toteutuneet kustannukset muuttuvat"
-  [app]
-  (let [kohdekuukausi (get-in app [:vastaus-lomake :vastauskuukausi])
-        lupaus-kuukausi (lupaus-domain/etsi-lupaus-kuukausi
-                          (get-in app [:vastaus-lomake :lupaus-kuukaudet])
-                          kohdekuukausi)
-        kustannusennuste (:kustannusennuste lupaus-kuukausi)
-        {:keys [tavoitehinta toteutuneet-kustannukset]} kustannusennuste]
-    (if (and tavoitehinta toteutuneet-kustannukset (pos? tavoitehinta))
-      (let [poikkeama-prosentti (Math/abs (/ (* 100 (- toteutuneet-kustannukset tavoitehinta))
-                                             tavoitehinta))
-            pisteet (laske-pisteet-poikkeaman-perusteella poikkeama-prosentti kohdekuukausi)
-            pyoristetty-poikkeama (/ (Math/round (* poikkeama-prosentti 10)) 10)]
-        ;; Päivitä lupaus-kuukaudet rakenteeseen
-        (-> app
-          (paivita-kuukauden-kustannusennuste kohdekuukausi :poikkeama-prosentti pyoristetty-poikkeama)
-          (paivita-kuukauden-kustannusennuste kohdekuukausi :pisteet pisteet)))
-      ;; Jos arvot puuttuvat, nollaa lasketut kentät 
-      (-> app
-        (paivita-kuukauden-kustannusennuste kohdekuukausi :poikkeama-prosentti nil)
-        (paivita-kuukauden-kustannusennuste kohdekuukausi :pisteet nil)))))
-
 
 (extend-protocol tuck/Event
   HoitokausiVaihdettu
@@ -534,63 +482,55 @@
     (viesti/nayta-toast! "Kuukausipisteiden lisäys epäonnistui!" :varoitus)
     app)
 
+  PaivitaKustannusennuste
+  (process-event [{kuukausi :kuukausi kentta :kentta arvo :arvo} app]
+    (paivita-kuukauden-kustannusennuste app kuukausi kentta arvo))
+
   AsetaNykyhetki
   (process-event [{nykyhetki :nykyhetki} app]
     (-> app
         (assoc :nykyhetki nykyhetki)
         hae-urakan-lupaustiedot))
   
-  AsetaKustannusennusteTavoitehinta
-  (process-event [{arvo :arvo} app]
-    (let [kohdekuukausi (get-in app [:vastaus-lomake :vastauskuukausi])
-          uusi-app (paivita-kuukauden-kustannusennuste app kohdekuukausi :tavoitehinta arvo)]
-      (laske-kustannusennuste-automaattiset-arvot uusi-app)))
-  
-  AsetaKustannusennusteToteutuneet
-  (process-event [{arvo :arvo} app]
-    (let [kohdekuukausi (get-in app [:vastaus-lomake :vastauskuukausi])
-          uusi-app (paivita-kuukauden-kustannusennuste app kohdekuukausi :toteutuneet-kustannukset arvo)]
-      (laske-kustannusennuste-automaattiset-arvot uusi-app)))
-
   TallennaKustannusennuste
-  (process-event [_ app]
-    (let [kohdekuukausi (get-in app [:vastaus-lomake :vastauskuukausi])
-          lupaus-kuukausi (lupaus-domain/etsi-lupaus-kuukausi
-                            (get-in app [:vastaus-lomake :lupaus-kuukaudet])
-                            kohdekuukausi)
-          kuukauden-kustannusennuste (:kustannusennuste lupaus-kuukausi)
-          lupaus-id (get-in app [:vastaus-lomake :lupaus-id])
-          kohdevuosi (get-in app [:vastaus-lomake :vastausvuosi])
-          urakka-id (-> @tila/tila :yleiset :urakka :id)
-          lupaus (get-in app [:vastaus-lomake])  ; Koko lupaus-objekti
-          vastaus-data {:lupaus-id lupaus-id
-                        :urakka-id urakka-id
-                        :kuukausi kohdekuukausi
-                        :vuosi kohdevuosi
-                        :paatos (if (or (= kohdekuukausi (:paatos-kk lupaus))
-                                      (= 0 (:paatos-kk lupaus)))
-                                  true false)
-                        :vastaus nil
-                        :lupaus-vaihtoehto-id nil
-                        :kustannusennuste kuukauden-kustannusennuste}]
-      (tuck-apurit/post! :vastaa-lupaukseen
-        vastaus-data
-        {:onnistui ->TallennaKustannusennusteOnnistui
-         :epaonnistui ->TallennaKustannusennusteEpaonnistui})
-      (-> app
-        (assoc-in [:vastaus-lomake :lahetetty-vastaus] vastaus-data)
-        (assoc :lupausta-lahetataan {:kohdekuukausi kohdekuukausi
-                                     :lupaus-id lupaus-id
-                                     :tyyppi :kustannusennuste}))))
+    (process-event [_ app]
+      (let [kohdekuukausi (get-in app [:vastaus-lomake :vastauskuukausi])
+            lupaus-kuukausi (lupaus-domain/etsi-lupaus-kuukausi
+                              (get-in app [:vastaus-lomake :lupaus-kuukaudet])
+                              kohdekuukausi)
+            kuukauden-kustannusennuste (:kustannusennuste lupaus-kuukausi)
+            lupaus-id (get-in app [:vastaus-lomake :lupaus-id])
+            kohdevuosi (get-in app [:vastaus-lomake :vastausvuosi])
+            urakka-id (-> @tila/tila :yleiset :urakka :id)
+            lupaus (get-in app [:vastaus-lomake])  ; Koko lupaus-objekti
+            vastaus-data {:lupaus-id lupaus-id
+                          :urakka-id urakka-id
+                          :kuukausi kohdekuukausi
+                          :vuosi kohdevuosi
+                          :paatos (if (or (= kohdekuukausi (:paatos-kk lupaus))
+                                        (= 0 (:paatos-kk lupaus)))
+                                    true false)
+                          :vastaus nil
+                          :lupaus-vaihtoehto-id nil
+                          :kustannusennuste kuukauden-kustannusennuste}]
+        (tuck-apurit/post! :vastaa-lupaukseen
+          vastaus-data
+          {:onnistui ->TallennaKustannusennusteOnnistui
+           :epaonnistui ->TallennaKustannusennusteEpaonnistui})
+        (-> app
+          (assoc-in [:vastaus-lomake :lahetetty-vastaus] vastaus-data)
+          (assoc :lupausta-lahetataan {:kohdekuukausi kohdekuukausi
+                                       :lupaus-id lupaus-id
+                                       :tyyppi :kustannusennuste}))))
   
-  TallennaKustannusennusteOnnistui
-  (process-event [{vastaus :vastaus} app]
-    ;; Koska vastauksen antaminen muuttaa sekä vastauslomaketta, että vastauslistaa, niin haetaan koko setti uusiksi
-    (hae-urakan-lupaustiedot app (-> @tila/tila :yleiset :urakka))
-    (viesti/nayta! "Kustannusennuste tallennettu onnistuneesti" :success)
-    app)
+    TallennaKustannusennusteOnnistui
+    (process-event [{vastaus :vastaus} app]
+      ;; Koska vastauksen antaminen muuttaa sekä vastauslomaketta, että vastauslistaa, niin haetaan koko setti uusiksi
+      (hae-urakan-lupaustiedot app (-> @tila/tila :yleiset :urakka))
+      (viesti/nayta! "Kustannusennuste tallennettu onnistuneesti" :success)
+      app)
   
-  TallennaKustannusennusteEpaonnistui
-  (process-event [{vastaus :vastaus} app]
-    (viesti/nayta! "Kustannusennusteen tallentaminen epäonnistui" :danger)
-    (dissoc app :lupausta-lahetataan)))
+    TallennaKustannusennusteEpaonnistui
+    (process-event [{vastaus :vastaus} app]
+      (viesti/nayta! "Kustannusennusteen tallentaminen epäonnistui" :danger)
+      (dissoc app :lupausta-lahetataan)))

--- a/src/cljs/harja/ui/kentat.cljs
+++ b/src/cljs/harja/ui/kentat.cljs
@@ -1890,10 +1890,11 @@
           [:div.kentta
            [tee-kentta kentta-params arvo-atom]])]])
 
-(defn nayta-otsikollinen-kentta [{:keys [otsikko kentta-params arvo-atom luokka]}]
-  [:span {:class (or luokka "label-ja-kentta")}
+(defn nayta-otsikollinen-kentta [{:keys [otsikko kentta-params arvo-atom luokka tyylit]}]
+  [:span {:class (str (or luokka "label-ja-kentta") " lukutila-kentta")
+          :style tyylit}
    [:span.kentan-otsikko otsikko]
-   [:div.kentta
+   [:div.kentta.lukutila-arvo
     [nayta-arvo kentta-params arvo-atom]]])
 
 (def aika-pattern #"^(\d{1,2})(:(\d{1,2}))(:(\d{1,2}))?$")

--- a/src/cljs/harja/views/urakka/lupaus/kuukausipaatos_tilat.cljs
+++ b/src/cljs/harja/views/urakka/lupaus/kuukausipaatos_tilat.cljs
@@ -45,8 +45,9 @@
   [:div {:style {:color (asioiden-ulkoasu/tilan-vari "hylatty")}} [ikonit/harja-icon-status-denied]])
 
 (defn kuukausi-wrapper [e!
-                        {:keys [lupaus-id] :as lupaus}
-                        {:keys [kuukausi vuosi odottaa-kannanottoa? paatos-hylatty? paattava-kuukausi? nykyhetkeen-verrattuna vastaus] :as lupaus-kuukausi}
+                        {:keys [lupaus-id lupaustyyppi] :as lupaus}
+                        {:keys [kuukausi vuosi odottaa-kannanottoa? paatos-hylatty? 
+                                paattava-kuukausi? maarapaiva-mennyt-ohi? nykyhetkeen-verrattuna vastaus kustannusennuste] :as lupaus-kuukausi}
                         listauksessa?
                         valittu?
                         lupaus->kuukausi->kommentit]
@@ -54,7 +55,12 @@
         saa-vastata? (lupaus-domain/kayttaja-saa-vastata? @istunto/kayttaja lupaus-kuukausi)
         nayta-himmennettyna? (not saa-vastata?)
         nayta-kommentti-ikoni? (and (not listauksessa?)
-                                    (seq (get-in lupaus->kuukausi->kommentit [lupaus-id kuukausi])))]
+                                    (seq (get-in lupaus->kuukausi->kommentit [lupaus-id kuukausi])))
+        ;; Kustannusennusteen tilan määrittely
+        kustannusennuste-syotetty? (and kustannusennuste
+                                        (:tavoitehinta kustannusennuste)
+                                        (:toteutuneet-kustannukset kustannusennuste))
+        kustannusennuste-lupaus? (= "kustannusennuste" lupaustyyppi)]
     [:div.col-xs-1.pallo-ja-kk.ei-sulje-sivupaneelia
      (merge {:class (str (when paattava-kuukausi? " paatoskuukausi")
                          (when valittu? " vastaus-kk")
@@ -65,6 +71,22 @@
                              (.preventDefault e)
                              (e! (lupaus-tiedot/->AvaaLupausvastaus lupaus kuukausi vuosi))))}))
      (cond
+       ;; Kustannusennuste - määräpäivä ohitettu ja ei syötetty ajoissa  
+       (and kustannusennuste-lupaus? maarapaiva-mennyt-ohi? (not kustannusennuste-syotetty?))
+       [:div {:style {:color "#FF6B6B"}} [ikonit/harja-icon-status-help]]
+
+       ;; Kustannusennuste - määräpäivä ohitettu mutta syötetty ajoissa (read-only)
+       (and kustannusennuste-lupaus? maarapaiva-mennyt-ohi? kustannusennuste-syotetty?)
+       [:div {:style {:color "#28A745"}} [ikonit/harja-icon-status-selected]]
+
+       ;; Kustannusennuste - kustannusennuste syötetty (normaali tila)
+       (and kustannusennuste-lupaus? kustannusennuste-syotetty?)
+       [:div {:style {:color "#28A745"}} [ikonit/harja-icon-status-selected]]
+
+       ;; Kustannusennuste - odottaa syöttöä
+       (and kustannusennuste-lupaus? (not kustannusennuste-syotetty?) vastauskuukausi?)
+       [odottaa-vastausta]
+
        (or odottaa-kannanottoa?
            (and vastauskuukausi? (= :kuluva-kuukausi nykyhetkeen-verrattuna)))
        [odottaa-vastausta]

--- a/src/cljs/harja/views/urakka/lupaus/vastauslomake.cljs
+++ b/src/cljs/harja/views/urakka/lupaus/vastauslomake.cljs
@@ -71,7 +71,7 @@
    [:p "Hoitovuoden toteutuneet lupauspisteet todetaan laskemalla lupaustaulukon mukaan saatujen pisteiden keskiarvo. "
     [:strong "Mikäli jotain ennustetta ei tehdä määräaikaan mennessä, ennusteesta ei saa yhtään pistettä."]]])
 
-(defn- sisalto [e! vastaus]
+(defn- sisalto [_e! vastaus]
   [:div {:id "vastauslomake-sisalto"}
    [:hr]
    [:div.row
@@ -87,8 +87,9 @@
         (str "Pisteet 0 - " (:kyselypisteet vastaus)))]]
     [:div.caption.vastauslomake-lupaus-kuvaus (:kuvaus vastaus)]
     [:div.sisalto {:dangerouslySetInnerHTML {:__html (:sisalto vastaus)}}]
-    [kustannusennuste-taulukko]
-    ]])
+    ;; Näytä kustannusennuste-taulukko vain "kustannusennuste" lupaustyypille
+    (when (= "kustannusennuste" (:lupaustyyppi vastaus))
+      [kustannusennuste-taulukko])]])
 
 (defn- kommentti-rivi [e! {:keys [id luotu luoja etunimi sukunimi kommentti poistettu]}]
   [:div.kommentti-rivi
@@ -228,81 +229,95 @@
       :kaari-flex-row? false}
      kuukauden-vastaus-atom]]])
 
-(defn- kustannusennuste-syottokentit [e! {:keys [kohdekuukausi kohdevuosi lupaus disabled? ladataan?]}]
-  [:div.kustannusennuste-syottokentit
-   
-   ;; Ensimmäinen rivi - Tavoitehinta ja Ennuste
-   [:div.row
-    [:div.lihavoitu.sivupalkki-footer-otsikko.col-xs-12.col-md-12
-     [:h5 "Kustannusennusteen tiedot"]]
-    [:div.col-xs-12.col-md-6
-     [kentat/tee-otsikollinen-kentta
-      {:otsikko "Tavoitehinta € *"
-       :luokka "poista-label-top-margin"
-       :vayla-tyyli? true
-       :arvo-atom (r/atom nil)
-       :kentta-params {:tyyppi :numero
-                       :vayla-tyyli? true
-                       :disabled? disabled?
-                       :kokonaisosan-maara 10
-                       :desimaalien-maara 2
-                       :placeholder "0,00"}}]]
+(defn- kustannusennuste-syottokentit [e! {:keys [kohdekuukausi kohdevuosi lupaus disabled? ladataan?]} app]
+  (let [;; Hae kuukauden tiedot samalla tavalla kuin muut vastaukset
+        lupaus-kuukausi (lupaus-domain/etsi-lupaus-kuukausi 
+                          (get-in app [:vastaus-lomake :lupaus-kuukaudet]) 
+                          kohdekuukausi)
+        ;; Hae kuukauden kustannusennuste samalla tavalla kuin kuukauden-vastaus
+        kuukauden-kustannusennuste (:kustannusennuste lupaus-kuukausi)
+        ;; Jos on lähetetty vastaus, käytä sitä (kuten muissakin vastauksissa)
+        lahetetty-vastaus (get-in app [:vastaus-lomake :lahetetty-vastaus])
+        kustannusennuste (if (:kustannusennuste lahetetty-vastaus)
+                          (:kustannusennuste lahetetty-vastaus)
+                          kuukauden-kustannusennuste)
+        ;; Tarkista onko tallentaminen käynnissä
+        tallentaa-kustannusennustetta? (and 
+                                        (= (get-in app [:lupausta-lahetataan :tyyppi]) :kustannusennuste)
+                                        (= (get-in app [:lupausta-lahetataan :kohdekuukausi]) kohdekuukausi)
+                                        (= (get-in app [:lupausta-lahetataan :lupaus-id]) (:lupaus-id lupaus)))]
+    [:div.kustannusennuste-syottokentit
 
-    [:div.col-xs-12.col-md-6
-     [kentat/tee-otsikollinen-kentta
-      {:otsikko "Ennuste € *"
-       :luokka "poista-label-top-margin"
-       :vayla-tyyli? true
-       :arvo-atom (r/atom nil)
-       :kentta-params {:tyyppi :numero
-                       :vayla-tyyli? true
-                       :disabled? disabled?
-                       :kokonaisosan-maara 10
-                       :desimaalien-maara 2
-                       :placeholder "0,00"}}]]]
+     ;; Ensimmäinen rivi - Tavoitehinta ja Ennuste
+     [:div.row
+      [:div.lihavoitu.sivupalkki-footer-otsikko.col-xs-12.col-md-12
+       [:h5 "Kustannusennusteen tiedot"]]
+      [:div.col-xs-12.col-md-6
+       [kentat/tee-otsikollinen-kentta
+        {:otsikko "Tavoitehinta € *"
+         :luokka "poista-label-top-margin"
+         :vayla-tyyli? true
+         :arvo-atom (r/wrap (:tavoitehinta kustannusennuste)
+                      #(e! (lupaus-tiedot/->AsetaKustannusennusteTavoitehinta %)))
+         :kentta-params {:tyyppi :numero
+                         :vayla-tyyli? true
+                         :disabled? disabled?
+                         :kokonaisosan-maara 10
+                         :desimaalien-maara 2
+                         :placeholder "0,00"}}]]]
 
-   ;; Toinen rivi - Toteutunut ja Poikkeama
-   [:div.row
-    [:div.col-xs-12.col-md-6
-     [kentat/tee-otsikollinen-kentta
-      {:otsikko "Toteutuneet kustannukset € *"
-       :luokka "poista-label-top-margin"
-       :vayla-tyyli? true
-       :arvo-atom (r/atom nil)
-       :kentta-params {:tyyppi :numero
-                       :vayla-tyyli? true
-                       :disabled? disabled?
-                       :kokonaisosan-maara 10
-                       :desimaalien-maara 2
-                       :placeholder "0,00"}}]]
+     ;; Toinen rivi - Toteutunut ja Poikkeama
+     [:div.row
+      [:div.col-xs-12.col-md-6
+       [kentat/tee-otsikollinen-kentta
+        {:otsikko "Toteutuneet kustannukset € *"
+         :luokka "poista-label-top-margin"
+         :vayla-tyyli? true
+         :arvo-atom (r/wrap (:toteutuneet-kustannukset kustannusennuste)
+                      #(e! (lupaus-tiedot/->AsetaKustannusennusteToteutuneet %)))
+         :kentta-params {:tyyppi :numero
+                         :vayla-tyyli? true
+                         :disabled? disabled?
+                         :kokonaisosan-maara 10
+                         :desimaalien-maara 2
+                         :placeholder "0,00"}}]]
 
-    [:div.col-xs-12.col-md-6
-     [kentat/tee-otsikollinen-kentta
-      {:otsikko "Poikkeama %"
-       :luokka "poista-label-top-margin"
-       :vayla-tyyli? true
-       :arvo-atom (r/atom nil)
-       :kentta-params {:tyyppi :numero
-                       :vayla-tyyli? true
-                       :disabled? true ;; Laskettu automaattisesti
-                       :kokonaisosan-maara 3
-                       :desimaalien-maara 1
-                       :placeholder "0,0"}}]]]
+      [:div.col-xs-12.col-md-6
+       [kentat/tee-otsikollinen-kentta
+        {:otsikko "Poikkeama %"
+         :luokka "poista-label-top-margin"
+         :vayla-tyyli? true
+         :arvo-atom (r/atom (:poikkeama-prosentti kustannusennuste))
+         :kentta-params {:tyyppi :numero
+                         :vayla-tyyli? true
+                         :disabled? true ;; Laskettu automaattisesti
+                         :kokonaisosan-maara 3
+                         :desimaalien-maara 1
+                         :placeholder "0,0"}}]]]
 
-   ;; Kolmas rivi - Pisteet (keskitetty)
-   [:div.row
-    [:div.col-xs-12.col-md-6
-     [kentat/tee-otsikollinen-kentta
-      {:otsikko "Pisteet"
-       :luokka "poista-label-top-margin"
-       :vayla-tyyli? true
-       :arvo-atom (r/atom nil)
-       :kentta-params {:tyyppi :numero
-                       :vayla-tyyli? true
-                       :disabled? true ;; Laskettu automaattisesti
-                       :kokonaisosan-maara 2
-                       :desimaalien-maara 0
-                       :placeholder "0"}}]]]])
+     ;; Kolmas rivi - Pisteet
+     [:div.row
+      [:div.col-xs-12.col-md-6
+       [kentat/tee-otsikollinen-kentta
+        {:otsikko "Pisteet"
+         :luokka "poista-label-top-margin"
+         :vayla-tyyli? true
+         :arvo-atom (r/atom (:pisteet kustannusennuste))
+         :kentta-params {:tyyppi :numero
+                         :vayla-tyyli? true
+                         :disabled? true ;; Laskettu automaattisesti
+                         :kokonaisosan-maara 2
+                         :desimaalien-maara 0
+                         :placeholder "0"}}]]]
+     [:div.row
+      [:div.col-xs-12
+       [:div.margin-top-16.text-right
+        [napit/tallenna
+         "Tallenna kustannusennuste"
+         #(e! (lupaus-tiedot/->TallennaKustannusennuste))
+         {:disabled (or disabled? ladataan? tallentaa-kustannusennustetta?)
+          :vayla-tyyli? true
+          :luokka "btn-primary"}]]]]]))
 
 
 (defn- vastaukset [e! app luokka]
@@ -349,7 +364,7 @@
                                            :kohdevuosi kohdevuosi
                                            :lupaus lupaus
                                            :disabled? disabled?
-                                           :ladataan? ladataan?}]
+                                           :ladataan? ladataan?} app]
         [sulje-nappi e! {:luokka "pull-right"}]]
     
        ;; Yksittäinen lupaus (kyllä/ei)
@@ -419,6 +434,7 @@
     (fn [e! app]
       [:div.overlay-oikealla.ei-sulje-sivupaneelia {:style {:width "632px"}
                                                     :id "lupaukset-sivupaneeli"}
+       [debug app]
        [:div.sivupalkki-sisalto {:class (lupaus-css-luokka app)}
         [otsikko e! app]
         [sisalto e! (:vastaus-lomake app)]

--- a/src/cljs/harja/views/urakka/lupaus/vastauslomake.cljs
+++ b/src/cljs/harja/views/urakka/lupaus/vastauslomake.cljs
@@ -83,16 +83,7 @@
      [:h3.vastauslomake-lupaus-jarjestys
       (str "Lupaus " (:lupaus-jarjestys vastaus))] 
      [:h3.vastauslomake-lupaus-pisteet
-      (cond
-        (= "yksittainen" (:lupaustyyppi vastaus))
-        (:pisteet vastaus)
-        
-        (= "kustannusennuste" (:lupaustyyppi vastaus))
-        (str "Pisteet 0 - " (:pisteet vastaus))
-        
-        ;; kysely ja monivalinta käyttävät kyselypisteitä
-        :else
-        (str "Pisteet 0 - " (:kyselypisteet vastaus)))]] 
+      (lupaus-domain/lupaus->pistenakyma vastaus)]] 
     [:div.caption.vastauslomake-lupaus-kuvaus (:kuvaus vastaus)]
     [:div.sisalto {:dangerouslySetInnerHTML {:__html (:sisalto vastaus)}}]
     ;; Näytä kustannusennuste-taulukko vain "kustannusennuste" lupaustyypille
@@ -285,9 +276,7 @@
        ;; Ensimmäinen rivi - Tavoitehinta ja Ennuste
        [:div.row
         [:div.lihavoitu.sivupalkki-footer-otsikko.col-xs-12.col-md-6
-         [:h5 (if kayta-readonly-nakymaa?
-                "Kustannusennusteen tiedot (määräpäivä ohitettu)"
-                "Kustannusennusteen tiedot")]]
+         [:h5 "Kustannusennusteen tiedot"]]
         (when pisteet-laskettu?
           [:div.lihavoitu.sivupalkki-footer-otsikko.col-xs-12.col-md-6
            [:h5 "Hoitovuoden lopun tilanne"]])]
@@ -298,7 +287,6 @@
            ;; Read-only näkymä määräpäivän ohituttua
            [kentat/nayta-otsikollinen-kentta
             {:otsikko "Tavoitehinta € (syötetty ajoissa)"
-             :luokka "poista-label-top-margin"
              :vayla-tyyli? true
              :arvo-atom (r/atom (:tavoitehinta kustannusennuste))
              :kentta-params {:tyyppi :numero
@@ -339,7 +327,6 @@
            ;; Read-only näkymä määräpäivän ohituttua
            [kentat/nayta-otsikollinen-kentta
             {:otsikko "Toteutuneet kustannukset € (syötetty ajoissa)"
-             :luokka "poista-label-top-margin"
              :vayla-tyyli? true
              :arvo-atom (r/atom (:toteutuneet-kustannukset kustannusennuste))
              :kentta-params {:tyyppi :numero

--- a/src/cljs/harja/views/urakka/lupaus/vastauslomake.cljs
+++ b/src/cljs/harja/views/urakka/lupaus/vastauslomake.cljs
@@ -11,6 +11,7 @@
             [harja.ui.ikonit :as ikonit]
             [harja.ui.yleiset :as yleiset]
             [harja.ui.varmista-kayttajalta :as varmista-kayttajalta]
+            [harja.fmt :as fmt]
             [harja.views.urakka.lupaus.kuukausipaatos-tilat :as kuukausitilat]
             [harja.domain.lupaus-domain :as lupaus-domain]
             [harja.ui.yleiset :as y]
@@ -229,7 +230,7 @@
       :kaari-flex-row? false}
      kuukauden-vastaus-atom]]])
 
-(defn- kustannusennuste-syottokentit [e! {:keys [kohdekuukausi kohdevuosi lupaus disabled? ladataan?]} app]
+(defn- kustannusennuste-syottokentät [e! {:keys [kohdekuukausi kohdevuosi lupaus disabled? ladataan?]} app]
   (let [;; Hae kuukauden tiedot samalla tavalla kuin muut vastaukset
         lupaus-kuukausi (lupaus-domain/etsi-lupaus-kuukausi 
                           (get-in app [:vastaus-lomake :lupaus-kuukaudet]) 
@@ -250,8 +251,10 @@
 
      ;; Ensimmäinen rivi - Tavoitehinta ja Ennuste
      [:div.row
-      [:div.lihavoitu.sivupalkki-footer-otsikko.col-xs-12.col-md-12
+      [:div.lihavoitu.sivupalkki-footer-otsikko.col-xs-12.col-md-6
        [:h5 "Kustannusennusteen tiedot"]]
+      [:div.lihavoitu.sivupalkki-footer-otsikko.col-xs-12.col-md-6
+       [:h5 "Hoitovuoden lopun tilanne"]]
       [:div.col-xs-12.col-md-6
        [kentat/tee-otsikollinen-kentta
         {:otsikko "Tavoitehinta € *"
@@ -259,6 +262,17 @@
          :vayla-tyyli? true
          :arvo-atom (r/wrap (:tavoitehinta kustannusennuste)
                       #(e! (lupaus-tiedot/->AsetaKustannusennusteTavoitehinta %)))
+         :kentta-params {:tyyppi :numero
+                         :vayla-tyyli? true
+                         :disabled? disabled?
+                         :kokonaisosan-maara 10
+                         :desimaalien-maara 2
+                         :placeholder "0,00"}}]]
+      [:div.col-xs-12.col-md-6
+       [kentat/nayta-otsikollinen-kentta
+        {:otsikko "Lopun Tavoitehinta €"
+         :vayla-tyyli? true
+         :arvo-atom (r/atom (get-in app [:yhteenveto :oikaistu-tavoitehinta]))
          :kentta-params {:tyyppi :numero
                          :vayla-tyyli? true
                          :disabled? disabled?
@@ -281,19 +295,17 @@
                          :kokonaisosan-maara 10
                          :desimaalien-maara 2
                          :placeholder "0,00"}}]]
-
       [:div.col-xs-12.col-md-6
-       [kentat/tee-otsikollinen-kentta
-        {:otsikko "Poikkeama %"
-         :luokka "poista-label-top-margin"
+       [kentat/nayta-otsikollinen-kentta
+        {:otsikko "Lopun Toteutuneet kustannukset €"
          :vayla-tyyli? true
-         :arvo-atom (r/atom (:poikkeama-prosentti kustannusennuste))
+         :arvo-atom (r/atom (get-in app [:yhteenveto :oikaistu-toteutuneet-kustannukset]))
          :kentta-params {:tyyppi :numero
                          :vayla-tyyli? true
-                         :disabled? true ;; Laskettu automaattisesti
-                         :kokonaisosan-maara 3
-                         :desimaalien-maara 1
-                         :placeholder "0,0"}}]]]
+                         :disabled? disabled?
+                         :kokonaisosan-maara 10
+                         :desimaalien-maara 2
+                         :placeholder "0,00"}}]]]
 
      ;; Kolmas rivi - Pisteet
      [:div.row
@@ -308,16 +320,29 @@
                          :disabled? true ;; Laskettu automaattisesti
                          :kokonaisosan-maara 2
                          :desimaalien-maara 0
-                         :placeholder "0"}}]]]
+                         :placeholder "0"}}]]
+      [:div.col-xs-12.col-md-6
+       [kentat/tee-otsikollinen-kentta
+        {:otsikko "Poikkeama %"
+         :luokka "poista-label-top-margin"
+         :vayla-tyyli? true
+         :arvo-atom (r/atom (:poikkeama-prosentti kustannusennuste))
+         :kentta-params {:tyyppi :numero
+                         :vayla-tyyli? true
+                         :disabled? true ;; Laskettu automaattisesti
+                         :kokonaisosan-maara 3
+                         :desimaalien-maara 1
+                         :placeholder "0,0"}}]]]
      [:div.row
       [:div.col-xs-12
-       [:div.margin-top-16.text-right
+       [:div.margin-top-16.text-left
         [napit/tallenna
          "Tallenna kustannusennuste"
          #(e! (lupaus-tiedot/->TallennaKustannusennuste))
          {:disabled (or disabled? ladataan? tallentaa-kustannusennustetta?)
           :vayla-tyyli? true
-          :luokka "btn-primary"}]]]]]))
+          :luokka "btn-primary"}]
+        [sulje-nappi e! {:luokka "pull-right"}]]]]]))
 
 
 (defn- vastaukset [e! app luokka]
@@ -360,12 +385,11 @@
        ;; Kustannusennustelupaus - näytä syöttökentät
        (= "kustannusennuste" (:lupaustyyppi lupaus))
        [:div
-        [kustannusennuste-syottokentit e! {:kohdekuukausi kohdekuukausi
+        [kustannusennuste-syottokentät e! {:kohdekuukausi kohdekuukausi
                                            :kohdevuosi kohdevuosi
                                            :lupaus lupaus
                                            :disabled? disabled?
-                                           :ladataan? ladataan?} app]
-        [sulje-nappi e! {:luokka "pull-right"}]]
+                                           :ladataan? ladataan?} app]]
     
        ;; Yksittäinen lupaus (kyllä/ei)
        (lupaus-domain/yksittainen? lupaus)
@@ -434,7 +458,7 @@
     (fn [e! app]
       [:div.overlay-oikealla.ei-sulje-sivupaneelia {:style {:width "632px"}
                                                     :id "lupaukset-sivupaneeli"}
-       [debug app]
+       ;; [debug app]
        [:div.sivupalkki-sisalto {:class (lupaus-css-luokka app)}
         [otsikko e! app]
         [sisalto e! (:vastaus-lomake app)]

--- a/src/cljs/harja/views/urakka/lupaus/vastauslomake.cljs
+++ b/src/cljs/harja/views/urakka/lupaus/vastauslomake.cljs
@@ -14,6 +14,8 @@
             [harja.fmt :as fmt]
             [harja.views.urakka.lupaus.kuukausipaatos-tilat :as kuukausitilat]
             [harja.domain.lupaus-domain :as lupaus-domain]
+            [harja.tiedot.navigaatio :as nav]
+            [harja.tiedot.urakka.siirtymat :as siirtymat]
             [harja.ui.yleiset :as y]
             [harja.ui.debug :refer [debug]]))
 
@@ -37,13 +39,11 @@
            [kuukausivastauksen-status e! lupaus-kuukausi lupaus app]]))]]))
 
 (defn kustannusennuste-taulukko []
-  [:div.kustannusennuste-taulukko
-   [:p "Ennustamme urakan hoitovuoden lopun tavoitehintaa ja toteutuvia kustannuksia 4 kertaa vuodessa alla mainittuihin määräpäiviin mennessä."]
-  
+  [:div.kustannusennuste-taulukko 
    [:table.table.table-striped
     [:thead
      [:tr.paivamaara
-      [:th {:colSpan 2} "15.10."]
+      [:th {:colSpan 2} "31.8.*"]
       [:th {:colSpan 2} "15.1."]
       [:th {:colSpan 2} "30.4."]
       [:th {:colSpan 2} "30.6."]]
@@ -68,7 +68,7 @@
       [:td "≤ 4,0 %"] [:td "8"]
       [:td "≤ 2,0 %"] [:td "8"]
       [:td "≤ 1,0 %"] [:td "8"]]]]
-  
+   [:p "*Tulevan hoitovuoden ennuste. Määräpäivä urakan ensimmäisenä hoitovuotena 15.10."]
    [:p "Hoitovuoden toteutuneet lupauspisteet todetaan laskemalla lupaustaulukon mukaan saatujen pisteiden keskiarvo. "
     [:strong "Mikäli jotain ennustetta ei tehdä määräaikaan mennessä, ennusteesta ei saa yhtään pistettä."]]])
 
@@ -81,11 +81,18 @@
      (str (lupaus-domain/numero->kirjain (:lupausryhma-jarjestys vastaus)) ". " (:lupausryhma-otsikko vastaus))]
     [:div.flex-row
      [:h3.vastauslomake-lupaus-jarjestys
-      (str "Lupaus " (:lupaus-jarjestys vastaus))]
+      (str "Lupaus " (:lupaus-jarjestys vastaus))] 
      [:h3.vastauslomake-lupaus-pisteet
-      (if (= "yksittainen" (:lupaustyyppi vastaus))
+      (cond
+        (= "yksittainen" (:lupaustyyppi vastaus))
         (:pisteet vastaus)
-        (str "Pisteet 0 - " (:kyselypisteet vastaus)))]]
+        
+        (= "kustannusennuste" (:lupaustyyppi vastaus))
+        (str "Pisteet 0 - " (:pisteet vastaus))
+        
+        ;; kysely ja monivalinta käyttävät kyselypisteitä
+        :else
+        (str "Pisteet 0 - " (:kyselypisteet vastaus)))]] 
     [:div.caption.vastauslomake-lupaus-kuvaus (:kuvaus vastaus)]
     [:div.sisalto {:dangerouslySetInnerHTML {:__html (:sisalto vastaus)}}]
     ;; Näytä kustannusennuste-taulukko vain "kustannusennuste" lupaustyypille
@@ -232,95 +239,169 @@
 
 (defn- kustannusennuste-syottokentät [e! {:keys [kohdekuukausi kohdevuosi lupaus disabled? ladataan?]} app]
   (let [;; Hae kuukauden tiedot samalla tavalla kuin muut vastaukset
-        lupaus-kuukausi (lupaus-domain/etsi-lupaus-kuukausi 
-                          (get-in app [:vastaus-lomake :lupaus-kuukaudet]) 
+        lupaus-kuukausi (lupaus-domain/etsi-lupaus-kuukausi
+                          (get-in app [:vastaus-lomake :lupaus-kuukaudet])
                           kohdekuukausi)
+        maarapaiva-mennyt-ohi? (:maarapaiva-mennyt-ohi? lupaus-kuukausi)
+        maarapaiva (:maarapaiva lupaus-kuukausi)
         ;; Hae kuukauden kustannusennuste samalla tavalla kuin kuukauden-vastaus
         kuukauden-kustannusennuste (:kustannusennuste lupaus-kuukausi)
         ;; Jos on lähetetty vastaus, käytä sitä (kuten muissakin vastauksissa)
         lahetetty-vastaus (get-in app [:vastaus-lomake :lahetetty-vastaus])
         kustannusennuste (if (:kustannusennuste lahetetty-vastaus)
-                          (:kustannusennuste lahetetty-vastaus)
-                          kuukauden-kustannusennuste) 
+                           (:kustannusennuste lahetetty-vastaus)
+                           kuukauden-kustannusennuste)
         pisteet-laskettu? (get-in app [:yhteenveto :kustannusennuste-pisteet-laskettu :kaikki-laskettu])
-        ;; Tarkista onko tallentaminen käynnissä
-        tallentaa-kustannusennustetta? (and 
-                                        (= (get-in app [:lupausta-lahetataan :tyyppi]) :kustannusennuste)
-                                        (= (get-in app [:lupausta-lahetataan :kohdekuukausi]) kohdekuukausi)
-                                        (= (get-in app [:lupausta-lahetataan :lupaus-id]) (:lupaus-id lupaus)))]
-    [:div.kustannusennuste-syottokentit
+        tallentaa-kustannusennustetta? (and
+                                         (= (get-in app [:lupausta-lahetataan :tyyppi]) :kustannusennuste)
+                                         (= (get-in app [:lupausta-lahetataan :kohdekuukausi]) kohdekuukausi)
+                                         (= (get-in app [:lupausta-lahetataan :lupaus-id]) (:lupaus-id lupaus)))
+        ;; Määrittele onko kustannusennuste syötetty ajoissa
+        tiedot-syotetty-ajoissa? (and kuukauden-kustannusennuste
+                                   (:tavoitehinta kuukauden-kustannusennuste)
+                                   (:toteutuneet-kustannukset kuukauden-kustannusennuste))
+        ;; Määrittele käytetäänkö read-only näkymää
+        kayta-readonly-nakymaa? (and maarapaiva-mennyt-ohi? tiedot-syotetty-ajoissa?)]
 
-     ;; Ensimmäinen rivi - Tavoitehinta ja Ennuste
-     [:div.row
-      [:div.lihavoitu.sivupalkki-footer-otsikko.col-xs-12.col-md-6
-       [:h5 "Kustannusennusteen tiedot"]]
-      (when pisteet-laskettu? 
+    (cond
+      ;; Jos määräpäivä ohitettu eikä tietoja syötetty ajoissa
+      (and maarapaiva-mennyt-ohi? (not tiedot-syotetty-ajoissa?))
+      [:div.kustannusennuste-maarapaiva-ohitettu
+       [:div.row
+        [:div.col-xs-12
+         [:div.alert.alert-warning
+          [:h4 "Määräpäivä ohitettu"]
+          [:p (str "Hoitovuoden lopun ennustetta ei tehty määräpäivään "
+                (when maarapaiva (pvm/pvm maarapaiva)) " mennessä.")]
+          [:p [:strong "Mikäli jotain ennustetta ei tehdä määräaikaan mennessä, ennusteesta ei saa yhtään pistettä."]]]]]
+       [:div.row
+        [:div.col-xs-12
+         [:div.margin-top-16.text-left
+          [sulje-nappi e! {:luokka "pull-right"}]]]]]
+
+      ;; Muissa tapauksissa näytetään kentät (joko muokattavina tai read-only)
+      :else
+      [:div.kustannusennuste-syottokentit
+       ;; Ensimmäinen rivi - Tavoitehinta ja Ennuste
+       [:div.row
         [:div.lihavoitu.sivupalkki-footer-otsikko.col-xs-12.col-md-6
-       [:h5 "Hoitovuoden lopun tilanne"]])]
-     [:div.row
-      [:div.col-xs-12.col-md-6
-       [kentat/tee-otsikollinen-kentta
-        {:otsikko "Tavoitehinta € *"
-         :luokka "poista-label-top-margin"
-         :vayla-tyyli? true
-         :arvo-atom (r/wrap (:tavoitehinta kustannusennuste)
-                      #(let [kohdekuukausi (get-in app [:vastaus-lomake :vastauskuukausi])]
-                         (e! (lupaus-tiedot/->PaivitaKustannusennuste kohdekuukausi :tavoitehinta %))))
-         :kentta-params {:tyyppi :numero
-                         :vayla-tyyli? true
-                         :disabled? disabled?
-                         :kokonaisosan-maara 10
-                         :desimaalien-maara 2
-                         :placeholder "0,00"}}]]
-      (when pisteet-laskettu? [:div.col-xs-12.col-md-6
-                               [kentat/nayta-otsikollinen-kentta
-                                {:otsikko "Lopun Tavoitehinta €"
-                                 :vayla-tyyli? true
-                                 :arvo-atom (r/atom (get-in app [:yhteenveto :oikaistu-tavoitehinta]))
-                                 :kentta-params {:tyyppi :numero
-                                                 :vayla-tyyli? true
-                                                 :disabled? disabled?
-                                                 :kokonaisosan-maara 10
-                                                 :desimaalien-maara 2
-                                                 :placeholder "0,00"}}]])]
+         [:h5 (if kayta-readonly-nakymaa?
+                "Kustannusennusteen tiedot (määräpäivä ohitettu)"
+                "Kustannusennusteen tiedot")]]
+        (when pisteet-laskettu?
+          [:div.lihavoitu.sivupalkki-footer-otsikko.col-xs-12.col-md-6
+           [:h5 "Hoitovuoden lopun tilanne"]])]
 
-     ;; Toinen rivi - Toteutunut ja Poikkeama
-     [:div.row
-      [:div.col-xs-12.col-md-6
-       [kentat/tee-otsikollinen-kentta
-        {:otsikko "Toteutuneet kustannukset € *"
-         :luokka "poista-label-top-margin"
-         :vayla-tyyli? true
-         :arvo-atom (r/wrap (:toteutuneet-kustannukset kustannusennuste)
-                      #(let [kohdekuukausi (get-in app [:vastaus-lomake :vastauskuukausi])]
-                         (e! (lupaus-tiedot/->PaivitaKustannusennuste kohdekuukausi :toteutuneet-kustannukset %))))
-         :kentta-params {:tyyppi :numero
-                         :vayla-tyyli? true
-                         :disabled? disabled?
-                         :kokonaisosan-maara 10
-                         :desimaalien-maara 2
-                         :placeholder "0,00"}}]]
-      (when pisteet-laskettu? [:div.col-xs-12.col-md-6
-                               [kentat/nayta-otsikollinen-kentta
-                                {:otsikko "Lopun Toteutuneet kustannukset €"
-                                 :vayla-tyyli? true
-                                 :arvo-atom (r/atom (get-in app [:yhteenveto :oikaistu-toteutuneet-kustannukset]))
-                                 :kentta-params {:tyyppi :numero
-                                                 :vayla-tyyli? true
-                                                 :disabled? disabled?
-                                                 :kokonaisosan-maara 10
-                                                 :desimaalien-maara 2
-                                                 :placeholder "0,00"}}]])]
-     [:div.row
-      [:div.col-xs-12
-       [:div.margin-top-16.text-left
-        [napit/tallenna
-         "Tallenna kustannusennuste"
-         #(e! (lupaus-tiedot/->TallennaKustannusennuste))
-         {:disabled (or disabled? ladataan? tallentaa-kustannusennustetta?)
-          :vayla-tyyli? true
-          :luokka "btn-primary"}]
-        [sulje-nappi e! {:luokka "pull-right"}]]]]]))
+       [:div.row
+        [:div.col-xs-12.col-md-6
+         (if kayta-readonly-nakymaa?
+           ;; Read-only näkymä määräpäivän ohituttua
+           [kentat/nayta-otsikollinen-kentta
+            {:otsikko "Tavoitehinta € (syötetty ajoissa)"
+             :luokka "poista-label-top-margin"
+             :vayla-tyyli? true
+             :arvo-atom (r/atom (:tavoitehinta kustannusennuste))
+             :kentta-params {:tyyppi :numero
+                             :vayla-tyyli? true
+                             :kokonaisosan-maara 10
+                             :desimaalien-maara 2
+                             :fmt fmt/euro-opt}}]
+           ;; Normaali muokattava kenttä
+           [kentat/tee-otsikollinen-kentta
+            {:otsikko "Tavoitehinta € *"
+             :luokka "poista-label-top-margin"
+             :vayla-tyyli? true
+             :arvo-atom (r/wrap (:tavoitehinta kustannusennuste)
+                          #(let [kohdekuukausi (get-in app [:vastaus-lomake :vastauskuukausi])]
+                             (e! (lupaus-tiedot/->PaivitaKustannusennuste kohdekuukausi :tavoitehinta %))))
+             :kentta-params {:tyyppi :numero
+                             :vayla-tyyli? true
+                             :disabled? disabled?
+                             :kokonaisosan-maara 10
+                             :desimaalien-maara 2
+                             :placeholder "0,00"}}])]
+        (when pisteet-laskettu?
+          [:div.col-xs-12.col-md-6
+           [kentat/nayta-otsikollinen-kentta
+            {:otsikko "Lopun Tavoitehinta €"
+             :vayla-tyyli? true
+             :arvo-atom (r/atom (get-in app [:yhteenveto :oikaistu-tavoitehinta]))
+             :kentta-params {:tyyppi :numero
+                             :vayla-tyyli? true
+                             :kokonaisosan-maara 10
+                             :desimaalien-maara 2
+                             :fmt fmt/euro-opt}}]])]
+
+       ;; Toinen rivi - Toteutuneet kustannukset
+       [:div.row
+        [:div.col-xs-12.col-md-6
+         (if kayta-readonly-nakymaa?
+           ;; Read-only näkymä määräpäivän ohituttua
+           [kentat/nayta-otsikollinen-kentta
+            {:otsikko "Toteutuneet kustannukset € (syötetty ajoissa)"
+             :luokka "poista-label-top-margin"
+             :vayla-tyyli? true
+             :arvo-atom (r/atom (:toteutuneet-kustannukset kustannusennuste))
+             :kentta-params {:tyyppi :numero
+                             :vayla-tyyli? true
+                             :kokonaisosan-maara 10
+                             :desimaalien-maara 2
+                             :fmt fmt/euro-opt}}]
+           ;; Normaali muokattava kenttä
+           [kentat/tee-otsikollinen-kentta
+            {:otsikko "Toteutuneet kustannukset € *"
+             :luokka "poista-label-top-margin"
+             :vayla-tyyli? true
+             :arvo-atom (r/wrap (:toteutuneet-kustannukset kustannusennuste)
+                          #(let [kohdekuukausi (get-in app [:vastaus-lomake :vastauskuukausi])]
+                             (e! (lupaus-tiedot/->PaivitaKustannusennuste kohdekuukausi :toteutuneet-kustannukset %))))
+             :kentta-params {:tyyppi :numero
+                             :vayla-tyyli? true
+                             :disabled? disabled?
+                             :kokonaisosan-maara 10
+                             :desimaalien-maara 2
+                             :placeholder "0,00"}}])]
+        (when pisteet-laskettu?
+          [:div.col-xs-12.col-md-6
+           [kentat/nayta-otsikollinen-kentta
+            {:otsikko "Lopun Toteutuneet kustannukset €"
+             :vayla-tyyli? true
+             :arvo-atom (r/atom (get-in app [:yhteenveto :oikaistu-toteutuneet-kustannukset]))
+             :kentta-params {:tyyppi :numero
+                             :vayla-tyyli? true
+                             :kokonaisosan-maara 10
+                             :desimaalien-maara 2
+                             :fmt fmt/euro-opt}}]
+           [:div.margin-top-8
+            [yleiset/linkki
+             "Siirry välikatselmukseen"
+             #(let [hoitokauden-alkuvuosi (if (>= kohdekuukausi 10)
+                                            kohdevuosi
+                                            (dec kohdevuosi))
+                    valittu-hoitokausi [(pvm/hoitokauden-alkupvm hoitokauden-alkuvuosi)
+                                        (pvm/hoitokauden-loppupvm hoitokauden-alkuvuosi)]]
+                (siirtymat/avaa-valikatselmus
+                  @nav/valittu-hallintayksikko-id
+                  (:id @nav/valittu-urakka)
+                  valittu-hoitokausi))]]])]
+
+       [:div.row
+        [:div.col-xs-12
+         (if kayta-readonly-nakymaa?
+           ;; Read-only tilassa ei tallennusnappia
+           [:div.margin-top-16.text-left
+            [:div.alert.alert-info.margin-bottom-16
+             [:p [:strong "Tiedot on syötetty määräpäivään mennessä."] " Muokkaus ei ole enää mahdollista."]]
+            [sulje-nappi e! {:luokka "pull-right"}]]
+           ;; Normaali tallennusnäkymä
+           [:div.margin-top-16.text-left
+            [napit/tallenna
+             "Tallenna kustannusennuste"
+             #(e! (lupaus-tiedot/->TallennaKustannusennuste))
+             {:disabled (or disabled? ladataan? tallentaa-kustannusennustetta?)
+              :vayla-tyyli? true
+              :luokka "btn-primary"}]
+            [sulje-nappi e! {:luokka "pull-right"}]])]]])))
 
 
 (defn- vastaukset [e! app luokka]

--- a/src/cljs/harja/views/urakka/lupaus/vastauslomake.cljs
+++ b/src/cljs/harja/views/urakka/lupaus/vastauslomake.cljs
@@ -35,6 +35,42 @@
                                  (e! (lupaus-tiedot/->ValitseVastausKuukausi (:kuukausi lupaus-kuukausi) (:vuosi lupaus-kuukausi)))))})
            [kuukausivastauksen-status e! lupaus-kuukausi lupaus app]]))]]))
 
+(defn kustannusennuste-taulukko []
+  [:div.kustannusennuste-taulukko
+   [:p "Ennustamme urakan hoitovuoden lopun tavoitehintaa ja toteutuvia kustannuksia 4 kertaa vuodessa alla mainittuihin määräpäiviin mennessä."]
+  
+   [:table.table.table-striped
+    [:thead
+     [:tr.paivamaara
+      [:th {:colSpan 2} "15.10."]
+      [:th {:colSpan 2} "15.1."]
+      [:th {:colSpan 2} "30.4."]
+      [:th {:colSpan 2} "30.6."]]
+     [:tr.aliotsikko
+      [:th "Tarkkuus"] [:th "Pisteet"]
+      [:th "Tarkkuus"] [:th "Pisteet"]
+      [:th "Tarkkuus"] [:th "Pisteet"]
+      [:th "Tarkkuus"] [:th "Pisteet"]]]
+    [:tbody
+     [:tr
+      [:td "> 9,0 %"] [:td "1"]
+      [:td "> 6,0 %"] [:td "1"]
+      [:td "> 3,0 %"] [:td "1"]
+      [:td "> 2,0 %"] [:td "1"]]
+     [:tr
+      [:td "≤ 9,0 %"] [:td "4"]
+      [:td "≤ 6,0 %"] [:td "4"]
+      [:td "≤ 3,0 %"] [:td "4"]
+      [:td "≤ 2,0 %"] [:td "4"]]
+     [:tr
+      [:td "≤ 7,0 %"] [:td "8"]
+      [:td "≤ 4,0 %"] [:td "8"]
+      [:td "≤ 2,0 %"] [:td "8"]
+      [:td "≤ 1,0 %"] [:td "8"]]]]
+  
+   [:p "Hoitovuoden toteutuneet lupauspisteet todetaan laskemalla lupaustaulukon mukaan saatujen pisteiden keskiarvo. "
+    [:strong "Mikäli jotain ennustetta ei tehdä määräaikaan mennessä, ennusteesta ei saa yhtään pistettä."]]])
+
 (defn- sisalto [e! vastaus]
   [:div {:id "vastauslomake-sisalto"}
    [:hr]
@@ -50,7 +86,9 @@
         (:pisteet vastaus)
         (str "Pisteet 0 - " (:kyselypisteet vastaus)))]]
     [:div.caption.vastauslomake-lupaus-kuvaus (:kuvaus vastaus)]
-    [:div.sisalto {:dangerouslySetInnerHTML {:__html (:sisalto vastaus)}}]]])
+    [:div.sisalto {:dangerouslySetInnerHTML {:__html (:sisalto vastaus)}}]
+    [kustannusennuste-taulukko]
+    ]])
 
 (defn- kommentti-rivi [e! {:keys [id luotu luoja etunimi sukunimi kommentti poistettu]}]
   [:div.kommentti-rivi
@@ -190,7 +228,81 @@
       :kaari-flex-row? false}
      kuukauden-vastaus-atom]]])
 
+(defn- kustannusennuste-syottokentit [e! {:keys [kohdekuukausi kohdevuosi lupaus disabled? ladataan?]}]
+  [:div.kustannusennuste-syottokentit
+   
+   ;; Ensimmäinen rivi - Tavoitehinta ja Ennuste
+   [:div.row
+    [:div.lihavoitu.sivupalkki-footer-otsikko.col-xs-12.col-md-12
+     [:h5 "Kustannusennusteen tiedot"]]
+    [:div.col-xs-12.col-md-6
+     [kentat/tee-otsikollinen-kentta
+      {:otsikko "Tavoitehinta € *"
+       :luokka "poista-label-top-margin"
+       :vayla-tyyli? true
+       :arvo-atom (r/atom nil)
+       :kentta-params {:tyyppi :numero
+                       :vayla-tyyli? true
+                       :disabled? disabled?
+                       :kokonaisosan-maara 10
+                       :desimaalien-maara 2
+                       :placeholder "0,00"}}]]
 
+    [:div.col-xs-12.col-md-6
+     [kentat/tee-otsikollinen-kentta
+      {:otsikko "Ennuste € *"
+       :luokka "poista-label-top-margin"
+       :vayla-tyyli? true
+       :arvo-atom (r/atom nil)
+       :kentta-params {:tyyppi :numero
+                       :vayla-tyyli? true
+                       :disabled? disabled?
+                       :kokonaisosan-maara 10
+                       :desimaalien-maara 2
+                       :placeholder "0,00"}}]]]
+
+   ;; Toinen rivi - Toteutunut ja Poikkeama
+   [:div.row
+    [:div.col-xs-12.col-md-6
+     [kentat/tee-otsikollinen-kentta
+      {:otsikko "Toteutuneet kustannukset € *"
+       :luokka "poista-label-top-margin"
+       :vayla-tyyli? true
+       :arvo-atom (r/atom nil)
+       :kentta-params {:tyyppi :numero
+                       :vayla-tyyli? true
+                       :disabled? disabled?
+                       :kokonaisosan-maara 10
+                       :desimaalien-maara 2
+                       :placeholder "0,00"}}]]
+
+    [:div.col-xs-12.col-md-6
+     [kentat/tee-otsikollinen-kentta
+      {:otsikko "Poikkeama %"
+       :luokka "poista-label-top-margin"
+       :vayla-tyyli? true
+       :arvo-atom (r/atom nil)
+       :kentta-params {:tyyppi :numero
+                       :vayla-tyyli? true
+                       :disabled? true ;; Laskettu automaattisesti
+                       :kokonaisosan-maara 3
+                       :desimaalien-maara 1
+                       :placeholder "0,0"}}]]]
+
+   ;; Kolmas rivi - Pisteet (keskitetty)
+   [:div.row
+    [:div.col-xs-12.col-md-6
+     [kentat/tee-otsikollinen-kentta
+      {:otsikko "Pisteet"
+       :luokka "poista-label-top-margin"
+       :vayla-tyyli? true
+       :arvo-atom (r/atom nil)
+       :kentta-params {:tyyppi :numero
+                       :vayla-tyyli? true
+                       :disabled? true ;; Laskettu automaattisesti
+                       :kokonaisosan-maara 2
+                       :desimaalien-maara 0
+                       :placeholder "0"}}]]]])
 
 
 (defn- vastaukset [e! app luokka]
@@ -226,62 +338,75 @@
         ;; Kyllä/Ei valinnassa vaihtoehdot on true/false
         vastaus-ke (if lahetetty-vastaus
                      (:vastaus lahetetty-vastaus)
-                     (:vastaus kuukauden-vastaus))
+                     (:vastaus kuukauden-vastaus)) 
         miten-kuukausi-meni-str (str "Miten " (pvm/kuukauden-lyhyt-nimi kohdekuukausi) "kuu meni?")]
-    [:div.sivupalkki-footer {:class luokka} 
-     (if (lupaus-domain/yksittainen? lupaus)
-       ;; Yksittäinen
+    [:div.sivupalkki-footer {:class luokka}
+     (cond
+       ;; Kustannusennustelupaus - näytä syöttökentät
+       (= "kustannusennuste" (:lupaustyyppi lupaus))
+       [:div
+        [kustannusennuste-syottokentit e! {:kohdekuukausi kohdekuukausi
+                                           :kohdevuosi kohdevuosi
+                                           :lupaus lupaus
+                                           :disabled? disabled?
+                                           :ladataan? ladataan?}]
+        [sulje-nappi e! {:luokka "pull-right"}]]
+    
+       ;; Yksittäinen lupaus (kyllä/ei)
+       (lupaus-domain/yksittainen? lupaus)
        [:div.flex-row
         [:div.lihavoitu {:style {:margin-left "1rem"}} miten-kuukausi-meni-str]
         [kentat/kylla-ei-valinta
          {:on-click #(e! (lupaus-tiedot/->ValitseKE {:vastaus %
                                                      :kuukauden-vastaus-id (:id kuukauden-vastaus)}
-                                                    lupaus kohdekuukausi kohdevuosi))
+                           lupaus kohdekuukausi kohdevuosi))
           :ladataan? ladataan?
           :disabled? disabled?}
          vastaus-ke]
         [sulje-nappi e!]]
+    
        ;; Monivalinta
+       :else
        [:div
-            [:div.lihavoitu.sivupalkki-footer-otsikko {:style {:padding "0 32px 0 32px"}}
-             [:h4 miten-kuukausi-meni-str]]
-            (if (every? #(nil? (get % :vaihtoehto-askel)) vaihtoehdot)
-              ;; Yksi monivalinta
-              [monivalinta e! {:vaihtoehdot vaihtoehdot
-                               :lupaus lupaus
-                               :kohdekuukausi kohdekuukausi
-                               :kohdevuosi kohdevuosi
-                               :kuukauden-vastaus kuukauden-vastaus
-                               :kuukauden-vastaus-atom kuukauden-vastaus-atom
-                               :disabled? disabled?
-                               :ladataan? ladataan?}]
-              ;; Useita ketjutettuja monivalintoja
-              (let [edeltavat-arvot (lupaus-domain/etsi-edeltavat-monivalinnan-valitut-arvot valittu-arvo vaihtoehdot)
-                    lahetetty-askel (:vaihtoehto-askel lahetetty-vastaus)]
-                 (map (fn [[valinta-askel vaihtoehdot]]
-                        (let [otsikko (:ryhma-otsikko (first vaihtoehdot))
-                              edellinen-arvo (some #(when (= (:vaihtoehto-askel %) valinta-askel) %) edeltavat-arvot)
-                              edellinen-askel (:vaihtoehto-askel edellinen-arvo)
-                              edellinen-valittu-id (:id edellinen-arvo)
-                              monivalinta-ketju-atom (atom
-                                                       (cond
-                                                         (and lahetetty-vastaus-id (= valinta-askel lahetetty-askel)) lahetetty-vastaus-id
-                                                         (= valinta-askel edellinen-askel) edellinen-valittu-id
-                                                         :else (:lupaus-vaihtoehto-id kuukauden-vastaus)))]
-                          (when (some #{valinta-askel} naytettavat-vaiheet)
-                            ^{:key (str "monivalinta-" (hash valinta-askel))}
-                            [monivalinta e! {:vaihtoehdot vaihtoehdot
-                                             :valinta-askel valinta-askel
-                                             :lupaus lupaus
-                                             :kohdekuukausi kohdekuukausi
-                                             :kohdevuosi kohdevuosi
-                                             :kuukauden-vastaus kuukauden-vastaus
-                                             :kuukauden-vastaus-atom monivalinta-ketju-atom
-                                             :otsikko otsikko
-                                             :disabled? disabled?
-                                             :ladataan? ladataan?}])))
-                   vaihdoehdot-vaiheet)))
-            [sulje-nappi e! {:luokka "pull-right"}]])]))
+        [:div.lihavoitu.sivupalkki-footer-otsikko {:style {:padding "0 32px 0 32px"}}
+         [:h4 miten-kuukausi-meni-str]]
+        (if (every? #(nil? (get % :vaihtoehto-askel)) vaihtoehdot)
+          ;; Yksi monivalinta
+          [monivalinta e! {:vaihtoehdot vaihtoehdot
+                           :lupaus lupaus
+                           :kohdekuukausi kohdekuukausi
+                           :kohdevuosi kohdevuosi
+                           :kuukauden-vastaus kuukauden-vastaus
+                           :kuukauden-vastaus-atom kuukauden-vastaus-atom
+                           :disabled? disabled?
+                           :ladataan? ladataan?}]
+          ;; Useita ketjutettuja monivalintoja
+          (let [edeltavat-arvot (lupaus-domain/etsi-edeltavat-monivalinnan-valitut-arvot valittu-arvo vaihtoehdot)
+                lahetetty-askel (:vaihtoehto-askel lahetetty-vastaus)]
+            (map (fn [[valinta-askel vaihtoehdot]]
+                   (let [otsikko (:ryhma-otsikko (first vaihtoehdot))
+                         edellinen-arvo (some #(when (= (:vaihtoehto-askel %) valinta-askel) %) edeltavat-arvot)
+                         edellinen-askel (:vaihtoehto-askel edellinen-arvo)
+                         edellinen-valittu-id (:id edellinen-arvo)
+                         monivalinta-ketju-atom (atom
+                                                  (cond
+                                                    (and lahetetty-vastaus-id (= valinta-askel lahetetty-askel)) lahetetty-vastaus-id
+                                                    (= valinta-askel edellinen-askel) edellinen-valittu-id
+                                                    :else (:lupaus-vaihtoehto-id kuukauden-vastaus)))]
+                     (when (some #{valinta-askel} naytettavat-vaiheet)
+                       ^{:key (str "monivalinta-" (hash valinta-askel))}
+                       [monivalinta e! {:vaihtoehdot vaihtoehdot
+                                        :valinta-askel valinta-askel
+                                        :lupaus lupaus
+                                        :kohdekuukausi kohdekuukausi
+                                        :kohdevuosi kohdevuosi
+                                        :kuukauden-vastaus kuukauden-vastaus
+                                        :kuukauden-vastaus-atom monivalinta-ketju-atom
+                                        :otsikko otsikko
+                                        :disabled? disabled?
+                                        :ladataan? ladataan?}])))
+              vaihdoehdot-vaiheet)))
+        [sulje-nappi e! {:luokka "pull-right"}]])]))
 
 
 (defn vastauslomake [e! app]

--- a/src/cljs/harja/views/urakka/lupaus/vastauslomake.cljs
+++ b/src/cljs/harja/views/urakka/lupaus/vastauslomake.cljs
@@ -241,7 +241,8 @@
         lahetetty-vastaus (get-in app [:vastaus-lomake :lahetetty-vastaus])
         kustannusennuste (if (:kustannusennuste lahetetty-vastaus)
                           (:kustannusennuste lahetetty-vastaus)
-                          kuukauden-kustannusennuste)
+                          kuukauden-kustannusennuste) 
+        pisteet-laskettu? (get-in app [:yhteenveto :kustannusennuste-pisteet-laskettu :kaikki-laskettu])
         ;; Tarkista onko tallentaminen käynnissä
         tallentaa-kustannusennustetta? (and 
                                         (= (get-in app [:lupausta-lahetataan :tyyppi]) :kustannusennuste)
@@ -253,32 +254,35 @@
      [:div.row
       [:div.lihavoitu.sivupalkki-footer-otsikko.col-xs-12.col-md-6
        [:h5 "Kustannusennusteen tiedot"]]
-      [:div.lihavoitu.sivupalkki-footer-otsikko.col-xs-12.col-md-6
-       [:h5 "Hoitovuoden lopun tilanne"]]
+      (when pisteet-laskettu? 
+        [:div.lihavoitu.sivupalkki-footer-otsikko.col-xs-12.col-md-6
+       [:h5 "Hoitovuoden lopun tilanne"]])]
+     [:div.row
       [:div.col-xs-12.col-md-6
        [kentat/tee-otsikollinen-kentta
         {:otsikko "Tavoitehinta € *"
          :luokka "poista-label-top-margin"
          :vayla-tyyli? true
          :arvo-atom (r/wrap (:tavoitehinta kustannusennuste)
-                      #(e! (lupaus-tiedot/->AsetaKustannusennusteTavoitehinta %)))
+                      #(let [kohdekuukausi (get-in app [:vastaus-lomake :vastauskuukausi])]
+                         (e! (lupaus-tiedot/->PaivitaKustannusennuste kohdekuukausi :tavoitehinta %))))
          :kentta-params {:tyyppi :numero
                          :vayla-tyyli? true
                          :disabled? disabled?
                          :kokonaisosan-maara 10
                          :desimaalien-maara 2
                          :placeholder "0,00"}}]]
-      [:div.col-xs-12.col-md-6
-       [kentat/nayta-otsikollinen-kentta
-        {:otsikko "Lopun Tavoitehinta €"
-         :vayla-tyyli? true
-         :arvo-atom (r/atom (get-in app [:yhteenveto :oikaistu-tavoitehinta]))
-         :kentta-params {:tyyppi :numero
-                         :vayla-tyyli? true
-                         :disabled? disabled?
-                         :kokonaisosan-maara 10
-                         :desimaalien-maara 2
-                         :placeholder "0,00"}}]]]
+      (when pisteet-laskettu? [:div.col-xs-12.col-md-6
+                               [kentat/nayta-otsikollinen-kentta
+                                {:otsikko "Lopun Tavoitehinta €"
+                                 :vayla-tyyli? true
+                                 :arvo-atom (r/atom (get-in app [:yhteenveto :oikaistu-tavoitehinta]))
+                                 :kentta-params {:tyyppi :numero
+                                                 :vayla-tyyli? true
+                                                 :disabled? disabled?
+                                                 :kokonaisosan-maara 10
+                                                 :desimaalien-maara 2
+                                                 :placeholder "0,00"}}]])]
 
      ;; Toinen rivi - Toteutunut ja Poikkeama
      [:div.row
@@ -288,51 +292,25 @@
          :luokka "poista-label-top-margin"
          :vayla-tyyli? true
          :arvo-atom (r/wrap (:toteutuneet-kustannukset kustannusennuste)
-                      #(e! (lupaus-tiedot/->AsetaKustannusennusteToteutuneet %)))
+                      #(let [kohdekuukausi (get-in app [:vastaus-lomake :vastauskuukausi])]
+                         (e! (lupaus-tiedot/->PaivitaKustannusennuste kohdekuukausi :toteutuneet-kustannukset %))))
          :kentta-params {:tyyppi :numero
                          :vayla-tyyli? true
                          :disabled? disabled?
                          :kokonaisosan-maara 10
                          :desimaalien-maara 2
                          :placeholder "0,00"}}]]
-      [:div.col-xs-12.col-md-6
-       [kentat/nayta-otsikollinen-kentta
-        {:otsikko "Lopun Toteutuneet kustannukset €"
-         :vayla-tyyli? true
-         :arvo-atom (r/atom (get-in app [:yhteenveto :oikaistu-toteutuneet-kustannukset]))
-         :kentta-params {:tyyppi :numero
-                         :vayla-tyyli? true
-                         :disabled? disabled?
-                         :kokonaisosan-maara 10
-                         :desimaalien-maara 2
-                         :placeholder "0,00"}}]]]
-
-     ;; Kolmas rivi - Pisteet
-     [:div.row
-      [:div.col-xs-12.col-md-6
-       [kentat/tee-otsikollinen-kentta
-        {:otsikko "Pisteet"
-         :luokka "poista-label-top-margin"
-         :vayla-tyyli? true
-         :arvo-atom (r/atom (:pisteet kustannusennuste))
-         :kentta-params {:tyyppi :numero
-                         :vayla-tyyli? true
-                         :disabled? true ;; Laskettu automaattisesti
-                         :kokonaisosan-maara 2
-                         :desimaalien-maara 0
-                         :placeholder "0"}}]]
-      [:div.col-xs-12.col-md-6
-       [kentat/tee-otsikollinen-kentta
-        {:otsikko "Poikkeama %"
-         :luokka "poista-label-top-margin"
-         :vayla-tyyli? true
-         :arvo-atom (r/atom (:poikkeama-prosentti kustannusennuste))
-         :kentta-params {:tyyppi :numero
-                         :vayla-tyyli? true
-                         :disabled? true ;; Laskettu automaattisesti
-                         :kokonaisosan-maara 3
-                         :desimaalien-maara 1
-                         :placeholder "0,0"}}]]]
+      (when pisteet-laskettu? [:div.col-xs-12.col-md-6
+                               [kentat/nayta-otsikollinen-kentta
+                                {:otsikko "Lopun Toteutuneet kustannukset €"
+                                 :vayla-tyyli? true
+                                 :arvo-atom (r/atom (get-in app [:yhteenveto :oikaistu-toteutuneet-kustannukset]))
+                                 :kentta-params {:tyyppi :numero
+                                                 :vayla-tyyli? true
+                                                 :disabled? disabled?
+                                                 :kokonaisosan-maara 10
+                                                 :desimaalien-maara 2
+                                                 :placeholder "0,00"}}]])]
      [:div.row
       [:div.col-xs-12
        [:div.margin-top-16.text-left

--- a/src/cljs/harja/views/urakka/lupaus_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/lupaus_nakyma.cljs
@@ -81,9 +81,7 @@
     [:div {:style {:display "flex"
                    :align-items "center"
                    :padding 0}}
-     (if (= "yksittainen" (:lupaustyyppi lupaus))
-       [pisteet-div (:pisteet lupaus) "MAX"]
-       [pisteet-div (:kyselypisteet lupaus) "MAX"])]]])
+     [pisteet-div (lupaus-domain/lupaus->maksimipisteet lupaus) "MAX"]]]])
 
 (defn muodosta-kannanotto [ryhma]
   (cond

--- a/test/clj/harja/domain/lupaus_domain_test.clj
+++ b/test/clj/harja/domain/lupaus_domain_test.clj
@@ -131,6 +131,8 @@
         nykyhetki (pvm/luo-pvm 2022 0 1)
         valittu-hoitokausi [#inst "2021-09-30T21:00:00.000-00:00"
                             #inst "2022-09-30T20:59:59.000-00:00"]
+        hoitovuosi-nro 1
+        hoitovuoden-erikoisarvot []
         kuukaudet [;; Menneet kuukaudet
                    {:vuosi 2021
                     :kuukausi 10
@@ -181,26 +183,26 @@
                    {:vuosi 2022 :kuukausi 8 :odottaa-kannanottoa? false :paatos-hylatty? true :paattava-kuukausi? true :kirjauskuukausi? false :nykyhetkeen-verrattuna :tuleva-kuukausi}
                    {:vuosi 2022 :kuukausi 9 :odottaa-kannanottoa? false :paatos-hylatty? true :paattava-kuukausi? true :kirjauskuukausi? false :nykyhetkeen-verrattuna :tuleva-kuukausi}]]
     (is (= kuukaudet
-           (lupaus-domain/lupaus->kuukaudet lupaus nykyhetki valittu-hoitokausi)))
+           (lupaus-domain/lupaus->kuukaudet lupaus nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot)))
     (let [lupaus (dissoc lupaus :vastaukset)
           valittu-hoitokausi [#inst "2022-09-30T21:00:00.000-00:00"
                               #inst "2023-09-30T20:59:59.000-00:00"]
-          lupaus-kuukaudet (lupaus-domain/lupaus->kuukaudet lupaus nykyhetki valittu-hoitokausi)]
+          lupaus-kuukaudet (lupaus-domain/lupaus->kuukaudet lupaus nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot)]
       (is (= (repeat 12 false)
              (->> lupaus-kuukaudet (map :odottaa-kannanottoa?)))
-          "Tuleviin hoitokausiin ei oteta kantaa")
+        "Tuleviin hoitokausiin ei oteta kantaa")
       (is (= (repeat 12 :tuleva-kuukausi)
              (->> lupaus-kuukaudet (map :nykyhetkeen-verrattuna)))
-          "Vertailu nykyhetkeen toimii"))
+        "Vertailu nykyhetkeen toimii"))
 
     ;; Muutetaan 11/2021 vastaus myöntäväksi
     (let [lupaus (assoc-in lupaus [:vastaukset 1 :vastaus] true)
           kuukaudet (-> kuukaudet
-                        (assoc-in [1 :vastaus :vastaus] true)
-                        (assoc-in [2 :odottaa-kannanottoa?] true))
+                      (assoc-in [1 :vastaus :vastaus] true)
+                      (assoc-in [2 :odottaa-kannanottoa?] true))
           kuukaudet (map #(assoc % :paatos-hylatty? false) kuukaudet)]
       (is (= kuukaudet
-             (lupaus-domain/lupaus->kuukaudet lupaus nykyhetki valittu-hoitokausi))))))
+             (lupaus-domain/lupaus->kuukaudet lupaus nykyhetki valittu-hoitokausi hoitovuosi-nro hoitovuoden-erikoisarvot))))))
 
 (deftest odottaa-urakoitsijan-kannanottoa?
   (is (true? (lupaus-domain/odottaa-urakoitsijan-kannanottoa?
@@ -245,3 +247,53 @@
                  {:vuosi 2020 :kuukausi 8 :odottaa-vastausta? false}
                  {:vuosi 2020 :kuukausi 9 :odottaa-vastausta? true}]))
     "Ei odota urakoitsijan kannanottoa, koska ainoastaan päättävät pisteet on antamatta"))
+
+
+(deftest hoitovuoden-kirjauskuukaudet-test
+  (let [lupaus {:kirjaus-kkt [10 11 12 1 2 3 4 5 6 7 8 9]}
+        erikoisarvot {:kirjaus-kkt [10 1 4 6]}]
+
+    (testing "Käyttää erikoisarvoja kun ne on annettu"
+      (is (= [10 1 4 6]
+             (lupaus-domain/hoitovuoden-kirjauskuukaudet lupaus 1 erikoisarvot))))
+
+    (testing "Käyttää perusarvoja kun erikoisarvoja ei ole"
+      (is (= [10 11 12 1 2 3 4 5 6 7 8 9]
+             (lupaus-domain/hoitovuoden-kirjauskuukaudet lupaus 1 nil))))
+
+    (testing "Käyttää perusarvoja kun erikoisarvot on tyhjä"
+      (is (= [10 11 12 1 2 3 4 5 6 7 8 9]
+             (lupaus-domain/hoitovuoden-kirjauskuukaudet lupaus 1 {}))))))
+
+(deftest sallittu-kuukausi-hoitovuodelle-test
+  (let [lupaus {:kirjaus-kkt [10 11 12 1 2 3 4 5 6 7 8 9]
+                :paatos-kk 9}
+        erikoisarvot {:kirjaus-kkt [10 1 4 6]  ; Vain neljä kuukautta
+                      :paatos-kk 6}]           ; Kesäkuu päätös
+
+    (testing "Erikoisarvot rajoittavat kirjauskuukausia"
+      (is (true? (lupaus-domain/sallittu-kuukausi-hoitovuodelle? lupaus 10 false 1 erikoisarvot)))
+      (is (true? (lupaus-domain/sallittu-kuukausi-hoitovuodelle? lupaus 1 false 1 erikoisarvot)))
+      (is (false? (lupaus-domain/sallittu-kuukausi-hoitovuodelle? lupaus 11 false 1 erikoisarvot))))
+
+    (testing "Erikoisarvot muuttavat päätöskuukautta"
+      (is (true? (lupaus-domain/sallittu-kuukausi-hoitovuodelle? lupaus 6 true 1 erikoisarvot)))
+      (is (false? (lupaus-domain/sallittu-kuukausi-hoitovuodelle? lupaus 9 true 1 erikoisarvot))))
+
+    (testing "Ilman erikoisarvoja käyttää perusarvoja"
+      (is (true? (lupaus-domain/sallittu-kuukausi-hoitovuodelle? lupaus 11 false 1 nil)))
+      (is (true? (lupaus-domain/sallittu-kuukausi-hoitovuodelle? lupaus 9 true 1 nil))))))
+
+(deftest vaaditut-vastauskuukaudet-hoitovuodelle-test
+  (let [lupaus {:kirjaus-kkt [10 11 12 1 2 3 4 5 6 7 8 9]
+                :paatos-kk 9}
+        erikoisarvot {:kirjaus-kkt [10 1 4 6]
+                      :paatos-kk 6}]
+
+    (testing "Yhdistää erikoisarvojen kirjaus- ja päätöskuukaudet"
+      (is (= #{10 1 4 6}
+             (lupaus-domain/vaaditut-vastauskuukaudet-hoitovuodelle lupaus nil 1 erikoisarvot))))
+
+    (testing "Suodattaa kuluvan kuukauden mukaan"
+      (is (= #{10}
+             (lupaus-domain/vaaditut-vastauskuukaudet-hoitovuodelle lupaus 11 1 erikoisarvot))))))

--- a/test/clj/harja/palvelin/palvelut/lupaus_palvelu_test.clj
+++ b/test/clj/harja/palvelin/palvelut/lupaus_palvelu_test.clj
@@ -7,7 +7,6 @@
             [harja.domain.lupaus-domain :as lupaus-domain]
             [harja.palvelin.palvelut.lupaus.lupaus-palvelu :as lupaus-palvelu]))
 
-
 (defn jarjestelma-fixture [testit]
   (alter-var-root #'jarjestelma
                   (fn [_]
@@ -793,3 +792,69 @@
     (is (thrown? Exception (tallenna-kk-pisteet +kayttaja-uuno+ urakka-id vuosi kuukausi pisteet tyyppi)))
     (is (thrown? Exception (poista-kuukausittaiset-pisteet +kayttaja-uuno+ {:urakka-id urakka-id
                                                                             :id (:id poistettava)})))))
+
+(deftest laske-lopullinen-kustannusennuste-test
+
+  (let [urakka-id (hae-oulun-maanteiden-hoitourakan-2019-2024-id)
+        hoitovuoden-alkupvm (pvm/luo-pvm 2019 9 1)
+
+        ;; Yksinkertaiset testikustannusennusteet
+        testikustannusennusteet
+        [{:kuukausi 10 :vuosi 2019 :tavoitehinta 1000000 :toteutuneet-kustannukset 950000
+          :maarapaiva (pvm/luo-pvm 2019 10 15) :id 1}
+         {:kuukausi 1 :vuosi 2020 :tavoitehinta 1100000 :toteutuneet-kustannukset 1050000
+          :maarapaiva (pvm/luo-pvm 2020 1 15) :id 2}]]
+
+    (testing "Funktio on olemassa ja palauttaa oikean tyyppisen tuloksen"
+      (let [tulos (lupaus-palvelu/laske-lopullinen-kustannusennuste
+                    (:db jarjestelma) urakka-id testikustannusennusteet hoitovuoden-alkupvm nil)]
+
+        ;; Perusvalidointi
+        (is (or (nil? tulos) (vector? tulos))
+          "Funktio palauttaa joko nil tai vektorin")
+
+        (when (vector? tulos)
+          (is (= 2 (count tulos)) "Palautettu vektori sisältää 2 tulosta")
+
+          ;; Testaa ensimmäinen tulos
+          (let [ensimmainen-tulos (first tulos)]
+            (when (map? ensimmainen-tulos)
+              (is (contains? ensimmainen-tulos :kustannusennuste-id) "Sisältää kustannusennuste-id")
+              (is (contains? ensimmainen-tulos :kuukausi) "Sisältää kuukausi")
+              (is (contains? ensimmainen-tulos :vuosi) "Sisältää vuosi")
+
+              ;; Tarkista perustiedot
+              (is (= 1 (:kustannusennuste-id ensimmainen-tulos)) "Oikea kustannusennuste-id")
+              (is (= 10 (:kuukausi ensimmainen-tulos)) "Oikea kuukausi")
+              (is (= 2019 (:vuosi ensimmainen-tulos)) "Oikea vuosi"))))))
+
+    (testing "Funktio käsittelee tyhjiä syötteitä"
+      (let [tulos (lupaus-palvelu/laske-lopullinen-kustannusennuste
+                    (:db jarjestelma) urakka-id [] hoitovuoden-alkupvm nil)]
+        (is (or (nil? tulos) (empty? tulos))
+          "Tyhjä kustannusennuste-lista palauttaa tyhjän tuloksen")))
+
+    (testing "Funktio käsittelee nil-parametrit gracefully"
+      (let [tulos (try
+                    (lupaus-palvelu/laske-lopullinen-kustannusennuste
+                      nil urakka-id testikustannusennusteet hoitovuoden-alkupvm nil)
+                    (catch Exception e
+                      :virhe-odotetusti))]
+        (is (or (nil? tulos) (= tulos :virhe-odotetusti))
+          "Nil database käsitellään gracefully")))
+
+    (testing "Integraatio domain-funktioiden kanssa"
+      ;; Testaa että domain-funktiot toimivat odotetulla tavalla
+      (let [syotteet {:ennustettu-tavoitehinta 1000000
+                      :ennustettu-kustannus 950000
+                      :toteutunut-tavoitehinta 1000000
+                      :toteutunut-kustannus 950000
+                      :hoitovuoden-alun-tavoitehinta 1200000}
+
+            tarkkuus-tulos (lupaus-domain/laske-kustannusennusteen-tarkkuus syotteet)
+            kokonais-tulos (lupaus-domain/laske-kustannusennuste-tulos syotteet 10)]
+
+        (is (:tarkkuus-prosentti tarkkuus-tulos) "Domain-funktio laskee tarkkuuden")
+        (is (:pisteet kokonais-tulos) "Domain-funktio laskee pisteet")
+        (is (number? (:tarkkuus-prosentti tarkkuus-tulos)) "Tarkkuus on numero")
+        (is (number? (:pisteet kokonais-tulos)) "Pisteet on numero")))))

--- a/test/clj/harja/palvelin/palvelut/lupaus_palvelu_test.clj
+++ b/test/clj/harja/palvelin/palvelut/lupaus_palvelu_test.clj
@@ -96,9 +96,9 @@
     (is (= 30 (:pisteet-max ryhma-1)) "ryhmä 1 maksimipisteet")
     (is (= 30 (:pisteet-ennuste ryhma-1)) "ryhmä 1 piste-ennuste")
 
-    (is (= 10 (:pisteet ryhma-2)) "ryhmä 2 pisteet")
+    (is (= 18 (:pisteet ryhma-2)) "ryhmä 2 pisteet")
     (is (= 0 (:kyselypisteet ryhma-2)) "ryhmä 2 kyselypisteet")
-    (is (= 10 (:pisteet-max ryhma-2)) "ryhmä 2 maksimipisteet")
+    (is (= 18 (:pisteet-max ryhma-2)) "ryhmä 2 maksimipisteet")
     (is (= 10 (:pisteet-ennuste ryhma-2)) "ryhmä 2 piste-ennuste")
 
     (is (= 10 (:pisteet ryhma-3)) "ryhmä 3 pisteet")
@@ -116,8 +116,8 @@
     (is (= 25 (:pisteet-max ryhma-5)) "ryhmä 5 maksimipisteet")
     (is (= 25 (:pisteet-ennuste ryhma-5)) "ryhmä 5 piste-ennuste")
 
-    (is (= 100 (->> ryhmat (map :pisteet-max) (reduce +))))
-    (is (= 100 (get-in vastaus [:yhteenveto :pisteet :maksimi]))
+    (is (= 108 (->> ryhmat (map :pisteet-max) (reduce +))))
+    (is (= 108 (get-in vastaus [:yhteenveto :pisteet :maksimi]))
         "koko hoitovuoden piste-maksimi")
     (is (= 100 (get-in vastaus [:yhteenveto :pisteet :ennuste]))
         "koko hoitovuoden piste-ennuste")
@@ -203,8 +203,8 @@
 
     (is (= 1 (:odottaa-kannanottoa ryhma-1)))
 
-    (is (= 10 (get-in vastaus [:yhteenveto :odottaa-kannanottoa]))
-      "Yhteensä 10 lupausta odottaa kannanottoa tammikuussa: kaikki paitsi 1, 2, 12 ja 14")
+    (is (= 11 (get-in vastaus [:yhteenveto :odottaa-kannanottoa]))
+      "Yhteensä 11 lupausta odottaa kannanottoa tammikuussa: kaikki paitsi 1, 2, 12 ja 14")
     (is (= 4 (get-in vastaus [:yhteenveto :merkitsevat-odottaa-kannanottoa]))
       "Yhteensä 4 lupausta odottaa merkitsevää kannanottoa tammikuussa: 4, 8, 11 ja 13")))
 
@@ -794,67 +794,40 @@
                                                                             :id (:id poistettava)})))))
 
 (deftest laske-lopullinen-kustannusennuste-test
-
   (let [urakka-id (hae-oulun-maanteiden-hoitourakan-2019-2024-id)
-        hoitovuoden-alkupvm (pvm/luo-pvm 2019 9 1)
+        hoitokauden-alkuvuosi 2019
+        toteutunut-tavoitehinta 1000000M
+        toteutunut-kustannus 950000M
+        valikatselmus-pvm (pvm/luo-pvm 2020 6 15)
+        user-id (:id +kayttaja-jvh+)]
 
-        ;; Yksinkertaiset testikustannusennusteet
-        testikustannusennusteet
-        [{:kuukausi 10 :vuosi 2019 :tavoitehinta 1000000 :toteutuneet-kustannukset 950000
-          :maarapaiva (pvm/luo-pvm 2019 10 15) :id 1}
-         {:kuukausi 1 :vuosi 2020 :tavoitehinta 1100000 :toteutuneet-kustannukset 1050000
-          :maarapaiva (pvm/luo-pvm 2020 1 15) :id 2}]]
+    (testing "Funktio suorittuu oikeilla parametreilla"
+      ;; Funktio ei palauta mitään - se tekee vain tietokantaoperaatioita
+      (is (nil? (lupaus-palvelu/laske-lopullinen-kustannusennuste!
+                  (:db jarjestelma) urakka-id hoitokauden-alkuvuosi
+                  toteutunut-tavoitehinta toteutunut-kustannus
+                  valikatselmus-pvm user-id))
+        "Funktio suorittuu onnistuneesti")
 
-    (testing "Funktio on olemassa ja palauttaa oikean tyyppisen tuloksen"
-      (let [tulos (lupaus-palvelu/laske-lopullinen-kustannusennuste
-                    (:db jarjestelma) urakka-id testikustannusennusteet hoitovuoden-alkupvm nil)]
-
-        ;; Perusvalidointi
-        (is (or (nil? tulos) (vector? tulos))
-          "Funktio palauttaa joko nil tai vektorin")
-
-        (when (vector? tulos)
-          (is (= 2 (count tulos)) "Palautettu vektori sisältää 2 tulosta")
-
-          ;; Testaa ensimmäinen tulos
-          (let [ensimmainen-tulos (first tulos)]
-            (when (map? ensimmainen-tulos)
-              (is (contains? ensimmainen-tulos :kustannusennuste-id) "Sisältää kustannusennuste-id")
-              (is (contains? ensimmainen-tulos :kuukausi) "Sisältää kuukausi")
-              (is (contains? ensimmainen-tulos :vuosi) "Sisältää vuosi")
-
-              ;; Tarkista perustiedot
-              (is (= 1 (:kustannusennuste-id ensimmainen-tulos)) "Oikea kustannusennuste-id")
-              (is (= 10 (:kuukausi ensimmainen-tulos)) "Oikea kuukausi")
-              (is (= 2019 (:vuosi ensimmainen-tulos)) "Oikea vuosi"))))))
-
-    (testing "Funktio käsittelee tyhjiä syötteitä"
-      (let [tulos (lupaus-palvelu/laske-lopullinen-kustannusennuste
-                    (:db jarjestelma) urakka-id [] hoitovuoden-alkupvm nil)]
-        (is (or (nil? tulos) (empty? tulos))
-          "Tyhjä kustannusennuste-lista palauttaa tyhjän tuloksen")))
-
-    (testing "Funktio käsittelee nil-parametrit gracefully"
-      (let [tulos (try
-                    (lupaus-palvelu/laske-lopullinen-kustannusennuste
-                      nil urakka-id testikustannusennusteet hoitovuoden-alkupvm nil)
-                    (catch Exception e
-                      :virhe-odotetusti))]
-        (is (or (nil? tulos) (= tulos :virhe-odotetusti))
-          "Nil database käsitellään gracefully")))
-
-    (testing "Integraatio domain-funktioiden kanssa"
+      ;; Tarkista että lopputilanne tallentui tietokantaan
+      (let [lopputilanteen-rivit (q (str "SELECT lopullinen_tavoitehinta, lopulliset_kustannukset "
+                                      "FROM lupaus_hoitovuosi_lopputilanne "
+                                      "WHERE \"urakka-id\" = " urakka-id
+                                      " AND hoitovuosi_alkuvuosi = " hoitokauden-alkuvuosi))]
+        (is (seq lopputilanteen-rivit) "Lopputilanne tallentui tietokantaan")
+        (when (seq lopputilanteen-rivit)
+          (let [[tavoite kustannus] (first lopputilanteen-rivit)]
+            (is (= toteutunut-tavoitehinta tavoite) "Tavoitehinta tallentui oikein")
+            (is (= toteutunut-kustannus kustannus) "Kustannukset tallentuivat oikein")))))
+    
+    (testing "Domain-funktioiden integraatio"
       ;; Testaa että domain-funktiot toimivat odotetulla tavalla
-      (let [syotteet {:ennustettu-tavoitehinta 1000000
-                      :ennustettu-kustannus 950000
-                      :toteutunut-tavoitehinta 1000000
-                      :toteutunut-kustannus 950000
-                      :hoitovuoden-alun-tavoitehinta 1200000}
-
-            tarkkuus-tulos (lupaus-domain/laske-kustannusennusteen-tarkkuus syotteet)
-            kokonais-tulos (lupaus-domain/laske-kustannusennuste-tulos syotteet 10)]
+      (let [syotteet {:ennustettu-tavoitehinta 1000000M
+                      :ennustettu-kustannus 950000M
+                      :toteutunut-tavoitehinta 1000000M
+                      :toteutunut-kustannus 950000M
+                      :hoitovuoden-alun-tavoitehinta 1200000M}
+            tarkkuus-tulos (lupaus-domain/laske-kustannusennusteen-tarkkuus syotteet)]
 
         (is (:tarkkuus-prosentti tarkkuus-tulos) "Domain-funktio laskee tarkkuuden")
-        (is (:pisteet kokonais-tulos) "Domain-funktio laskee pisteet")
-        (is (number? (:tarkkuus-prosentti tarkkuus-tulos)) "Tarkkuus on numero")
-        (is (number? (:pisteet kokonais-tulos)) "Pisteet on numero")))))
+        (is (number? (:tarkkuus-prosentti tarkkuus-tulos)) "Tarkkuus on numero")))))

--- a/tietokanta/src/main/resources/db/migration/V1_1201__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1201__.sql
@@ -1,6 +1,29 @@
 -- Lisää kustannusennuste tyyppi
 ALTER TYPE lupaustyyppi ADD VALUE 'kustannusennuste';
 
+-- Lisää taulu pisterajojen tallentamiselle urakan-alkuvuosi kohtaisena
+CREATE TABLE lupaus_kustannusennuste_kuukausi_pisteet (
+    id SERIAL PRIMARY KEY,
+    "urakan-alkuvuosi" INTEGER NOT NULL,
+    kuukausi INTEGER NOT NULL CHECK (kuukausi BETWEEN 1 AND 12),
+    paiva INTEGER NOT NULL,
+    kuvaus VARCHAR(100) NOT NULL,
+    pisterajat JSONB NOT NULL,
+    luotu TIMESTAMP DEFAULT NOW(),
+    luoja INTEGER REFERENCES kayttaja(id),
+    UNIQUE ("urakan-alkuvuosi", kuukausi, paiva)
+);
+
+-- Indeksit nopeuttamaan hakuja
+CREATE INDEX idx_kustannusennuste_kuukausi_pisteet_alkuvuosi 
+ON lupaus_kustannusennuste_kuukausi_pisteet ("urakan-alkuvuosi");
+
+CREATE INDEX idx_kustannusennuste_kuukausi_pisteet_kuukausi_paiva 
+ON lupaus_kustannusennuste_kuukausi_pisteet (kuukausi, paiva);
+
+CREATE INDEX idx_kustannusennuste_kuukausi_pisteet_jsonb 
+ON lupaus_kustannusennuste_kuukausi_pisteet USING gin (pisterajat);
+
 -- Lisää lupaus_kustannusennuste taulu
 CREATE TABLE lupaus_kustannusennuste (
     id SERIAL PRIMARY KEY,
@@ -35,16 +58,6 @@ IS 'Laskennassa käytetyt syöttöarvot JSON-muodossa';
 
 COMMENT ON COLUMN lupaus_kustannusennuste.laskentakaava_vaiheet 
 IS 'Laskentavaiheet ja väliarvot JSON-muodossa auditointia varten';
-
--- Lisää taulu pisterajojen tallentamiselle
-CREATE TABLE lupaus_kustannusennuste_pisteraja (
-    id SERIAL PRIMARY KEY,
-    "lupaus-id" INTEGER NOT NULL REFERENCES lupaus (id),
-    maarapaiva_kk INTEGER NOT NULL, -- 10, 1, 4, 6
-    maarapaiva_pv INTEGER NOT NULL, -- 15, 15, 30, 30
-    tarkkuus_prosentti DECIMAL(5,2) NOT NULL,
-    pisteet INTEGER NOT NULL
-);
 
 CREATE TABLE lupaus_hoitovuosi_lopputilanne (
     id SERIAL PRIMARY KEY,

--- a/tietokanta/src/main/resources/db/migration/V1_1201__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1201__.sql
@@ -1,0 +1,68 @@
+-- Lisää kustannusennuste tyyppi
+ALTER TYPE lupaustyyppi ADD VALUE 'kustannusennuste';
+
+-- Lisää lupaus_kustannusennuste taulu
+CREATE TABLE lupaus_kustannusennuste (
+    id SERIAL PRIMARY KEY,
+    "lupaus-id" INTEGER NOT NULL REFERENCES lupaus (id),
+    "urakka-id" INTEGER NOT NULL REFERENCES urakka (id),
+    hoitovuosi_alkuvuosi INTEGER NOT NULL,
+    maarapaiva DATE NOT NULL,
+    ennustettu_tavoitehinta DECIMAL(15,2),
+    ennustetut_kustannukset DECIMAL(15,2),
+    syotetty_pvm TIMESTAMP,
+    lasketut_pisteet INTEGER, -- Tämän ennusteen saamat pisteet
+    luoja INTEGER NOT NULL REFERENCES kayttaja (id),
+    luotu TIMESTAMP NOT NULL DEFAULT NOW(),
+    muokkaaja INTEGER REFERENCES kayttaja (id),
+    muokattu TIMESTAMP,
+    CONSTRAINT lupaus_kustannusennuste_unique UNIQUE ("lupaus-id", "urakka-id", maarapaiva)
+);
+
+-- Lisää taulu pisterajojen tallentamiselle
+CREATE TABLE lupaus_kustannusennuste_pisteraja (
+    id SERIAL PRIMARY KEY,
+    "lupaus-id" INTEGER NOT NULL REFERENCES lupaus (id),
+    maarapaiva_kk INTEGER NOT NULL, -- 10, 1, 4, 6
+    maarapaiva_pv INTEGER NOT NULL, -- 15, 15, 30, 30
+    tarkkuus_prosentti DECIMAL(5,2) NOT NULL,
+    pisteet INTEGER NOT NULL
+);
+
+CREATE TABLE lupaus_hoitovuosi_lopputilanne (
+    id SERIAL PRIMARY KEY,
+    "urakka-id" INTEGER NOT NULL REFERENCES urakka (id),
+    hoitovuosi_alkuvuosi INTEGER NOT NULL,
+    lopullinen_tavoitehinta DECIMAL(15,2),
+    lopulliset_kustannukset DECIMAL(15,2),
+    valikatselmus_pvm DATE,
+    vahvistaja INTEGER REFERENCES kayttaja (id),
+    vahvistettu TIMESTAMP,
+    CONSTRAINT hoitovuosi_lopputilanne_unique UNIQUE ("urakka-id", hoitovuosi_alkuvuosi)
+);
+
+-- Mahdollistaa hoitovuosikohtaiset erikoisarvot lupauksen kirjauskuukausille
+-- sekä (vaihtoehtoisesti) päätöskuukaudelle ja joustovaran kuukausille.
+--
+-- Varasuunnitelmalogiikka: jos tälle (lupaus_id, hoitovuosi_nro) ei löydy riviä,
+-- käytetään lupaus-taulun alkuperäisiä sarakkeita (kirjaus-kkt, paatos-kk, joustovara-kkta).
+
+CREATE TABLE lupaus_hoitovuoden_kirjauskuukaudet (
+    id BIGSERIAL PRIMARY KEY,
+    "lupaus-id" BIGINT NOT NULL REFERENCES lupaus(id) ON DELETE CASCADE,
+    "hoitovuosi-nro" INTEGER NOT NULL CHECK ("hoitovuosi-nro" >= 1 AND "hoitovuosi-nro" <= 15),
+    "kirjaus-kkt" INTEGER[] NOT NULL,
+    "paatos-kk" INTEGER CHECK ("paatos-kk" BETWEEN 0 AND 12),
+    "joustovara-kkta" INTEGER CHECK ("joustovara-kkta" BETWEEN 0 AND 12),
+    luotu TIMESTAMP WITHOUT TIME ZONE DEFAULT now(),
+    luoja INTEGER REFERENCES kayttaja(id),
+    CONSTRAINT lupaus_hoitovuoden_kirjauskuukaudet_unique UNIQUE ("lupaus-id", "hoitovuosi-nro")
+);
+
+CREATE INDEX idx_lupaus_hoitovuoden_kirjauskuukaudet_lupaus_id ON lupaus_hoitovuoden_kirjauskuukaudet ("lupaus-id");
+
+COMMENT ON TABLE lupaus_hoitovuoden_kirjauskuukaudet IS 'Hoitovuosikohtaiset erikoisarvot lupauksen kirjauskuukausille ja tarvittaessa päätös- sekä joustovaratiedoille.';
+COMMENT ON COLUMN lupaus_hoitovuoden_kirjauskuukaudet."hoitovuosi-nro" IS 'Hoitovuoden järjestysnumero (1 = ensimmäinen hoitovuosi urakan alusta).';
+COMMENT ON COLUMN lupaus_hoitovuoden_kirjauskuukaudet."kirjaus-kkt" IS 'Hoitovuoden kirjauskuukaudet, korvaa lupaus.kirjaus-kkt';
+COMMENT ON COLUMN lupaus_hoitovuoden_kirjauskuukaudet."paatos-kk" IS 'Hoitovuoden päätöskuukausi, korvaa lupaus.paatos-kk jos ei NULL';
+COMMENT ON COLUMN lupaus_hoitovuoden_kirjauskuukaudet."joustovara-kkta" IS 'Hoitovuoden joustovara kuukausissa, korvaa lupaus.joustovara-kkta jos ei NULL';

--- a/tietokanta/src/main/resources/db/migration/V1_1201__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1201__.sql
@@ -13,12 +13,28 @@ CREATE TABLE lupaus_kustannusennuste (
     syotetty_pvm TIMESTAMP,
     lasketut_pisteet INTEGER, -- Tämän ennusteen saamat pisteet
     tarkkuus_prosentti DECIMAL(5,2),
+    laskentakaava_versio VARCHAR(10),
+    laskentakaava_teksti TEXT,
+    laskentakaava_parametrit JSONB,
+    laskentakaava_vaiheet JSONB,
     luoja INTEGER NOT NULL REFERENCES kayttaja (id),
     luotu TIMESTAMP NOT NULL DEFAULT NOW(),
     muokkaaja INTEGER REFERENCES kayttaja (id),
     muokattu TIMESTAMP,
     CONSTRAINT lupaus_kustannusennuste_unique UNIQUE ("lupaus-id", "urakka-id", maarapaiva)
 );
+
+COMMENT ON COLUMN lupaus_kustannusennuste.laskentakaava_versio 
+IS 'Käytetyn laskentakaavan versionumero, esim. v1.0';
+
+COMMENT ON COLUMN lupaus_kustannusennuste.laskentakaava_teksti 
+IS 'Laskentakaava ihmisluettavassa muodossa';
+
+COMMENT ON COLUMN lupaus_kustannusennuste.laskentakaava_parametrit 
+IS 'Laskennassa käytetyt syöttöarvot JSON-muodossa';
+
+COMMENT ON COLUMN lupaus_kustannusennuste.laskentakaava_vaiheet 
+IS 'Laskentavaiheet ja väliarvot JSON-muodossa auditointia varten';
 
 -- Lisää taulu pisterajojen tallentamiselle
 CREATE TABLE lupaus_kustannusennuste_pisteraja (

--- a/tietokanta/src/main/resources/db/migration/V1_1201__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1201__.sql
@@ -12,6 +12,7 @@ CREATE TABLE lupaus_kustannusennuste (
     ennustetut_kustannukset DECIMAL(15,2),
     syotetty_pvm TIMESTAMP,
     lasketut_pisteet INTEGER, -- Tämän ennusteen saamat pisteet
+    tarkkuus_prosentti DECIMAL(5,2),
     luoja INTEGER NOT NULL REFERENCES kayttaja (id),
     luotu TIMESTAMP NOT NULL DEFAULT NOW(),
     muokkaaja INTEGER REFERENCES kayttaja (id),

--- a/tietokanta/src/main/resources/db/migration/V1_1201__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1201__.sql
@@ -29,7 +29,7 @@ CREATE TABLE lupaus_kustannusennuste (
     id SERIAL PRIMARY KEY,
     "lupaus-id" INTEGER NOT NULL REFERENCES lupaus (id),
     "urakka-id" INTEGER NOT NULL REFERENCES urakka (id),
-    hoitovuosi_alkuvuosi INTEGER NOT NULL,
+    hoitovuosi INTEGER NOT NULL,
     maarapaiva DATE NOT NULL,
     ennustettu_tavoitehinta DECIMAL(15,2),
     ennustetut_kustannukset DECIMAL(15,2),

--- a/tietokanta/testidata/laskut.sql
+++ b/tietokanta/testidata/laskut.sql
@@ -225,5 +225,65 @@ INSERT INTO kulu_kohdistus (kulu, rivi, toimenpideinstanssi, tehtavaryhma, maksu
 ((select id from kulu where kokonaissumma = 10.20 AND erapaiva = '2020-04-22'),
  1, tinst_mhu_hoidon_johto, tehtava_erillishankinnat, 'kokonaishintainen'::MAKSUERATYYPPI, 'hankintakulu', 10.20, current_timestamp, kayttaja_id);
 
+-- Lupausten kustannukset
+
+-- Lisää budjetoituja kustannuksia eri toimenpiteille hoitovuosi 4 (2023-2024)
+INSERT INTO kustannusarvioitu_tyo (sopimus, toimenpideinstanssi, tehtavaryhma, summa, summa_indeksikorjattu, vuosi, kuukausi, tyyppi, luoja, luotu) 
+VALUES 
+-- Talvihoitokustannuksia (käytetään A - Talvihoito tehtäväryhmää)
+((SELECT id FROM sopimus WHERE urakka = (SELECT id FROM urakka WHERE sampoid = '1242141-II3') LIMIT 1),
+ (SELECT tpi.id FROM toimenpideinstanssi tpi JOIN toimenpide tp ON tpi.toimenpide = tp.id WHERE tpi.urakka = (SELECT id FROM urakka WHERE sampoid = '1242141-II3') AND tp.koodi = '23104' LIMIT 1),
+ (SELECT id FROM tehtavaryhma WHERE yksiloiva_tunniste = '6446eb02-5216-45a8-90aa-be60f3890aac'),
+ 15000, 15450, 2023, 10, 'kokonaishintainen', 1, NOW()),
+
+-- Liikenneympäristön hoitokustannuksia (käytetään B - Liikenneympäristön hoito tehtäväryhmää)
+((SELECT id FROM sopimus WHERE urakka = (SELECT id FROM urakka WHERE sampoid = '1242141-II3') LIMIT 1),
+ (SELECT tpi.id FROM toimenpideinstanssi tpi JOIN toimenpide tp ON tpi.toimenpide = tp.id WHERE tpi.urakka = (SELECT id FROM urakka WHERE sampoid = '1242141-II3') AND tp.koodi = '23116' LIMIT 1),
+ (SELECT id FROM tehtavaryhma WHERE yksiloiva_tunniste = '1855032a-2bb3-46d4-b9b4-c6d4e4c25d05'), 
+ 8000, 8240, 2023, 11, 'kokonaishintainen', 1, NOW()),
+
+-- Sorateiden hoitokustannuksia (käytetään C - Sorateiden hoito tehtäväryhmää)
+((SELECT id FROM sopimus WHERE urakka = (SELECT id FROM urakka WHERE sampoid = '1242141-II3') LIMIT 1),
+ (SELECT tpi.id FROM toimenpideinstanssi tpi JOIN toimenpide tp ON tpi.toimenpide = tp.id WHERE tpi.urakka = (SELECT id FROM urakka WHERE sampoid = '1242141-II3') AND tp.koodi = '23124' LIMIT 1),
+ (SELECT id FROM tehtavaryhma WHERE yksiloiva_tunniste = 'dc151971-facc-48c4-90c9-e429987206e1'),
+ 5000, 5150, 2023, 12, 'kokonaishintainen', 1, NOW());
+
+-- Lisää toteutuneita kuluja
+INSERT INTO kulu (urakka, erapaiva, kokonaissumma, luoja, luotu, koontilaskun_kuukausi)
+VALUES 
+((SELECT id FROM urakka WHERE sampoid = '1242141-II3'), '2023-10-15', 66000, 1, NOW(), 'lokakuu/4-hoitovuosi'),
+((SELECT id FROM urakka WHERE sampoid = '1242141-II3'), '2023-11-20', 35000, 1, NOW(), 'lokakuu/4-hoitovuosi'),
+((SELECT id FROM urakka WHERE sampoid = '1242141-II3'), '2023-12-10', 21000, 1, NOW(), 'lokakuu/4-hoitovuosi');
+
+-- Kohdista kulut toimenpiteisiin (käytetään tehtäväryhmiä)
+INSERT INTO kulu_kohdistus (kulu, rivi, summa, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, tyyppi, luoja, luotu, tavoitehintainen)
+VALUES 
+-- Talvihoito
+((SELECT id FROM kulu WHERE urakka = (SELECT id FROM urakka WHERE sampoid = '1242141-II3') AND kokonaissumma = 66000 LIMIT 1),
+ 1, 
+ 66000,
+ (SELECT tpi.id FROM toimenpideinstanssi tpi JOIN toimenpide tp ON tpi.toimenpide = tp.id WHERE tpi.urakka = (SELECT id FROM urakka WHERE sampoid = '1242141-II3') AND tp.koodi = '23104' LIMIT 1),
+ (SELECT id FROM tehtavaryhma WHERE yksiloiva_tunniste = '6446eb02-5216-45a8-90aa-be60f3890aac'),
+ 'kokonaishintainen'::MAKSUERATYYPPI,
+ 'hankintakulu', 1, NOW(), TRUE),
+
+-- Liikenneympäristön hoito  
+((SELECT id FROM kulu WHERE urakka = (SELECT id FROM urakka WHERE sampoid = '1242141-II3') AND kokonaissumma = 35000 LIMIT 1),
+ 1,  
+ 35000,
+ (SELECT tpi.id FROM toimenpideinstanssi tpi JOIN toimenpide tp ON tpi.toimenpide = tp.id WHERE tpi.urakka = (SELECT id FROM urakka WHERE sampoid = '1242141-II3') AND tp.koodi = '23116' LIMIT 1),
+ (SELECT id FROM tehtavaryhma WHERE yksiloiva_tunniste = '1855032a-2bb3-46d4-b9b4-c6d4e4c25d05'),
+ 'kokonaishintainen'::MAKSUERATYYPPI,
+ 'hankintakulu', 1, NOW(), TRUE),
+
+-- Sorateiden hoito
+((SELECT id FROM kulu WHERE urakka = (SELECT id FROM urakka WHERE sampoid = '1242141-II3') AND kokonaissumma = 21000 LIMIT 1),
+ 1,  
+ 21000,
+ (SELECT tpi.id FROM toimenpideinstanssi tpi JOIN toimenpide tp ON tpi.toimenpide = tp.id WHERE tpi.urakka = (SELECT id FROM urakka WHERE sampoid = '1242141-II3') AND tp.koodi = '23124' LIMIT 1),
+ (SELECT id FROM tehtavaryhma WHERE yksiloiva_tunniste = 'dc151971-facc-48c4-90c9-e429987206e1'),
+ 'kokonaishintainen'::MAKSUERATYYPPI,
+ 'hankintakulu', 1, NOW(), TRUE);
+
         END
 $$ LANGUAGE plpgsql;

--- a/tietokanta/testidata/lupaus_testidata.sql
+++ b/tietokanta/testidata/lupaus_testidata.sql
@@ -259,7 +259,7 @@ $$ LANGUAGE plpgsql;
   null,
   'kustannusennuste',
   10,
-  '{10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8, 9}',
+  '{1,4,6,8}',
   9,
   0,
   'Testi: Kustannusennustelupaus',
@@ -270,5 +270,4 @@ $$ LANGUAGE plpgsql;
 -- 
 INSERT INTO lupaus_hoitovuoden_kirjauskuukaudet ("lupaus-id", "hoitovuosi-nro", "kirjaus-kkt", "paatos-kk", "joustovara-kkta", luoja)
 VALUES 
-  ((SELECT id FROM lupaus WHERE jarjestys = 99 AND "urakan-alkuvuosi" = 2019 AND kuvaus = 'Testi: Kustannusennustelupaus'), 1, '{10,1,4,6}', 9, 0, 1),  -- Ensimmäinen hoitovuosi: erikoiskuukaudet
-  ((SELECT id FROM lupaus WHERE jarjestys = 99 AND "urakan-alkuvuosi" = 2019 AND kuvaus = 'Testi: Kustannusennustelupaus'), 2, '{10,1,4,6}', 9, 0, 1);  -- Toinen hoitovuosi: samat erikoiskuukaudet
+  ((SELECT id FROM lupaus WHERE jarjestys = 99 AND "urakan-alkuvuosi" = 2019 AND kuvaus = 'Testi: Kustannusennustelupaus'), 1, '{10,1,4,6}', 9, 0, 1);  -- Ensimmäinen hoitovuosi: erikoiskuukaudet

--- a/tietokanta/testidata/lupaus_testidata.sql
+++ b/tietokanta/testidata/lupaus_testidata.sql
@@ -258,16 +258,57 @@ $$ LANGUAGE plpgsql;
   (SELECT id FROM lupausryhma WHERE otsikko = 'Toiminnan suunnitelmallisuus' AND "urakan-alkuvuosi" = 2021),
   null,
   'kustannusennuste',
-  10,
+  8,
   '{1,4,6,8}',
-  9,
+  6,
   0,
-  'Testi: Kustannusennustelupaus',
-  'Testilupaus kustannusennusteen syöttöä ja testausta varten.',
+  'Hoitovuoden lopun tavoitehinnan ja toteutuvien kustannuksien ennustaminen',
+  'Ennustamme urakan hoitovuoden lopun tavoitehintaa ja toteutuvia kustannuksia 4 kertaa vuodessa alla mainittuihin määräpäiviin mennessä.',
   2019
 );
 
--- 
+-- Ensimmäinen hoitovuosi: erikoiskuukaudet
 INSERT INTO lupaus_hoitovuoden_kirjauskuukaudet ("lupaus-id", "hoitovuosi-nro", "kirjaus-kkt", "paatos-kk", "joustovara-kkta", luoja)
 VALUES 
-  ((SELECT id FROM lupaus WHERE jarjestys = 99 AND "urakan-alkuvuosi" = 2019 AND kuvaus = 'Testi: Kustannusennustelupaus'), 1, '{10,1,4,6}', 9, 0, 1);  -- Ensimmäinen hoitovuosi: erikoiskuukaudet
+  ((SELECT id FROM lupaus
+   WHERE jarjestys = 99 
+  AND "urakan-alkuvuosi" = 2019 
+  AND kuvaus = 'Hoitovuoden lopun tavoitehinnan ja toteutuvien kustannuksien ennustaminen'), 
+  1, 
+  '{10,1,4,6}', 
+  6,
+  0, 
+  1);  
+
+
+INSERT INTO lupaus_kustannusennuste_kuukausi_pisteet ("urakan-alkuvuosi", kuukausi, paiva, kuvaus, pisterajat) VALUES
+-- 2021 urakat
+(2021, 10, 15, 'Lokakuu 15. päivä (2021 urakat)', '[
+    {"operaattori": "≤", "raja": 7.0, "pisteet": 8, "kuvaus": "≤ 7,0%"}, 
+    {"operaattori": "≤", "raja": 9.0, "pisteet": 4, "kuvaus": "≤ 9,0%"}, 
+    {"operaattori": ">", "raja": 9.0, "pisteet": 1, "kuvaus": "> 9,0%"}
+]'),
+
+(2021, 1, 15, 'Tammikuu 15. päivä (2021 urakat)', '[
+    {"operaattori": "≤", "raja": 4.0, "pisteet": 8, "kuvaus": "≤ 4,0%"}, 
+    {"operaattori": "≤", "raja": 6.0, "pisteet": 4, "kuvaus": "≤ 6,0%"}, 
+    {"operaattori": ">", "raja": 6.0, "pisteet": 1, "kuvaus": "> 6,0%"}
+]'),
+
+(2021, 4, 30, 'Huhtikuu 30. päivä (2021 urakat)', '[
+    {"operaattori": "≤", "raja": 2.0, "pisteet": 8, "kuvaus": "≤ 2,0%"}, 
+    {"operaattori": "≤", "raja": 3.0, "pisteet": 4, "kuvaus": "≤ 3,0%"}, 
+    {"operaattori": ">", "raja": 3.0, "pisteet": 1, "kuvaus": "> 3,0%"}
+]'),
+
+(2021, 6, 30, 'Kesäkuu 30. päivä (2021 urakat)', '[
+    {"operaattori": "≤", "raja": 1.0, "pisteet": 8, "kuvaus": "≤ 1,0%"}, 
+    {"operaattori": "≤", "raja": 2.0, "pisteet": 4, "kuvaus": "≤ 2,0%"}, 
+    {"operaattori": ">", "raja": 2.0, "pisteet": 1, "kuvaus": "> 2,0%"}
+]'),
+
+(2021, 8, 15, 'Elokuu 15. päivä (2021 urakat)', '[
+    {"operaattori": "≤", "raja": 7.0, "pisteet": 8, "kuvaus": "≤ 7,0%"}, 
+    {"operaattori": "≤", "raja": 9.0, "pisteet": 4, "kuvaus": "≤ 9,0%"}, 
+    {"operaattori": ">", "raja": 9.0, "pisteet": 1, "kuvaus": "> 9,0%"}
+]');

--- a/tietokanta/testidata/lupaus_testidata.sql
+++ b/tietokanta/testidata/lupaus_testidata.sql
@@ -239,3 +239,36 @@ DO $$
         PERFORM luo_lupauksen_vaihtoehto(3, 2021, '> 5,3', 15, null,null, 3, null, ryhma_otsikko_id_2);
     END
 $$ LANGUAGE plpgsql;
+
+-- Kustannusennusten testausta varten
+ INSERT INTO lupaus (
+  jarjestys,
+  "lupausryhma-id",
+  "urakka-id",
+  lupaustyyppi,
+  pisteet,
+  "kirjaus-kkt",
+  "paatos-kk",
+  "joustovara-kkta",
+  kuvaus,
+  sisalto,
+  "urakan-alkuvuosi"
+) VALUES (
+  99, -- testijärjestys, muuta tarvittaessa
+  (SELECT id FROM lupausryhma WHERE otsikko = 'Toiminnan suunnitelmallisuus' AND "urakan-alkuvuosi" = 2021),
+  null,
+  'kustannusennuste',
+  10,
+  '{10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8, 9}',
+  9,
+  0,
+  'Testi: Kustannusennustelupaus',
+  'Testilupaus kustannusennusteen syöttöä ja testausta varten.',
+  2019
+);
+
+-- 
+INSERT INTO lupaus_hoitovuoden_kirjauskuukaudet ("lupaus-id", "hoitovuosi-nro", "kirjaus-kkt", "paatos-kk", "joustovara-kkta", luoja)
+VALUES 
+  ((SELECT id FROM lupaus WHERE jarjestys = 99 AND "urakan-alkuvuosi" = 2019 AND kuvaus = 'Testi: Kustannusennustelupaus'), 1, '{10,1,4,6}', 9, 0, 1),  -- Ensimmäinen hoitovuosi: erikoiskuukaudet
+  ((SELECT id FROM lupaus WHERE jarjestys = 99 AND "urakan-alkuvuosi" = 2019 AND kuvaus = 'Testi: Kustannusennustelupaus'), 2, '{10,1,4,6}', 9, 0, 1);  -- Toinen hoitovuosi: samat erikoiskuukaudet


### PR DESCRIPTION
- [ ] Refaktoroinnista mielessä että lupaus_kustannusennuste_kuukausi_pisteet voisi muuttaa toimimaan urakan-alkuvuosi filtteröinnin sijaan filtteröitymään lupaus-idn perusteella jotta olisi uniikimpi tapa erottaa rivit mitkä käytössä lupauksella.
- [x] Tällä hetkellä taulukko on embeddanu hiccup komponenttina -> Voisi kopsata html:n ja siirtää migraatioon?
- [ ] Tällä hetkellä ei validaatiota onko molemmat arvot syötetty -> voisi vähentää ihmettelyä
- [ ] Isompi refaktorointi olisi vielä Panun kanssa juttelun jälkeen muuttaa laskenta kaavaa vastaamaan conflun hieman epäselvää speksiä eli ensimmäisen vuoden jälkeen elokuun tulisi ennustaa seuraavaa hoitovuotta eli käsitimme että se tulisi poimia laskenta kaavaan mukaan edeltävältä hoitovuodelta - nyt elokuu on osa lupausnäkymässä valittua hoitovuotta.
- [ ] Koodia voisi vielä jossain määrin viedä geneerisempään muotoon vähemmän haaroitusta kustannusennusteeseen ja enemmän geneerisiin input syöttö tukeen