### PR TITLE
HARJA-2138 - Tehtävät ja määrät korjaa nollien näkyminen jos kokonaisluku

### DIFF
--- a/src/cljc/harja/fmt.cljc
+++ b/src/cljc/harja/fmt.cljc
@@ -726,9 +726,28 @@
     #?(:clj (/ (Math/round (* arvo kerroin)) kerroin)
        :cljs (/ (js/Math.round (* arvo kerroin)) kerroin))))
 
-(defn trimmaa-normaali-luku
-  "Monet formatointifunktiot formatoivat luvut ikään kuin ne olisivat rahoja. Eli kahteen desimaaliin.
-  Tällä formatoinnilla muutetaan luvun piste '.' pilkuksi ja leikataan kolmannen desimaalin jälkeen ylimääräiset pois."
+(defn desimaaliluku-opt-ilman-nollia
+  "Formatoi luvun näyttämään desimaalit vain tarvittaessa, ilman pakotettuja nollia.
+  
+  Käyttö:
+  - Kun halutaan jättää kokonaisluvut ilman desimaaleja (ei \" ,00\"-päätettä)
+  - Kun lähdedata voi olla numero tai numeric-string (tämä toimii myös stringeillä)
+  
+  Toiminta:
+  - Kokonaisluvut näytetään ilman desimaaleja: 10
+  - Desimaaliluvut näytetään tarpeen mukaan: 10,5 tai 10,25
+  - Muuntaa pisteen pilkuksi automaattisesti
+  - Jos desimaaleja on >3, pyöristää 2-3 desimaaliin (ks. pyorista-ehka-kolmeen)
+  
+  Esimerkit:
+  (desimaaliluku-opt-ilman-nollia 10)       => \"10\"
+  (desimaaliluku-opt-ilman-nollia 10.0)     => \"10\"
+  (desimaaliluku-opt-ilman-nollia 10.5)     => \"10,5\"
+  (desimaaliluku-opt-ilman-nollia 10.25)    => \"10,25\"
+  (desimaaliluku-opt-ilman-nollia 10.123)   => \"10,123\"
+  (desimaaliluku-opt-ilman-nollia 10.12345) => \"10,123\" (pyöristetty)
+  
+  Vrt. desimaaliluku-opt, kun haluat määrittää min/max desimaalit tarkasti."
   [luku]
   (when luku
     (let [desimaalit (s/split (str luku) #"\.")

--- a/src/cljs/harja/views/urakka/suunnittelu/tehtavat.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tehtavat.cljs
@@ -262,10 +262,10 @@
                "70%")}
             ;; ennen urakkaa -moodi
             (if sopimukset-syotetty?
-              {:otsikko "Tarjouksen määrä" :nimi :sopimus-maara :tyyppi :string :fmt #(fmt/trimmaa-normaali-luku %) :leveys "180px"
+              {:otsikko "Tarjouksen määrä" :nimi :sopimus-maara :tyyppi :string :fmt #(fmt/desimaaliluku-opt-ilman-nollia %) :leveys "180px"
                :validoi [[:ei-tyhja "Anna määrä"]]
                :muokattava? (constantly false) :tasaa :oikea :veda-oikealle? true}
-              {:otsikko "Tarjouksen määrä" :nimi :sopimus-maara :tyyppi :numero :fmt #(fmt/trimmaa-normaali-luku %) :leveys "180px"
+              {:otsikko "Tarjouksen määrä" :nimi :sopimus-maara :tyyppi :numero :fmt #(fmt/desimaaliluku-opt-ilman-nollia %) :leveys "180px"
                :validoi [[:ei-tyhja "Anna määrä"]]
                :muokattava? #(and
                                ;; Tallennuksen ajaksi laita sarakkeet kiinni
@@ -274,7 +274,7 @@
                :tasaa :oikea :veda-oikealle? true})
             ;; urakan ajan suunnittelu -moodi         
             (when sopimukset-syotetty?
-              {:otsikko "Muuttunut määrä" :nimi :maara-muuttunut-tarjouksesta :tyyppi :numero :fmt #(fmt/trimmaa-normaali-luku %) :muokattava? (comp kun-yksikko kun-ei-rahavaraus) :leveys "180px" :tasaa :oikea :veda-oikealle? true})
+              {:otsikko "Muuttunut määrä" :nimi :maara-muuttunut-tarjouksesta :tyyppi :numero :fmt #(fmt/desimaaliluku-opt-ilman-nollia %) :muokattava? (comp kun-yksikko kun-ei-rahavaraus) :leveys "180px" :tasaa :oikea :veda-oikealle? true})
             {:otsikko "Yksikkö" :nimi :yksikko :tyyppi :string :muokattava? (constantly false) :leveys "140px"}]
            aluetiedot-tila]])
        (when (and (> maara-tehtavia 0) nayta-suunniteltavat-tehtavat?)
@@ -310,19 +310,19 @@
                "70%")}
             ;; ennen urakkaa -moodi
             (when (not sopimukset-syotetty?)
-              {:otsikko "Tarjouksen määrä vuodessa" :nimi :sopimus-maara :tyyppi :numero :fmt #(fmt/trimmaa-normaali-luku %) :leveys "180px"
+              {:otsikko "Tarjouksen määrä vuodessa" :nimi :sopimus-maara :tyyppi :numero :fmt #(fmt/desimaaliluku-opt-ilman-nollia %) :leveys "180px"
                :validoi [[:ei-tyhja]]
                :muokattava? (comp kun-yksikko kun-kaikki-samat kun-ei-rahavaraus) :sarake-disabloitu-arvo-fn sarake-disabloitu-arvo
                :veda-oikealle? true :tasaa :oikea})
             ;; urakan ajan suunnittelu -moodi
             (when sopimukset-syotetty? 
               {:otsikko "Koko urakka-ajan määrä tarjouksessa" :nimi :sopimuksen-tehtavamaarat-yhteensa
-               :tyyppi :string :fmt #(fmt/trimmaa-normaali-luku %) :muokattava? (constantly false) :leveys "160px" :tasaa :oikea :veda-oikealle? true})
+               :tyyppi :string :fmt #(fmt/desimaaliluku-opt-ilman-nollia %) :muokattava? (constantly false) :leveys "160px" :tasaa :oikea :veda-oikealle? true})
             (when sopimukset-syotetty? 
-              {:otsikko "Koko urakka-ajan määrää jäljellä" :nimi :sovittuja-jaljella :tyyppi :string :fmt #(fmt/trimmaa-normaali-luku %)
+              {:otsikko "Koko urakka-ajan määrää jäljellä" :nimi :sovittuja-jaljella :tyyppi :string :fmt #(fmt/desimaaliluku-opt-ilman-nollia %)
                :muokattava? (constantly false) :leveys "160px" :tasaa :oikea :veda-oikealle? true})
             (when sopimukset-syotetty? 
-              {:otsikko "Hoitovuoden suunniteltu määrä" :nimi :maara-muuttunut-tarjouksesta :tyyppi :numero :fmt #(fmt/trimmaa-normaali-luku %) :tasaa :oikea :muokattava? kun-yksikko :leveys "180px" :veda-oikealle? true})
+              {:otsikko "Hoitovuoden suunniteltu määrä" :nimi :maara-muuttunut-tarjouksesta :tyyppi :numero :fmt #(fmt/desimaaliluku-opt-ilman-nollia %) :tasaa :oikea :muokattava? kun-yksikko :leveys "180px" :veda-oikealle? true})
             {:otsikko "Yksikkö" :nimi :yksikko :tyyppi :string :muokattava? (constantly false) :leveys "140px"}]
            maarat-tila]])])))
 

--- a/src/cljs/harja/views/urakka/suunnittelu/tehtavat_maarat_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/suunnittelu/tehtavat_maarat_nakyma.cljs
@@ -92,8 +92,8 @@
 (defn muutoksen-vaikutus-fn [arvo]
   (cond
     (nil? arvo) "-"
-    (pos? arvo) (str "+" (fmt/desimaaliluku-opt arvo 2))
-    :else (fmt/desimaaliluku-opt arvo 2)))
+    (pos? arvo) (str "+" (fmt/desimaaliluku-opt-ilman-nollia arvo))
+    :else (fmt/desimaaliluku-opt-ilman-nollia arvo)))
 
 (defn tehtava-vetolaatikko
   "Näyttää tehtävän muutokset vetolatikossa"
@@ -118,11 +118,11 @@
         :voi-kumota? false}
        [{:otsikko "Voimassa alkaen" :nimi :voimassa_alkaen :tyyppi :string :fmt pvm/pvm :leveys "10%"}
         {:otsikko "Edellinen määrä" :nimi :edellinen_maara :leveys "10%" :tyyppi :numero :desimaalien-maara 2 :tasaa :oikea
-         :fmt #(fmt/desimaaliluku-opt % 2)}
+         :fmt #(fmt/desimaaliluku-opt-ilman-nollia %)}
         {:otsikko "Pysyvät muutokset (+/-)" :nimi :maaramuutos :leveys "10%" :tyyppi :numero :tasaa :oikea
          :fmt (fn [arvo] (muutoksen-vaikutus-fn arvo))}
         {:otsikko "Muuttunut määrä" :nimi :uusi_maara :leveys "10%" :tyyppi :numero :desimaalien-maara 2 :tasaa :oikea
-         :fmt #(fmt/desimaaliluku-opt % 2)}
+         :fmt #(fmt/desimaaliluku-opt-ilman-nollia %)}
         {:otsikko "Lisätieto" :nimi :syy :leveys "60%" :tyyppi :string :tasaa :vasen}]
        muutokset]]]))
 
