### PR TITLE
HARJA-2101 - Tehtävä- ja määräluettelo -sivun tekstikorjaukset

### DIFF
--- a/cypress/e2e/tehtavat_ja_maarat.cy.js
+++ b/cypress/e2e/tehtavat_ja_maarat.cy.js
@@ -53,8 +53,8 @@ describe('Tehtävä- ja määräluettelo -näkymän testaus', () => {
     })
 
     it('Avaa tehtävä- ja määräluettelo', () => {
-        cy.get('h1').contains('Tehtävät ja määrät').should('be.visible');
-        cy.get('span').contains('Sovitut muutokset alkuperäisiin sopimuksen tehtävämääriin kirjataan muutokset-sivulla.').should('be.visible');
+        cy.get('h1').contains('Tehtävä ja määräluettelo').should('be.visible');
+        cy.get('span').contains('Pysyvät muutokset sopimuksen määriin kirjataan muutokset-sivulla.').should('be.visible');
 
         cy.get('table.grid').contains('Ise 2-ajorat.').should('be.visible');
         cy.get('table.grid').contains('Ise 1-ajorat.').should('be.visible');
@@ -64,7 +64,7 @@ describe('Tehtävä- ja määräluettelo -näkymän testaus', () => {
 
     });
 
-    it('Muokkaa sopimuksen määriä', () => {
+    it('Muokkaa alkuperäisen sopimuksen määriä', () => {
         cy.intercept('POST', '_/tallenna-tehtavat-ja-maarat').as('tallenna');
 
         cy.get('[data-cy="btn-muokkaa-sopimuksen-maaria"]').click();

--- a/src/cljs/harja/ui/grid/perus.cljs
+++ b/src/cljs/harja/ui/grid/perus.cljs
@@ -132,7 +132,15 @@
 
              [:td {:class (y/luokat "ei-muokattava" tasaus-luokka (grid-yleiset/tiivis-tyyli skeema esta-tiivis-grid?)
                             (when solun-luokka (solun-luokka arvo rivi)))}
-              ((or fmt str) (hae rivi))])))})))
+              (cond
+                (= tyyppi :komponentti) (apply komponentti rivi {:index index
+                                                                 :muokataan? false}
+                                          komponentti-args)
+                (= tyyppi :reagent-komponentti) (vec (concat [komponentti rivi {:index index
+                                                                                :muokataan? false}]
+                                                       komponentti-args))
+                fmt (fmt arvo)
+                :else [nayta-arvo sarake (vain-luku-atomina arvo)])])))})))
 
 (defn etsi-seuraava-input
   "Etsii seuraavan input-elementin annetun rivin suunnassa (:eteen tai :taakse).
@@ -854,7 +862,10 @@
   Jokainen skeeman itemi on mappi, jossa seuraavat avaimet:
 
   :nimi                                 kentän hakufn
-  :fmt                                  kentän näyttämis-fn (oletus str). Ottaa argumenttina kentän arvon.
+  :fmt                                  kentän näyttämis-fn. Ottaa argumenttina kentän arvon. Jos puuttuu,
+                                        arvo renderöidään `nayta-arvo`-multimethodilla (:tyyppi perusteella,
+                                        oletus `:default` -> `str`). Sama oletus koskee myös muokkaustilassa
+                                        ei-muokattavia soluja.
   :hae                                  funktio, jolla voidaan näyttää arvo kentässä. Ottaa argumenttina koko rivin.
   :otsikko                              ihmiselle näytettävä otsikko
   :otsikko-komp                         jos haluaa viedä sarakkeen yläriviin (theadin th) toiminnallisuutta, kuten checkboxin

--- a/src/cljs/harja/ui/grid/perus.cljs
+++ b/src/cljs/harja/ui/grid/perus.cljs
@@ -132,15 +132,7 @@
 
              [:td {:class (y/luokat "ei-muokattava" tasaus-luokka (grid-yleiset/tiivis-tyyli skeema esta-tiivis-grid?)
                             (when solun-luokka (solun-luokka arvo rivi)))}
-              (cond
-                (= tyyppi :komponentti) (apply komponentti rivi {:index index
-                                                                 :muokataan? false}
-                                          komponentti-args)
-                (= tyyppi :reagent-komponentti) (vec (concat [komponentti rivi {:index index
-                                                                                :muokataan? false}]
-                                                       komponentti-args))
-                fmt (fmt arvo)
-                :else [nayta-arvo sarake (vain-luku-atomina arvo)])])))})))
+              ((or fmt str) (hae rivi))])))})))
 
 (defn etsi-seuraava-input
   "Etsii seuraavan input-elementin annetun rivin suunnassa (:eteen tai :taakse).

--- a/src/cljs/harja/ui/grid/perus.cljs
+++ b/src/cljs/harja/ui/grid/perus.cljs
@@ -854,10 +854,7 @@
   Jokainen skeeman itemi on mappi, jossa seuraavat avaimet:
 
   :nimi                                 kentän hakufn
-  :fmt                                  kentän näyttämis-fn. Ottaa argumenttina kentän arvon. Jos puuttuu,
-                                        arvo renderöidään `nayta-arvo`-multimethodilla (:tyyppi perusteella,
-                                        oletus `:default` -> `str`). Sama oletus koskee myös muokkaustilassa
-                                        ei-muokattavia soluja.
+  :fmt                                  kentän näyttämis-fn (oletus str). Ottaa argumenttina kentän arvon.
   :hae                                  funktio, jolla voidaan näyttää arvo kentässä. Ottaa argumenttina koko rivin.
   :otsikko                              ihmiselle näytettävä otsikko
   :otsikko-komp                         jos haluaa viedä sarakkeen yläriviin (theadin th) toiminnallisuutta, kuten checkboxin

--- a/src/cljs/harja/views/urakka/suunnittelu/tehtavat_maarat_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tehtavat_maarat_nakyma.cljs
@@ -117,10 +117,12 @@
         :tunniste :id
         :voi-kumota? false}
        [{:otsikko "Voimassa alkaen" :nimi :voimassa_alkaen :tyyppi :string :fmt pvm/pvm :leveys "10%"}
-        {:otsikko "Edellinen määrä" :nimi :edellinen_maara :leveys "10%" :tyyppi :numero :desimaalien-maara 2 :tasaa :oikea}
+        {:otsikko "Edellinen määrä" :nimi :edellinen_maara :leveys "10%" :tyyppi :numero :desimaalien-maara 2 :tasaa :oikea
+         :fmt #(fmt/desimaaliluku-opt % 2)}
         {:otsikko "Pysyvät muutokset (+/-)" :nimi :maaramuutos :leveys "10%" :tyyppi :numero :tasaa :oikea
          :fmt (fn [arvo] (muutoksen-vaikutus-fn arvo))}
-        {:otsikko "Muuttunut määrä" :nimi :uusi_maara :leveys "10%" :tyyppi :numero :desimaalien-maara 2 :tasaa :oikea}
+        {:otsikko "Muuttunut määrä" :nimi :uusi_maara :leveys "10%" :tyyppi :numero :desimaalien-maara 2 :tasaa :oikea
+         :fmt #(fmt/desimaaliluku-opt % 2)}
         {:otsikko "Lisätieto" :nimi :syy :leveys "60%" :tyyppi :string :tasaa :vasen}]
        muutokset]]]))
 
