### PR TITLE
HARJA-2011 - Lisää ajastettu workflow, joka etsii hapantuneet PR:t ja ilmoittelee niistä

### DIFF
--- a/.github/workflows/cron_process-stale-prs.yml
+++ b/.github/workflows/cron_process-stale-prs.yml
@@ -1,0 +1,91 @@
+# Security hardening for GitHub Actions
+# https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
+
+name: '[Scheduled] Process stale PRs'
+run-name: '[Scheduled] Process stale PRs'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  # Anna edellisen deploymentin mennä rauhassa loppuun, koska mahdollisesti käynnissä olevaa AWS migration lambdaa ei pysty canceloimaan
+  # Jos edellinen deployment on ehtinyt migraatioiden ajon vaiheeseen, canceloiminen voi aiheuttaa ongelmia.
+  cancel-in-progress: false
+
+on:
+  # Manuaalisen käynnistyksen asetukset
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Dry-run (ei tee muutoksia)'
+        required: false
+        default: false
+        type: boolean
+
+  # Ajastettu käynnistys
+  # Ajetaan joka arkipäivä klo 9
+  # GitHub actions on UTC-aikavyöhykkeessä, joten erilliset säännöt karkeasti kesä- ja talviaikaan
+  schedule:
+    - cron: '0 7 * 11-12,1-3 1-5'
+    - cron: '0 6 * 4-10 1-5'
+
+# Aseta least-privilege default permissionit workflowille
+# Jos jokin job tarvitsee enemmän oikeuksia, ne pitää erikseen määritellä job-kohtaisesti
+# https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-secrets
+# https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+permissions:
+  contents: read
+  # Vaaditaan oikeus PR:ien käsittelyyn, jotta voidaan lisätä kommentteja tai sulkea PR automaattisesti
+  pull-requests: write
+
+jobs:
+  # Note: https://github.com/actions/stale
+  process-stale-prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find and label stale PRs
+        id: find-stale-prs
+        uses: actions/stale@997185467fa4f803885201cee163a9f38240193d # v10.1.1
+        with:
+          # TODO: Dry-run (debug) ajo ensin, kunnes varmistutaan että toimii oikein
+          #       Poistetaan kovakoodattu dry-run asetus myöhemmin, ja otetaan se käyttöön GitHub action inputista
+          debug-only: true
+          #debug-only: ${{ github.event.inputs.dry-run }}
+          stale-pr-label: "Stale"
+          days-before-pr-stale: 3
+          stale-pr-message: "Tämä PR on ollut avoin 3 päivää ilman kommentteja tai päivityksiä, joten se merkitään vanhentuneeksi. Voit perua merkinnän kommentoimalla tai päivittämällä PR:ää."
+          days-before-pr-close: ''
+          remove-pr-stale-when-updated: true
+          # Avoimeen PR:ään voi myös lisätä WIP-labelin, jolloin se ei vanhenee
+          exempt-pr-labels: "WIP"
+          # Draft-PR:iä ei ole tarpeen merkitä vanhentuneiksi, seurataan vain avoimia PR:iä
+          exempt-draft-pr: true
+      - name: Format Stale PRs list
+        if: ${{ steps.find-stale-prs.outputs.staled-issues-prs != '' && steps.find-stale-prs.outputs.staled-issues-prs != '[]' }}
+        id: stale-prs-list
+        uses: actions/github-script@v8
+        env:
+          STALE_PRS: ${{ steps.find-stale-prs.outputs.staled-issues-prs }}
+        with:
+          script: |
+            const stalePRs = JSON.parse(process.env.STALE_PRS);
+            const formattedList = stalePRs
+              .map(pr => `- <https://github.com/finnishtransportagency/harja/pull/${pr.number}|#${pr.number}>: ${pr.title}`)
+              .join('\n');
+            return formattedList;
+      - name: Send a summary of stale PRs into Slack
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
+        # https://github.com/actions/stale?tab=readme-ov-file#list-of-output-options
+        if: ${{ steps.stale-prs-list.outcome == 'success' && steps.stale-prs-list.outputs.result != '' }}
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Katselmointia kaipaavat PRt:\n${{ steps.stale-prs-list.outputs.result }}"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
## Motivaatio
Tarkoitus on tuoda paremmin esille PR:t, jotka ovat olleet auki pitkään ilman katselmointikommentteja tai muutoksia.
Kaikki kolmea päivää pidemmin auki olleet PR:t, jotka eivät ole saaneet huomiota nostetaan kehittäjien tietoon joka päivä klo 9 aamulla.

## Katselmointiohje
Tämä täytyy valitettavasti mergetä ensin, koska GitHub Actions ei välittömästi tarjoa saataville uutta workflowia PR-branchistä.
Mergen jälkeen jatkan iterointia, ja teen mahdolliset korjaukset.