### PR TITLE
HARJA-1980 Kattohinnan ylityspäätöksen seuraavalle vuodelle siirrettävä summa siirretään analytikkaan 

### DIFF
--- a/src/clj/harja/palvelin/integraatiot/api/analytiikka.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/analytiikka.clj
@@ -1031,6 +1031,7 @@
                                                                  :siirretaan-seuraavalle-hoitovuodelle (cond
                                                                                                          (= "Tavoitehinnan alitus" (:nimi p)) (:siirron_maara p)
                                                                                                          (= "Tavoitehinnan ylitys" (:nimi p)) (:siirto p)
+                                                                                                         (= "Kattohinnan ylitys" (:nimi p)) (:siirrettava_maara p)
                                                                                                          :else nil)
                                                                  :tavoitehinta (if (or
                                                                                      (= "Lupaukset" (:nimi p))

--- a/test/clj/harja/palvelin/integraatiot/api/analytiikka_kustannukset_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/analytiikka_kustannukset_test.clj
@@ -397,7 +397,7 @@
           (bigdec (get-in juuri-luotu-paatos-rajapinnasta [:hoitovuoden-paatos :paatoksen-tulos :tilaaja-maksaa]))) "Rajapinnan tavoitehinnan muutos ei täsmää.")
     (is (= false (get-in juuri-luotu-paatos-rajapinnasta [:hoitovuoden-paatos :poistettu])))))
 
-(deftest hae-toteutuneet-kustannukset-kattohinnan-ylityspaatos-onnistuu-test
+(deftest hae-toteutuneet-kustannukset-kattohinnan-ylityspaatos-urakoitsija-maksaa-onnistuu-test
   (let [;; Pakotetaan urakaksi Oulu MHU
         urakka-id (hae-urakan-id-nimella "Oulun MHU 2019-2024")
         urakan-parametrit (first (urakka-kyselyt/hae-urakan-parametrit (:db jarjestelma) {:urakkaid urakka-id}))
@@ -432,7 +432,7 @@
         vastaus (api-tyokalut/get-kutsu [(str "/api/analytiikka/toteutuneet-kustannukset/" urakka-id)] kayttaja-analytiikka portti)
         encoodattu-body (cheshire/decode (:body vastaus) true)
         juuri-luotu-paatos-rajapinnasta (first (filter (fn [k]
-                                                         (= (bigdec (get-in k [:hoitovuoden-paatos :paatoksen-tulos :urakoitsija-maksaa])) urakoitsija-maksaa))
+                                                         (= (get-in k [:hoitovuoden-paatos :paatostyyppi]) "kattohinnan-ylitys"))
                                                  (get-in encoodattu-body [:toteutuneet-kustannukset :hoitovuoden-paatokset])))
 
         ;; Siivoa roskat - Poistetaan päätös
@@ -444,6 +444,57 @@
             (bigdec (get-in juuri-luotu-paatos-rajapinnasta [:hoitovuoden-paatos :paatoksen-tulos :urakoitsija-maksaa]))) "Rajapinnan tavoitehinnan muutos ei täsmää.")
     (is (= false (get-in juuri-luotu-paatos-rajapinnasta [:hoitovuoden-paatos :poistettu])))))
 