@@ -156,6 +158,7 @@
                                      [:div.body-text.strong valiotsikko]))}
                      {:otsikko "Alkuperäisen sopimuksen määrä"
                       :leveys "12.5%"
+                      :fmt #(fmt/desimaaliluku-opt % 2)
                       :nimi :tarjous_maara
                       :tyyppi :positiivinen-numero
                       :desimaalien-maara 2
@@ -178,8 +181,9 @@
                       :desimaalien-maara 2
                       :muokattava? (constantly false)
                       :solun-luokka solun-luokka-fn
-                      :tasaa :oikea}
-                   {:otsikko "Yksikkö" :leveys "12.5%" :nimi :yksikko :tyyppi :teksti :tasaa :vasen :muokattava? (constantly false) :solun-luokka solun-luokka-fn}]]
+                        :tasaa :oikea
+                        :fmt #(fmt/desimaaliluku-opt % 2)}
+                     {:otsikko "Yksikkö" :leveys "12.5%" :nimi :yksikko :tyyppi :teksti :tasaa :vasen :muokattava? (constantly false) :solun-luokka solun-luokka-fn}]]
     (if haku-kaynnissa?
       [ajax-loader-pieni]
       [grid/grid

--- a/src/cljs/harja/views/urakka/suunnittelu/tehtavat_maarat_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tehtavat_maarat_nakyma.cljs
@@ -1,5 +1,5 @@
 (ns harja.views.urakka.suunnittelu.tehtavat-maarat-nakyma
-  (:require [reagent.core :refer [atom] :as r]
+  (:require [reagent.core :as r]
             [harja.pvm :as pvm]
             [harja.ui.dom :as dom]
             [tuck.core :as tuck]
@@ -92,9 +92,8 @@
 (defn muutoksen-vaikutus-fn [arvo]
   (cond
     (nil? arvo) "-"
-    (pos? arvo) (str "+" arvo)
-    (neg? arvo) (str arvo)
-    :else arvo))
+    (pos? arvo) (str "+" (fmt/desimaaliluku-opt arvo 2))
+    :else (fmt/desimaaliluku-opt arvo 2)))
 
 (defn tehtava-vetolaatikko
   "Näyttää tehtävän muutokset vetolatikossa"
@@ -166,23 +165,20 @@
                                     ;; Älä anna muokata väliotsikkorivejä
                                     (nil? (:valiotsikko %)))
                     :solun-luokka solun-luokka-fn}
-                   {:otsikko "Pysyvät muutokset (+/-)" :leveys "12.5%"
-                    :nimi :muutos_maaramuutos
-                    :solun-luokka solun-luokka-fn
-                    :tasaa :oikea
-                    :tyyppi :komponentti
-                    :komponentti (fn [{:keys [tehtava_id muutos_maaramuutos] :as rivi}]
-                                   (if tehtava_id
-                                     [:span (muutoksen-vaikutus-fn muutos_maaramuutos)]
-                                     [:span]))}
-                   {:otsikko "Muuttunut määrä" :leveys "12.5%" :nimi :yhteensa
-                    :tyyppi :komponentti
-                    :solun-luokka solun-luokka-fn
-                    :tasaa :oikea
-                    :komponentti (fn [{:keys [tehtava_id yhteensa] :as rivi}]
-                                   (if tehtava_id
-                                     [:span (fmt/desimaaliluku-opt yhteensa 2)]
-                                     [:span]))}
+                     {:otsikko "Pysyvät muutokset (+/-)" :leveys "12.5%"
+                      :nimi :muutos_maaramuutos
+                      :solun-luokka solun-luokka-fn
+                      :tasaa :oikea
+                      :tyyppi :numero
+                      :desimaalien-maara 2
+                      :muokattava? (constantly false)
+                      :fmt muutoksen-vaikutus-fn}
+                     {:otsikko "Muuttunut määrä" :leveys "12.5%" :nimi :yhteensa
+                      :tyyppi :numero
+                      :desimaalien-maara 2
+                      :muokattava? (constantly false)
+                      :solun-luokka solun-luokka-fn
+                      :tasaa :oikea}
                    {:otsikko "Yksikkö" :leveys "12.5%" :nimi :yksikko :tyyppi :teksti :tasaa :vasen :muokattava? (constantly false) :solun-luokka solun-luokka-fn}]]
     (if haku-kaynnissa?
       [ajax-loader-pieni]

--- a/src/cljs/harja/views/urakka/suunnittelu/tehtavat_maarat_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tehtavat_maarat_nakyma.cljs
@@ -68,7 +68,7 @@
      [:div.painikkeet.text-right.grid-status-viestit
       [:span {:style {:margin-left "1rem"}}
        [napit/muokkaa
-       "Muokkaa sopimuksen määriä"
+         "Muokkaa alkuperäisen sopimuksen määriä"
         #(e! (tiedot/->ToggleTallennusTila))
         {:data-cy "btn-muokkaa-sopimuksen-maaria"}]]])])
 
