### PR TITLE
HARJA-2071 - Tehtävä ja määräluettelon suunnittelemattomille tehtäville tulee turhat nullit min

### DIFF
--- a/src/clj/harja/kyselyt/tehtavat_maarat_kyselyt.clj
+++ b/src/clj/harja/kyselyt/tehtavat_maarat_kyselyt.clj
@@ -1,5 +1,6 @@
 (ns harja.kyselyt.tehtavat-maarat-kyselyt
   (:require [harja.kyselyt.konversio :as konversio]
+            [harja.tyokalut.big :as big]
             [jeesql.core :refer [defqueries]]))
 
 (defqueries "harja/kyselyt/tehtavat_maarat_kyselyt.sql"
@@ -11,23 +12,35 @@
   paivita-tarjous-tehtava<! lisaa-tarjous-tehtava<!)
 
 (defn tallenna-tarjouksen-tehtavat-ja-maarat [db urakka-id kayttaja-id hk-alkuvuosi tehtavat]
-  ;; Filtteröidään valiotsikot pois
-  (doseq [{:keys [tehtava_id tarjous_maara nimi] :as tehtava} (filter #(nil? (:valiotsikko %)) tehtavat)]
-    (let [dbtehtava (first (hae-tarjous-tehtava-idlla db {:tehtavaid tehtava_id
-                                                          :urakkaid urakka-id
-                                                          :hoitokauden-alkuvuosi hk-alkuvuosi}))
-          dbvastaus (if dbtehtava
-                      ;; Tehtävä löytyy kannasta
-                      (paivita-tarjous-tehtava<! db {:tarjous_tehtava_id (:id dbtehtava)
-                                                     :urakkaid urakka-id
-                                                     :maara tarjous_maara
-                                                     :muokkaaja kayttaja-id})
-                      ;; Lisätään uutena
-                      (lisaa-tarjous-tehtava<! db {:tehtavaid tehtava_id
-                                                   :urakkaid urakka-id
-                                                   :maara tarjous_maara
-                                                   :luoja kayttaja-id
-                                                   :hoitokauden-alkuvuosi hk-alkuvuosi}))])))
+  (doseq [{:keys [tehtava_id tarjous_maara]} (remove :valiotsikko tehtavat)]
+    ;; Tallennetaan vain tehtävät, joille on annettu arvo.
+    ;; Tämä estää tilanteen, jossa nil päätyy urakka_tehtavamaara.maara-kenttään.
+    (when-some [tarjous-maara-arvo tarjous_maara]
+      (let [tarjous-maara (bigdec tarjous-maara-arvo)
+            dbtehtava (first (hae-tarjous-tehtava-idlla db {:tehtavaid tehtava_id
+                                                            :urakkaid urakka-id
+                                                            :hoitokauden-alkuvuosi hk-alkuvuosi}))
+            db-maara (:maara dbtehtava)
+            sama-maara? (big/bigdecimal-arvot-samat? tarjous-maara db-maara)]
+        (cond
+          ;; Ei päivitetä turhaan, jotta muokattu/muokkaaja eivät vääristy.
+          sama-maara?
+          nil
+
+          ;; Tehtävä löytyy kannasta
+          dbtehtava
+          (paivita-tarjous-tehtava<! db {:tarjous_tehtava_id (:id dbtehtava)
+                                         :urakkaid urakka-id
+                                         :maara tarjous-maara
+                                         :muokkaaja kayttaja-id})
+
+          ;; Lisätään uutena
+          :else
+          (lisaa-tarjous-tehtava<! db {:tehtavaid tehtava_id
+                                       :urakkaid urakka-id
+                                       :maara tarjous-maara
+                                       :luoja kayttaja-id
+                                       :hoitokauden-alkuvuosi hk-alkuvuosi}))))))
 
 (defn hae-tehtavat-ja-maarat
   [db urakka-id hoitokauden-alkuvuosi]

--- a/src/cljc/harja/tyokalut/big.cljc
+++ b/src/cljc/harja/tyokalut/big.cljc
@@ -115,3 +115,12 @@
      (if (big? b)
        (:b b)
        b)))
+
+#?(:clj
+  (defn bigdecimal-arvot-samat?
+    "True, jos kahden BigDecimalin numeerinen arvo on sama (scale huomioimatta).
+  Palauttaa false, jos jompikumpi arvoista on nil."
+    [^java.math.BigDecimal a ^java.math.BigDecimal b]
+    (and (some? a)
+       (some? b)
+       (zero? (.compareTo a b)))))