+(deftest hae-toteutuneet-kustannukset-kattohinnan-ylityspaatos-siirto-onnistuu-test
+  (let [;; Pakotetaan urakaksi Oulu MHU
+        urakka-id (hae-urakan-id-nimella "Oulun MHU 2019-2024")
+        urakan-parametrit (first (urakka-kyselyt/hae-urakan-parametrit (:db jarjestelma) {:urakkaid urakka-id}))
+        urakan-tiedot (first (urakat-kyselyt/hae-urakka (:db jarjestelma) {:id urakka-id}))
+        urakan-alkupvm (:alkupvm urakan-tiedot)
+        hoitokauden-alkuvuosi 2019
+        kattohinta 275000M
+        ylityksen-maara 10000M
+        toteutuneet-kustannukset (+ kattohinta ylityksen-maara)
+        urakoitsija-maksaa 0M
+        siirtorajoitus-prosentti (:kattohintaylityksen_siirron_prosenttirajoitus urakan-parametrit)
+        maksimi-siirrettava-maara ylityksen-maara
+        siirrettava-maara ylityksen-maara
+        viimeinen_hoitokausi false
+
+        ;; Luodaan kulu, jolla ylitetään kattohinta
+        uusi-kulu (uusi-kulu-kustannukset-testiin urakka-id toteutuneet-kustannukset hoitokauden-alkuvuosi urakan-alkupvm)
+
+        kulu-vastaus (kutsu-palvelua (:http-palvelin jarjestelma) :tallenna-kulu
+                       +kayttaja-jvh+
+                       {:urakka-id urakka-id
+                        :kulu-kohdistuksineen uusi-kulu})
+
+        kulu-id (:id kulu-vastaus)
+        kayttajaid (:id +kayttaja-jvh+)
+
+        kattohinnan-ylitys-paatos (paatos-apurit/kattohinnan-ylityspaatos urakka-id hoitokauden-alkuvuosi kattohinta toteutuneet-kustannukset
+                                    ylityksen-maara urakoitsija-maksaa siirrettava-maara kulu-id viimeinen_hoitokausi maksimi-siirrettava-maara siirtorajoitus-prosentti kayttajaid)
+        db-paatos (paatos-kyselyt/tee-kattohinnan-ylityspaatos (:db jarjestelma) kattohinnan-ylitys-paatos)
+
+        ;; Hae päätöksen tiedot
+        paatos-tiedot (q-map (format "SELECT * FROM paatos_kattohinta WHERE urakkaid = %s AND hoitokauden_alkuvuosi = %s" urakka-id hoitokauden-alkuvuosi))
+        _ (println "Paatos tiedot:" (pr-str paatos-tiedot))
+
+        ;; Varmista, että vastauksesta löytyy juuri luotu oikaisu
+        vastaus (api-tyokalut/get-kutsu [(str "/api/analytiikka/toteutuneet-kustannukset/" urakka-id)] kayttaja-analytiikka portti)
+        encoodattu-body (cheshire/decode (:body vastaus) true)
+        _ (println "encoodattu-body analytiikka vastaus;" (pr-str encoodattu-body))
+        juuri-luotu-paatos-rajapinnasta (first (filter (fn [k]
+                                                         (= (get-in k [:hoitovuoden-paatos :paatostyyppi]) "kattohinnan-ylitys"))
+                                                 (get-in encoodattu-body [:toteutuneet-kustannukset :hoitovuoden-paatokset])))
+
+        ;; Siivoa roskat - Poistetaan päätös
+        _ (paatos-kyselyt/poista-kattohinnan-ylityspaatos (:db jarjestelma) urakka-id kayttajaid (:id db-paatos))]
+
+    (is (= 200 (:status vastaus)))
+    (is (not (nil? (get-in juuri-luotu-paatos-rajapinnasta [:hoitovuoden-paatos :paatos :id]))))
+    (is (= siirrettava-maara
+          (bigdec (get-in juuri-luotu-paatos-rajapinnasta [:hoitovuoden-paatos :paatoksen-tulos :siirretaan-seuraavalle-hoitovuodelle]))) "Kattohinnan ylityksen siirto seuraavalle hoitovuodelle ei täsmää.")
+    (is (= false (get-in juuri-luotu-paatos-rajapinnasta [:hoitovuoden-paatos :poistettu])))))
 
 (deftest hae-kustannussuunnitelma-onnistuu-test
   (let [;; Pakotetaan urakaksi Oulu MHU

--- a/test/clj/harja/palvelin/palvelut/kulut/kulu_apurit.clj
+++ b/test/clj/harja/palvelin/palvelut/kulut/kulu_apurit.clj
@@ -1,0 +1,30 @@
+(ns harja.palvelin.palvelut.kulut.kulu-apurit
+  (:require [harja.testi :refer :all]
+            [harja.pvm :as pvm]
+            [harja.domain.kulut :as domain-kulut]))
+
+(defn uusi-kulu [urakka-id summa vuosi urakan-alkupvm]
+  (let [erapaiva (pvm/->pvm (str "1.11." vuosi))]
+    {:id nil
+     :urakka urakka-id
+     :viite "12345678"
+     :erapaiva erapaiva
+     :kokonaissumma summa
+     :tyyppi "laskutettava"
+     :kohdistukset [{:kohdistus-id nil
+                     :rivi 1
+                     :summa (/ summa 2)
+                     :toimenpideinstanssi (hae-toimenpideinstanssi-id urakka-id "23116")
+                     :tehtavaryhma (hae-tehtavaryhman-id "V - Vesakonraivaukset ja puun poisto")
+                     :tehtava nil
+                     :tyyppi :hankintakulu
+                     :tavoitehintainen :true}
+                    {:kohdistus-id nil
+                     :rivi 2
+                     :summa (/ summa 2)
+                     :toimenpideinstanssi (hae-toimenpideinstanssi-id urakka-id "23116")
+                     :tehtavaryhma (hae-tehtavaryhman-id "V - Vesakonraivaukset ja puun poisto")
+                     :tehtava nil
+                     :tyyppi :hankintakulu
+                     :tavoitehintainen :true}]
+     :koontilaskun-kuukausi (domain-kulut/pvm->koontilaskun-kuukausi erapaiva urakan-alkupvm)}))

--- a/test/clj/harja/palvelin/palvelut/valikatselmus/paatokset_test.clj
+++ b/test/clj/harja/palvelin/palvelut/valikatselmus/paatokset_test.clj
@@ -1,10 +1,13 @@
 (ns harja.palvelin.palvelut.valikatselmus.paatokset-test
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
+            [harja.kyselyt.urakat :as urakat-kyselyt]
+            [harja.palvelin.palvelut.kulut.kulut :as kulut]
             [harja.testi :refer :all]
             [com.stuartsierra.component :as component]
             [harja.pvm :as pvm]
             [harja.tyokalut.yleiset :refer [round2]]
+            [harja.palvelin.palvelut.kulut.kulu-apurit :as kuluapurit]
             [harja.palvelin.komponentit.tietokanta :as tietokanta]
             [harja.palvelin.palvelut.valikatselmus.paatos-apurit :as paatos-apurit]
             [harja.kyselyt.paatos-kyselyt :as paatos-kyselyt]
@@ -27,7 +30,10 @@
           :http-palvelin (testi-http-palvelin)
           :valikatselmus (component/using
                            (valikatselmukset/->Valikatselmukset)
-                           [:http-palvelin :db :db-replica])))))
+                           [:http-palvelin :db :db-replica])
+          :kulut (component/using
+                   (kulut/->Kulut)
+                   [:http-palvelin :db])))))
 
   (testit)
   (alter-var-root #'jarjestelma component/stop))
@@ -817,7 +823,7 @@
     (is (nil? poistettu-paatos))))
 
 ;; Kattohinnan ylitys lisäys
