### PR TITLE
Harja 2083 leveampi maksuera th

### DIFF
--- a/src/cljs/harja/views/urakka/kulut/kulut.cljs
+++ b/src/cljs/harja/views/urakka/kulut/kulut.cljs
@@ -55,8 +55,8 @@
   [:tr.klikattava
    {:on-click (fn [] (e! (tiedot/->AvaaKulu id)))}
    [:td.col-xs-1 (str (when erapaiva (pvm/pvm erapaiva)))]
-   [:td.col-xs-1.sailyta-rivilla (if maksuera-alias (str "HA" maksuera " / " maksuera-alias) (str "HA" maksuera))]
-   [:td.col-xs-4 toimenpide-nimi]
+   [:td.col-xs-2.sailyta-rivilla (if maksuera-alias (str "HA" maksuera " / " maksuera-alias) (str "HA" maksuera))]
+   [:td.col-xs-3 toimenpide-nimi]
    [:td.col-xs-4 tehtavaryhma-nimi]
    [:td.col-xs-1.tasaa-oikealle.sailyta-rivilla (fmt/euro-opt summa)]
    [:td.col-xs-1.tasaa-oikealle (when-not (empty? liitteet) [ikonit/harja-icon-action-add-attachment])]])
@@ -131,8 +131,8 @@
       [:thead
        [:tr
         [:th.col-xs-1 "Pvm"]
-        [:th.col-xs-1 "Maksuerä"]
-        [:th.col-xs-4 "Toimenpide"]
+        [:th.col-xs-2 "Maksuerä"]
+        [:th.col-xs-3 "Toimenpide"]
         [:th.col-xs-4 "Tehtäväryhmä"]
         [:th.col-xs-1.tasaa-oikealle "Määrä"]
         [:th.col-xs-1 ""]]]

