### PR TITLE
HARJA-1818 Palauta lisätty paksuus MS- ja SJYR-toimenpiteille

### DIFF
--- a/src/clj/harja/kyselyt/paallystys.sql
+++ b/src/clj/harja/kyselyt/paallystys.sql
@@ -675,6 +675,7 @@ UPDATE pot2_alusta
        tr_ajorata = :tr-ajorata,
        tr_kaista = :tr-kaista,
        toimenpide = :toimenpide,
+       lisatty_paksuus = :lisatty-paksuus,
        massamenekki = :massamenekki,
        murske = :murske,
        kasittelysyvyys = :kasittelysyvyys,
@@ -694,7 +695,7 @@ UPDATE pot2_alusta
 -- name: luo-pot2-alusta<!
 INSERT INTO pot2_alusta (tr_numero, tr_alkuetaisyys, tr_alkuosa, tr_loppuetaisyys,
                          tr_loppuosa, tr_ajorata, tr_kaista, toimenpide,
-                         massamenekki, murske,
+                         lisatty_paksuus, massamenekki, murske,
                          kasittelysyvyys, leveys, pinta_ala,
                          kokonaismassamaara, massa, sideaine,
                          sideainepitoisuus, sideaine2,
@@ -702,7 +703,7 @@ INSERT INTO pot2_alusta (tr_numero, tr_alkuetaisyys, tr_alkuosa, tr_loppuetaisyy
                          pot2_id)
 VALUES (:tr-numero, :tr-alkuetaisyys, :tr-alkuosa, :tr-loppuetaisyys,
         :tr-loppuosa, :tr-ajorata, :tr-kaista, :toimenpide,
-        :massamenekki, :murske,
+        :lisatty-paksuus, :massamenekki, :murske,
         :kasittelysyvyys, :leveys, :pinta-ala,
         :kokonaismassamaara, :massa, :sideaine,
         :sideainepitoisuus, :sideaine2,

--- a/src/cljc/harja/domain/pot2.cljc
+++ b/src/cljc/harja/domain/pot2.cljc
@@ -21,9 +21,13 @@
 (def +rem-tas-toimenpide+ 4)
 
 (def alusta-toimenpide-kaikki-lisaavaimet
+  {:lisatty-paksuus {:nimi :lisatty-paksuus :otsikko "Lisätty paksuus" :yksikko "cm"
+                     :validoi [[:rajattu-numero-tai-tyhja 1 500 "Arvon tulee olla välillä 1-500cm"]]
+                     :tyyppi :positiivinen-numero :kokonaisluku? true
+                     :validoi-kentta-fn (fn [numero] (v/validoi-numero numero 1 500 0))}
   ;; Alustatoimenpiteet näkyvät päällystysilmoituksessa koosteena Toimenpiteen tiedot-sarakkeessa.
   ;; :lisatty-paksuus on poistettu koosteesta lokakuussa 2025
-   {:massamenekki {:nimi :massamenekki :otsikko "Massamenekki" :yksikko "kg/m²"
+   :massamenekki {:nimi :massamenekki :otsikko "Massamenekki" :yksikko "kg/m²"
                   :tyyppi :positiivinen-numero :desimaalien-maara 1
                   :validoi-kentta-fn (fn [numero] (v/validoi-numero numero 0 1000000 1))}
    :murske {:nimi :murske :otsikko "Murske"
@@ -125,10 +129,11 @@
                                                22           ;; ABS
                                                [:massa :pinta-ala :kokonaismassamaara :massamenekki]
                                                23           ;; MS
-                                               [:murske]
+                                               [:lisatty-paksuus :murske]
                                                24           ;; SJYR
                                                [:kasittelysyvyys
-                                                {:nimi :murske :pakollinen? false}]
+                                                {:nimi :murske :pakollinen? false}
+                                                {:nimi :lisatty-paksuus :jos :murske}]
                                                31           ;; TASK
                                                []
                                                32           ;; TAS


### PR DESCRIPTION
Katselmoidessa voi verrata tähän pulleroon, jossa poistettiin liikaa: 
https://github.com/finnishtransportagency/harja/pull/4101/

Tämän pulleron tarkoitus on palauttaa lisätty paksuus muuten, mutta ei MV-toimenpiteelle.