### PR TITLE
Harja 2110 lisatyot ei nay tuotannossa

### DIFF
--- a/src/clj/harja/kyselyt/lisatyot_kyselyt.sql
+++ b/src/clj/harja/kyselyt/lisatyot_kyselyt.sql
@@ -1,18 +1,17 @@
 -- name: hae-urakan-lisatyot
-
-SELECT rivi,
-       kulu,
+SELECT kk.rivi,
+       kk.kulu,
        k.urakka,
-       summa,
-       toimenpideinstanssi,
-       maksueratyyppi,
-       erapaiva,
-       lisatyon_lisatieto,
+       kk.summa,
+       kk.toimenpideinstanssi,
+       kk.maksueratyyppi,
+       k.erapaiva,
+       kk.lisatyon_lisatieto,
        tp.nimi AS toimenpide
   FROM kulu_kohdistus kk
            JOIN kulu k ON kk.kulu = k.id AND k.poistettu IS NOT TRUE
-           JOIN toimenpide tp ON tp.id = kk.toimenpideinstanssi
- WHERE maksueratyyppi = 'lisatyo'
+           JOIN toimenpideinstanssi tp ON tp.id = kk.toimenpideinstanssi
+ WHERE kk.maksueratyyppi = 'lisatyo'
    AND k.urakka = :urakka
-   AND erapaiva BETWEEN :alkupvm::DATE AND :loppupvm::DATE
+   AND k.erapaiva BETWEEN :alkupvm::DATE AND :loppupvm::DATE
  ORDER BY erapaiva;

--- a/src/clj/harja/kyselyt/urakat.sql
+++ b/src/clj/harja/kyselyt/urakat.sql
@@ -261,7 +261,7 @@ FROM urakka u
   LEFT JOIN siltapalvelusopimus sps ON u.urakkanro = sps.urakkanro
   LEFT JOIN yhatiedot yt ON u.id = yt.urakka
   LEFT JOIN kayttaja k ON k.id = yt.kohdeluettelo_paivittaja
-WHERE hallintayksikko = :hallintayksikko
+WHERE u.hallintayksikko = :hallintayksikko
       AND u.poistettu = false
       AND (u.id IN (:sallitut_urakat)
            OR (('elinvoimakeskus'::organisaatiotyyppi = :kayttajan_org_tyyppi :: organisaatiotyyppi OR

--- a/src/clj/harja/palvelin/raportointi/raportit/lisatyo.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/lisatyo.clj
@@ -9,6 +9,8 @@
 (defqueries "harja/kyselyt/lisatyot_kyselyt.sql"
   {:positional? true})
 
+(declare hae-urakan-lisatyot)
+
 (defn suorita [db user {:keys [urakka-id alkupvm loppupvm] :as parametrit}]
   (log/debug "Lisätyöraportti :: suorita urakka_id=" urakka-id " alkupvm=" alkupvm " loppupvm=" loppupvm
     " parametrit=" parametrit)

--- a/src/cljs/harja/tiedot/navigaatio.cljs
+++ b/src/cljs/harja/tiedot/navigaatio.cljs
@@ -589,12 +589,9 @@
     (let [uri (Uri/parse url)
           polku (.getPath uri)
           parametrit (.getQueryData uri)
-          hy-id-urlista (some-> parametrit (.get "hy") js/parseInt)
-          hallintayksikko-id-vaihtui? (not (= hy-id-urlista @valittu-hallintayksikko-id))
+          _ (reset! valittu-hallintayksikko-id (some-> parametrit (.get "hy") js/parseInt))
           u-id-urlista (some-> parametrit (.get "u") js/parseInt)
           i-id-urlista (some-> parametrit (.get "i") js/parseInt)]
-      (when hallintayksikko-id-vaihtui?
-        (reset! valittu-hallintayksikko-id hy-id-urlista))
       (when-not (= u-id-urlista @valittu-urakka-id)
         (reset! valittu-urakka-id u-id-urlista))
       (when-not (= i-id-urlista @valittu-ilmoitus-id)
@@ -607,7 +604,7 @@
                      {:arvo :vesivayla}
                      {:arvo :hoito})]
           (vaihda-vaylamuoto! arvo)))
-      (when hallintayksikko-id-vaihtui?
+      (when @valittu-hallintayksikko-id
         (reset! valittu-vaylamuoto (<! (hy/hallintayksikon-vaylamuoto @valittu-hallintayksikko-id))))
 
       (<! (hy/aseta-hallintayksikot-vaylamuodolle! @valittu-vaylamuoto))


### PR DESCRIPTION
**Tässä korjataan kaksi bugia.**
1. 
Ensimäinen on simppeli. Korjataan tuo, että lisätyöraportti ei toimi. Se johtui siitä, että siinä haettiin toimenpideinstansseja toimenpide -taulusta.

2.
Toisessa korjataan vesiväyläurakoiden valinta. Se johtui siitä, että hallintayksikkö atomin resetointi ei toiminut oikein ja tästä syystä, kun vesiväyläurakan hallintayksiköt (joita on kolme ja ne ei ole elyjä) valittiin, niin atomin tyhjyyden takia siihen renderöitiin elyt, kun olisi pitänyt renderöidä valitun hallitayksikön urakat. 
Ja sitten kun valitsi vaikka "uusimaa" niin sieltä ei löytynyt kanavaurakoita, koska ne ei kuulu elylle, vaan hallintayksikölle, jonka nimi voi olla vaikka "Kanavat ja avattavat sillat".