@@ -118,12 +118,13 @@
         :tunniste :id
         :voi-kumota? false}
        [{:otsikko "Voimassa alkaen" :nimi :voimassa_alkaen :tyyppi :string :fmt pvm/pvm :leveys "10%"}
-        {:otsikko "Edellinen määrä" :nimi :edellinen_maara :leveys "10%" :tyyppi :numero :tasaa :oikea}
-        {:otsikko "Muutoksen vaikutus" :nimi :maaramuutos :leveys "10%" :tyyppi :numero :tasaa :oikea
+        {:otsikko "Edellinen määrä" :nimi :edellinen_maara :leveys "10%" :tyyppi :numero :desimaalien-maara 2 :tasaa :oikea}
+        {:otsikko "Pysyvät muutokset (+/-)" :nimi :maaramuutos :leveys "10%" :tyyppi :numero :tasaa :oikea
          :fmt (fn [arvo] (muutoksen-vaikutus-fn arvo))}
-        {:otsikko "Muuttunut määrä" :nimi :uusi_maara :leveys "10%" :tyyppi :numero :tasaa :oikea}
+        {:otsikko "Muuttunut määrä" :nimi :uusi_maara :leveys "10%" :tyyppi :numero :desimaalien-maara 2 :tasaa :oikea}
         {:otsikko "Lisätieto" :nimi :syy :leveys "60%" :tyyppi :string :tasaa :vasen}]
        muutokset]]]))
