### PR TITLE
HARJA-1940 Muut kulut välikatselmuksen yhteenvetoon

### DIFF
--- a/cypress/e2e/valitavoitteet.cy.js
+++ b/cypress/e2e/valitavoitteet.cy.js
@@ -1,29 +1,29 @@
-import * as apurit from '../support/apurit.js';
+import {ladataanHarjaaTimeout, clickTimeout} from "../support/apurit.js";
 
 function avaaValitavoitteet(urakkanimi, hallintayksikko) {
     cy.visit('/');
 
     // Varmista, että pääsivu on ladattu ennen testien aloitusta
-    cy.get('.ladataan-harjaa', { timeout: 30000 }).should('not.exist');
+    cy.get('.ladataan-harjaa', { timeout: ladataanHarjaaTimeout }).should('not.exist');
 
     // Valitse hallintayksikkö
-    cy.contains('.haku-lista-item', hallintayksikko, { timeout: 30000 }).click();
-    cy.get('.ajax-loader', { timeout: 10000 }).should('not.exist');
+    cy.contains('.haku-lista-item', hallintayksikko, { timeout: ladataanHarjaaTimeout }).click();
+    cy.get('.ajax-loader', { timeout: ladataanHarjaaTimeout }).should('not.exist');
     
     // Näytä päättyneet urakat (jos tarvitaan)
-    cy.contains('Näytä päättyneet').click();
+    cy.contains('Näytä päättyneet', {timeout: clickTimeout}).click();
 
     // Valitse urakka
-    cy.contains('[data-cy=urakat-valitse-urakka] li', urakkanimi, { timeout: 10000 }).click();
+    cy.contains('[data-cy=urakat-valitse-urakka] li', urakkanimi, { timeout: ladataanHarjaaTimeout }).click();
     
     // Mene "Lupaukset ja tavoitteet" välilehdelle
-    cy.get('[data-cy="tabs-taso1-Lupaukset ja tavoitteet"]', { timeout: 20000 }).click();
+    cy.get('[data-cy="tabs-taso1-Lupaukset ja tavoitteet"]', { timeout: ladataanHarjaaTimeout }).click();
     
     // Avaa Välitavoitteet
     cy.get('[data-cy=tabs-taso2-Valitavoitteet]').click();
     
     // Odota että ajax-loader häviää
-    cy.get('img[src="images/ajax-loader.gif"]', { timeout: 20000 }).should('not.exist');
+    cy.get('img[src="images/ajax-loader.gif"]', { timeout: ladataanHarjaaTimeout }).should('not.exist');
     
     // Varmista että URL sisältää välitavoitteet
     cy.url().should('include', 'valitavoitteet');

--- a/src/cljs/harja/views/urakka/valikatselmus/yhteenvetolaatikko.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/yhteenvetolaatikko.cljs
@@ -22,6 +22,7 @@
         erillishankinnat (or (get-in yhteenvedon-tiedot [:kustannukset :erillishankinnat-toteutunut]) 0)
         johto-ja-hallintokorvaus (or (get-in yhteenvedon-tiedot [:kustannukset :johto-ja-hallintokorvaus-toteutunut]) 0)
         hoidonjohtopalkkio (or (get-in yhteenvedon-tiedot [:kustannukset :hoidonjohdonpalkkio-toteutunut]) 0)
+        muut-kulut (or (get-in yhteenvedon-tiedot [:kustannukset :muukulu-tavoitehintainen-toteutunut]) 0)
         toteuma-yht (get-in yhteenvedon-tiedot [:kustannukset-yhteensa :yht-toteutunut-summa])
 
         ;; Urakoitsijan saatavat
@@ -104,6 +105,10 @@
      [:div.flex-row.summa-rivi
       [:span "Hoidonjohtopalkkio"]
       [:span (fmt/euro-opt false hoidonjohtopalkkio)]]
+     (when (> muut-kulut 0)
+       [:div.flex-row.summa-rivi
+        [:span "Muut kulut"]
+        [:span (fmt/euro-opt false muut-kulut)]])
      [:hr]
      [:div.flex-row.summa-rivi-ylin
       [:span.laskenta-rivi-lukema "Toteutuma yhteensä"]


### PR DESCRIPTION
Näytä muut kulut Välikatselmuksen yhteenvedossa, mikäli niitä on olemassa.

Tästä tuli palautetta asiakkaalta ja päätettiin lisätä se tarkennukseksi, jos muita kuluja on syötettynä (jotka kuuluu tavoitehintaan)