### PR TITLE
HARJA-1819 Ympäristöraportilla sama tehtävä kahdella rivillä

### DIFF
--- a/src/clj/harja/palvelin/raportointi/raportit/ymparisto.sql
+++ b/src/clj/harja/palvelin/raportointi/raportit/ymparisto.sql
@@ -50,6 +50,7 @@ SELECT
     CASE
         WHEN tk.yksikko = 'tonni'
             THEN 't'
+            ELSE tk.yksikko
         END AS materiaali_yksikko,
     'paikkausmateriaali'::MATERIAALITYYPPI AS materiaali_tyyppi,
     date_trunc('month', rtmaarat.alkanut) AS kk,


### PR DESCRIPTION
HARJA-1819
Jos paikkaustehtävän yksikkö ei ole tonni, näkyy se ympäristöraportilla kahdella rivillä: toisella rivillä on suunnittelutieto ja toisella toteumatieto.

Johtui siitä, että suunniteltujen ja toteumien yksikkö oli eri. Haetaan molempiin yksikkö mukaan niin korjaantuu.