@@ -158,7 +158,7 @@
                                      [:div.body-text.strong valiotsikko]))}
                      {:otsikko "Alkuperäisen sopimuksen määrä"
                       :leveys "12.5%"
-                      :fmt #(fmt/desimaaliluku-opt % 2)
+                      :fmt #(fmt/desimaaliluku-opt-ilman-nollia %)
                       :nimi :tarjous_maara
                       :tyyppi :positiivinen-numero
                       :desimaalien-maara 2
@@ -182,7 +182,7 @@
                       :muokattava? (constantly false)
                       :solun-luokka solun-luokka-fn
                         :tasaa :oikea
-                        :fmt #(fmt/desimaaliluku-opt % 2)}
+                        :fmt #(fmt/desimaaliluku-opt-ilman-nollia %)}
                      {:otsikko "Yksikkö" :leveys "12.5%" :nimi :yksikko :tyyppi :teksti :tasaa :vasen :muokattava? (constantly false) :solun-luokka solun-luokka-fn}]]
     (if haku-kaynnissa?
       [ajax-loader-pieni]


### PR DESCRIPTION
## Tiivistelmä
Tehtävämäärien näyttämisen formatointi yhtenäistettiin vanhan näkymän kanssa: kokonaisluvut näytetään ilman pakotettuja desimaalinollia ja desimaalit vain tarvittaessa. Tämä vähentää “,00”-hälyä ja tekee muutoksien (+/-) tulkinnasta selkeämpää suunnittelun näkymissä. Vaikutus on UI-esitystapaan; data ja laskenta pysyvät ennallaan.

## Muutokset
- Lisättiin uusi formatteri `desimaaliluku-opt-ilman-nollia` tiedostoon [src/cljc/harja/fmt.cljc](src/cljc/harja/fmt.cljc) (piste→pilkku, desimaalit vain tarvittaessa, >3 desimaalia pyöristyslogiikka).
- Päivitettiin tehtävien suunnittelun taulukoiden määrä-sarakkeiden formatointi käyttämään uutta formatteria: [src/cljs/harja/views/urakka/suunnittelu/tehtavat.cljs](src/cljs/harja/views/urakka/suunnittelu/tehtavat.cljs).
- Päivitettiin “Tehtävät ja määräluettelo” -näkymän muutosrivit ja määräsarakkeet käyttämään uutta formatteria (myös +/−-etuliitteinen esitys): [src/cljs/harja/views/urakka/suunnittelu/tehtavat_maarat_nakyma.cljs](src/cljs/harja/views/urakka/suunnittelu/tehtavat_maarat_nakyma.cljs).

## Muita huomioita
- Tekninen yksityiskohta: formatteri toimii myös numeric-string -syötteillä (käyttää `(str luku)` + split + piste→pilkku).
- Mahdolliset breaking changes: tässä commitissa vanha nimi `trimmaa-normaali-luku` poistuu (repo-tasolla ei jäänyt yhtään viittausta siihen commitin sisällä).
- Manuaalinen testaus: tarkista suunnittelun näkymissä, että arvot kuten 10 näkyvät “10”, ja arvot kuten 10.5/10.25 näkyvät “10,5”/“10,25”; varmista myös muutoslistan +/−-muotoilu.
- Riskit/huomiot: jos syötteessä on >3 desimaalia, arvo pyöristyy (2–3 desimaaliin), mikä voi muuttaa esitystä verrattuna aiempaan “aina 2 desimaalia” -malliin.