### PR TITLE
HARJA-2111, HARJA-2114 Korjaa muutosten kuluvalidointeja

### DIFF
--- a/dev-resources/less/pages/muutos_tyylit.less
+++ b/dev-resources/less/pages/muutos_tyylit.less
@@ -196,4 +196,8 @@
   .lasketut-muutokset-grid-haku {
     position: absolute;
   }
+  
+  .johto-ja-hallintokorvaus-muutokset-grid {
+    padding-top: @valistys-16;
+  }
 }

--- a/src/clj/harja/kyselyt/muutos_kyselyt.sql
+++ b/src/clj/harja/kyselyt/muutos_kyselyt.sql
@@ -263,6 +263,16 @@ WHERE
   AND k.erapaiva < :voimassa::DATE
   AND kk.muutos = :muutos;
 
+-- name: muutostyolle-jo-kirjatut-kulut-yhteensa
+-- single?: true
+SELECT COALESCE(SUM(kk.summa), 0) AS kirjattu_summa
+ FROM kulu k
+         JOIN kulu_kohdistus kk ON kk.kulu = k.id
+WHERE
+    kk.tyyppi = :tyyppi::kohdistustyyppi
+  AND kk.poistettu IS FALSE
+  AND kk.muutos = :muutos;
+
 -- name: luo-jjh-kulun-kohdistus<!
 INSERT INTO kulu_kohdistus (kulu, rivi, summa, toimenpideinstanssi, tehtavaryhma, maksueratyyppi, tyyppi, luotu, luoja,
                             tavoitehintainen)

--- a/src/clj/harja/kyselyt/muutos_kyselyt.sql
+++ b/src/clj/harja/kyselyt/muutos_kyselyt.sql
@@ -705,8 +705,17 @@ SELECT  DISTINCT ON (m.id)
         m.tyyppi, 
         m.alityyppi,
         m.nimi, 
-        m.voimassa_alkaen
+        m.voimassa_alkaen,
+        mmk.summa AS budjetoitu_summa,
+        COALESCE(kk.kirjattu_summa, 0) AS kirjattu_summa
  FROM mhu_muutos m
+ JOIN mhu_muutos_kustannusvaikutus mmk ON mmk.muutos = m.id
+ LEFT JOIN (
+     SELECT muutos, SUM(summa) AS kirjattu_summa
+     FROM kulu_kohdistus
+     WHERE poistettu IS NOT TRUE
+     GROUP BY muutos
+ ) kk ON kk.muutos = m.id
 WHERE m.tyyppi =  'muutostyo'::MHU_MUUTOSTYYPPI
   AND m.urakka =  :urakka
   AND (m.voimassa_alkaen BETWEEN :alkupvm::DATE AND :loppupvm::DATE)

