### PR TITLE
HARJA-1795 Älä tallenna hakuaikaleimaa

### DIFF
--- a/src/clj/harja/palvelin/integraatiot/api/analytiikka.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/analytiikka.clj
@@ -282,9 +282,7 @@
                    {:reittitoteumat
                     (map (fn [toteuma]
                            (konversio/alaviiva->rakenne toteuma))
-                      toteumat)})
-        _ (toteuma-kyselyt/paivita-palautettu-analytiikalle-aikaleima! db {:alkuaika alkuaika
-                                                                       :loppuaika loppuaika})]
+                      toteumat)})]
     toteumat))
 
 (defn palauta-materiaalit


### PR DESCRIPTION
Ehkä katsotaan joskus myöhemmin lisätäänkö update koodiin takaisin. Tarvitaan toinen tietokanta mukaan funktioon, että on kanta, johon voi kirjoittaa updatella. Nyt funktiossa käytössä read-only kanta, minkä takia virhe.

Täytyy saada virhe nopeasti korjattua, niin poistetaan koko update. Se on muutenkin luonteeltaan nice-to-have.