### PR TITLE
HARJA-2112 Korjaa pysyvän muutoksen muokkauksen rajoitteet

### DIFF
--- a/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lomake/lomake_pysyva.cljs
@@ -275,12 +275,15 @@
         (:mahdolliset-hoitovuodet-lomakkeella muokattava-muutos))))
 
 (defn taulukko-pysyvan-muutoksen-vaikutukset
-  [e! {:keys [urakan-hoitokaudet muokattava-muutos budjettitavoitteet] :as app}]
+  [e! {:keys [urakan-hoitokaudet muokattava-muutos budjettitavoitteet] :as app} voimassa-alkaen-lukittu?]
   (let [hoitovuosi (:hoitovuosi muokattava-muutos)
         voimassa-alkaen (:voimassa_alkaen muokattava-muutos)
         {:keys [tavoitehinta-indeksikorjattu-per-hoitovuosi]} budjettitavoitteet
         hoitovuosi-lukittu? (muutos-domain/pysyva-muutos-hoitovuosi-lukittu? tavoitehinta-indeksikorjattu-per-hoitovuosi voimassa-alkaen hoitovuosi)
+        hoitovuosi-vahvistettu? (get tavoitehinta-indeksikorjattu-per-hoitovuosi (some-> hoitovuosi first (pvm/vuosi)))
         voi-muokata? (and
+                       ;; Onko kustis jo vahvistettu 
+                       (not hoitovuosi-vahvistettu?)
                        ;; Voi muokata, jos "voimassa alkaen" osuu johonkin hoitovuoteen tai hoitovuosi on sen jälkeen
                        (muutos-domain/voimassa-alkaen-hoitovuodella-tai-jalkeen? voimassa-alkaen hoitovuosi)
                        ;; Voi muokata, jos hoitovuosi ei ole vielä lukittu
@@ -308,9 +311,19 @@
      [:div.pysyvan-muutoksen-grid-header
       (if voi-muokata?
         [yleiset/vihje "Valitse toimenpiteet, joita muutos koskee."]
-        [yleiset/vihje (str "Hoitovuoden tietoja ei voi muokata. "
-                         (when (not (muutos-domain/voimassa-alkaen-hoitovuodella-tai-jalkeen? voimassa-alkaen hoitovuosi))
-                           "Voimassa alkaen-päivämäärä ei ole valitulla hoitovuodella."))])
+
+        (cond
+          hoitovuosi-vahvistettu?
+          [yleiset/info-laatikko :vahva-ilmoitus
+           "Hoitovuoden alun tavoitehintoja on vahvistettu"
+           "Peru vahvistukset kirjataksesi muutoksia."
+           nil
+           {:ikoni-fn #(ikonit/harja-icon-status-alert)}]
+
+          :else
+          [yleiset/vihje (str "Hoitovuoden tietoja ei voi muokata. "
+                           (when (not (muutos-domain/voimassa-alkaen-hoitovuodella-tai-jalkeen? voimassa-alkaen hoitovuosi))
+                             "Voimassa alkaen-päivämäärä ei ole valitulla hoitovuodella."))]))
 
       [napit/nappi "Kopioi tiedot tuleville hoitovuosille"
        (fn []
@@ -323,6 +336,7 @@
               :toiminto-fn #(kopioi-tuleville-hoitovuosille! e! muokattava-muutos)})
            (kopioi-tuleville-hoitovuosille! e! muokattava-muutos)))
        {:ikoni (ikonit/action-copy)
+        :disabled hoitovuosi-vahvistettu?
         :luokka "nappi-toissijainen pysyvan-muutoksen-kopiointinappi"}]]
 
      [grid-pysyvan-muutoksen-vaikutukset*
@@ -334,32 +348,21 @@
   [e! {:keys [urakan-hoitokaudet muokattava-muutos budjettitavoitteet haku-kaynnissa? muutoksen-tiedot-haku-kaynnissa?
               valittu-hoitokausi] :as app}]
 
-  (let [muokataan? (:id muokattava-muutos)
+  (let [muutos-id (:id muokattava-muutos)
         voimassa-alkaen (:voimassa_alkaen muokattava-muutos)
         hoitovuosi (:hoitovuosi muokattava-muutos)
         {:keys [tavoitehinta-indeksikorjattu-per-hoitovuosi]} budjettitavoitteet
-        ;; Voimassa-alkaen lukitus tarkastatetaan vain muokkaustilanteessa
-        voimassa-alkaen-lukittu? (if muokataan?
-                                   (muutos-domain/pysyva-muutos-voimassa-alkaen-lukittu? tavoitehinta-indeksikorjattu-per-hoitovuosi)
-                                   false)]
+        voimassa-alkaen-lukittu? (muutos-domain/pysyva-muutos-voimassa-alkaen-lukittu? tavoitehinta-indeksikorjattu-per-hoitovuosi)]
+
     [(lomake/ryhma {:otsikko "Perustiedot"}
        (yhteiset/+rivi-muutoksen-syy+)
 
-       (when
-         voimassa-alkaen-lukittu?
-         {:uusi-rivi? true
-          :tyyppi :komponentti
-          :komponentti (fn [_]
-                         [yleiset/info-laatikko :vahva-ilmoitus
-                          "Hoitovuoden alun tavoitehintoja on vahvistettu"
-                          "Peru vahvistukset muokataksesi voimassa alkaen päivämäärää."
-                          nil
-                          {:ikoni-fn #(ikonit/harja-icon-status-alert)}])})
-
        (yhteiset/+rivi-muutos-voimassa+ urakan-hoitokaudet valittu-hoitokausi
          {:pakota-valittuun-hoitokauteen? false
-
-          :voi-muokata? (not voimassa-alkaen-lukittu?)})
+          :esta-hoitovuodet tavoitehinta-indeksikorjattu-per-hoitovuosi
+          :voi-muokata? (not (and
+                               (some? muutos-id)
+                               voimassa-alkaen-lukittu?))})
 
        ;; -- Info-laatikot --
        (when (muutos-domain/muutos-voimassa-kesken-hoitokauden? voimassa-alkaen hoitovuosi)

--- a/src/cljs/harja/views/urakka/muutokset/yhteiset.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/yhteiset.cljs
@@ -87,7 +87,7 @@
 (defn +rivi-muutos-voimassa+
   ([urakan-hoitokaudet valittu-hoitokausi]
    (+rivi-muutos-voimassa+ urakan-hoitokaudet valittu-hoitokausi {}))
-  ([urakan-hoitokaudet valittu-hoitokausi {:keys [pakota-valittuun-hoitokauteen? voi-muokata?]
+  ([urakan-hoitokaudet valittu-hoitokausi {:keys [pakota-valittuun-hoitokauteen? voi-muokata? esta-hoitovuodet]
                                            :or {pakota-valittuun-hoitokauteen? true
                                                 voi-muokata? true} :as opts}]
    {:otsikko "Voimassa alkaen"
@@ -97,9 +97,10 @@
     :pakollinen? true
     ;; Rajoita valinta hoitokaudelle 
     :validoi [(fn [valittu-pvm]
-                (if pakota-valittuun-hoitokauteen?
+                (cond
                   ;; Katsotaan että voimassa alkaen osuu valittuun hoitokauteen
                   ;; Erityisesti tärkeä muutostyö kirjauksissa 
+                  pakota-valittuun-hoitokauteen?
                   (let [pvm-hk-valissa? (boolean (when valittu-hoitokausi
                                                    (pvm/valissa?
                                                      valittu-pvm
@@ -118,7 +119,19 @@
                   ;; Esimerkiksi pysyvässä muutoksessa kevyempi validointi riittää,
                   ;; koska pysyvässä muutoksessa valitaan hoitokausi erikseen ja voimassa-alkaen
                   ;; saa osua mihin tahansa hoitokauteen
-                  (when (nil? valittu-pvm) "Syötä muutoksen voimassaolo pvm")))]
+                  (nil? valittu-pvm)
+                  "Syötä muutoksen voimassaolo pvm"
+
+                  ;; Jos valitun hoitovuoden alun tavoitehinta on vahvistettu, ei sallita
+                  ;; valittua voimassa-alkaen päivämäärää (pysyvä muutos)
+                  esta-hoitovuodet
+                  (when (some (fn [[y a?]]
+                                (and a?
+                                  (let [[alku loppu] (pvm/vuodesta-hoitokausi y)]
+                                    (pvm/valissa? valittu-pvm alku loppu))))
+                          esta-hoitovuodet)
+                    "Valitun hoitovuoden alun tavoitehinta on vahvistettu.")))]
+
     ;; Pysyvän muutoksen lomakkeella valitaan hoitokausi mistä eteenpäin muutos vaikuttaa. Se ei saa olla
     ;; pienempi kuin voimassa alkaen, joten kutsuttava :aseta funktiota. Ei vaikuta ainakaan vielä muissa muutostyypeissä
     :aseta (fn [rivi arvo]


### PR DESCRIPTION
Ratkaisuehdotus uuden pysyvän muutoksen tekoon


**"Luo uusi pysyvä muutos"** sallii nyt voimassa alkaen asettamisen, 
mutta ei salli sen asettamista vahvistetuille vuosille:

<img width="450" height="132" alt="image" src="https://github.com/user-attachments/assets/0ec95312-f454-453d-b954-4a451a8fff43" />



Lomake on myös disabloituna siltä hoitovuodelta, sekä vihjetekstiä siirretty: 

<img width="500" height="645" alt="image" src="https://github.com/user-attachments/assets/2529d946-b715-4dc1-8eba-0e3949dff3f0" />

Eli, uuden muutoksen voi nyt tehdä, sekä voimassa alkaen asettaa, mutta ei voi asettaa vahvistetulle vuodelle. 
Teon jälkeen, voimassa alkaen ei voi enää muuttaa (ellei vahvistuksia ensin peruta). 
Tämä on joustavampi, ja vähemmän virhealtis, kun nykyinen toteutus.