--- a/src/clj/harja/palvelin/palvelut/kulut/kulut.clj
+++ b/src/clj/harja/palvelin/palvelut/kulut/kulut.clj
@@ -3,6 +3,7 @@
   (:require [com.stuartsierra.component :as component]
             [clojure.java.jdbc :as jdbc]
             [clojure.string :as str]
+            [harja.fmt :as fmt]
             [harja.palvelin.integraatiot.api.tyokalut.virheet :as virheet]
             [taoensso.timbre :as log]
             [harja.kyselyt
@@ -46,7 +47,7 @@
 (defn- laske-summat [k rivi]
   (+ k (or (:summa rivi) 0)))
 
-(defn- laske-summat-nro-ja-pvm-tasolle 
+(defn- laske-summat-nro-ja-pvm-tasolle
   [k [_ {:keys [summa]}]]
   (+ k summa))
 
@@ -63,64 +64,64 @@
   [[tagi tiedot]]
   [(first tagi) tiedot])
 
-(defn- jarjesta-laskun-nro-0-tai-pvm-mukaan 
+(defn- jarjesta-laskun-nro-0-tai-pvm-mukaan
   "Laskun numero 0 on, jos laskun numeroa ei ole määritelty, joten ne tulevat erikseen aina pohjalle"
   [rivi1 rivi2]
-  (cond 
+  (cond
     (and (= 0 (first rivi1))
-         (not= 0 (first rivi2)))
+      (not= 0 (first rivi2)))
     false
 
     (and (= 0 (first rivi2))
-         (not= 0 (first rivi1)))
+      (not= 0 (first rivi1)))
     true
-    
+
     :else
     (jarjesta-koko-pvm-mukaan (second rivi1) (second rivi2))))
 
-(defn- kasittele-toimenpideinstanssi-ryhmitellyt-rivit 
+(defn- kasittele-toimenpideinstanssi-ryhmitellyt-rivit
   [[tpi rivit]]
-  [tpi {:rivit rivit 
+  [tpi {:rivit rivit
         :summa (reduce laske-summat 0 rivit)}])
 
 (defn- kasittele-laskun-nro-ryhmitellyt-rivit [[laskun-nro rivit]]
-  (let [kasitellyt (mapv kasittele-toimenpideinstanssi-ryhmitellyt-rivit 
-                         (group-by (juxt :toimenpideinstanssi 
-                                         erapaiva-pvm-stringina) 
-                                   rivit))
+  (let [kasitellyt (mapv kasittele-toimenpideinstanssi-ryhmitellyt-rivit
+                     (group-by (juxt :toimenpideinstanssi
+                                 erapaiva-pvm-stringina)
+                       rivit))
         kasitellyt (sort-by ota-erapaiva jarjesta-koko-pvm-mukaan kasitellyt)
-        kasitellyt (mapv poista-erapaiva kasitellyt)] 
-    [[laskun-nro (-> rivit first erapaiva-pvm-stringina)] 
+        kasitellyt (mapv poista-erapaiva kasitellyt)]
+    [[laskun-nro (-> rivit first erapaiva-pvm-stringina)]
      {:rivit kasitellyt
-      :summa (reduce 
-              laske-summat-nro-ja-pvm-tasolle
-              0
-              kasitellyt)}]))
+      :summa (reduce
+               laske-summat-nro-ja-pvm-tasolle
+               0
+               kasitellyt)}]))
 
 (defn- kasittele-vuoden-ja-kuukauden-mukaan-ryhmitellyt-rivit [[paivamaara rivit]]
   (let [kasitellyt
         (sort-by first
-                 jarjesta-laskun-nro-0-tai-pvm-mukaan
-                 (mapv kasittele-laskun-nro-ryhmitellyt-rivit
-                       (group-by #(or (:laskun-numero %)
-                                      0)
-                                 rivit)))
+          jarjesta-laskun-nro-0-tai-pvm-mukaan
+          (mapv kasittele-laskun-nro-ryhmitellyt-rivit
+            (group-by #(or (:laskun-numero %)
+                         0)
+              rivit)))
         kasitellyt (mapv poista-erapaiva
-                         kasitellyt)] 
-    [paivamaara 
-     {:rivit kasitellyt 
-      :summa (reduce 
-              laske-summat-nro-ja-pvm-tasolle
-              0
-              kasitellyt)} ]))
+                     kasitellyt)]
+    [paivamaara
+     {:rivit kasitellyt
+      :summa (reduce
+               laske-summat-nro-ja-pvm-tasolle
+               0
+               kasitellyt)}]))
 
 (defn ryhmittele-urakan-kulut
   "Kulutaulusta tulevat tiedot ryhmitellään VVVV/kk mukaan, laskun numeron mukaan ja viimeisenä toimenpideinstanssin mukaan"
   [uudet-rivit]
-  (into [] 
-        (sort-by first jarjesta-vuoden-ja-kuukauden-mukaan 
-                 (mapv kasittele-vuoden-ja-kuukauden-mukaan-ryhmitellyt-rivit 
-                       (group-by #(when (:erapaiva %) (pvm/kokovuosi-ja-kuukausi (:erapaiva %))) uudet-rivit)))))
+  (into []
+    (sort-by first jarjesta-vuoden-ja-kuukauden-mukaan
+      (mapv kasittele-vuoden-ja-kuukauden-mukaan-ryhmitellyt-rivit
+        (group-by #(when (:erapaiva %) (pvm/kokovuosi-ja-kuukausi (:erapaiva %))) uudet-rivit)))))
 
 (defn lisaa-tpi-rivit
   [acc [tpi {rivit :rivit summa :summa}]]
@@ -143,26 +144,26 @@
   "Palauttaa urakan kulut valitulta ajanjaksolta ilman kohdistuksia."
   [db user hakuehdot]
   (oikeudet/vaadi-lukuoikeus oikeudet/urakat-kulut-laskunkirjoitus user (:urakka-id hakuehdot))
-  (q/hae-urakan-kulut db {:urakka   (:urakka-id hakuehdot)
-                           :alkupvm  (:alkupvm hakuehdot)
-                           :loppupvm (:loppupvm hakuehdot)}))
+  (q/hae-urakan-kulut db {:urakka (:urakka-id hakuehdot)
+                          :alkupvm (:alkupvm hakuehdot)
+                          :loppupvm (:loppupvm hakuehdot)}))
 
 (defn kasittele-kohdistukset
-  [db kulut-ja-kohdistukset] 
+  [db kulut-ja-kohdistukset]
   (reduce
-   (fn [acc [id kohdistukset]]
-     (let [liitteet (into [] (q/hae-liitteet db {:kulu-id id}))]
-       (apply conj acc (mapv #(assoc % :liitteet liitteet) kohdistukset))))
-   []
-   kulut-ja-kohdistukset))
+    (fn [acc [id kohdistukset]]
+      (let [liitteet (into [] (q/hae-liitteet db {:kulu-id id}))]
+        (apply conj acc (mapv #(assoc % :liitteet liitteet) kohdistukset))))
+    []
+    kulut-ja-kohdistukset))
 
 (defn hae-kulut-kohdistuksineen
   "Helpottaa REPL-käyttöä, niin siksi tämä eriytetty (ei tarvi keksiä useria)"
   [db hakuehdot]
   (let [kulukohdistukset (group-by :id (into []
                                          (map konv/alaviiva->rakenne)
-                                         (q/hae-urakan-kulut-kohdistuksineen db {:urakka   (:urakka-id hakuehdot)
-                                                                                 :alkupvm  (:alkupvm hakuehdot)
+                                         (q/hae-urakan-kulut-kohdistuksineen db {:urakka (:urakka-id hakuehdot)
+                                                                                 :alkupvm (:alkupvm hakuehdot)
                                                                                  :loppupvm (:loppupvm hakuehdot)})))
         kulukohdistukset (kasittele-kohdistukset db kulukohdistukset)
         kulukohdistukset (ryhmittele-urakan-kulut kulukohdistukset)
@@ -189,9 +190,9 @@
                                                kohdistus
                                                (dissoc kohdistus :rahavaraus_id :rahavaraus_nimi))
                                    ;; Muutetaan tavoitehintainen keywordiksi
-                                    kohdistus (-> kohdistus
-                                                  (update :tavoitehintainen #(keyword (str %)))
-                                                  (update :tehtava konv/jsonb->clojuremap))]
+                                   kohdistus (-> kohdistus
+                                               (update :tavoitehintainen #(keyword (str %)))
+                                               (update :tehtava konv/jsonb->clojuremap))]
                                kohdistus))
                        kohdistukset)
         ;; Frontilla kulun muokkauksessa on olennaista, että kulun kohdistuksen rahavaraus sisältää kaikki mahdolliset tehtäväryhmät
@@ -219,13 +220,13 @@
   (cond
     (or lisatyo?) "lisatyo"
     (or (.contains (or (:nimi (first (q/hae-tehtavan-nimi db {:id tehtava-id}))) "") "Äkilliset hoitotytöt")
-        (.contains (or (:nimi (first (q/hae-tehtavaryhman-nimi db {:id tehtavaryhma-id}))) "") "ÄKILLISET HOITOTYÖT")
-        (.contains (or (:nimi (first (q/hae-tehtavaryhman-nimi db {:id tehtavaryhma-id}))) "") "Äkilliset hoitotyöt,"))
+      (.contains (or (:nimi (first (q/hae-tehtavaryhman-nimi db {:id tehtavaryhma-id}))) "") "ÄKILLISET HOITOTYÖT")
+      (.contains (or (:nimi (first (q/hae-tehtavaryhman-nimi db {:id tehtavaryhma-id}))) "") "Äkilliset hoitotyöt,"))
     "akillinen-hoitotyo"
     (or (.contains (or (:nimi (first (q/hae-tehtavan-nimi db {:id tehtava-id}))) "") "vahinkojen korja")
-        (.contains (or (:nimi (first (q/hae-tehtavaryhman-nimi db {:id tehtavaryhma-id}))) "") "VAHINKOJEN KORJAAMINEN")
-        (.contains (or (:nimi (first (q/hae-tehtavaryhman-nimi db {:id tehtavaryhma-id}))) "") "Vahinkojen korjaukset,"))
-    "muu"                                                   ;; vahinkojen korjaukset
+      (.contains (or (:nimi (first (q/hae-tehtavaryhman-nimi db {:id tehtavaryhma-id}))) "") "VAHINKOJEN KORJAAMINEN")
+      (.contains (or (:nimi (first (q/hae-tehtavaryhman-nimi db {:id tehtavaryhma-id}))) "") "Vahinkojen korjaukset,"))
+    "muu" ;; vahinkojen korjaukset
     :else
     "kokonaishintainen"))
 
@@ -242,9 +243,9 @@
                         ;; Jos kyseessä on "Muu tehtävä", tehtävä-id:tä ei tallenneta
                         :tehtava-id (when-not on-muu-tehtava? tehtava-id)
                         :muu-tehtava-kaytossa (when on-muu-tehtava? true)
-                        :maksueratyyppi (kohdistuksen-maksueratyyppi db 
-                                          (:tehtavaryhma kohdistus) 
-                                          (when-not on-muu-tehtava? tehtava-id) 
+                        :maksueratyyppi (kohdistuksen-maksueratyyppi db
+                                          (:tehtavaryhma kohdistus)
+                                          (when-not on-muu-tehtava? tehtava-id)
                                           (:lisatyo? kohdistus))
                         :kayttaja (:id user)
                         :lisatyon-lisatieto (:lisatyon-lisatieto kohdistus)
@@ -255,22 +256,22 @@
         ;; Haetaan tehtäväryhmät, joilla tehtävä on pakollinen
         tehtavaryhmat-joilla-tehtava (tehtavaryhma-kyselyt/hae-tehtavaryhmat-joilla-tehtava-on-pakollinen db)
         ;; Tarkistetaan, että hankintakulun kulukohdistukselle on lisätty tehtävä, jos tehtäväryhmä vaatii sen
-        _ (when (and (= "hankintakulu" (:tyyppi kohdistus)) 
+        _ (when (and (= "hankintakulu" (:tyyppi kohdistus))
                   (some #(= (:id %) (:tehtavaryhma kohdistus)) tehtavaryhmat-joilla-tehtava)
-                     (nil? tehtava-id))
+                  (nil? tehtava-id))
             (throw+ {:type virheet/+viallinen-kutsu+
                      :virheet [{:koodi virheet/+sisainen-kasittelyvirhe+
                                 :viesti "Valitulle tehtäväryhmälle on valittava myös tehtävä!"}]}))]
-    
+
     (if (nil? (:kohdistus-id kohdistus))
       (let [vastaus (q/luo-kulun-kohdistus<! db (assoc kulu_kohdistus :kulu kulu-id :rivi (:rivi kohdistus)))
             luotu-kohdistus-id (:id vastaus)]
         ;; Tee kohdistukseen linkitys, jos tämä on muutostyölle kirjattu kulu 
         (muutos-palvelu/paivita-muutostyo-kulu-kohdistus db muutostyo luotu-kohdistus-id))
-      (do 
+      (do
         (muutos-palvelu/paivita-muutostyo-kulu-kohdistus db muutostyo (:kohdistus-id kohdistus))
         (q/paivita-kulun-kohdistus<! db kulu_kohdistus))))
-  
+
   (kust-q/merkitse-maksuerat-likaisiksi! db {:toimenpideinstanssi
                                              (:toimenpideinstanssi kohdistus)}))
 
@@ -288,17 +289,17 @@
                       (pvm/suomen-aikavyohykkeeseen (pvm/joda-timeksi loppupvm)))]
     (when-not (sisalla?-fn (pvm/suomen-aikavyohykkeeseen (pvm/joda-timeksi erapaiva)))
       (throw (IllegalArgumentException.
-              (str "Eräpäivä " erapaiva " ei ole koontilaskun-kuukauden " koontilaskun-kuukausi
-                   " sisällä. Urakka id = " urakka-id))))))
+               (str "Eräpäivä " erapaiva " ei ole koontilaskun-kuukauden " koontilaskun-kuukausi
+                 " sisällä. Urakka id = " urakka-id))))))
 
 (defn poista-kulun-kohdistus
   "Poistaa yksittäisen rivin kulun kohdistuksista. Palauttaa päivittyneen kantatilanteen."
   [db user {:keys [urakka-id id kohdistuksen-id kohdistus]}]
   (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-kulut-laskunkirjoitus user urakka-id)
-  (q/poista-kulun-kohdistus! db {:id              id
-                                  :urakka          urakka-id
-                                  :kohdistuksen-id kohdistuksen-id
-                                  :kayttaja        (:id user)})
+  (q/poista-kulun-kohdistus! db {:id id
+                                 :urakka urakka-id
+                                 :kohdistuksen-id kohdistuksen-id
+                                 :kayttaja (:id user)})
   (kust-q/merkitse-maksuerat-likaisiksi! db {:toimenpideinstanssi
                                              (:toimenpideinstanssi kohdistus)})
   (hae-kulu-kohdistuksineen db user {:id id}))
@@ -371,10 +372,12 @@
                    (q/paivita-kulu<! db (assoc kulu :id id)))
 
           vanhat-kohdistukset (q/hae-kulun-kohdistukset db {:kulu (:id kuludb) :urakka_id urakka-id})
+          edellinen-maara (apply + (keep #(:summa %) vanhat-kohdistukset))
           sisaan-tulevat-kohdistus-idt (into #{} (map :kohdistus-id kohdistukset))
           puuttuvat-kohdistukset (remove
                                    #(sisaan-tulevat-kohdistus-idt (:kohdistus-id %))
                                    vanhat-kohdistukset)
+
           liitteet-tyhjia? (or (nil? liitteet) (empty? liitteet))]
 
       ;; Liitteet 
@@ -396,11 +399,21 @@
         (let [muutostyo (:valittu-muutostyo kohdistusrivi)
               muutostyo (assoc muutostyo :muutos (:muutos kohdistusrivi))
               muutostyo-voimassa-alkaen (:voimassa_alkaen muutostyo)
+
+              budjetoitu-summa (:budjetoitu_summa muutostyo) ;; Muutostyölle kirjattu summa 
+              kirjattu-summa (:kirjattu_summa muutostyo) ;; Muutostyölle tähän mennessä kirjattujen kulujen summa 
+              lisatty-budjetti (- kokonaissumma edellinen-maara)
+              lisatty-budjetti (+ kirjattu-summa lisatty-budjetti) ;; Tällä kululla muutostyölle lisättävä summa
+              budjettia-jaljella (- budjetoitu-summa lisatty-budjetti) ;; Muutostyölle jäljellä oleva budjetti tämän kulun jälkeen
+
+              budjetti-ylittyy? (boolean
+                                  (when budjettia-jaljella (< budjettia-jaljella 0M)))
+
               yhteensopiva? (:tarkista_t_tr_ti_yhteensopivuus
-                             (first (q/tarkista-kohdistuksen-yhteensopivuus db
-                                      {:tehtava-id nil
-                                       :tehtavaryhma-id (:tehtavaryhma kohdistusrivi)
-                                       :toimenpideinstanssi-id (:toimenpideinstanssi kohdistusrivi)})))
+                              (first (q/tarkista-kohdistuksen-yhteensopivuus db
+                                       {:tehtava-id nil
+                                        :tehtavaryhma-id (:tehtavaryhma kohdistusrivi)
+                                        :toimenpideinstanssi-id (:toimenpideinstanssi kohdistusrivi)})))
 
               ;; Tarkista onko muutostyön voimassa_alkaen validi kulun päivämäärään 
               muutostyo-voimassa? (boolean
@@ -424,7 +437,9 @@
                                            ;; Jos muutostyötä ei ole valittu -> palauta vaan true 
                                            true)]
 
-          (if (and muutostyo-voimassa? muutostyo-erapaiva-validi? yhteensopiva?)
+          (if (and
+                (not budjetti-ylittyy?)
+                muutostyo-voimassa? muutostyo-erapaiva-validi? yhteensopiva?)
             (as-> kohdistusrivi kohdistus
               (update kohdistus :summa big/unwrap)
               (assoc kohdistus :kulu (:id kuludb))
@@ -460,6 +475,14 @@
                                             (pvm/pvm (second muutostyo-hk))
                                             ".")}]})
 
+              budjetti-ylittyy?
+              (throw+ {:type virheet/+viallinen-kutsu+
+                       :virheet [{:koodi virheet/+sisainen-kasittelyvirhe+
+                                  :viesti (str
+                                            "Tallennus epäonnistui. "
+                                            "Erillisrahoitetun muutostyön budjetti ylittyy. "
+                                            "Budjetissa jäljellä: " (fmt/euro-opt budjettia-jaljella))}]})
+
               :else
               (throw+ {:type virheet/+viallinen-kutsu+
                        :virheet [{:koodi virheet/+sisainen-kasittelyvirhe+
@@ -476,12 +499,12 @@
     (when (not (empty? liitteet))
       (doseq [{liite-id :liite-id} liitteet]
         (q/poista-kulun-ja-liitteen-linkitys! db {:kulu-id id :liite-id liite-id :kayttaja (:id user)})))
-    (q/poista-kulu! db {:urakka   urakka-id
-                         :id       id
-                         :kayttaja (:id user)})
-    (q/poista-kulun-kohdistukset! db {:urakka   urakka-id
-                                       :id       id
-                                       :kayttaja (:id user)})
+    (q/poista-kulu! db {:urakka urakka-id
+                        :id id
+                        :kayttaja (:id user)})
+    (q/poista-kulun-kohdistukset! db {:urakka urakka-id
+                                      :id id
+                                      :kayttaja (:id user)})
     (kust-q/merkitse-maksuerat-likaisiksi! db {:toimenpideinstanssi
                                                (:toimenpideinstanssi poistettu-kulu)})
     poistettu-kulu))
@@ -512,16 +535,16 @@
   [db user {:keys [urakka-id urakka-nimi alkupvm loppupvm]}]
   (oikeudet/vaadi-lukuoikeus oikeudet/urakat-kulut-laskunkirjoitus user urakka-id)
   (assert (and alkupvm loppupvm) "alkupvm ja loppupvm oltava annettu")
-  (let [kulut (q/hae-kulut-kohdistuksineen-tietoineen-vientiin db {:urakka   urakka-id
-                                                            :alkupvm  (konv/sql-timestamp alkupvm)
-                                                            :loppupvm (konv/sql-timestamp loppupvm)})
+  (let [kulut (q/hae-kulut-kohdistuksineen-tietoineen-vientiin db {:urakka urakka-id
+                                                                   :alkupvm (konv/sql-timestamp alkupvm)
+                                                                   :loppupvm (konv/sql-timestamp loppupvm)})
         kulut-kuukausien-mukaan (group-by #(pvm/kokovuosi-ja-kuukausi (:erapaiva %))
-                                          (sort-by :erapaiva
-                                                   kulut))]
+                                  (sort-by :erapaiva
+                                    kulut))]
     (kpdf/kulu-pdf urakka-nimi
-                   (pvm/pvm alkupvm)
-                   (pvm/pvm loppupvm)
-                   kulut-kuukausien-mukaan)))
+      (pvm/pvm alkupvm)
+      (pvm/pvm loppupvm)
+      kulut-kuukausien-mukaan)))
 
 (defn hae-urakan-hintapaatokset
   "Haetaan urakalle vuodet, joille on olemassa hintapäätös. Ja ui:lla voidaan sen mukaan näyttää päiviä,
@@ -536,9 +559,9 @@
         loppupvm (:loppupvm urakan-tiedot)
         hintapaatokset (map :hoitokauden-alkuvuosi (valikatselmus-kyselyt/hae-urakan-hintapaatokset db {:urakka-id urakka-id}))
         vuosittaiset-hintapaatokset (reduce (fn [listaus vuosi]
-                                                (conj listaus {:vuosi vuosi
-                                                               :paatos-tehty? (some #(= vuosi %) hintapaatokset)}))
-                                        [] (range (pvm/vuosi alkupvm) (pvm/vuosi loppupvm)))]
+                                              (conj listaus {:vuosi vuosi
+                                                             :paatos-tehty? (some #(= vuosi %) hintapaatokset)}))
+                                      [] (range (pvm/vuosi alkupvm) (pvm/vuosi loppupvm)))]
     vuosittaiset-hintapaatokset))
 
 (def db-vastaus->speqcl-avaimet
@@ -558,9 +581,9 @@
         urakan-rahavaraukset (->> urakan-rahavaraukset
                                (mapv #(update % :tehtavaryhmat konv/jsonb->clojuremap))
                                (mapv #(update % :tehtavaryhmat
-                                                                (fn [rivit]
-                                                                  (let [tulos (keep (fn [r] (clojure.set/rename-keys r db-vastaus->speqcl-avaimet)) rivit)]
-                                                                    tulos)))))]
+                                        (fn [rivit]
+                                          (let [tulos (keep (fn [r] (clojure.set/rename-keys r db-vastaus->speqcl-avaimet)) rivit)]
+                                            tulos)))))]
     urakan-rahavaraukset))
 
 (defn- kulu-excel
@@ -568,12 +591,12 @@
   (oikeudet/vaadi-lukuoikeus oikeudet/urakat-kulut-laskunkirjoitus user urakka-id)
   (assert (and alkupvm loppupvm) "alkupvm ja loppupvm oltava annettu")
   (let [kulut (sort-by :erapaiva
-                       (q/hae-kulut-kohdistuksineen-tietoineen-vientiin db {:urakka   urakka-id
-                                                                            :alkupvm  (konv/sql-timestamp alkupvm)
-                                                                            :loppupvm (konv/sql-timestamp loppupvm)}))
+                (q/hae-kulut-kohdistuksineen-tietoineen-vientiin db {:urakka urakka-id
+                                                                     :alkupvm (konv/sql-timestamp alkupvm)
+                                                                     :loppupvm (konv/sql-timestamp loppupvm)}))
         kulut-kuukausien-mukaan (group-by #(pvm/kokovuosi-ja-kuukausi (:erapaiva %))
-                                          (sort-by :erapaiva
-                                                   kulut))
+                                  (sort-by :erapaiva
+                                    kulut))
         sarakkeet [{:otsikko "Eräpäivä"}
                    {:otsikko
                     "Maksuerä"}
@@ -592,15 +615,15 @@
                    (let [yhteenvetorivi [[nil nil nil "Yhteensä:" [:kaava {:kaava :summaa-yllaolevat
                                                                            :alkurivi eka-rivi-jossa-kustannuksia
                                                                            :loppurivi (+ (count rivit)
-                                                                                         (- eka-rivi-jossa-kustannuksia 1))}]]]]
+                                                                                        (- eka-rivi-jossa-kustannuksia 1))}]]]]
                      (conj kaikki
-                           [:taulukko {:nimi urakka-nimi
-                                       :sheet-nimi vuosi-kuukausi
-                                       :viimeinen-rivi-yhteenveto? true}
-                            sarakkeet (into []
-                                            (concat
-                                              (mapv luo-rivi rivit)
-                                              yhteenvetorivi))])))
+                       [:taulukko {:nimi urakka-nimi
+                                   :sheet-nimi vuosi-kuukausi
+                                   :viimeinen-rivi-yhteenveto? true}
+                        sarakkeet (into []
+                                    (concat
+                                      (mapv luo-rivi rivit)
+                                      yhteenvetorivi))])))
         taulukot (reduce luo-data [] kulut-kuukausien-mukaan)
         taulukko (concat
                    [:raportti {:raportin-yleiset-tiedot {:urakka urakka-nimi
@@ -612,9 +635,9 @@
                      [[:taulukko {:nimi urakka-nimi}
                        [{:otsikko (str urakka-nimi " " (pvm/pvm alkupvm) "-" (pvm/pvm loppupvm))}]
                        [["Ei kuluja valitulla aikavälillä"]]]]
-                       taulukot))]
+                     taulukot))]
     (excel/muodosta-excel (vec taulukko)
-                          workbook)))
+      workbook)))
 
 (defn- luo-pdf
   [pdf user hakuehdot]
@@ -629,30 +652,30 @@
           pdf (:pdf-vienti this)
           excel (:excel-vienti this)]
       (julkaise-palvelu http :kulut
-                        (fn [user hakuehdot]
-                          (hae-urakan-kulut db user hakuehdot)))
+        (fn [user hakuehdot]
+          (hae-urakan-kulut db user hakuehdot)))
       (julkaise-palvelu http :kulut-kohdistuksineen
-                        (fn [user hakuehdot]
-                          (hae-urakan-kulut-kohdistuksineen db user hakuehdot)))
+        (fn [user hakuehdot]
+          (hae-urakan-kulut-kohdistuksineen db user hakuehdot)))
       (julkaise-palvelu http :hae-kulu
-                        (fn [user hakuehdot]
-                          (hae-kulu-kohdistuksineen db user hakuehdot)))
+        (fn [user hakuehdot]
+          (hae-kulu-kohdistuksineen db user hakuehdot)))
       (julkaise-palvelu http :tallenna-kulu
-                        (fn [user kulu-kohdistuksineen]
-                          (tallenna-kulu db user kulu-kohdistuksineen))
-                        {:kysely-spec ::kulut/talenna-kulu})
+        (fn [user kulu-kohdistuksineen]
+          (tallenna-kulu db user kulu-kohdistuksineen))
+        {:kysely-spec ::kulut/talenna-kulu})
       (julkaise-palvelu http :poista-kulu
-                        (fn [user hakuehdot]
-                          (poista-kulu db user hakuehdot)))
+        (fn [user hakuehdot]
+          (poista-kulu db user hakuehdot)))
       (julkaise-palvelu http :poista-kohdistus
-                        (fn [user hakuehdot]
-                          (poista-kulun-kohdistus db user hakuehdot)))
+        (fn [user hakuehdot]
+          (poista-kulun-kohdistus db user hakuehdot)))
       (julkaise-palvelu http :poista-kulun-liite
-                        (fn [user hakuehdot]
-                          (poista-kulun-liite db user hakuehdot)))
+        (fn [user hakuehdot]
+          (poista-kulun-liite db user hakuehdot)))
       (julkaise-palvelu http :tarkista-laskun-numeron-paivamaara
-                        (fn [user hakuehdot]
-                          (tarkista-laskun-numeron-paivamaara db user hakuehdot)))
+        (fn [user hakuehdot]
+          (tarkista-laskun-numeron-paivamaara db user hakuehdot)))
       (julkaise-palvelu http :hae-urakan-hintapaatokset
         (fn [user hakuehdot]
           (hae-urakan-hintapaatokset db user hakuehdot)))

