### PR TITLE
Korjaa kustannusennusteen näkyvyys kun ei olla määräpäivän kuukaudessa

### DIFF
--- a/src/cljs/harja/views/urakka/lupaus/vastauslomake.cljs
+++ b/src/cljs/harja/views/urakka/lupaus/vastauslomake.cljs
@@ -232,8 +232,8 @@
          [:div.margin-top-16.text-left
           [sulje-nappi e! {:luokka "pull-right"}]]]]]
       
-       ;; Jos määräpäivä ohitettu eikä tietoja syötetty ajoissa
-      ei-maarapaivan-kuukausi?
+      ;; Jos ei olla määräpäivän kuukaudessa JA tietoja ei ole syötetty
+      (and ei-maarapaivan-kuukausi? (not tiedot-syotetty-ajoissa?))
       [:div.kustannusennuste-vaara-kuukausi
        [:div.row
         [:div.col-xs-12
@@ -250,6 +250,9 @@
           [sulje-nappi e! {:luokka "pull-right"}]]]]]
 
       ;; Muissa tapauksissa näytetään kentät (joko muokattavina tai read-only)
+      ;; Tämä sisältää tapaukset:
+      ;; - Ollaan määräpäivän kuukaudessa
+      ;; - Tiedot on syötetty ajoissa (näytetään read-only)
       :else
       [:div.kustannusennuste-syottokentit
        ;; Ensimmäinen rivi - Tavoitehinta ja Ennuste


### PR DESCRIPTION
Kustannusennusteessa oli bugi, jossa jos käyttäjä oli syöttänyt tavoitehinnan ja 
toteutuneet kustannukset määräpäivään mennessä, mutta katsoi lomaketta myöhemmin 
eri kuukaudessa, näytettiin virheellisesti viesti:

"Kirjaus ei ole mahdollista tässä kuussa"

Tämä esti käyttäjää näkemästä ajoissa syöttämiään tietoja.

Muutettu ehto tarkistamaan onko tiedot syötetty ajoissa:
`(and ei-maarapaivan-kuukausi? (not tiedot-syotetty-ajoissa?))
`