### PR TITLE
Harja 1426  - lupausten kuukauden indikointi

### DIFF
--- a/src/cljc/harja/domain/lupaus_domain.cljc
+++ b/src/cljc/harja/domain/lupaus_domain.cljc
@@ -556,29 +556,31 @@
   Excel (roolit.xlsx) määrittää kaikki oikeudet - katso dokumentaatio excelistä tai oikeudet.cljc"
   [kayttaja lupaus-kuukausi lupaustyyppi urakka-id]
   (and (vastauskuukausi? lupaus-kuukausi)
-     (cond
-       ;; Kirjauskuukaudet: perustason kirjoitusoikeus riittää (Excel: W)
-       (:kirjauskuukausi? lupaus-kuukausi)
-       (oikeudet/voi-kirjoittaa? oikeudet/urakat-lupaukset urakka-id kayttaja)
-
-       ;; Päättävät kuukaudet: Excel määrittää erikoisoikeudet
-       (:paattava-kuukausi? lupaus-kuukausi)
-       (case lupaustyyppi
-         ;; Kustannusennuste: Excel määrittää kuka saa (W,kustannusennuste)
-         "kustannusennuste" 
-         (oikeudet/on-muu-oikeus? "kustannusennuste"
-                                  oikeudet/urakat-lupaukset
-                                  urakka-id
-                                  kayttaja)
-         
-         ;; Muut lupaukset: Excel määrittää kuka saa tehdä päätöksiä (W,päätös)
-         (oikeudet/on-muu-oikeus? "päätös"
-                                  oikeudet/urakat-lupaukset
-                                  urakka-id
-                                  kayttaja))
-
-       ;; Ei kirjaus- eikä päättävä kuukausi
-       :else false)))
+    (boolean
+      ;; Ota huomioon että lupaus-kuukausi voi olla sekä päättävä-kuukausi? että kirjauskuukausi?
+      (cond
+        ;; Päättävät kuukaudet: Excel määrittää erikoisoikeudet
+        (:paattava-kuukausi? lupaus-kuukausi)
+        (case lupaustyyppi
+          ;; Kustannusennuste: Excel määrittää kuka saa (W,kustannusennuste)
+          "kustannusennuste"
+          (oikeudet/on-muu-oikeus? "kustannusennuste"
+                                   oikeudet/urakat-lupaukset
+                                   urakka-id
+                                   kayttaja)
+          
+          ;; Muut lupaukset: Excel määrittää kuka saa tehdä päätöksiä (W,päätös)
+          (oikeudet/on-muu-oikeus? "päätös"
+                                   oikeudet/urakat-lupaukset
+                                   urakka-id
+                                   kayttaja))
+        
+        ;; Kirjauskuukaudet: perustason kirjoitusoikeus riittää (Excel: W)
+        (:kirjauskuukausi? lupaus-kuukausi)
+        (oikeudet/voi-kirjoittaa? oikeudet/urakat-lupaukset urakka-id kayttaja)
+        
+        ;; Ei kirjaus- eikä päättävä kuukausi
+        :else false))))
 
 (defn ennusteen-tila->saa-vastata? [ennusteen-tila]
   ;; Vastauksia ei saa enää muuttaa välikatselmuksen jälkeen.

--- a/src/cljs/harja/views/urakka/lupaus/kuukausipaatos_tilat.cljs
+++ b/src/cljs/harja/views/urakka/lupaus/kuukausipaatos_tilat.cljs
@@ -95,9 +95,15 @@
        ;; Kustannusennuste - odottaa syöttöä
        (and kustannusennuste-lupaus? (not kustannusennuste-syotetty?) vastauskuukausi?)
        [odottaa-vastausta]
-
-       (or odottaa-kannanottoa?
-           (and vastauskuukausi? (= :kuluva-kuukausi nykyhetkeen-verrattuna)))
+       
+        ;; Kuluva kuukausi ilman vastausta - näytä kysymysmerkki
+       (and vastauskuukausi? 
+            (= :kuluva-kuukausi nykyhetkeen-verrattuna)
+            (not (lupaus-domain/vastattu? vastaus)))
+       [odottaa-vastausta]
+       
+       ;; Odottaa kannanottoa (menneet kuukaudet ilman vastausta)
+       odottaa-kannanottoa?
        [odottaa-vastausta]
 
        ;; Tälle kuukaudelle ei voi antaa vastausta ollenkaan
@@ -114,7 +120,7 @@
 
        ;; Monivalinta vastauksen kuukausi, jossa on pisteet
        (and (:lupaus-vaihtoehto-id vastaus)
-            (:pisteet vastaus))
+         (:pisteet vastaus))
        [:div.kuukausi-pisteet (:pisteet vastaus)]
 
        ;; Joustovara on ylittynyt