--- a/test/clj/harja/palvelin/integraatiot/api/analytiikka_kustannukset_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/analytiikka_kustannukset_test.clj
@@ -495,40 +495,42 @@
     (is (= false (get-in juuri-luotu-paatos-rajapinnasta [:hoitovuoden-paatos :poistettu])))))
 
 (deftest hae-kustannussuunnitelma-onnistuu-test
-  (let [;; Pakotetaan urakaksi Oulu MHU
-        urakka-id (hae-urakan-id-nimella "Oulun MHU 2019-2024")
+  (let [;; Hae kaikki MHU urakat
+        urakkalistaus (q-map "SELECT id, nimi FROM urakka WHERE tyyppi = 'teiden-hoito'")]
+    (doseq [urakka urakkalistaus]
+      (let [urakka-id (:id urakka)
 
-        ;; Kiinteät kustannukset kannasta
-        kiinteat-kulut-kannasta (:summa (first (q-map
-                                                 (format "SELECT SUM(kit.summa) as summa
+            ;; Kiinteät kustannukset kannasta
+            kiinteat-kulut-kannasta (:summa (first (q-map
+                                                     (format "SELECT COALESCE(SUM(kit.summa), 0) as summa
                                              FROM kiinteahintainen_tyo kit
                                             WHERE kit.sopimus =  (SELECT id FROM sopimus WHERE urakka =  %s);" urakka-id))))
 
-        ;; Arvioidut kustannukset kannasta
-        arvioidut-kulut-kannasta (:summa (first (q-map
-                                                  (format "SELECT SUM(kt.summa) as summa
+            ;; Arvioidut kustannukset kannasta
+            arvioidut-kulut-kannasta (:summa (first (q-map
+                                                      (format "SELECT COALESCE(SUM(kt.summa), 0) as summa
                                               FROM kustannusarvioitu_tyo kt
                                              WHERE kt.sopimus = (SELECT id FROM sopimus WHERE urakka =  %s);" urakka-id))))
 
-        ;; Johto-ja-hallintokorvaukset kannasta
-        johto-ja-hallintokulut-kannasta (:summa (first (q-map
-                                                         (format "SELECT SUM(jjh.tuntipalkka * jjh.tunnit) as summa
+            ;; Johto-ja-hallintokorvaukset kannasta
+            johto-ja-hallintokulut-kannasta (:summa (first (q-map
+                                                             (format "SELECT COALESCE(SUM(jjh.tuntipalkka * jjh.tunnit), 0) as summa
                                                      FROM johto_ja_hallintokorvaus jjh
                                                     WHERE jjh.\"urakka-id\" = %s;" urakka-id))))
 
-        vastaus (api-tyokalut/get-kutsu [(str "/api/analytiikka/suunnitellut-kustannukset/" urakka-id)] kayttaja-analytiikka portti)
-        encoodattu-body (cheshire/decode (:body vastaus) true)
-        kiinteat-kulut-rajapinnasta (apply + (map #(get-in % [:kustannus :summa])
-                                               (get-in encoodattu-body [:suunnitellut-kustannukset :kiinteat-kustannukset])))
-        arvioidut-kulut-rajapinnasta (apply + (map #(get-in % [:kustannus :summa])
-                                                (get-in encoodattu-body [:suunnitellut-kustannukset :arvioidut-kustannukset])))
-        johto-ja-hallintokorvaukset-rajapinnasta (apply + (map #(get-in % [:toimenkuvan-kustannus :summa])
-                                                            (get-in encoodattu-body [:suunnitellut-kustannukset :johto-ja-hallintokorvaukset])))]
+            vastaus (api-tyokalut/get-kutsu [(str "/api/analytiikka/suunnitellut-kustannukset/" urakka-id)] kayttaja-analytiikka portti)
+            encoodattu-body (cheshire/decode (:body vastaus) true)
+            kiinteat-kulut-rajapinnasta (apply + (map #(get-in % [:kustannus :summa])
+                                                   (get-in encoodattu-body [:suunnitellut-kustannukset :kiinteat-kustannukset])))
+            arvioidut-kulut-rajapinnasta (apply + (map #(get-in % [:kustannus :summa])
+                                                    (get-in encoodattu-body [:suunnitellut-kustannukset :arvioidut-kustannukset])))
+            johto-ja-hallintokorvaukset-rajapinnasta (apply + (map #(get-in % [:toimenkuvan-kustannus :summa])
+                                                                (get-in encoodattu-body [:suunnitellut-kustannukset :johto-ja-hallintokorvaukset])))]
 
-    (is (= 200 (:status vastaus)))
-    (is (= kiinteat-kulut-kannasta (bigdec kiinteat-kulut-rajapinnasta)))
-    (is (= arvioidut-kulut-kannasta (bigdec arvioidut-kulut-rajapinnasta)))
-    (is (= johto-ja-hallintokulut-kannasta (bigdec johto-ja-hallintokorvaukset-rajapinnasta)))))
+        (is (= 200 (:status vastaus)))
+        (is (= kiinteat-kulut-kannasta (bigdec kiinteat-kulut-rajapinnasta)))
+        (is (= arvioidut-kulut-kannasta (bigdec arvioidut-kulut-rajapinnasta)))
+        (is (= johto-ja-hallintokulut-kannasta (bigdec johto-ja-hallintokorvaukset-rajapinnasta)))))))
 
 (deftest hae-kustannussuunnitelma-puutteellisilla-tunnuksilla
   (let [;; Pakotetaan urakaksi Oulu MHU

--- a/tietokanta/testidata/suunnitellut_tyot.sql
+++ b/tietokanta/testidata/suunnitellut_tyot.sql
@@ -537,17 +537,17 @@ BEGIN
 
     FOR i IN 10..12 LOOP
             INSERT INTO kiinteahintainen_tyo (vuosi, kuukausi, summa, summa_indeksikorjattu, toimenpideinstanssi, sopimus)
-        VALUES (urakan_alkuvuosi, i, 8000 + i*100, testidata_indeksikorjaa(8000 + i*100, urakan_alkuvuosi, i, urakka_id),(select id from toimenpideinstanssi where nimi = toimenpideinstanssin_nimi ), null);
+        VALUES (urakan_alkuvuosi, i, 8000 + i*100, testidata_indeksikorjaa(8000 + i*100, urakan_alkuvuosi, i, urakka_id),(select id from toimenpideinstanssi where nimi = toimenpideinstanssin_nimi ), urakan_sopimus);
     END LOOP;
     FOR i IN 1..12 LOOP
       FOR vuosi_ IN 1..4 LOOP
         INSERT INTO kiinteahintainen_tyo (vuosi, kuukausi, summa, summa_indeksikorjattu, toimenpideinstanssi, sopimus)
-          VALUES (vuosi_ + urakan_alkuvuosi, i, 8000 + i*100, testidata_indeksikorjaa(8000 + i*100, vuosi_ + urakan_alkuvuosi, i,  urakka_id), (select id from toimenpideinstanssi where nimi = toimenpideinstanssin_nimi ), null);
+          VALUES (vuosi_ + urakan_alkuvuosi, i, 8000 + i*100, testidata_indeksikorjaa(8000 + i*100, vuosi_ + urakan_alkuvuosi, i,  urakka_id), (select id from toimenpideinstanssi where nimi = toimenpideinstanssin_nimi ), urakan_sopimus);
       END LOOP;
     END LOOP;
     FOR i IN 1..9 LOOP
       INSERT INTO kiinteahintainen_tyo (vuosi, kuukausi, summa, summa_indeksikorjattu, toimenpideinstanssi, sopimus)
-        VALUES (5 + urakan_alkuvuosi, i, 8000 + i*100, testidata_indeksikorjaa(8000 + i*100, 5 + urakan_alkuvuosi, i, urakka_id),(select id from toimenpideinstanssi where nimi = toimenpideinstanssin_nimi ), null);
+        VALUES (5 + urakan_alkuvuosi, i, 8000 + i*100, testidata_indeksikorjaa(8000 + i*100, 5 + urakan_alkuvuosi, i, urakka_id),(select id from toimenpideinstanssi where nimi = toimenpideinstanssin_nimi ), urakan_sopimus);
     END LOOP;
   END LOOP;
 
@@ -839,17 +839,17 @@ BEGIN
     FOR i IN 10..12 LOOP
       INSERT INTO kiinteahintainen_tyo (vuosi, kuukausi, summa, summa_indeksikorjattu, toimenpideinstanssi, sopimus)
         VALUES (urakan_alkuvuosi, i, 8000 + i*100, testidata_indeksikorjaa(8000 + i*100, urakan_alkuvuosi, i, urakka_id)
-, (select id from toimenpideinstanssi where nimi = toimenpideinstanssin_nimi ), null);
+, (select id from toimenpideinstanssi where nimi = toimenpideinstanssin_nimi ), urakan_sopimus);
     END LOOP;
     FOR i IN 1..12 LOOP
       FOR vuosi_ IN 1..4 LOOP
         INSERT INTO kiinteahintainen_tyo (vuosi, kuukausi, summa, summa_indeksikorjattu, toimenpideinstanssi, sopimus)
-          VALUES ((vuosi_ + urakan_alkuvuosi), i, 8000 + i*100, testidata_indeksikorjaa(8000 + i*100, (vuosi_ + urakan_alkuvuosi), i, urakka_id), (select id from toimenpideinstanssi where nimi = toimenpideinstanssin_nimi ), null);
+          VALUES ((vuosi_ + urakan_alkuvuosi), i, 8000 + i*100, testidata_indeksikorjaa(8000 + i*100, (vuosi_ + urakan_alkuvuosi), i, urakka_id), (select id from toimenpideinstanssi where nimi = toimenpideinstanssin_nimi ), urakan_sopimus);
       END LOOP;
     END LOOP;
     FOR i IN 1..9 LOOP
       INSERT INTO kiinteahintainen_tyo (vuosi, kuukausi, summa, summa_indeksikorjattu, toimenpideinstanssi, sopimus)
-        VALUES ((5 + urakan_alkuvuosi), i, 8000 + i*100, testidata_indeksikorjaa(8000 + i*100, (5 + urakan_alkuvuosi), i, urakka_id), (select id from toimenpideinstanssi where nimi = toimenpideinstanssin_nimi ), null);
+        VALUES ((5 + urakan_alkuvuosi), i, 8000 + i*100, testidata_indeksikorjaa(8000 + i*100, (5 + urakan_alkuvuosi), i, urakka_id), (select id from toimenpideinstanssi where nimi = toimenpideinstanssin_nimi ), urakan_sopimus);
     END LOOP;
   END LOOP;
 
@@ -1309,12 +1309,12 @@ BEGIN
 
     FOR i IN 10..12 LOOP
       INSERT INTO kiinteahintainen_tyo (vuosi, kuukausi, summa, summa_indeksikorjattu, toimenpideinstanssi, sopimus)
-      VALUES (urakan_alkuvuosi, i, 8000 + i*100, testidata_indeksikorjaa(8000 + i * 100, urakan_alkuvuosi, i,  urakka_id), (select id from toimenpideinstanssi where nimi = toimenpideinstanssin_nimi ), null);
+      VALUES (urakan_alkuvuosi, i, 8000 + i*100, testidata_indeksikorjaa(8000 + i * 100, urakan_alkuvuosi, i,  urakka_id), (select id from toimenpideinstanssi where nimi = toimenpideinstanssin_nimi ), urakan_sopimus);
     END LOOP;
     FOR i IN 1..12 LOOP
       FOR vuosi_ IN 1..4 LOOP
        INSERT INTO kiinteahintainen_tyo (vuosi, kuukausi, summa, summa_indeksikorjattu, toimenpideinstanssi, sopimus)
-        VALUES ((vuosi_ + urakan_alkuvuosi), i, 8000 + i*100, testidata_indeksikorjaa(8000 + i * 100, (vuosi_ + urakan_alkuvuosi), i,  urakka_id), (select id from toimenpideinstanssi where nimi = toimenpideinstanssin_nimi ), null);
+        VALUES ((vuosi_ + urakan_alkuvuosi), i, 8000 + i*100, testidata_indeksikorjaa(8000 + i * 100, (vuosi_ + urakan_alkuvuosi), i,  urakka_id), (select id from toimenpideinstanssi where nimi = toimenpideinstanssin_nimi ), urakan_sopimus);
       END LOOP;
     END LOOP;
     FOR i IN 1..9 LOOP
@@ -1324,7 +1324,7 @@ BEGIN
           EXIT;
       END IF;
         INSERT INTO kiinteahintainen_tyo (vuosi, kuukausi, summa, summa_indeksikorjattu, toimenpideinstanssi, sopimus)
-          VALUES ((5 + urakan_alkuvuosi), i, 8000 + i*100, testidata_indeksikorjaa(8000 + i * 100, (5 + urakan_alkuvuosi), i,  urakka_id), (select id from toimenpideinstanssi where nimi = toimenpideinstanssin_nimi ), null);
+          VALUES ((5 + urakan_alkuvuosi), i, 8000 + i*100, testidata_indeksikorjaa(8000 + i * 100, (5 + urakan_alkuvuosi), i,  urakka_id), (select id from toimenpideinstanssi where nimi = toimenpideinstanssin_nimi ), urakan_sopimus);
     END LOOP;
   END LOOP;
 


### PR DESCRIPTION
Nyt elinvoimakeskus muutoksessa hetken aikaa on osalla urakoista maksuerässä kaksi tunnistetta. Näillä maksuerä kolumni on liian kapea. Levennetään sitä hieman.

Lisäsin samalla myös pienen parannuksen analytiikan palauttamien suunniteltujen kulujen rajapinnan testaukseen.