### PR TITLE
Harja 1802 siirra toteutuneet kustannukset

### DIFF
--- a/src/clj/harja/kyselyt/toteutuneet_kustannukset.sql
+++ b/src/clj/harja/kyselyt/toteutuneet_kustannukset.sql
@@ -7,17 +7,17 @@ SELECT count(*) as maara
    AND (kt.tehtavaryhma = (SELECT id FROM tehtavaryhma WHERE yksiloiva_tunniste = '37d3752c-9951-47ad-a463-c1704cf22f4c') -- Erillishankinnat (W)
      OR kt.tehtava in (SELECT id
                       FROM tehtava t
-                      WHERE t.yksiloiva_tunniste = '8376d9c4-3daf-4815-973d-cd95ca3bb388' -- "Toimistotarvike- ja ICT-kulut, tiedotus, opastus, kokousten järjestäminen jne."
-                         OR t.yksiloiva_tunniste = 'c9712637-fbec-4fbd-ac13-620b5619c744') -- Hoitourakan työnjohto
+                      WHERE t.yksiloiva_tunniste = '8376d9c4-3daf-4815-973d-cd95ca3bb388'   -- "Toimistotarvike- ja ICT-kulut, tiedotus, opastus, kokousten järjestäminen jne."
+                         OR t.yksiloiva_tunniste = 'c9712637-fbec-4fbd-ac13-620b5619c744'   -- Hoitourakan työnjohto
+                        OR t.yksiloiva_tunniste =   '53647ad8-0632-4dd3-8302-8dfae09908c8') -- Hoidonjohtopalkkio
      )
    -- Verrataan tyyliin: 2020-02-01 00:00:00.000000 < 2021-02-01 00:00:00.000000
-   AND (SELECT (date_trunc('MONTH', format('%s-%s-%s', kt.vuosi, kt.kuukausi, 1)::DATE))) < date_trunc('month', current_date)
+   AND (SELECT (date_trunc('MONTH', format('%s-%s-%s', kt.vuosi, kt.kuukausi, 1)::DATE))) < date_trunc('month', :pvm::DATE) + interval '10 day'
  UNION ALL
 SELECT count(*) as maara
   FROM johto_ja_hallintokorvaus jjh
 WHERE jjh."siirretty?" = false
- AND (SELECT (date_trunc('MONTH', format('%s-%s-%s', jjh.vuosi, jjh.kuukausi, 1)::DATE))) <
-      date_trunc('month', current_date)) AS m;
+ AND (SELECT (date_trunc('MONTH', format('%s-%s-%s', jjh.vuosi, jjh.kuukausi, 1)::DATE))) < date_trunc('month', :pvm::DATE) + interval '10 day') AS m;
 
 -- name: siirra-budjetoidut-tyot-toteutumiin
 select siirra_budjetoidut_tyot_toteumiin(:pvm);

--- a/src/clj/harja/palvelin/ajastetut_tehtavat/kustannusarvioiden_toteumat.clj
+++ b/src/clj/harja/palvelin/ajastetut_tehtavat/kustannusarvioiden_toteumat.clj
@@ -25,19 +25,12 @@
   [db & args]
   (let [annettu-nyt (first args)
         nyt (or annettu-nyt (pvm/nyt))
-        nyt-paiva (pvm/paiva nyt)
-        onko-kuukauden-ensimmainen-paiva? (= nyt-paiva 1)
-        onko-siirto-tehty? (if onko-kuukauden-ensimmainen-paiva?
-                             ;; Kuukauden ensimmäisenä päivänä tehdään aina siirto
-                             false
-                             ;; Tarkista onko siirto tehty
-                             (onko-toteumat-jo-siirretty? db))]
-    (log/info "Siirretään kustannusarvoitu_tyo taulusta toteutueet_kustannukset tauluun, jos on kuukauden ensimmäinen päivä tai jos siirtoa ei ole vielä tehty.")
+        onko-siirto-tehty? (onko-toteumat-jo-siirretty? db nyt)]
+    (log/info "Siirretään kustannusarvoitu_tyo taulusta toteutueet_kustannukset tauluun kuukauden 10. päivä tai jos siirtoa ei ole vielä tehty.")
     (if (not onko-siirto-tehty?)
       (do
         ;; Siirrä rivit
         (q/siirra-budjetoidut-tyot-toteutumiin db {:pvm nyt})
-
         (println "Siirto valamis!"))
       (log/info "Ei tehdä toista kertaa."))))
 

--- a/src/clj/harja/palvelin/ajastetut_tehtavat/kustannusarvioiden_toteumat.clj
+++ b/src/clj/harja/palvelin/ajastetut_tehtavat/kustannusarvioiden_toteumat.clj
@@ -12,8 +12,8 @@
   Oletus on lähtökohtaisesti niin, että jos yksikin siirto on tehty, kaikki siirrot on tehty.
   Joka aiheuttaa sen ongelman, että jos on mahdollista muokata menneisyyden budjetteja, niin niitä ei ikinä
   siirretä toteutuneiksi."
