### PR TITLE
HARJA-2065 - Turha logitus ja muita bugeja

### DIFF
--- a/src/clj/harja/kyselyt/lampotilat.clj
+++ b/src/clj/harja/kyselyt/lampotilat.clj
@@ -3,3 +3,5 @@
 
 (defqueries "harja/kyselyt/lampotilat.sql"
   {:positional? true})
+
+(declare hae-urakan-lampotilat)

--- a/src/clj/harja/kyselyt/materiaalit.clj
+++ b/src/clj/harja/kyselyt/materiaalit.clj
@@ -15,4 +15,4 @@
   hae-urakan-toteumat-materiaalille hae-toteuman-materiaalitiedot poista-urakan-materiaalinkaytto!
   poista-materiaalinkaytto-id! paivita-materiaalinkaytto-maara! luo-materiaalinkaytto<!
   paivita-toteuma-materiaali! luo-toteuma-materiaali<! paivita-sopimuksen-materiaalin-kaytto-toteumapvm
-  hae-suolauksen-toimenpidekoodi)
+  hae-suolauksen-toimenpidekoodi hae-talvisuolan-hoitovuoden-kokonaismaara)

--- a/src/clj/harja/kyselyt/paatos_kyselyt.clj
+++ b/src/clj/harja/kyselyt/paatos_kyselyt.clj
@@ -409,7 +409,7 @@
                   (nil? paatos)
                   (not= urakkaid (:urakkaid paatos)))
             ;; Throw exception
-            (throw (Exception. "Hoindonjohtopalkkionmuutospäätöstä ei löydy annetulla id:llä tai se ei kuulu annetulle urakalle")))
+            (throw (Exception. "Hoidonjohtopalkkionmuutospäätöstä ei löydy annetulla id:llä tai se ei kuulu annetulle urakalle")))
         vastaus (poista-hoidonjohtopalkkio-paatos<! db {:poistaja kayttajaid :id paatosid})]
     vastaus))
 
@@ -440,6 +440,6 @@
                   (nil? paatos)
                   (not= urakkaid (:urakkaid paatos)))
             ;; Throw exception
-            (throw (Exception. "Hoindonjohtopalkkionmuutospäätöstä ei löydy annetulla id:llä tai se ei kuulu annetulle urakalle")))
+            (throw (Exception. "Raporttipäätöstä ei löydy annetulla id:llä tai se ei kuulu annetulle urakalle")))
         vastaus (poista-poytakirjan-raporttipaatos<! db {:poistaja kayttajaid :id paatosid})]
     vastaus))