-(deftest kysely-kattohinnan-ylitys-lisays-onnistuu-test
+(deftest kysely-kattohinnan-ylitys-lisays-2024-onnistuu-test
   (let [;; Hae vaativa mhu urakka
         urakkaid (hae-urakan-id-nimella "POP MHU Suomussalmi 2024-2029")
         urakan-parametrit (first (urakka-kyselyt/hae-urakan-parametrit (:db jarjestelma) {:urakkaid urakkaid}))
@@ -839,7 +845,7 @@
     (testaa-kattohinnan-ylityspaatos vastaus urakkaid hoitokauden-alkuvuosi kattohinta toteutuneet-kustannukset
       ylityksen-maara urakoitsija-maksaa siirrettava-maara kulu-id viimeinen_hoitokausi maksimi-siirrettava-maara siirtorajoitus-prosentti kayttajaid)))
 
-(deftest kysely-kattohinnan-ylitys-lisays-onnistuu-test
+(deftest kysely-kattohinnan-ylitys-lisays-2025-onnistuu-test
   (let [;; Hae vaativa mhu urakka
         urakkaid (hae-urakan-id-nimella "Kittilän MHU 2025-2030")
         urakan-parametrit (first (urakka-kyselyt/hae-urakan-parametrit (:db jarjestelma) {:urakkaid urakkaid}))
@@ -864,7 +870,7 @@
     ;; -25 alkavalla urakalla siirtorajoitusprosentti pitää olla kolme
     (is (= 0.03M (:siirtorajoitus_prosentti vastaus)))))
 
-(deftest rajapinta-kattohinnan-ylitys-lisays-onnistuu-2024-test
+(deftest rajapinta-kattohinnan-ylitys-lisays-epaonnistuu-2024-test
   (let [;; Hae vaativa mhu urakka
         urakkaid (hae-urakan-id-nimella "POP MHU Suomussalmi 2024-2029")
         urakan-parametrit (first (urakka-kyselyt/hae-urakan-parametrit (:db jarjestelma) {:urakkaid urakkaid}))
@@ -886,10 +892,63 @@
                                 valikatselmus-kyselyt/hae-oikaistu-kattohinta (fn [db hakuparametrit]
                                                                                 kattohinta)]
                     (kutsu-palvelua (:http-palvelin jarjestelma) :tee-kattohinnan-ylityspaatos +kayttaja-jvh+ paatos))
-                  (catch Exception e e))
+                  (catch Exception e
+                    (is (not (nil? e)))))
         tallennettu-paatos (valitse-paatos (:paatokset vastaus) :kattohinnan-ylitys)]
     ;; Koska ehdot eivät täyty, niin kattohinnan ylityspäätöksen default päätöstä ei voida palauttaa
     (is (nil? tallennettu-paatos))))
+
+(deftest rajapinta-kattohinnan-ylitys-lisays-onnistuu-2024-test
+  (let [;; Hae vaativa mhu urakka
+        urakkaid (hae-urakan-id-nimella "POP MHU Suomussalmi 2024-2029")
+        urakan-tiedot (first (urakat-kyselyt/hae-urakka (:db jarjestelma) {:id urakkaid}))
+        urakan-alkupvm (:alkupvm urakan-tiedot)
+        urakan-parametrit (first (urakka-kyselyt/hae-urakan-parametrit (:db jarjestelma) {:urakkaid urakkaid}))
+        kayttajaid (:id +kayttaja-jvh+)
+        hoitokauden-alkuvuosi 2024
+        kattohinta 50M
+        toteutuneet-kustannukset 55M
+        ylityksen-maara (- toteutuneet-kustannukset kattohinta)
+        urakoitsija-maksaa ylityksen-maara
+        siirrettava-maara 0M
+        siirtorajoitus-prosentti (:kattohintaylityksen_siirron_prosenttirajoitus urakan-parametrit)
+        maksimi-siirrettava-maara ylityksen-maara           ;; koska rajoitus ei ole käytössä, niin voidaan siirtää koko ylitys
+
+        ;; Luodaan kulu, jolla ylitetään kattohinta
+        uusi-kulu (kuluapurit/uusi-kulu urakkaid toteutuneet-kustannukset hoitokauden-alkuvuosi urakan-alkupvm)
+
+        kulu-vastaus (kutsu-palvelua (:http-palvelin jarjestelma) :tallenna-kulu
+                       +kayttaja-jvh+
+                       {:urakka-id urakkaid
+                        :kulu-kohdistuksineen uusi-kulu})
+
+        kulu-id (:id kulu-vastaus)
+        paatos (paatos-apurit/kattohinnan-ylityspaatos urakkaid hoitokauden-alkuvuosi kattohinta toteutuneet-kustannukset
+                 ylityksen-maara urakoitsija-maksaa siirrettava-maara kulu-id false maksimi-siirrettava-maara siirtorajoitus-prosentti kayttajaid)
+
+        vastaus (try
+                  (with-redefs [;; Feikataan vastaus kattohinnan hakemiseen, koska urakalla ei ole välttämättä kattohintaa tallennettuna
+                                budjettisuunnittelu-kyselyt/hae-budjettitavoite (fn [db hakuparametrit]
+                                                                                  [{:hoitovuoden-lopun-kattohinta kattohinta
+                                                                                    :hoitokauden-alkuvuosi hoitokauden-alkuvuosi}])
+                                budjettisuunnittelu-kyselyt/onko-kustannussuunnitelma-vahvistettu (fn [db hakuparametrit]
+                                                                                                    [{:exists true}])]
+                    (kutsu-palvelua (:http-palvelin jarjestelma) :tee-kattohinnan-ylityspaatos +kayttaja-jvh+ paatos))
+                  (catch Exception e
+                    (println "ERROR: " e)
+                    (is (nil? e))))
+        tallennettu-paatos (valitse-paatos (:paatokset vastaus) :kattohinnan-ylitys)
+        ;; Hae päätöksen tiedot tietokannasta, jotta nekin voidaan tarkistaa
+        paatos-tiedot (first (q-map (format "SELECT * FROM paatos_kattohinta WHERE urakkaid = %s AND hoitokauden_alkuvuosi = %s" urakkaid hoitokauden-alkuvuosi)))]
+
+    (is (= kattohinta (:kattohinta tallennettu-paatos)) "Kattohinta täsmää tallennuksen jälkeen")
+    (is (= kattohinta (:kattohinta paatos-tiedot)) "Kattohinta täsmää tallennuksen jälkeen")
+    (is (= toteutuneet-kustannukset (:toteutuneet_kustannukset tallennettu-paatos)) "Toteutuneet kustannukset täsmää tallennuksen jälkeen")
+    (is (= toteutuneet-kustannukset (:toteutuneet_kustannukset paatos-tiedot)) "Toteutuneet kustannukset täsmää tallennuksen jälkeen")
+    (is (= siirrettava-maara (:siirrettava_maara tallennettu-paatos)) "Siirrettävä määrä täsmää tallennuksen jälkeen")
+    (is (= siirrettava-maara (:siirrettava_maara paatos-tiedot)) "Siirrettävä määrä täsmää tallennuksen jälkeen")
+    (is (= ylityksen-maara (:ylityksen_maara tallennettu-paatos)) "Siirrettävä määrä täsmää tallennuksen jälkeen")
+    (is (= ylityksen-maara (:ylityksen_maara paatos-tiedot)) "Siirrettävä määrä täsmää tallennuksen jälkeen")))
 
 (deftest rajapinta-kattohinnan-ylitys-epaonnistuu-viimeisena-vuotena-test
   (let [;; Hae vaativa mhu urakka


### PR DESCRIPTION
Lisää kattohoinnan ylitpäätökseen, joka välitetään analytiikkaan seuraavalle vuodelle siirrettävä summa

Ja lisää ja korjaa testit, joilla varmistetaan, että tämä toimii