### PR TITLE
Yhdistä PR:in haku ja formatointi

### DIFF
--- a/.github/workflows/cron_process-stale-prs.yml
+++ b/.github/workflows/cron_process-stale-prs.yml
@@ -63,36 +63,25 @@ jobs:
           days-before-issue-stale: -1
           days-before-issue-close: -1
 
-      - name: Get all PRs labeled as Stale
-        id: stale-prs
+      - name: Get and format all PRs labeled as Stale
+        id: stale-prs-list
         uses: actions/github-script@v8
         with:
           script: |
             const { data: pullRequests } = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              per_page: 100,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'open',
+            per_page: 100,
             });
 
             const stalePRs = pullRequests.filter(pr => 
-              pr.labels.some(label => label.name === 'Stale')
+            pr.labels.some(label => label.name === 'Stale')
             );
             
             console.log(`Found ${stalePRs.length} stale PR(s).`);
             console.log(stalePRs.map(pr => `#${pr.number}: ${pr.title}`).join('\n'));
             
-            core.setOutput("stale-prs", stalePRs);
-
-      - name: Format Stale PRs list
-        if: ${{ steps.stale-prs.outputs.stale-prs != '[]' }}
-        id: stale-prs-list
-        uses: actions/github-script@v8
-        env:
-          STALE_PRS: ${{ steps.stale-prs.outputs.stale-prs }}
-        with:
-          script: |
-            const stalePRs = JSON.parse(process.env.STALE_PRS);
             const formattedList = stalePRs
               .map(pr => `- <https://github.com/finnishtransportagency/harja/pull/${pr.number}|#${pr.number}>: ${pr.title}`)
               .join('\\n');


### PR DESCRIPTION
* GitHub Actions lokituksessa tai GHA script työkalussa on rajoituksia, jotka voivat johtaa NodeJS ajon kaatumiseen virheellä 'Argument list too long'
* Tässä yhdistetään PR:ien etsintä ja formatointi samaan script-blokkiin, jotta tuloksia ei tarvitse välittää ENV-muuttujalla stepiltä toiselle