--- a/src/cljs/harja/tiedot/urakka/suunnittelu/tehtavat_maarat_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/suunnittelu/tehtavat_maarat_tiedot.cljs
@@ -55,13 +55,28 @@
 (def ^:private puuttuva-tarjousmaara-viesti
   "Syötä määrä tai aseta 0. Tyhjää arvoa ei voi tallentaa.")
 
-(defn- puuttuuko-tarjous-maara?
+(defn- tyhja-tarjous-maara?
   "True jos tehtäväriviltä puuttuu sopimuksen määrä (nil/tyhjä)."
-  [{:keys [valiotsikko tehtava_id tarjous_maara]}]
+  [{:keys [tarjous_maara]}]
+  (or (nil? tarjous_maara)
+      (and (string? tarjous_maara) (str/blank? tarjous_maara))))
+
+(defn- tehtavarivi?
+  [{:keys [valiotsikko tehtava_id]}]
   (and (nil? valiotsikko)
-       (some? tehtava_id)
-       (or (nil? tarjous_maara)
-           (and (string? tarjous_maara) (str/blank? tarjous_maara)))))
+       (some? tehtava_id)))
+
+(defn- tyhjennettiinko-aiempi-tarjous-maara?
+  "True jos rivillä oli aiemmin arvo ja se on nyt tyhjä.
+
+  Periaate: sallitaan tallennus, vaikka osalla riveistä ei ole koskaan ollut arvoa,
+  mutta estetään käyttäjää tyhjentämästä aiemmin syötettyä arvoa (syötä tällöin 0)."
+  [tehtava-id->alkuperainen-rivi {:keys [tehtava_id] :as rivi}]
+  (when (tehtavarivi? rivi)
+    (let [alkuperainen (get tehtava-id->alkuperainen-rivi tehtava_id)
+          alkuperainen-maara (:tarjous_maara alkuperainen)]
+      (and (some? alkuperainen-maara)
+           (tyhja-tarjous-maara? rivi)))))
 
 (extend-protocol tuck/Event
 
@@ -88,8 +103,16 @@
 
   TallennaTehtavat
   (process-event [{tehtavat :tehtavat kopioi-tuleville-vuosille? :kopioi-tuleville-vuosille?} app]
-    (if (and (not kopioi-tuleville-vuosille?)
-             (some puuttuuko-tarjous-maara? tehtavat))
+    (let [tehtava-id->alkuperainen-rivi (into {}
+                                          (keep (fn [rivi]
+                                                  (when (tehtavarivi? rivi)
+                                                    [(:tehtava_id rivi) rivi])))
+                                          (:kaikki-tehtavat app))
+          tyhjennys-yritys? (and (not kopioi-tuleville-vuosille?)
+                                 (some (partial tyhjennettiinko-aiempi-tarjous-maara?
+                                                tehtava-id->alkuperainen-rivi)
+                                       tehtavat))]
+      (if tyhjennys-yritys?
       (do
         (viesti/nayta-toast!
           puuttuva-tarjousmaara-viesti
@@ -105,7 +128,7 @@
           {:onnistui ->TallennaTehtavatOnnistui
            :epaonnistui ->TallennaTehtavatEpaonnistui
            :paasta-virhe-lapi? true})
-        (assoc app :tallennus-kaynnissa? true))))
+        (assoc app :tallennus-kaynnissa? true)))))
 
   TallennaTehtavatOnnistui
   (process-event [{vastaus :vastaus} app]

--- a/src/cljs/harja/tiedot/urakka/suunnittelu/tehtavat_maarat_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/suunnittelu/tehtavat_maarat_tiedot.cljs
@@ -88,7 +88,8 @@
 
   TallennaTehtavat
   (process-event [{tehtavat :tehtavat kopioi-tuleville-vuosille? :kopioi-tuleville-vuosille?} app]
-    (if (some puuttuuko-tarjous-maara? tehtavat)
+    (if (and (not kopioi-tuleville-vuosille?)
+             (some puuttuuko-tarjous-maara? tehtavat))
       (do
         (viesti/nayta-toast!
           puuttuva-tarjousmaara-viesti

--- a/src/cljs/harja/tiedot/urakka/suunnittelu/tehtavat_maarat_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/suunnittelu/tehtavat_maarat_tiedot.cljs
@@ -33,7 +33,7 @@
 (defrecord AvaaRivi [valiotsikko])
 (defrecord NollaaTehtavatJaMaaratMuutokset [])
 
-(defn hae-tehtavat-ja-maarat [parametrit]
+(defn hae-tehtavat-ja-maarat [_parametrit]
   (tuck-apurit/post! :hae-tehtavat-ja-maarat
     {:urakka-id (:id (-> @tiedot/tila :yleiset :urakka))
      :valittu-hoitokausi @u/valittu-hoitokausi}
@@ -52,6 +52,17 @@
       tehtavat)
     tehtavat))
 
+(def ^:private puuttuva-tarjousmaara-viesti
+  "Syötä määrä tai aseta 0. Tyhjää arvoa ei voi tallentaa.")
+
+(defn- puuttuuko-tarjous-maara?
+  "True jos tehtäväriviltä puuttuu sopimuksen määrä (nil/tyhjä)."
+  [{:keys [valiotsikko tehtava_id tarjous_maara]}]
+  (and (nil? valiotsikko)
+       (some? tehtava_id)
+       (or (nil? tarjous_maara)
+           (and (string? tarjous_maara) (str/blank? tarjous_maara)))))
+
 (extend-protocol tuck/Event
 
   HaeTehtavatJaMaarat
@@ -61,7 +72,7 @@
     (assoc app :haku-kaynnissa? true))
 
   HaeTehtavatJaMaaratOnnistui
-  (process-event [{vastaus :vastaus parametrit :parametrit} app]
+  (process-event [{vastaus :vastaus} app]
     (-> app
       (assoc :haku-kaynnissa? false)
       (assoc :tehtavat-ja-maarat (:tehtavat vastaus))
@@ -70,22 +81,30 @@
       (assoc :viimeisin-muokkaaja (:viimeisin-muokkaaja vastaus))))
 
   HaeTehtavatJaMaaratEpaonnistui
-  (process-event [{vastaus :vastaus parametrit :parametrit} app]
+  (process-event [{vastaus :vastaus} app]
     (viesti/nayta-toast! (str "Tietojen hakeminen epäonnistui: " (pr-str vastaus)) :varoitus viesti/viestin-nayttoaika-keskipitka)
     (-> app
       (assoc :haku-kaynnissa? false)))
 
   TallennaTehtavat
   (process-event [{tehtavat :tehtavat kopioi-tuleville-vuosille? :kopioi-tuleville-vuosille?} app]
-    (tuck-apurit/post! :tallenna-tehtavat-ja-maarat
-      {:urakka-id (:id (-> @tiedot/tila :yleiset :urakka))
-       :tehtavat tehtavat
-       :kopioi-tuleville-vuosille? kopioi-tuleville-vuosille?
-       :valittu-hoitokausi @u/valittu-hoitokausi}
-      {:onnistui ->TallennaTehtavatOnnistui
-       :epaonnistui ->TallennaTehtavatEpaonnistui
-       :paasta-virhe-lapi? true})
-    (assoc app :tallennus-kaynnissa? true))
+    (if (some puuttuuko-tarjous-maara? tehtavat)
+      (do
+        (viesti/nayta-toast!
+          puuttuva-tarjousmaara-viesti
+          :varoitus
+          viesti/viestin-nayttoaika-keskipitka)
+        app)
+      (do
+        (tuck-apurit/post! :tallenna-tehtavat-ja-maarat
+          {:urakka-id (:id (-> @tiedot/tila :yleiset :urakka))
+           :tehtavat tehtavat
+           :kopioi-tuleville-vuosille? kopioi-tuleville-vuosille?
+           :valittu-hoitokausi @u/valittu-hoitokausi}
+          {:onnistui ->TallennaTehtavatOnnistui
+           :epaonnistui ->TallennaTehtavatEpaonnistui
+           :paasta-virhe-lapi? true})
+        (assoc app :tallennus-kaynnissa? true))))
 
   TallennaTehtavatOnnistui
   (process-event [{vastaus :vastaus} app]

--- a/test/clj/harja/palvelin/palvelut/suunnittelu/tehtavat_maarat_test.clj
+++ b/test/clj/harja/palvelin/palvelut/suunnittelu/tehtavat_maarat_test.clj
@@ -239,6 +239,37 @@
           (is (= (:tarjous_maara tehtava2) 20M) "Ise 1-ajorat (eli tehtävä2) määrä on tallennettu oikein")
           (is (= (:tarjous_maara tehtava3) 30M) "Ise rampit (eli tehtävä3) määrä on tallennettu oikein"))))))
 
+(deftest ei-tallenna-nulleja-sopimuksen-maariin
+  (testing "Tallennus ei saa kirjoittaa NULL-maaria niille tehtäville joihin ei ole koskettu"
+    (let [db (:db jarjestelma)
+          urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
+          kayttaja-id (:id +kayttaja-jvh+)
+          hoitokauden-alkuvuosi 2024
+          haettu (tm-kyselyt/hae-tehtavat-ja-maarat db urakka-id hoitokauden-alkuvuosi)
+          kaikki-rivit (:tehtavat haettu)
+          tehtavarivit (filter (fn [rivi]
+                                (some? (:tehtava_id rivi)))
+                       kaikki-rivit)
+          muokattava-tehtava-id (:tehtava_id (first tehtavarivit))
+          nil-tehtava-id (:tehtava_id (second tehtavarivit))
+          tehtavat (mapv (fn [t]
+                           (cond
+                             (= (:tehtava_id t) muokattava-tehtava-id) (assoc t :tarjous_maara 100M)
+                             (= (:tehtava_id t) nil-tehtava-id) (assoc t :tarjous_maara nil)
+                             :else t))
+                    kaikki-rivit)]
+
+      (is (some? muokattava-tehtava-id) "Testidata: löytyi muokattava tehtävä")
+      (is (some? nil-tehtava-id) "Testidata: löytyi toinen tehtävä, jolle asetetaan nil")
+
+      (tm-kyselyt/tallenna-tarjouksen-tehtavat-ja-maarat db urakka-id kayttaja-id hoitokauden-alkuvuosi tehtavat)
+
+      (let [nulleja (or (:lkm (first (q-map (format "SELECT COUNT(*) AS lkm\n                                             FROM urakka_tehtavamaara\n                                            WHERE urakka = %s\n                                              AND \"hoitokauden-alkuvuosi\" = %s\n                                              AND maara IS NULL"
+                                            urakka-id hoitokauden-alkuvuosi))))
+                    0)]
+        (is (= 0 nulleja)
+            (str "Kantaan ei saa tallentua NULL-maaria. NULL-riveja: " nulleja))))))
+
 (deftest muutokset-sisaltavat-oikeat-kentat
   (testing "Muutokset-kentässä on edellinen_maara, maaramuutos ja uusi_maara oikein"
     (let [db (:db jarjestelma)


### PR DESCRIPTION
## Tiivistelmä
Korjaa tilanteen, jossa Tehtävä- ja määräluettelon suunnittelemattomille tehtäville tallentui turhia `NULL`-arvoja, kun käyttäjä ei ollut syöttänyt mitään. Lisäksi tallennus estetään UI:ssa, jos sopimuksen määrä puuttuu (ohje: syötä arvo tai aseta 0). Vaikutus: tietokannan data pysyy eheänä ja `NULL`-rivien syntyminen estyy.

## Muutokset
- Backend: ohitetaan `nil`-määrät tallennuksessa, jolloin `urakka_tehtavamaara.maara` ei päivity `NULL`:ksi ([src/clj/harja/kyselyt/tehtavat_maarat_kyselyt.clj](src/clj/harja/kyselyt/tehtavat_maarat_kyselyt.clj)).
- Lisätty BigDecimal-apuri määrien vertailuun (päivitystarpeen vähentämiseksi) ([src/cljc/harja/tyokalut/big.cljc](src/cljc/harja/tyokalut/big.cljc)).
- Frontend: estetään tallennus, jos tehtäväriviltä puuttuu sopimuksen määrä (nil/tyhjä) ja näytetään toast-viesti ([src/cljs/harja/tiedot/urakka/suunnittelu/tehtavat_maarat_tiedot.cljs](src/cljs/harja/tiedot/urakka/suunnittelu/tehtavat_maarat_tiedot.cljs)).
- Testit: lisätty regressiotesti varmistamaan, ettei nulleja tallennu sopimuksen määriin ([test/clj/harja/palvelin/palvelut/suunnittelu/tehtavat_maarat_test.clj](test/clj/harja/palvelin/palvelut/suunnittelu/tehtavat_maarat_test.clj)).

## Muita huomioita
- Tekniset huomiot: muutos pidetty minimissä (ei tuotu mukaan PR #4304:n laajempia UI-uudistuksia), mutta backend pysyy edelleen puolustavana.
- Breaking changes: ei tiedossa.
- Testisuositus: `lein test :only harja.palvelin.palvelut.suunnittelu.tehtavat-maarat-test/ei-tallenna-nulleja-sopimuksen-maariin` (+ halutessa relevantit suunnittelu-palvelun testit).
- Riippuvuudet: ei uusia riippuvuuksia.
- Riskit/huomiot: UI-esto perustuu nil/tyhjään arvoon; `0` on sallittu ja ohjeistettu käyttöliittymäviestissä.