-  [db]
-  (let [siirtamattomat (q/hae-siirtamattomat-kustannukset db)
+  [db pvm]
+  (let [siirtamattomat (q/hae-siirtamattomat-kustannukset db {:pvm pvm})
         _ (log/debug "Näin monta riviä on vielä siirtämättä: " (pr-str siirtamattomat))]
     (if (> siirtamattomat 0)
       false

--- a/test/clj/harja/palvelin/ajastetut_tehtavat/kustannusarvioiden_toteumat_siirto_test.clj
+++ b/test/clj/harja/palvelin/ajastetut_tehtavat/kustannusarvioiden_toteumat_siirto_test.clj
@@ -1,8 +1,10 @@
 (ns harja.palvelin.ajastetut-tehtavat.kustannusarvioiden-toteumat-siirto-test
   (:require [clojure.test :refer :all]
+            [harja.pvm :as pvm]
             [taoensso.timbre :as log]
             [clj-time.periodic :refer [periodic-seq]]
             [harja.palvelin.ajastetut-tehtavat.kustannusarvioiden-toteumat :as kustannusarvioiden-toteumat]
+            [harja.kyselyt.toteutuneet-kustannukset :as toteutuneet-kustannukset-kyselyt]
             [harja.testi :refer :all]
             [harja.palvelin.komponentit.fim-test :as fim-test]
             [harja.palvelin.komponentit.tietokanta :as tietokanta]
@@ -32,23 +34,23 @@
 
 (deftest siirra-kustanukset-toimii-idempotentisti
   (let [testitietokanta (:db jarjestelma)
-        hae-maarat (fn []
-                     [(first (first (q "SELECT count(*) FROM kustannusarvioitu_tyo
-                                        WHERE \"siirretty?\" ")))
-                      (first (first
-                               (q "SELECT count(*) FROM johto_ja_hallintokorvaus
-                                   WHERE \"siirretty?\" ")))])
-        merkkaa-kaikki (fn []
-                        (u "UPDATE kustannusarvioitu_tyo SET \"siirretty?\" = false;")
-                        (u "UPDATE johto_ja_hallintokorvaus SET \"siirretty?\" = false;"))
-        _ (merkkaa-kaikki)
-        pvm (luo-pvm 2021 7 8)
+        toimiva-vuosi (inc (pvm/vuosi (pvm/nyt)))
+        pvm (luo-pvm toimiva-vuosi 3 8)
+        merkkaa-kaikki-siirtamattomaksi (fn []
+                                          (u "UPDATE kustannusarvioitu_tyo SET \"siirretty?\" = false;")
+                                          (u "UPDATE johto_ja_hallintokorvaus SET \"siirretty?\" = false;"))
+        siirtamattomat-aluksi (toteutuneet-kustannukset-kyselyt/hae-siirtamattomat-kustannukset testitietokanta {:pvm pvm})
+        _ (merkkaa-kaikki-siirtamattomaksi)
+        siirtamattomat (toteutuneet-kustannukset-kyselyt/hae-siirtamattomat-kustannukset testitietokanta {:pvm pvm})
         _ (kustannusarvioiden-toteumat/siirra-kustannukset testitietokanta pvm)
-        maarat-alussa (hae-maarat)
-        _ (merkkaa-kaikki)
-        _ (kustannusarvioiden-toteumat/siirra-kustannukset testitietokanta pvm)
-        maarat-lopussa (hae-maarat)
-        _ (kustannusarvioiden-toteumat/siirra-kustannukset testitietokanta pvm)
-        maarat-lopussa-toinen-kutsu (hae-maarat)]
-    (is (= maarat-alussa maarat-lopussa maarat-lopussa-toinen-kutsu))))
+        siirtamattomat-siirron-jalkeen (toteutuneet-kustannukset-kyselyt/hae-siirtamattomat-kustannukset testitietokanta {:pvm pvm})
+        uusi-pvm (luo-pvm toimiva-vuosi 6 15)
+        _ (kustannusarvioiden-toteumat/siirra-kustannukset testitietokanta uusi-pvm)
+        siirtamattomat-myohemmin (toteutuneet-kustannukset-kyselyt/hae-siirtamattomat-kustannukset testitietokanta {:pvm (luo-pvm toimiva-vuosi 12 15)})
+        _ (kustannusarvioiden-toteumat/siirra-kustannukset testitietokanta pvm)]
+
+    (is (not= siirtamattomat siirtamattomat-aluksi))  ;; Siirron jälkeen siirtämättömien määrä muuttui
+    (is (< 0M siirtamattomat))  ;; Siirretty? = false merkinnän jälkeen siirtämättömiä löytyy
+    ;; Varmistetaan, että kaikkia ei ole siirretty, vaan että päivämäärä valinta toimii
+    (is (< siirtamattomat-siirron-jalkeen siirtamattomat-myohemmin))))
 


### PR DESCRIPTION
Siirrä suunnitellut/budjetoidut kustannukset toteutuneiksi kustannuksiksi joka kuukauden 10 päivä.
Eli jos kustannusarvioitu_tyo tai johto_ja_hallintokorvaus tauluissa on rivi, joka kohdistuu esim kuukaudelle 2025-10 (2025 vuoden lokakuu) niin 10. päivä lokakuuta summa siirtyy toteutuneet_kustannukset tauluun ja rivi merkataan siirtyneeksi.