--- a/src/clj/harja/palvelin/palvelut/kulut/kulut.clj
+++ b/src/clj/harja/palvelin/palvelut/kulut/kulut.clj
@@ -402,14 +402,15 @@
               muutostyo (assoc muutostyo :muutos (:muutos kohdistusrivi))
               muutostyo-voimassa-alkaen (:voimassa_alkaen muutostyo)
 
-              budjetoitu-summa (:budjetoitu_summa muutostyo) ;; Muutostyölle kirjattu summa 
-              kirjattu-summa (:kirjattu_summa muutostyo) ;; Muutostyölle tähän mennessä kirjattujen kulujen summa 
-              lisatty-budjetti (- kokonaissumma edellinen-maara)
-              lisatty-budjetti (+ kirjattu-summa lisatty-budjetti) ;; Tällä kululla muutostyölle lisättävä summa
-              budjettia-jaljella (- budjetoitu-summa lisatty-budjetti) ;; Muutostyölle jäljellä oleva budjetti tämän kulun jälkeen
+              budjetoitu-summa (:budjetoitu_summa muutostyo) ;; Muutostyölle kirjattu tavoitehinnan muutos 
+              kirjattu-summa (:kirjattu_summa muutostyo) ;; Muutostyölle tähän mennessä kirjattujen kulut yht 
+              lisatty-budjetti (- (or kokonaissumma 0) (or edellinen-maara 0))
+              lisatty-budjetti (+ (or kirjattu-summa 0) (or lisatty-budjetti 0)) ;; Tällä kululla budjettiin lisättävä summa
+              budjettia-jaljella (- (or budjetoitu-summa 0) lisatty-budjetti) ;; Muutostyölle jäljellä oleva budjetti tämän kulun jälkeen
 