--- a/test/clj/harja/domain/lupaus_domain_test.clj
+++ b/test/clj/harja/domain/lupaus_domain_test.clj
@@ -401,7 +401,37 @@
                     lupaus-kuukausi
                     "yksittainen"
                     123))
-          "Ei-vastauskuukauteen ei saa vastata"))))
+          "Ei-vastauskuukauteen ei saa vastata")))
+
+  (testing "Sekä kirjaus- että päättävä kuukausi - päätösoikeus vaaditaan"
+    (let [lupaus-kuukausi {:kirjauskuukausi? true :paattava-kuukausi? true}
+          tilaajan-kayttaja {:id 3}
+          urakoitsijan-kayttaja {:id 4}]
+
+      ;; Mockaa molemmat oikeusfunktiot
+      (with-redefs [oikeudet/on-muu-oikeus? (fn [oikeus _ urakka-id kayttaja]
+                                               (and (= "päätös" oikeus)
+                                                    (= 3 (:id kayttaja))))
+                    oikeudet/voi-kirjoittaa? (fn [_ urakka-id kayttaja]
+                                                (= 4 (:id kayttaja)))]
+        
+        ;; Tilaajalla on päätösoikeus - saa vastata
+        (is (true? (lupaus-domain/kayttaja-saa-vastata?
+                     tilaajan-kayttaja
+                     lupaus-kuukausi
+                     "yksittainen"
+                     123))
+            "Tilaaja saa vastata kun on päätösoikeus (vaikka on myös kirjauskuukausi)")
+
+        ;; Urakoitsijalla on vain kirjoitusoikeus, mutta EI päätösoikeutta
+        ;; Koska päättävä-kuukausi tarkistetaan ENSIN, urakoitsija ei saa vastata
+        (is (false? (lupaus-domain/kayttaja-saa-vastata?
+                      urakoitsijan-kayttaja
+                      lupaus-kuukausi
+                      "yksittainen"
+                      123))
+            "Urakoitsija ei saa vastata vaikka on kirjoitusoikeus, koska päätösoikeus puuttuu")))))
+
 (deftest kustannusennuste-maarapaiva-paattely-test
   "Testaa määräpäivän päättelylogiikkaa eri ajanhetkinä."
   (let [maarapaiva (pvm/luo-pvm 2025 10 15)


### PR DESCRIPTION

Lupausten kuukausilistauksessa näytettiin kysymysmerkki-ikoni (`harja-icon-status-help`) **kuluvan kuukauden** kohdalla, vaikka käyttäjä oli jo vastannut lupaukseen kyseisessä kuukaudessa. Ikoni näytettiin virheellisesti kaikille vastauskuukausille, jotka olivat kuluvassa kuukaudessa.

## Korjattu alkuperäisen ongelman lisäksi

Urakoitsijan vastuuhenkilöllä on W (kirjoitusoikeus) lupaukset-osioon, mutta ei W,päätös erikoisoikeutta. Frontend-logiikka oli liian salliva:

Tarkisti ensin kirjauskuukauden → antoi true jos W-oikeus
Jos kuukausi oli sekä kirjaus- että päätöskuukausi, vastuuhenkilö sai true vaikka hänellä ei ollut päätösoikeutta
Backend kuitenkin esti tallennuksen oikein

#### Ratkaisu

Muutettu cond-lausekkeen järjestys tarkistamaan päättävä kuukausi ensin.
Lisätty testi joka varmistaa että toimii oikein silloinkin kun molemmat true {:kirjauskuukausi? true :paattava-kuukausi? true}