+
 
 (defn tehtava-taulukko [e! haku-kaynnissa? tallennustila? tehtavat-ja-maarat avatut-tehtavaryhmat]
   (let [;; Filtteröidään listasta pois ne rivit, joita ei ole aukaistu
@@ -154,13 +155,18 @@
                                    (if tehtava_id
                                      [:<> nimi]
                                      [:div.body-text.strong valiotsikko]))}
-                   {:otsikko "Sopimuksen määrä" :leveys "12.5%" :nimi :tarjous_maara :tyyppi :positiivinen-numero :tasaa :oikea
-                    :muokattava? #(and
+                     {:otsikko "Alkuperäisen sopimuksen määrä"
+                      :leveys "12.5%"
+                      :nimi :tarjous_maara
+                      :tyyppi :positiivinen-numero
+                      :desimaalien-maara 2
+                      :tasaa :oikea
+                      :muokattava? #(and
                                     tallennustila?
                                     ;; Älä anna muokata väliotsikkorivejä
                                     (nil? (:valiotsikko %)))
                     :solun-luokka solun-luokka-fn}
-                   {:otsikko "Muutoksen vaikutus" :leveys "12.5%"
+                   {:otsikko "Pysyvät muutokset (+/-)" :leveys "12.5%"
                     :nimi :muutos_maaramuutos
                     :solun-luokka solun-luokka-fn
                     :tasaa :oikea
@@ -175,7 +181,7 @@
                     :tasaa :oikea
                     :komponentti (fn [{:keys [tehtava_id yhteensa] :as rivi}]
                                    (if tehtava_id
-                                     [:span yhteensa]
+                                     [:span (fmt/desimaaliluku-opt yhteensa 2)]
                                      [:span]))}
                    {:otsikko "Yksikkö" :leveys "12.5%" :nimi :yksikko :tyyppi :teksti :tasaa :vasen :muokattava? (constantly false) :solun-luokka solun-luokka-fn}]]
     (if haku-kaynnissa?
@@ -215,7 +221,7 @@
         onko-viimeinen-vuosi? (= valitun-hoitokauden-alkuvuosi urakan-loppuvuoden-alkuvuosi)]
     [:div#vayla
      [:div.row
-      [:h1 "Tehtävät ja määrät"]]
+      [:h1 "Tehtävä ja määräluettelo"]]
 
      [:div.flex-row {:style {:justify-content "space-between"}}
       [:div.filtteri
@@ -234,7 +240,7 @@
                                  :toiminta-f #(e! (tiedot/->FiltteroiTehtavat %))}
               (r/atom haku)]]]]
      [:div.flex-row
-      [:span "Sovitut muutokset alkuperäisiin sopimuksen tehtävämääriin kirjataan muutokset-sivulla. "
+                [:span "Pysyvät muutokset sopimuksen määriin kirjataan muutokset-sivulla. "
        [yleiset/linkki "Siirry muutokset-sivulle"
         #(siirtymat/siirry-annettuun-valilehteen
            @nav/valittu-hallintayksikko-id (:id @nav/valittu-urakka)


### PR DESCRIPTION
## Tiivistelmä
Päivittää Tehtävä- ja määräluettelo -näkymän tekstejä ja yhtenäistää määrien esitystä (2 desimaalia). Tämä selkeyttää terminologiaa ja tekee numeroista johdonmukaisempia käyttäjälle. Cypress E2E -testi on päivitetty vastaamaan uusia otsikoita/tekstejä.

## Muutokset
- Päivittää näkymän otsikon ja ohjetekstin sekä muokkauspainikkeen tekstin (“Muokkaa alkuperäisen sopimuksen määriä”).
- Tarkentaa sarakeotsikoita (“Pysyvät muutokset (+/-)”) ja varmistaa määrien/yhteensä-kenttien 2 desimaalin esityksen sekä muutoksen etumerkin (+/-).
- Päivittää Cypress-testin odotukset uusille otsikoille/teksteille.

## Muita huomioita
- Breaking changes: ei API-muutoksia, mutta UI-tekstit muuttuvat (voi vaikuttaa muihin tekstipohjaisiin testiodotuksiin).
- Testing recommendations: aja Cypress-speci esim. `npx cypress run --spec cypress/e2e/tehtavat_ja_maarat.cy.js`, ja tee nopea manuaalinen smoke “Tehtävä ja määräluettelo” -näkymässä.