-              budjetti-ylittyy? (boolean
-                                  (when budjettia-jaljella (< budjettia-jaljella 0M)))
+              muutos-budjetti-ylittyy? (if-not (:muutos muutostyo) false
+                                         (boolean
+                                           (when budjettia-jaljella (< budjettia-jaljella 0M))))
 
               yhteensopiva? (:tarkista_t_tr_ti_yhteensopivuus
                               (first (q/tarkista-kohdistuksen-yhteensopivuus db
@@ -440,7 +441,7 @@
                                            true)]
 
           (if (and
-                (not budjetti-ylittyy?)
+                (not muutos-budjetti-ylittyy?)
                 muutostyo-voimassa? muutostyo-erapaiva-validi? yhteensopiva?)
             (as-> kohdistusrivi kohdistus
               (update kohdistus :summa big/unwrap)
@@ -477,7 +478,7 @@
                                             (pvm/pvm (second muutostyo-hk))
                                             ".")}]})
 
-              budjetti-ylittyy?
+              muutos-budjetti-ylittyy?
               (throw+ {:type virheet/+viallinen-kutsu+
                        :virheet [{:koodi virheet/+sisainen-kasittelyvirhe+
                                   :viesti (str

--- a/src/clj/harja/palvelin/palvelut/kulut/kulut.clj
+++ b/src/clj/harja/palvelin/palvelut/kulut/kulut.clj
@@ -402,11 +402,15 @@
               muutostyo (assoc muutostyo :muutos (:muutos kohdistusrivi))
               muutostyo-voimassa-alkaen (:voimassa_alkaen muutostyo)
 
-              budjetoitu-summa (or (:budjetoitu_summa muutostyo) 0) ;; Muutostyölle kirjattu tavoitehinnan muutos 
-              kirjattu-summa (or (:kirjattu_summa muutostyo) 0) ;; Muutostyölle tähän mennessä kirjattujen kulut yht 
-              lisatty-budjetti (- kokonaissumma edellinen-maara)
-              lisatty-budjetti (+ kirjattu-summa lisatty-budjetti) ;; Tällä kululla budjettiin lisättävä summa
-              budjettia-jaljella (- budjetoitu-summa lisatty-budjetti) ;; Muutostyölle jäljellä oleva budjetti tämän kulun jälkeen
+              kohdistusrivi (if (nil? (:summa kohdistusrivi))
+                              (assoc kohdistusrivi :summa 0M)
+                              kohdistusrivi)
+
+              muutos-budjetoitu-summa (or (:budjetoitu_summa muutostyo) 0) ;; Muutostyölle kirjattu tavoitehinnan muutos 
+              muutos-kirjattu-summa (or (:kirjattu_summa muutostyo) 0) ;; Muutostyölle tähän mennessä kirjatut kulut yht 
+              muutos-lisatty-budjetti (- kokonaissumma edellinen-maara)
+              muutos-lisatty-budjetti (+ muutos-kirjattu-summa muutos-lisatty-budjetti) ;; Tällä kululla budjettiin lisättävä summa
+              budjettia-jaljella (- muutos-budjetoitu-summa muutos-lisatty-budjetti) ;; Muutostyölle jäljellä oleva budjetti tämän kulun jälkeen
 
               muutos-budjetti-ylittyy? (if-not (:valittu-muutostyo kohdistusrivi) false
                                          (boolean

--- a/src/clj/harja/palvelin/palvelut/kulut/kulut.clj
+++ b/src/clj/harja/palvelin/palvelut/kulut/kulut.clj
@@ -1,11 +1,10 @@
 (ns harja.palvelin.palvelut.kulut.kulut
   "Nimiavaruutta käytetään vain urakkatyypissä teiden-hoito (MHU)."
-  (:require [com.stuartsierra.component :as component]
-            [clojure.java.jdbc :as jdbc]
-            [clojure.string :as str]
-            [harja.fmt :as fmt]
-            [harja.palvelin.integraatiot.api.tyokalut.virheet :as virheet]
+  (:require [clojure.string :as str]
             [taoensso.timbre :as log]
+            [clojure.java.jdbc :as jdbc]
+            [com.stuartsierra.component :as component]
+
             [harja.kyselyt
              [kulut :as q]
              [kustannusarvioidut-tyot :as kust-q]
@@ -14,17 +13,20 @@
              [urakat :as urakka-kyselyt]
              [tehtavaryhmat :as tehtavaryhma-kyselyt]
              [konversio :as konv]]
-            [harja.palvelin.komponentit.http-palvelin :refer [julkaise-palvelu poista-palvelut]]
+
+            [harja.fmt :as fmt]
+            [harja.pvm :as pvm]
+            [harja.tyokalut.big :as big]
             [harja.domain.kulut :as kulut]
             [harja.domain.oikeudet :as oikeudet]
-            [harja.tyokalut.big :as big]
-            [harja.palvelin.palvelut.kulut.pdf :as kpdf]
             [harja.palvelin.palvelut.urakat :as urakat]
+            [harja.palvelin.raportointi.excel :as excel]
+            [harja.palvelin.palvelut.kulut.pdf :as kpdf]
             [harja.palvelin.komponentit.pdf-vienti :as pdf-vienti]
             [harja.palvelin.komponentit.excel-vienti :as excel-vienti]
-            [harja.palvelin.raportointi.excel :as excel]
+            [harja.palvelin.integraatiot.api.tyokalut.virheet :as virheet]
             [harja.palvelin.palvelut.muutos.muutos-palvelu :as muutos-palvelu]
-            [harja.pvm :as pvm])
+            [harja.palvelin.komponentit.http-palvelin :refer [julkaise-palvelu poista-palvelut]])
   (:use [slingshot.slingshot :only [throw+]]))
 
 
@@ -481,7 +483,7 @@
                                   :viesti (str
                                             "Tallennus epäonnistui. "
                                             "Erillisrahoitetun muutostyön budjetti ylittyy. "
-                                            "Budjetissa jäljellä: " (fmt/euro-opt budjettia-jaljella))}]})
+                                            "Budjetin ylitys: " (fmt/euro-opt (Math/abs (double budjettia-jaljella))))}]})
 
               :else
               (throw+ {:type virheet/+viallinen-kutsu+

--- a/src/clj/harja/palvelin/palvelut/kulut/kulut.clj
+++ b/src/clj/harja/palvelin/palvelut/kulut/kulut.clj
@@ -408,7 +408,7 @@
               lisatty-budjetti (+ (or kirjattu-summa 0) (or lisatty-budjetti 0)) ;; Tällä kululla budjettiin lisättävä summa
               budjettia-jaljella (- (or budjetoitu-summa 0) lisatty-budjetti) ;; Muutostyölle jäljellä oleva budjetti tämän kulun jälkeen
 
-              muutos-budjetti-ylittyy? (if-not (:muutos muutostyo) false
+              muutos-budjetti-ylittyy? (if-not (:valittu-muutostyo kohdistusrivi) false
                                          (boolean
                                            (when budjettia-jaljella (< budjettia-jaljella 0M))))
 

--- a/src/clj/harja/palvelin/palvelut/kulut/kulut.clj
+++ b/src/clj/harja/palvelin/palvelut/kulut/kulut.clj
@@ -402,11 +402,11 @@
               muutostyo (assoc muutostyo :muutos (:muutos kohdistusrivi))
               muutostyo-voimassa-alkaen (:voimassa_alkaen muutostyo)
 
-              budjetoitu-summa (:budjetoitu_summa muutostyo) ;; Muutostyölle kirjattu tavoitehinnan muutos 
-              kirjattu-summa (:kirjattu_summa muutostyo) ;; Muutostyölle tähän mennessä kirjattujen kulut yht 
-              lisatty-budjetti (- (or kokonaissumma 0) (or edellinen-maara 0))
-              lisatty-budjetti (+ (or kirjattu-summa 0) (or lisatty-budjetti 0)) ;; Tällä kululla budjettiin lisättävä summa
-              budjettia-jaljella (- (or budjetoitu-summa 0) lisatty-budjetti) ;; Muutostyölle jäljellä oleva budjetti tämän kulun jälkeen
+              budjetoitu-summa (or (:budjetoitu_summa muutostyo) 0) ;; Muutostyölle kirjattu tavoitehinnan muutos 
+              kirjattu-summa (or (:kirjattu_summa muutostyo) 0) ;; Muutostyölle tähän mennessä kirjattujen kulut yht 
+              lisatty-budjetti (- kokonaissumma edellinen-maara)
+              lisatty-budjetti (+ kirjattu-summa lisatty-budjetti) ;; Tällä kululla budjettiin lisättävä summa
+              budjettia-jaljella (- budjetoitu-summa lisatty-budjetti) ;; Muutostyölle jäljellä oleva budjetti tämän kulun jälkeen
 
               muutos-budjetti-ylittyy? (if-not (:valittu-muutostyo kohdistusrivi) false
                                          (boolean

--- a/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
@@ -6,6 +6,7 @@
             [slingshot.slingshot :refer [throw+]]
 
             [harja.pvm :as pvm]
+            [harja.fmt :as fmt]
             [harja.domain.mhu :as mhu]
             [harja.kyselyt.konversio :as konv]
             [harja.kyselyt.urakat :as q-urakat]
@@ -750,11 +751,23 @@
           (hae-aiempien-vuosien-pysyvat-muutokset db urakka-id (:hoitokauden_alkuvuosi maaramuutos) true))))))
 
 