--- a/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
+++ b/src/clj/harja/kyselyt/uusi_kustannussuunnitelma_kyselyt.clj
@@ -143,7 +143,7 @@
 
 (defn hae-hoidonjohtopalkkiot [db sopimus-id urakka-id hoitovuoden-alkuvuosi]
   (let [;; Hae hoidonjohto toimenpideinstannssi
-        ;; Hoindonjohto toimenpide.koodi = 23151
+        ;; Hoidonjohto toimenpide.koodi = 23151
         hoidonjohto-tpi-id (:id (first (tpi-kyselyt/hae-urakan-toimenpideinstanssi-toimenpidekoodilla db
                                          {:urakka urakka-id
                                           :koodi "23151"})))
@@ -357,7 +357,7 @@
                       [] toimenkuvat)
 
         ;; Muut kulut - kuten toimisto, ict yms on käyttöliittymässä lisätty toimenkuva -taulukkoon. Haetaan nekin
-        ;; Hoindonjohto toimenpide.koodi = 23151
+        ;; Hoidonjohto toimenpide.koodi = 23151
         hoidonjohto-tpi-id (:id (first (tpi-kyselyt/hae-urakan-toimenpideinstanssi-toimenpidekoodilla db
                                          {:urakka urakka-id
                                           :koodi "23151"})))
@@ -452,7 +452,7 @@
 
 (defn hae-erillishankinnat [db sopimus-id urakka-id hoitovuoden-alkuvuosi]
   (let [;; Hae hoidonjohto toimenpideinstannssi
-        ;; Hoindonjohto toimenpide.koodi = 23151
+        ;; Hoidonjohto toimenpide.koodi = 23151
         hoidonjohto-tpi-id (:id (first (tpi-kyselyt/hae-urakan-toimenpideinstanssi-toimenpidekoodilla db
                                          {:urakka urakka-id
                                           :koodi "23151"})))
@@ -783,7 +783,7 @@
         urakan-indeksit (indeksi-kyselyt/hae-urakan-indeksikertoimet db urakka-id)
         sopimus-id (urakat-q/urakan-paasopimus-id db urakka-id)
         ;; Hae hoidonjohto toimenpideinstannssi
-        ;; Hoindonjohto toimenpide.koodi = 23151
+        ;; Hoidonjohto toimenpide.koodi = 23151
         hoidonjohto-tpi-id (:id (first (tpi-kyselyt/hae-urakan-toimenpideinstanssi-toimenpidekoodilla db
                                          {:urakka urakka-id
                                           :koodi "23151"})))

--- a/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
@@ -124,7 +124,7 @@
         (do
           ;; Varoita vain, jos kustannusennusten-lupaus vaaditaan urakalle. Ja se vaaditaan vasta -25 ja sen jälkeen
           (when (>= (pvm/vuosi (:alkupvm urakan-tiedot)) 2025)
-            (log/warn "Kustannusennuste-lupausta ei löytynyt urakalle" urakka-id))
+            (log/warn "Kustannusennustelupausta ei löytynyt urakalle" urakka-id))
           {})
         (let [maarapaivat (kustannusennuste-kyselyt/hae-kustannusennuste-maarapaivat
                             db {:lupaus-id (:lupaus-id kustannusennuste-lupaus)

--- a/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/lupaus/lupaus_palvelu.clj
@@ -122,7 +122,9 @@
     (let [kustannusennuste-lupaus (first (filter #(= (:lupaustyyppi %) "kustannusennuste") lupaukset))]
       (if-not kustannusennuste-lupaus
         (do
-          (log/warn "Kustannusennuste-lupausta ei löytynyt urakalle" urakka-id)
+          ;; Varoita vain, jos kustannusennusten-lupaus vaaditaan urakalle. Ja se vaaditaan vasta -25 ja sen jälkeen
+          (when (>= (pvm/vuosi (:alkupvm urakan-tiedot)) 2025)
+            (log/warn "Kustannusennuste-lupausta ei löytynyt urakalle" urakka-id))
           {})
         (let [maarapaivat (kustannusennuste-kyselyt/hae-kustannusennuste-maarapaivat
                             db {:lupaus-id (:lupaus-id kustannusennuste-lupaus)

--- a/src/clj/harja/palvelin/raportointi/raportit/talvihoitosuolan_kokonaiskayttomaara.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/talvihoitosuolan_kokonaiskayttomaara.clj
@@ -108,23 +108,33 @@
       keskilampo-pitka)))
 
 (defn paattele-raportin-viimeinen-hoitovuosi
-  "Aina ei voida näyttää koko hoitokautta tai kaikkia esim viittä vuotta, koska urakka on kesken.
-  Päätellään tässä, että mikä on viimeinen valmistunut hoitokausi."
-  [urakan-loppupvm]
-  (let [nyt-kuukausi (pvm/kuukausi (pvm/nyt))
-        vuoden-loppu? (case nyt-kuukausi
-                        10 true
-                        11 true
-                        12 true
-                        false)]
-    (if (pvm/ennen? (pvm/paivan-lopussa urakan-loppupvm) (pvm/nyt))
+  "Aina ei voida näyttää koko hoitokautta tai kaikkia esim viittä vuotta, koska urakka on kesken ja
+  lämpötilatietoja ei välttämättä ole vielä syötetty.
+  Päätellään tässä, että mikä on viimeinen valmistunut hoitokausi tai viimeinen vuosi, jolle lämpötilatiedot on.
+  Näytetään aikaisintaan 1.3. kuluvan hoitokauden tiedot, edellyttäen, että lämpötilatiedot on jo syötetty. "
+  [urakan-loppupvm lampotilat]
+  (let [nyt (pvm/nyt)
+        ;nyt #inst "2026-03-04T05:20:24.028-00:00"
+        nyt-vuosi (pvm/vuosi nyt)
+        nyt-kuukausi (pvm/kuukausi nyt)
+        ;; Hoitokausi on valmis vain jos olemme lokakuussa tai myöhemmin
+        hoitokausi-valmis? (>= nyt-kuukausi 10)
+        ;; maalis - syyskuu = 3 - 9
+        maalis-syyskuu? (>= nyt-kuukausi 3)]
+    (cond
+      ;; Jos urakka on päättynyt, palautetaan päättymispäivän vuosi
+      (pvm/ennen? (pvm/paivan-lopussa urakan-loppupvm) nyt)
       (pvm/vuosi urakan-loppupvm)
-      ;; Jos kuukausi on 10,11 tai 12, niin sama vuosi riittää,
-      ;; muuten riittää tarkastukseksi että onko edellinen vuosi
-      (if vuoden-loppu?
-        (pvm/vuosi (pvm/nyt))
-        ;; Jos on vuoden alku, niin otetaan nykypäivästä yksi vuosi pois
-        (dec (pvm/vuosi (pvm/nyt)))))))
+
+      ;; Jos ollaan lokakuussa tai myöhemmin, nykyinen hoitokausi on valmis
+      hoitokausi-valmis?
+      nyt-vuosi
+
+      ;; Jos ollaan maalis-syyskuussa, palautetaan viimeisin lämpötiladatavuosi, mutta ei tulevaisuuden vuosia, vaikka lämpötildataa vahingossa sinne olisi voinut syöttää
+      :else
+      (if maalis-syyskuu?
+        (min nyt-vuosi (pvm/vuosi (:loppupvm (last lampotilat))))
+        (dec nyt-vuosi)))))
 
 (defn jasenna-raportin-otsikko [urakan-tiedot hoitovuodet]
   (if hoitovuodet
@@ -135,10 +145,14 @@
   (let [konteksti (cond urakka-id :urakka
                     hallintayksikko-id :hallintayksikko
                     :default :koko-maa)
+
+        ;; Haetaan hoitovuodelle keskilämpötilojen keskiarvo tarkastelujaksolla
+        urakan-lampotilat (lampotilat-kyselyt/hae-urakan-lampotilat db {:urakka urakka-id})
+
         ;; Haetaan tiedot hoitokausittain - ja siihen tarvitaan urakan kesto
         urakan-tiedot (first (urakat-kyselyt/hae-yksittainen-urakka db {:urakka_id urakka-id}))
         urakan_alkuvuosi (pvm/vuosi (:alkupvm urakan-tiedot))
-        viimeinen-mahdollinen-vuosi (paattele-raportin-viimeinen-hoitovuosi (:loppupvm urakan-tiedot))
+        viimeinen-mahdollinen-vuosi (paattele-raportin-viimeinen-hoitovuosi (:loppupvm urakan-tiedot) urakan-lampotilat)
         ;; Jos urakka on vasta alkanut ja valmistuneita hoitokausia ei ole, niin ei haeta tietoja
         hoitovuodet (if (not= viimeinen-mahdollinen-vuosi (pvm/vuosi (:alkupvm urakan-tiedot)))
                       (range
@@ -146,9 +160,6 @@
                         ;; Näytetään vain päättyneiltä hoitokausilta
                         viimeinen-mahdollinen-vuosi)
                       nil)
-
-        ;; Haetaan hoitovuodelle keskilämpötilojen keskiarvo tarkastelujaksolla
-        urakan-lampotilat (lampotilat-kyselyt/hae-urakan-lampotilat db {:urakka urakka-id})
 
         ;; Koostetaan data map tyyppiseen rakenteeseen
         data (when hoitovuodet

--- a/src/clj/harja/palvelin/raportointi/raportit/talvihoitosuolan_kokonaiskayttomaara.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/talvihoitosuolan_kokonaiskayttomaara.clj
@@ -114,7 +114,6 @@
   Näytetään aikaisintaan 1.3. kuluvan hoitokauden tiedot, edellyttäen, että lämpötilatiedot on jo syötetty. "
   [urakan-loppupvm lampotilat]
   (let [nyt (pvm/nyt)
-        ;nyt #inst "2026-03-04T05:20:24.028-00:00"
         nyt-vuosi (pvm/vuosi nyt)
         nyt-kuukausi (pvm/kuukausi nyt)
         ;; Hoitokausi on valmis vain jos olemme lokakuussa tai myöhemmin

--- a/src/cljs/harja/tiedot/urakka/laadunseuranta/siltatarkastukset.cljs
+++ b/src/cljs/harja/tiedot/urakka/laadunseuranta/siltatarkastukset.cljs
@@ -32,9 +32,7 @@
                                    :silta-id silta
                                    :siltatarkastus-id tarkastus}))
 
-(defonce valittu-silta (local-storage/local-storage-atom :valittu-silta-siltatarkastuksessa
-                                                          nil
-                                                          nil))
+(defonce valittu-silta (atom nil))
 
 (defonce valitun-sillan-tarkastukset
   (reaction<! [urakka-id (:id @nav/valittu-urakka)

--- a/src/cljs/harja/ui/kentat.cljs
+++ b/src/cljs/harja/ui/kentat.cljs
@@ -330,20 +330,21 @@
            [:div (- pituus-max (count @data)) " merkkiä jäljellä"])]))))
 
 (defn- normalisoi-numero [n salli-whitespace?]
-  (when n (-> n
-            ;; Poistetaan whitespace, jos ei sallittu
-            (as-> n n
-              (if-not salli-whitespace? (str/replace n #"\s" "")
-                n))
-            ;; Poistetaan mahd. euromerkki lopusta
-            (str/replace #"€$" "")
-            ;; Korvataan välimerkin variaatiot tavallisellä välimerkillä (hyphen)
-            ;; fmt/desimaaliluku-opt muuntaa negatiivisen numeron väliviivan matemaattiseksi väliviivaksi (U+2212)
-            ;; joka voi sotkea numerosyötteen validoinnin ja käsittelyn
-            (str/replace #"[−–—]" "-")
+  (when (and n (string? n))
+    (-> n
+      ;; Poistetaan whitespace, jos ei sallittu
+      (as-> n n
+        (if-not salli-whitespace? (str/replace n #"\s" "")
+          n))
+      ;; Poistetaan mahd. euromerkki lopusta
+      (str/replace #"€$" "")
+      ;; Korvataan välimerkin variaatiot tavallisellä välimerkillä (hyphen)
+      ;; fmt/desimaaliluku-opt muuntaa negatiivisen numeron väliviivan matemaattiseksi väliviivaksi (U+2212)
+      ;; joka voi sotkea numerosyötteen validoinnin ja käsittelyn
+      (str/replace #"[−–—]" "-")
 
-            ;; Poistetaan ympäröivä whitespace joka tapauksessa
-            (str/trim))))
+      ;; Poistetaan ympäröivä whitespace joka tapauksessa
+      (str/trim))))
 
 (def +desimaalin-oletus-tarkkuus+ 2)
 

--- a/test/clj/harja/palvelin/palvelut/laskutusyhteenveto_mhu_test.clj
+++ b/test/clj/harja/palvelin/palvelut/laskutusyhteenveto_mhu_test.clj
@@ -524,10 +524,10 @@
                               :loppupvm (pvm/->pvm "30.9.2020")})
         ;; Hoidonjohtopalkkio on vaan MHY ylläpidon alla, mutta lasketaan se kaikkien alta, koska se on muualla nolla
         ;; Ja jos ei ole, niin silloin on virhetilanne ja se löytyy samalla testillä.
-        hoindonjohtopalkkio-laskutusyhteenvedossa (apply + (map :hj_palkkio_laskutetaan laskutusyhteenveto))
+        hoidonjohtopalkkio-laskutusyhteenvedossa (apply + (map :hj_palkkio_laskutetaan laskutusyhteenveto))
         _ (is (= (+ hoidonjohtopalkkio-kustannusarvioidut-tyot hoidonjohtopalkkio-kulut)
                 (+ hoidonjohtopalkkio-toteutuneet_kustannukset hoidonjohtopalkkio-kulut)
-                hoindonjohtopalkkio-laskutusyhteenvedossa))]))
+                hoidonjohtopalkkio-laskutusyhteenvedossa))]))
 
 (deftest toteutuneet-erilliskustannukset
   ;; Erilliskustannukset suunnitellaan kustannusarvioitu_tyo tauluun. Ja ne on

--- a/test/clj/harja/palvelin/raportointi/talvisuolan_kokonaiskayttomaarat_ja_lampotilat_test.clj
+++ b/test/clj/harja/palvelin/raportointi/talvisuolan_kokonaiskayttomaarat_ja_lampotilat_test.clj
@@ -49,19 +49,65 @@
     {:otsikko "Toteuma (kuivatonnia)", :leveys 1, :fmt :numero, :tasaa :oikea}
     {:otsikko "Erotus (kuivatonnia)", :leveys 1, :fmt :numero, :tasaa :oikea}))
 
+(def lampotiladata '({:id 1906, :alkupvm #inst "2021-09-30T21:00:00.000-00:00", :loppupvm #inst "2022-09-29T21:00:00.000-00:00", :keskilampotila -9.20M, :keskilampotila-1991-2020 nil, :keskilampotila-1981-2010 -9.90M, :keskilampotila-1971-2000 nil}
+                     {:id 2008, :alkupvm #inst "2022-09-30T21:00:00.000-00:00", :loppupvm #inst "2023-09-29T21:00:00.000-00:00", :keskilampotila -6.30M, :keskilampotila-1991-2020 -8.80M, :keskilampotila-1981-2010 -9.90M, :keskilampotila-1971-2000 nil}
+                     {:id 2106, :alkupvm #inst "2023-09-30T21:00:00.000-00:00", :loppupvm #inst "2024-09-29T21:00:00.000-00:00", :keskilampotila -11.20M, :keskilampotila-1991-2020 -8.80M, :keskilampotila-1981-2010 -9.90M, :keskilampotila-1971-2000 nil}
+                     {:id 2305, :alkupvm #inst "2024-09-30T21:00:00.000-00:00", :loppupvm #inst "2025-09-29T21:00:00.000-00:00", :keskilampotila -6.80M, :keskilampotila-1991-2020 -8.80M, :keskilampotila-1981-2010 -9.90M, :keskilampotila-1971-2000 -8.80M}))
+
 ;; Testit
 
 (deftest paattele-raportin-viimeinen-hoitovuosi-test
   (with-redefs [t/now #(t/date-time 2023 8 15 12)]
     ;; Tyhjän saa pyytämättäkin
     (is (= nil nil))
-    (is (= 1900 (talvisuola-rap/paattele-raportin-viimeinen-hoitovuosi (pvm/luo-pvm-dec-kk 1900 9 30))))
+    (is (= 1900 (talvisuola-rap/paattele-raportin-viimeinen-hoitovuosi (pvm/luo-pvm-dec-kk 1900 9 30) lampotiladata)))
     ;; Nykyhetkeksi on määritelty 2023 elokuu, joten hoitokausi on kesken, ja oikeaa päätösvuotta ei voida käyttää
-    (is (= 2023 (talvisuola-rap/paattele-raportin-viimeinen-hoitovuosi (pvm/luo-pvm-dec-kk 2023 9 30))))
+    (is (= 2023 (talvisuola-rap/paattele-raportin-viimeinen-hoitovuosi (pvm/luo-pvm-dec-kk 2023 9 30) lampotiladata)))
     ;; Nykyhetkeksi on määritelty 3023 elokuu, joten hoitokausi on kesken, ja oikeaa päätösvuotta ei voida käyttää
     ;; Vaikka se olisi kuinka myöhään tulevaisuudessa
     (is (= (pvm/vuosi (first (pvm/paivamaaran-hoitokausi (pvm/nyt))))
-          (talvisuola-rap/paattele-raportin-viimeinen-hoitovuosi (pvm/luo-pvm-dec-kk 3023 9 30))))))
+          (talvisuola-rap/paattele-raportin-viimeinen-hoitovuosi (pvm/luo-pvm-dec-kk 3023 9 30) lampotiladata)))))
+
+(deftest paattele-raportin-viimeinen-hoitovuosi-2-test
+  (testing "Urakka on päättynyt"
+    (with-redefs [t/now #(t/date-time 2023 8 15 12)]
+      (is (= 1900 (talvisuola-rap/paattele-raportin-viimeinen-hoitovuosi
+                    (pvm/luo-pvm-dec-kk 1900 9 30)
+                    [])))
+      (is (= 2022 (talvisuola-rap/paattele-raportin-viimeinen-hoitovuosi
+                    (pvm/luo-pvm-dec-kk 2022 9 30)
+                    [])))))
+
+  (testing "Hoitokausi valmis - ollaan lokakuussa tai myöhemmin"
+    (with-redefs [pvm/nyt (constantly (pvm/luo-pvm-dec-kk 2025 10 15))]
+      (is (= 2025 (talvisuola-rap/paattele-raportin-viimeinen-hoitovuosi
+                    (pvm/luo-pvm-dec-kk 2025 9 30)
+                    lampotiladata))))
+    (with-redefs [pvm/nyt (constantly (pvm/luo-pvm-dec-kk 2023 8 15))]
+      (is (= 2023 (talvisuola-rap/paattele-raportin-viimeinen-hoitovuosi
+                    (pvm/luo-pvm-dec-kk 2025 9 30)
+                    lampotiladata))))
+    (with-redefs [pvm/nyt (constantly (pvm/luo-pvm-dec-kk 2023 3 15))]
+      (is (= 2023 (talvisuola-rap/paattele-raportin-viimeinen-hoitovuosi
+                    (pvm/luo-pvm-dec-kk 2025 9 30)
+                    lampotiladata))))
+    (with-redefs [pvm/nyt (constantly (pvm/luo-pvm-dec-kk 2023 11 15))]
+      (is (= 2023 (talvisuola-rap/paattele-raportin-viimeinen-hoitovuosi
+                    (pvm/luo-pvm-dec-kk 2025 9 30)
+                    lampotiladata))))
+    (with-redefs [pvm/nyt (constantly (pvm/luo-pvm-dec-kk 2023 12 31))]
+      (is (= 2023 (talvisuola-rap/paattele-raportin-viimeinen-hoitovuosi
+                    (pvm/luo-pvm-dec-kk 2025 9 30)
+                    lampotiladata)))))
+
+  (testing "Tammi-elokuu, edellisen vuoden lämpötiladata löytyy"
+    (let [lampotilat [{:alkupvm #inst "2022-09-30T21:00:00.000-00:00" :loppupvm #inst "2023-09-29T21:00:00.000-00:00"}
+                      {:alkupvm #inst "2023-09-30T21:00:00.000-00:00" :loppupvm #inst "2024-09-29T21:00:00.000-00:00"}]]
+      (with-redefs [pvm/nyt (constantly (pvm/luo-pvm-dec-kk 2023 1 15))]
+        (is (= 2022 (talvisuola-rap/paattele-raportin-viimeinen-hoitovuosi
+                      (pvm/luo-pvm-dec-kk 2024 9 30)
+                      lampotilat)))))))
+
 
 (deftest kohtuullistettu-kayttoraja-test
   (is (= 1.0 (talvisuola-rap/kohtuullistettu-kayttoraja 1 0)))


### PR DESCRIPTION
Tähän on koottu pieniä parannuksia ja useamman bugien korjauksia.

Useita kirjoitusvirheitä korjattu.

HARJA-1378 - Lämpötilatarkasteluraportti on muutettu näyttämään lämpötilatiedot 1.3. alkaen, mikäli ne on syötetty hallinnasta. Ne on käsin syötettävä ja se on määritelty adminpaneelissa, että ne on maaliskuusta lähtien mahdollista hakea. (esim vielä sieltä ei tullut mitään, näin helmikuun alussa)

HARJA-2025 - local storage esti siltatarkastusten avaamisen erillisiin välilehtiin. Local storage vaihdettu tavalliseen atomiin ja avot. Nyt pystyy avaamaan useamman siltatarkastuksen eri välilehtiin.

HARJA-2065 Turha logitus lupauksissa, kun kustannusennuste lupausta muodostettiin.

:numero tyyppisen kentän räsähdys korjattu. Tuli esille lämpötilatietoja hakiessa Ilmatieteenlaitokselta. Ilmatieteenlaitos palauttaa hassuja arvoja, jotka tulkitaan NAN arvoiksi ja tuolla sivulla räsähti tyyliin 100 :numero tyyppistä kentää. Tämä estetty sillä, että yritetään string replacea vain string tyyppisiin arvoihin.