-(defn- tarkista-muutoksen-kirjatut-kulut [db {:keys [id voimassa_alkaen] :as muutos} alityyppi]
+(defn- tarkista-muutoksen-kirjatut-kulut [db {:keys [id voimassa_alkaen] :as muutos} alityyppi kustannusvaikutukset]
   ;; Jos tehdään muutostyö jolle voi kirjata kuluja 
   ;; -> tämän jälkeen vaihdetaan voimassa_alkaen päivää 
   ;; -> pitää tarkistaa voidaanko näin tehdä, esim jos kuluja on jo kirjattu
-  (let [vuosi (when voimassa_alkaen (pvm/vuosi voimassa_alkaen))
+  ;; Sama tarkastus budjetille (tavoitehinnan muutos)
+  (let [tavoitehinnan-muutos (apply + (keep #(:summa %) kustannusvaikutukset))
+        jo-kirjatut-kulut (muutos-kyselyt/muutostyolle-jo-kirjatut-kulut-yhteensa db
+                            {:muutos id
+                             :tyyppi (cond
+                                       (= alityyppi "erillisrahoitus")
+                                       "erillisrahoitettu-muutos"
+                                       :else nil)})
+
+        budjetti-ylittyy? (boolean (when (and tavoitehinnan-muutos jo-kirjatut-kulut)
+                                     (> (bigdec jo-kirjatut-kulut) (bigdec tavoitehinnan-muutos))))
+
+        vuosi (when voimassa_alkaen (pvm/vuosi voimassa_alkaen))
         kk (when voimassa_alkaen (pvm/kuukausi voimassa_alkaen))
         paiva (when voimassa_alkaen (pvm/paiva voimassa_alkaen))
         voimassa-alkaen-sql (when voimassa_alkaen (str vuosi "-" kk "-" paiva))
@@ -770,7 +783,15 @@
                    :voimassa voimassa-alkaen-sql})
         kuluja-kirjattu? (boolean vastaus)]
 
-    (when kuluja-kirjattu?
+    (cond
+      budjetti-ylittyy?
+      (throw+ {:type virheet/+viallinen-kutsu+
+               :virheet [{:koodi virheet/+sisainen-kasittelyvirhe+
+                          :viesti (str
+                                    "Muutostyön budjetti ylittyy. "
+                                    "Kuluja on jo kirjattu yhteensä " (fmt/euro-opt jo-kirjatut-kulut))}]})
+
+      kuluja-kirjattu?
       (throw+ {:type virheet/+viallinen-kutsu+
                :virheet [{:koodi virheet/+sisainen-kasittelyvirhe+
                           :viesti (str
@@ -841,7 +862,7 @@
             tavoitehinta-indeksikorjattu-per-hoitovuosi (urakan-tavoitehinnat-indeksikorjattu db urakka-id)]
         (cond
           tyyppi-muutostyo?
-          (tarkista-muutoksen-kirjatut-kulut conn muutos alityyppi)
+          (tarkista-muutoksen-kirjatut-kulut conn muutos alityyppi kustannusvaikutukset)
 
           tyyppi-pysyva?
           ;; Estä tallennus, mikäli yritetään muokata lukittua pysyvän muutoksen voimassa_alkaen päivämäärää

--- a/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
@@ -759,10 +759,7 @@
   (let [tavoitehinnan-muutos (apply + (keep #(:summa %) kustannusvaikutukset))
         jo-kirjatut-kulut (muutos-kyselyt/muutostyolle-jo-kirjatut-kulut-yhteensa db
                             {:muutos id
-                             :tyyppi (cond
-                                       (= alityyppi "erillisrahoitus")
-                                       "erillisrahoitettu-muutos"
-                                       :else nil)})
+                             :tyyppi (when (= alityyppi "erillisrahoitus") "erillisrahoitettu-muutos")})
 
         budjetti-ylittyy? (boolean (when (and tavoitehinnan-muutos jo-kirjatut-kulut)
                                      (> (bigdec jo-kirjatut-kulut) (bigdec tavoitehinnan-muutos))))

--- a/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
@@ -595,34 +595,56 @@
                         :laskun_numero (:laskun-numero rivi)
                         :koontilaskun-kuukausi (kulut-domain/pvm->koontilaskun-kuukausi (:pvm rivi) (:alkupvm urakka))
                         :kokonaissumma (:tavoitehinnan-muutos rivi)}
+                  tavoitehinnan-muutos (:tavoitehinnan-muutos rivi)
                   ;; 1.10.2025 ja jälkeen alkavissa urakassa vaaditaan negatiivinen summa näiden muutosten kuluissa
                   _ (when (and
                             (= :vahennys
                               (muutos-domain/jjh-korvaus-muutos-vai-vahennys? (:alkupvm urakka)))
-                            (> (:tavoitehinnan-muutos rivi) 0))
+                            (> tavoitehinnan-muutos 0))
                       (throw (Error. "1.10.2025 tai sen jälkeen alkavissa urakoissa Johto- ja hallintokorvausmuutoksen kulut voivat olla vain vähennyksiä eli miinusmerkkisiä.")))
                   ;; jotta saadaan talteen muutoshistoria, aina luodaan uusi kulu ja sen kohdistus, vanhat merkitään poistetuksi
-                  kulu-id-db (:id (kulu-kyselyt/luo-kulu<! db kulu))
-                  ;; luodaan aina uusi kohdistus, jos kyseessä "päivitys", poistetaan vanha kohdistus jotta jää historia talteen
-                  kulu-kohdistus-db (muutos-kyselyt/luo-jjh-kulun-kohdistus<! db
-                                      {:kulu kulu-id-db
-                                       :summa (:tavoitehinnan-muutos rivi)
-                                       :toimenpideinstanssi hoidon-johto-tpi-id
-                                       :kayttaja (:id kayttaja)
-                                       :tyyppi "jjh-muutos"})]]
+                  kulu-id-db (when (not= tavoitehinnan-muutos 0)
+                               (:id (kulu-kyselyt/luo-kulu<! db kulu)))]]
+
+      ;; luodaan aina uusi kohdistus, jos kyseessä "päivitys", poistetaan vanha kohdistus jotta jää historia talteen
+      (when kulu-id-db
+        (muutos-kyselyt/luo-jjh-kulun-kohdistus<! db
+          {:kulu kulu-id-db
+           :summa (:tavoitehinnan-muutos rivi)
+           :toimenpideinstanssi hoidon-johto-tpi-id
+           :kayttaja (:id kayttaja)
+           :tyyppi "jjh-muutos"}))
+
+      (cond
+        ;; Esim voimassa alkaen pvm muutettiin, rivi muuttui nollaksi -> poista 
+        (and (:kulu-id rivi) (= tavoitehinnan-muutos 0))
+        (poista-vanhat-kulutiedot! db kayttaja rivi)
+
+        ;; Päivitetään olemassa oleva 
+        (and
+          kulu-id-db
+          (:kulu-id rivi)
+          (not= tavoitehinnan-muutos 0))
+        (do
+          (muutos-kyselyt/paivita-muutos-kulu-linkitys! db {:versio (:versio muutos-id-ja-versio)
+                                                            :muutos (:id muutos-id-ja-versio)
+                                                            :vanha-kulu (:kulu-id rivi)
+                                                            :uusi-kulu kulu-id-db})
+          (poista-vanhat-kulutiedot! db kayttaja rivi))
+
+        ;; Tehdään uusi 
+        (and kulu-id-db (not (:kulu-id rivi)))
+        (do
+          (muutos-kyselyt/luo-muutos-kulu-linkitys<! db {:versio (:versio muutos-id-ja-versio)
+                                                         :muutos (:id muutos-id-ja-versio)
+                                                         :kulu kulu-id-db})
+          (poista-vanhat-kulutiedot! db kayttaja rivi)))
+
 
       ;; TODO: Korjaa kulun luominen ja päivittäminen, kun teet johto- ja hallintokorvaus muutoksia
       ;;       Pitää pystyä päivittämään vanhaa kulu-riviä siten, että uudet kulutiedot korvaavat vanhat ja versio päivittyy
       ;; FIXME: Tämä on näemmä vielä kesken. Rivin mukana ei tule vielä kulu-id:tä ainakaan testeissä
-      (if (:kulu-id rivi)
-        (muutos-kyselyt/paivita-muutos-kulu-linkitys! db {:versio (:versio muutos-id-ja-versio)
-                                                          :muutos (:id muutos-id-ja-versio)
-                                                          :vanha-kulu (:kulu-id rivi)
-                                                          :uusi-kulu kulu-id-db})
-        (muutos-kyselyt/luo-muutos-kulu-linkitys<! db {:versio (:versio muutos-id-ja-versio)
-                                                       :muutos (:id muutos-id-ja-versio)
-                                                       :kulu kulu-id-db}))
-      (poista-vanhat-kulutiedot! db kayttaja rivi))))
+      )))
 
 
 (defn- tallenna-muutoksen-liitteet [db aiti-muutos-id-ja-versio liitteet]

--- a/src/cljs/harja/tiedot/urakka/muutokset/yhteiset_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/muutokset/yhteiset_tiedot.cljs
@@ -306,9 +306,10 @@
           mahdolliset-hoitovuodet-lomakkeella (:urakan-hoitokaudet app)
           hoitovuosi-lomakkeelle (if (and hyppaa-hoitovuoteen? lomakkeen-hoitokausi)
                                    lomakkeen-hoitokausi
-                                   (or (when aikaisin-hoitovuosi-jossa-kirjauksia
-                                         (pvm/vuodesta-hoitokausi aikaisin-hoitovuosi-jossa-kirjauksia))
-                                     (first mahdolliset-hoitovuodet-lomakkeella)))
+                                   (or
+                                     (when aikaisin-hoitovuosi-jossa-kirjauksia
+                                       (pvm/vuodesta-hoitokausi aikaisin-hoitovuosi-jossa-kirjauksia))
+                                     valittu-hoitokausi))
 
           johto-ja-hallinto (johto-ja-hallintokorvausmuutoksen-rivit valittu-hoitokausi (:kulut vastaus))
           app (-> app

--- a/src/cljs/harja/tiedot/urakka/muutokset/yhteiset_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/muutokset/yhteiset_tiedot.cljs
@@ -386,9 +386,10 @@
                   {:keys [laskenta-automatiikka?] :as app}]
     (let [urakka (:urakka @tila/yleiset)
           kulut (when (= (:tyyppi muutos) "johto-ja-hallintokorvaus")
-                  ;; luodaan vain kuluja, joiden summa on eri suuri kuin 0 (eli niillä on jotain vaikutusta laskentoihin)
-                  (filter #(and
-                             (some? (:tavoitehinnan-muutos %))
+                  ;; Salli 0 arvo, jos kulu-id on olemassa (se poistetaan)
+                  ;; Muuten vaadi, että tavoitehinnan muutos ei ole 0.
+                  (filter #(or
+                             (:kulu-id %)
                              (not= 0 (:tavoitehinnan-muutos %)))
                     (vals (:johto-ja-hallintokorvaukset muutos))))
           muutos (assoc muutos :kulut kulut)

--- a/src/cljs/harja/views/urakka/muutokset/lomake/lomake_johto_hallinto.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lomake/lomake_johto_hallinto.cljs
@@ -38,6 +38,7 @@
                    (let [jjh-muutokset (:johto-ja-hallintokorvaukset rivi)
                          jjh-muutokset (reduce-kv (fn [acc k v]
                                                     ;; Jos rivi ei osu voimassa alkaen pvm, nollaa tavoitehinnan muutos
+                                                    ;; Tämä poistaa myös kirjatun kulun, jos sellainen on kirjattu 
                                                     (assoc acc k (if (and
                                                                        (not= 0 (:tavoitehinnan-muutos v))
                                                                        (pvm/ennen? (:pvm v) arvo))

--- a/src/cljs/harja/views/urakka/muutokset/lomake/lomake_johto_hallinto.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lomake/lomake_johto_hallinto.cljs
@@ -31,7 +31,25 @@
         :hae #(fmt/hoitokauden-jarjestysluku-ja-vuodet valittu-hoitokausi urakan-hoitokaudet "Hoitovuosi")}
 
        (yhteiset/+rivi-muutoksen-syy+)
-       (yhteiset/+rivi-muutos-voimassa+ urakan-hoitokaudet valittu-hoitokausi))
+
+       (merge
+         (yhteiset/+rivi-muutos-voimassa+ urakan-hoitokaudet valittu-hoitokausi)
+         {:aseta (fn [rivi arvo]
+                   (let [jjh-muutokset (:johto-ja-hallintokorvaukset rivi)
+                         jjh-muutokset (reduce-kv (fn [acc k v]
+                                                    ;; Jos rivi ei osu voimassa alkaen pvm, nollaa tavoitehinnan muutos
+                                                    (assoc acc k (if (and
+                                                                       (not= 0 (:tavoitehinnan-muutos v))
+                                                                       (pvm/ennen? (:pvm v) arvo))
+                                                                   (assoc v :tavoitehinnan-muutos 0)
+                                                                   v)))
+                                         {}
+                                         jjh-muutokset)]
+
+                     (-> rivi
+                       (assoc :voimassa_alkaen arvo)
+                       (assoc :mahdolliset-hoitovuodet-lomakkeella urakan-hoitokaudet)
+                       (assoc :johto-ja-hallintokorvaukset jjh-muutokset))))}))
 
      (first (yhteiset/liite-kentta e! app))
 
@@ -40,7 +58,6 @@
         :uusi-rivi? true
         :komponentti (fn [_rivi]
                        [yleiset/ajax-loader "Haetaan muutoksen tietoja..."])}
-
        {:nimi :johto-ja-hallintokorvaus-muutokset
         :otsikko ""
         :palstoja 2
@@ -48,13 +65,13 @@
         :uusi-rivi? true
         :komponentti
         (fn [_e! _]
-          [:span
-           [:hr]
+          [:span [:hr]
            [:h3 "Muutokset tavoitehintaan ja kuluihin"]
 
            [grid/muokkaus-grid
             {:tunniste :pvm
              :luokat ["johto-ja-hallintokorvaus-muutokset-grid"]
+             :jarjesta :pvm
              :piilota-toiminnot? true
              :voi-lisata? false
              :voi-kumota? false
@@ -64,7 +81,6 @@
              :rivi-jalkeen [{:teksti "Yhteensä" :sarakkeita 1 :luokka "yhteensa"}
                             {:teksti (fmt/euro-opt summa) :tasaa :oikea :luokka "yhteensa"}]}
 
-            ;; Taulukon kentät
             [{:otsikko "Kalenterikuukausi"
               :nimi :pvm
               :tyyppi :string
@@ -80,7 +96,13 @@
               :tyyppi :numero
               :fmt fmt/euro-opt
               :tasaa :oikea
-              :leveys 8}]
+              :leveys 8
+              :muokattava? (fn [r]
+                             ;; Ei ole muokattava, jos ei osu voimassa alkaen sisään
+                             (let [voimassa (:voimassa_alkaen muokattava-muutos)
+                                   rivi-voimassa? (boolean (when voimassa
+                                                             (pvm/ennen? voimassa (:pvm r))))]
+                               rivi-voimassa?))}]
             rivit-atom]
 
            [yleiset/info-laatikko :neutraali

--- a/test/clj/harja/palvelin/palvelut/muutos_kustannukset_test.clj
+++ b/test/clj/harja/palvelin/palvelut/muutos_kustannukset_test.clj
@@ -178,7 +178,7 @@
 
 (deftest muutos-kulun-tallennus-sekä-validointi-toimii
   (let [erillisrahoitettu-muutostyo (hae-muutostyot)
-
+        erillisrahoitettu-muutostyo (assoc erillisrahoitettu-muutostyo :tavoitehinnan-muutos 10000M)
         ;; Kulu joka tallennetaan kantaan
         uusi-muutos-kulu {:kokonaissumma 188,
                           :kohdistukset [{:rivi 0
@@ -281,10 +281,32 @@
            eräpäivä ei voi olla erillä hoitokaudella muutostyön voimassaolosta")))
 
 
+    (testing "Muutostyön kulun kirjaus heittää virheen, budjetti ylittyy"
+      (let [odotettu-poikkeus "Tallennus epäonnistui. Erillisrahoitetun muutostyön budjetti ylittyy"
+            kulu-erapaiva (pvm/->pvm "03.10.2025")
+            uusi-muutos-kulu (paivita-erapaivat-fn "2025-10-01" kulu-erapaiva)
+
+            uusi-muutos-kulu (-> uusi-muutos-kulu
+                               ;; Laita summaksi yli budjetin (budjetti = tavoitehinnan muutos)
+                               (assoc :kokonaissumma 100000M)
+                               (update :kohdistukset #(assoc-in % [0 :summa] 100000M)))
+
+            vastaus (try
+                      (kutsu-palvelua
+                        (:http-palvelin jarjestelma)
+                        :tallenna-kulu +kayttaja-jvh+
+                        {:urakka-id +urakka+
+                         :kulu-kohdistuksineen uusi-muutos-kulu})
+                      (catch Exception e e))]
+        (is
+          (true? (str/includes? vastaus odotettu-poikkeus))
+          "Odotettu virhe heitetään, 
+           erillisrahoitetun muutostyön budjetti ylittyy")))
+
+
     (testing "Tallennus validointi toimii, kun kuluja on jo kirjattu (erillisrahoitus)"
       (let [virheellinen-voimassa-alkaen (pvm/->pvm "11.11.2025")
             odotettu-poikkeus "Muutostyölle on jo kirjattu kuluja ennen 11.11.2025"
-
             muutos erillisrahoitettu-muutostyo
             muutos (assoc muutos
                      :tyyppi "muutostyo"
@@ -304,4 +326,31 @@
         (is
           (true? (str/includes? vastaus odotettu-poikkeus))
           "Odotettu virhe heitetään, 
-           voimassa ennen ei voi asettaa kirjattujen kulujen eräpäivien jälkeen")))))
+           voimassa ennen ei voi asettaa kirjattujen kulujen eräpäivien jälkeen")))
+
+
+    (testing "Tallennus validointi toimii, budjetti ylittyy (erillisrahoitus)"
+      (let [virheellinen-voimassa-alkaen (pvm/->pvm "11.11.2025")
+            odotettu-poikkeus "Muutostyön budjetti ylittyy."
+
+            muutos erillisrahoitettu-muutostyo
+            muutos (assoc muutos
+                     :tyyppi "muutostyo"
+                     :alityyppi :erillisrahoitus
+                     :tavoitehinnan-muutos 0M ;; Ei voi olla 0, kun kuluja on jo kirjattu
+                     :voimassa_alkaen virheellinen-voimassa-alkaen)
+
+            payload {:muutos muutos
+                     :urakka-id +urakka+
+                     :hoitokaudet +hoitokaudet+
+                     :valittu-hoitokausi (last +hoitokaudet+)}
+
+            vastaus (try
+                      (kutsu-palvelua
+                        (:http-palvelin jarjestelma)
+                        :tallenna-muutos +kayttaja-jvh+ payload)
+                      (catch Exception e e))]
+        (is
+          (true? (str/includes? vastaus odotettu-poikkeus))
+          "Odotettu virhe heitetään, 
+           tavoitehinnan muutos ei voi olla 0, kun kuluja on jo kirjattu")))))

--- a/test/clj/harja/palvelin/palvelut/muutos_palvelu_test.clj
+++ b/test/clj/harja/palvelin/palvelut/muutos_palvelu_test.clj
@@ -1763,10 +1763,10 @@
                           :voimassa_alkaen #inst "2025-10-20T10:07:32.000-00:00"
                           :syy "Erillisrahoitettu testimuutos poistoa varten"
                           :nimi "Poistettava erillisrahoitettu muutos"
-                          :tavoitehinnan-muutos 5000
+                          :tavoitehinnan-muutos 5250
                           :kustannusvaikutukset [{:hoitokauden_alkuvuosi 2025
                                                   :kustannuslaji "erillishankinnat"
-                                                  :summa 5000
+                                                  :summa 5250
                                                   :toimenpideinstanssi nil}]}
           _ (kutsu-palvelua (:http-palvelin jarjestelma)
               :tallenna-muutos
@@ -1836,7 +1836,7 @@
           kulu {:kokonaissumma 250
                 :erapaiva (pvm/->pvm "25.10.2025")
                 :kohdistukset [{:tyyppi :erillisrahoitettu-muutos
-                                :valittu-muutostyo luotu-muutos
+                                :valittu-muutostyo (assoc luotu-muutos :budjetoitu_summa 5000)
                                 :toimenpideinstanssi tpi-id
                                 :rivi 0
                                 :summa 250


### PR DESCRIPTION
Nämä fixattu:
> Erillisrahoitettuun muutostyöhön voi kirjata enemmän euroja kuin muutoksessa budjetoitu
> Muutokseen liittyvä kulu ei päivity, kun uusi summa on tyhjä tai nolla ( JJH )