### PR TITLE
HARJA-2119 - Poista vanhentuneet sarakkeet mhu_muutos_tehtava_ja_maaraluettelo taulusta

### DIFF
--- a/src/clj/harja/kyselyt/muutos_kyselyt.sql
+++ b/src/clj/harja/kyselyt/muutos_kyselyt.sql
@@ -37,21 +37,16 @@ SELECT m.id,
               AND kust.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
            ),
            '[]'::json) AS kustannusvaikutukset,
-       COALESCE(
-           (SELECT JSON_AGG(
-                       JSONB_BUILD_OBJECT(
-                           'tehtava', tjm.tehtava,
-                           'suunniteltu_maara', ut.maara,
-                           'maaramuutos', tjm.maaramuutos,
-                           -- TODO: Edellinen_maara ja uusi_maara tietokannan tasolla voivat olla obsolete,
-                           --       koska on sovittu suunniteltu_maara tiedon olevan baseline, jonka päälle määrämuutokset
-                           --      lasketaan. Katsotaan myöhemmin, voidaanko nämä sarakkeet poistaa, vai tarvitaanko niitä.
-                           'edellinen_maara', tjm.edellinen_maara,
-                           'uusi_maara', tjm.uusi_maara,
-                           'hoitokauden_alkuvuosi', tjm.hoitokauden_alkuvuosi,
-                           'versio', tjm.versio)
-                       ORDER BY tjm.tehtava, tjm.hoitokauden_alkuvuosi
-                   )
+    COALESCE(
+        (SELECT JSON_AGG(
+                    JSONB_BUILD_OBJECT(
+                        'tehtava', tjm.tehtava,
+                        'suunniteltu_maara', ut.maara,
+                        'maaramuutos', tjm.maaramuutos,
+                        'hoitokauden_alkuvuosi', tjm.hoitokauden_alkuvuosi,
+                        'versio', tjm.versio)
+                    ORDER BY tjm.tehtava, tjm.hoitokauden_alkuvuosi
+                )
             FROM ONLY mhu_muutos_tehtava_ja_maaraluettelo tjm
                      LEFT JOIN urakka_tehtavamaara ut
                                ON ut.urakka = :urakka
@@ -401,11 +396,6 @@ SELECT
                         'tehtava', tjm.tehtava,
                         'suunniteltu_maara', ut.maara,
                         'maaramuutos', tjm.maaramuutos,
-                        -- TODO: Edellinen_maara ja uusi_maara tietokannan tasolla voivat olla obsolete,
-                        --       koska on sovittu suunniteltu_maara tiedon olevan baseline, jonka päälle määrämuutokset
-                        --      lasketaan. Katsotaan myöhemmin, voidaanko nämä sarakkeet poistaa, vai tarvitaanko niitä.
-                        'edellinen_maara', tjm.edellinen_maara,
-                        'uusi_maara', tjm.uusi_maara,
                         'hoitokauden_alkuvuosi', tjm.hoitokauden_alkuvuosi,
                         'versio', tjm.versio)
                     ORDER BY tjm.tehtava, tjm.hoitokauden_alkuvuosi
@@ -464,20 +454,16 @@ ORDER BY tp.jarjestys;
 
 -- name: luo-tai-paivita-tehtavan-maaramuutos<!
 -- Poikkeaminen tehtävä- ja määräluettelon määrästä
-INSERT INTO mhu_muutos_tehtava_ja_maaraluettelo AS tjm (versio, muutos, tehtava, hoitokauden_alkuvuosi, edellinen_maara,
-                                                        maaramuutos, uusi_maara)
+INSERT INTO mhu_muutos_tehtava_ja_maaraluettelo AS tjm (versio, muutos, tehtava, hoitokauden_alkuvuosi,
+                                                        maaramuutos)
 VALUES (:versio,
         :muutos-id,
         :tehtava,
         :hoitokauden_alkuvuosi,
-        :edellinen_maara,
-        :maaramuutos,
-        :uusi_maara)
+        :maaramuutos)
     ON CONFLICT (muutos, tehtava, hoitokauden_alkuvuosi)
         DO UPDATE SET versio          = EXCLUDED.versio,
-                      edellinen_maara = EXCLUDED.edellinen_maara,
-                      maaramuutos     = EXCLUDED.maaramuutos,
-                      uusi_maara      = EXCLUDED.uusi_maara
+                      maaramuutos     = EXCLUDED.maaramuutos
 -- Päivitetään vain jos tulee uusi määrämuutos
  WHERE (tjm.maaramuutos) IS DISTINCT FROM (excluded.maaramuutos);
 

--- a/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
+++ b/src/clj/harja/palvelin/palvelut/muutos/muutos_palvelu.clj
@@ -702,14 +702,12 @@
 
 
 (defn luo-tehtava-ja-maaramuutos
-  [aiti-muutos-id versio {:keys [tehtava maaramuutos uusi_maara edellinen_maara hoitokauden_alkuvuosi] :as sql-opts}]
+  [aiti-muutos-id versio {:keys [tehtava maaramuutos hoitokauden_alkuvuosi] :as sql-opts}]
   {:muutos-id aiti-muutos-id
    :versio versio
    :tehtava tehtava
    :hoitokauden_alkuvuosi hoitokauden_alkuvuosi
-   :maaramuutos maaramuutos
-   :uusi_maara uusi_maara
-   :edellinen_maara edellinen_maara})
+   :maaramuutos maaramuutos})
 
 (defn tallenna-muutoksen-tehtavien-maaramuutokset
   "Poikkeaminen tehtävä- ja määräluettelon määristä"
@@ -734,14 +732,7 @@
       ;; Vain määrämuutokset joilla on positiviinen tehtävän id käsitellään.
       ;; Negatiivisilla id:llä merkityt rivit ovat UI:ssa rivejä, joille ei ole vielä valittu tehtävää
       (when (pos? (:tehtava maaramuutos))
-        (let [maaramuutos (luo-tehtava-ja-maaramuutos muutos-id (or muutos-versio 1)
-                            (assoc maaramuutos
-                              ;; TODO: Edellinen_maara ja uusi_maara tietokannan tasolla voivat olla obsolete,
-                              ;;       koska on sovittu suunniteltu_maara tiedon olevan baseline, jonka päälle määrämuutokset
-                              ;;       lasketaan. Katsotaan myöhemmin voidaanko nämä sarakkeet poistaa, vai tarvitaanko niitä.
-                              ;;       Ja kuinka monimutkaiseksi useamman muutoksen tietojen yhdistely menee.
-                              #_:uusi_maara 0
-                              #_:edellinen_maara 0))]
+        (let [maaramuutos (luo-tehtava-ja-maaramuutos muutos-id (or muutos-versio 1) maaramuutos)]
           (muutos-kyselyt/luo-tai-paivita-tehtavan-maaramuutos<! db maaramuutos))))
 
     ;; Päivitä tavoite ja kattohinta 

--- a/test/clj/harja/palvelin/palvelut/muutos_palvelu_test.clj
+++ b/test/clj/harja/palvelin/palvelut/muutos_palvelu_test.clj
@@ -63,12 +63,10 @@
                                       :nimi "Päällysteen paikkausmuutos"
                                       :syy "Täytyykin tehdä enemmän päällysteiden paikkausta, koska pahat kelirikot."
                                       :tavoitehinnan-muutos 1000
-                                      :tehtavat_ja_maarat (list {:edellinen_maara 1000
-                                                                 :hoitokauden_alkuvuosi 2025
+                                      :tehtavat_ja_maarat (list {:hoitokauden_alkuvuosi 2025
                                                                  :maaramuutos 100
                                                                  :suunniteltu_maara 0
                                                                  :tehtava 24628
-                                                                 :uusi_maara 1100
                                                                  :versio 1})
                                       :tyyppi "pysyva"
                                       :urakka 36
@@ -108,19 +106,15 @@
                                       :nimi "Tämän hoitovuoden määräpoikkeamamuutos"
                                       :syy "Ei tehdä tänä kesänä rumpuja, ovat vielä kunnossa."
                                       :tavoitehinnan-muutos 1000
-                                      :tehtavat_ja_maarat (list {:edellinen_maara 40
-                                                                 :hoitokauden_alkuvuosi 2025
+                                      :tehtavat_ja_maarat (list {:hoitokauden_alkuvuosi 2025
                                                                  :maaramuutos -40
                                                                  :suunniteltu_maara nil
                                                                  :tehtava 1406
-                                                                 :uusi_maara 0
                                                                  :versio 1}
-                                                            {:edellinen_maara 30
-                                                             :hoitokauden_alkuvuosi 2025
+                                                            {:hoitokauden_alkuvuosi 2025
                                                              :maaramuutos -30
                                                              :suunniteltu_maara 8
                                                              :tehtava 9454
-                                                             :uusi_maara 0
                                                              :versio 1})
                                       :tyyppi "muutostyo"
                                       :urakka 36
@@ -556,68 +550,50 @@
                                      ;; lapsi-taulujen rivejä. Versioita ei ole tarpeen nostaa turhaan riveille, jotka eivät muutu.
                                      {:tehtava 6953 :maaramuutos 100, :hoitokauden_alkuvuosi 2028}]
         odotettu-vastaus (list
-                           {:edellinen_maara nil
-                            :hoitokauden_alkuvuosi 2027
+                           {:hoitokauden_alkuvuosi 2027
                             :maaramuutos 333
                             :suunniteltu_maara nil
                             :tehtava 6875
-                            :uusi_maara nil
                             :versio 2}
-                           {:edellinen_maara nil
-                            :hoitokauden_alkuvuosi 2026
+                           {:hoitokauden_alkuvuosi 2026
                             :maaramuutos 222
                             :suunniteltu_maara nil
                             :tehtava 6953
-                            :uusi_maara nil
                             :versio 2}
-                           {:edellinen_maara nil
-                            :hoitokauden_alkuvuosi 2027
+                           {:hoitokauden_alkuvuosi 2027
                             :maaramuutos 333
                             :suunniteltu_maara nil
                             :tehtava 6953
-                            :uusi_maara nil
                             :versio 2}
-                           {:edellinen_maara nil
-                            :hoitokauden_alkuvuosi 2028
+                           {:hoitokauden_alkuvuosi 2028
                             :maaramuutos 100
                             :suunniteltu_maara nil
                             :tehtava 6953
-                            :uusi_maara nil
                             :versio 2}
-                           {:edellinen_maara nil
-                            :hoitokauden_alkuvuosi 2025
+                           {:hoitokauden_alkuvuosi 2025
                             :maaramuutos 111
                             :suunniteltu_maara nil
                             :tehtava 11235
-                            :uusi_maara nil
                             :versio 2}
-                           {:edellinen_maara 1000
-                            :hoitokauden_alkuvuosi 2026
+                           {:hoitokauden_alkuvuosi 2026
                             :maaramuutos 100
                             :suunniteltu_maara 0
                             :tehtava 24628
-                            :uusi_maara 1100
                             :versio 1}
-                           {:edellinen_maara 1000
-                            :hoitokauden_alkuvuosi 2027
+                           {:hoitokauden_alkuvuosi 2027
                             :maaramuutos 100
                             :suunniteltu_maara 0
                             :tehtava 24628
-                            :uusi_maara 1100
                             :versio 1}
-                           {:edellinen_maara 1000
-                            :hoitokauden_alkuvuosi 2028
+                           {:hoitokauden_alkuvuosi 2028
                             :maaramuutos 100
                             :suunniteltu_maara 0
                             :tehtava 24628
-                            :uusi_maara 1100
                             :versio 1}
-                           {:edellinen_maara nil
-                            :hoitokauden_alkuvuosi 2026
+                           {:hoitokauden_alkuvuosi 2026
                             :maaramuutos 222
                             :suunniteltu_maara 0
                             :tehtava 17350
-                            :uusi_maara nil
                             :versio 2})
 
         _ (muutos-palvelu/tallenna-muutoksen-tehtavien-maaramuutokset (:db jarjestelma) (:id +kayttaja-jvh+) urakka-id muutos tehtava-maaramuutos-payload)
@@ -680,9 +656,9 @@
                                              {:tehtava 11235, :uusi? true, :maaramuutos 111, :hoitokauden_alkuvuosi 2025}
                                              {:tehtava 17350, :uusi? true, :maaramuutos 222, :hoitokauden_alkuvuosi 2026}
                                              {:tehtava 6875, :uusi? true, :maaramuutos 333, :hoitokauden_alkuvuosi 2027}
-                                             {:tehtava 6953, :uusi_maara 1100, :maaramuutos 111, :edellinen_maara 1000, :hoitokauden_alkuvuosi 2025}
-                                             {:tehtava 6953, :uusi_maara 1100, :maaramuutos 222, :edellinen_maara 1000, :hoitokauden_alkuvuosi 2026}
-                                             {:tehtava 6953, :uusi_maara 1100, :maaramuutos 333, :edellinen_maara 1000, :hoitokauden_alkuvuosi 2027}],
+                                             {:tehtava 6953, :maaramuutos 111, :hoitokauden_alkuvuosi 2025}
+                                             {:tehtava 6953, :maaramuutos 222, :hoitokauden_alkuvuosi 2026}
+                                             {:tehtava 6953, :maaramuutos 333, :hoitokauden_alkuvuosi 2027}],
                         :kustannusvaikutukset [{:toimenpideinstanssi 129, :kustannuslaji "hankintakustannukset", :summa 1111, :hoitokauden_alkuvuosi 2025}
                                                {:toimenpideinstanssi 129, :kustannuslaji "hankintakustannukset", :summa 2222, :hoitokauden_alkuvuosi 2026}
                                                {:toimenpideinstanssi 129, :kustannuslaji "hankintakustannukset", :summa 3333, :hoitokauden_alkuvuosi 2027}
@@ -721,26 +697,20 @@
                                         :syy "Esko tehdä pyöräytti uutta tietä 500 kilometria, täytyy vähän justeerata määriä"
                                         :tavoitehinnan-muutos 2222
                                         :tehtavat_ja_maarat (list
-                                                              {:edellinen_maara 1000
-                                                               :hoitokauden_alkuvuosi 2025
+                                                              {:hoitokauden_alkuvuosi 2025
                                                                :maaramuutos 111
                                                                :suunniteltu_maara nil
                                                                :tehtava 6953
-                                                               :uusi_maara 1100
                                                                :versio 1}
-                                                              {:edellinen_maara nil
-                                                               :hoitokauden_alkuvuosi 2025
+                                                              {:hoitokauden_alkuvuosi 2025
                                                                :maaramuutos 111
                                                                :suunniteltu_maara nil
                                                                :tehtava 11235
-                                                               :uusi_maara nil
                                                                :versio 1}
-                                                              {:edellinen_maara nil
-                                                               :hoitokauden_alkuvuosi 2025
+                                                              {:hoitokauden_alkuvuosi 2025
                                                                :maaramuutos 10
                                                                :suunniteltu_maara 0
                                                                :tehtava 17345
-                                                               :uusi_maara nil
                                                                :versio 1})
                                         :tyyppi "pysyva"
                                         :alityyppi nil
@@ -791,26 +761,20 @@
                                         :syy "Esko teki 100 km lisää tietä, pitääpä justeerata määriä uudestaan"
                                         :tavoitehinnan-muutos 1113
                                         :tehtavat_ja_maarat (list
-                                                              {:edellinen_maara 1000
-                                                               :hoitokauden_alkuvuosi 2025
+                                                              {:hoitokauden_alkuvuosi 2025
                                                                :maaramuutos 111
                                                                :suunniteltu_maara nil
                                                                :tehtava 6953
-                                                               :uusi_maara 1100
                                                                :versio 1}
-                                                              {:edellinen_maara nil
-                                                               :hoitokauden_alkuvuosi 2025
+                                                              {:hoitokauden_alkuvuosi 2025
                                                                :maaramuutos 2
                                                                :suunniteltu_maara nil
                                                                :tehtava 11235
-                                                               :uusi_maara nil
                                                                :versio 2}
-                                                              {:edellinen_maara nil
-                                                               :hoitokauden_alkuvuosi 2025
+                                                              {:hoitokauden_alkuvuosi 2025
                                                                :maaramuutos 10
                                                                :suunniteltu_maara 0
                                                                :tehtava 17345
-                                                               :uusi_maara nil
                                                                :versio 1})
                                         :tyyppi "pysyva"
                                         :alityyppi nil
@@ -953,26 +917,20 @@
                                        :tavoitehinnan-muutos 2111
                                        :tavoitehinnan-muutos-indeksikorjattu 2345.321
                                        :tehtavat_ja_maarat (list
-                                                             {:edellinen_maara nil
-                                                              :hoitokauden_alkuvuosi 2025
+                                                             {:hoitokauden_alkuvuosi 2025
                                                               :maaramuutos 111
                                                               :suunniteltu_maara nil
                                                               :tehtava 6953
-                                                              :uusi_maara nil
                                                               :versio 1}
-                                                             {:edellinen_maara nil
-                                                              :hoitokauden_alkuvuosi 2025
+                                                             {:hoitokauden_alkuvuosi 2025
                                                               :maaramuutos 111
                                                               :suunniteltu_maara nil
                                                               :tehtava 11235
-                                                              :uusi_maara nil
                                                               :versio 1}
-                                                             {:edellinen_maara nil
-                                                              :hoitokauden_alkuvuosi 2025
+                                                             {:hoitokauden_alkuvuosi 2025
                                                               :maaramuutos 10
                                                               :suunniteltu_maara 0
                                                               :tehtava 17345
-                                                              :uusi_maara nil
                                                               :versio 1})
                                        :tyyppi "pysyva"
                                        :urakka 45
@@ -1042,26 +1000,20 @@
                                   :tavoitehinnan-muutos 2111
                                   :tavoitehinnan-muutos-indeksikorjattu 2345.321
                                   :tehtavat_ja_maarat (list
-                                                        {:edellinen_maara nil
-                                                         :hoitokauden_alkuvuosi 2025
+                                                        {:hoitokauden_alkuvuosi 2025
                                                          :maaramuutos 111
                                                          :suunniteltu_maara nil
                                                          :tehtava 6953
-                                                         :uusi_maara nil
                                                          :versio 1}
-                                                        {:edellinen_maara nil
-                                                         :hoitokauden_alkuvuosi 2025
+                                                        {:hoitokauden_alkuvuosi 2025
                                                          :maaramuutos 111
                                                          :suunniteltu_maara nil
                                                          :tehtava 11235
-                                                         :uusi_maara nil
                                                          :versio 1}
-                                                        {:edellinen_maara nil
-                                                         :hoitokauden_alkuvuosi 2025
+                                                        {:hoitokauden_alkuvuosi 2025
                                                          :maaramuutos 10
                                                          :suunniteltu_maara 0
                                                          :tehtava 17345
-                                                         :uusi_maara nil
                                                          :versio 1})
                                   :tyyppi "pysyva"
                                   :urakka 45
@@ -1086,19 +1038,15 @@
                                                          :versio 2})
                                 :tavoitehinnan-muutos 2
                                 :tehtavat_ja_maarat (list
-                                                      {:edellinen_maara nil
-                                                       :hoitokauden_alkuvuosi 2026
+                                                      {:hoitokauden_alkuvuosi 2026
                                                        :maaramuutos 1
                                                        :suunniteltu_maara nil
                                                        :tehtava 6953
-                                                       :uusi_maara nil
                                                        :versio 2}
-                                                      {:edellinen_maara nil
-                                                       :hoitokauden_alkuvuosi 2026
+                                                      {:hoitokauden_alkuvuosi 2026
                                                        :maaramuutos 1
                                                        :suunniteltu_maara 0
                                                        :tehtava 17350
-                                                       :uusi_maara nil
                                                        :versio 2})}]
 
     (is (= vastaus-tallennuksen-jalkeen odotetut-tallennuksen-jalkeen) "Pysyvä muutos tallennuksen jälkeen")
@@ -1298,33 +1246,25 @@
                                                                                 :toimenpideinstanssi 125
                                                                                 :versio 1})
                                                        :tehtavat_ja_maarat (list
-                                                                             {:edellinen_maara 1000
-                                                                              :hoitokauden_alkuvuosi 2025
+                                                                             {:hoitokauden_alkuvuosi 2025
                                                                               :maaramuutos 100
                                                                               :suunniteltu_maara 0
                                                                               :tehtava 24628
-                                                                              :uusi_maara 1100
                                                                               :versio 1}
-                                                                             {:edellinen_maara 1000
-                                                                              :hoitokauden_alkuvuosi 2026
+                                                                             {:hoitokauden_alkuvuosi 2026
                                                                               :maaramuutos 100
                                                                               :suunniteltu_maara 0
                                                                               :tehtava 24628
-                                                                              :uusi_maara 1100
                                                                               :versio 1}
-                                                                             {:edellinen_maara 1000
-                                                                              :hoitokauden_alkuvuosi 2027
+                                                                             {:hoitokauden_alkuvuosi 2027
                                                                               :maaramuutos 100
                                                                               :suunniteltu_maara 0
                                                                               :tehtava 24628
-                                                                              :uusi_maara 1100
                                                                               :versio 1}
-                                                                             {:edellinen_maara 1000
-                                                                              :hoitokauden_alkuvuosi 2028
+                                                                             {:hoitokauden_alkuvuosi 2028
                                                                               :maaramuutos 100
                                                                               :suunniteltu_maara 0
                                                                               :tehtava 24628
-                                                                              :uusi_maara 1100
                                                                               :versio 1})
                                                        :toimenpide "Päällysteiden paikkaus"
                                                        :toimenpideinstanssi tpi-id-paallpaikk
@@ -1372,8 +1312,8 @@
    :voimassa_alkaen #inst"2025-09-30T21:00:00.000-00:00",
    :syy "Ei tehdä tänä kesänä rumpuja, ovat vielä kunnossa.",
    :tehtavat_ja_maarat (list
-                         {:tehtava 17341, :uusi_maara 0, :maaramuutos -40, :edellinen_maara 40 :hoitokauden_alkuvuosi 2025}
-                         {:tehtava 17346, :uusi_maara 0, :maaramuutos -30, :edellinen_maara 30 :hoitokauden_alkuvuosi 2025})
+                         {:tehtava 17341, :maaramuutos -40, :hoitokauden_alkuvuosi 2025}
+                         {:tehtava 17346, :maaramuutos -30, :hoitokauden_alkuvuosi 2025})
    :urakka urakka-id,
    :nimi "Tämän hoitovuoden määräpoikkeamamuutos",
    :id muutos-id,

--- a/test/clj/harja/palvelin/palvelut/suunnittelu/suolarajoitus_palvelu_test.clj
+++ b/test/clj/harja/palvelin/palvelut/suunnittelu/suolarajoitus_palvelu_test.clj
@@ -1257,10 +1257,10 @@
           
           ;; Lisää tehtävä ja määrä muutokseen  
           _ (t/u (format "INSERT INTO mhu_muutos_tehtava_ja_maaraluettelo 
-                          (muutos, tehtava, hoitokauden_alkuvuosi, edellinen_maara, maaramuutos, uusi_maara) 
-                          VALUES (%s, %s, %s, %s, %s, %s)" 
-                   muutos-id suolaus-tehtava-id hk-alkuvuosi tarjous-maara muutos-maara (+ tarjous-maara muutos-maara)))
-          
+                          (muutos, tehtava, hoitokauden_alkuvuosi, maaramuutos)
+                          VALUES (%s, %s, %s, %s)"
+                   muutos-id suolaus-tehtava-id hk-alkuvuosi muutos-maara))
+
           ;; Hae käyttöraja
           hakutulos (t/kutsu-palvelua (:http-palvelin t/jarjestelma)
                       :hae-talvisuolan-kayttorajat t/+kayttaja-jvh+

--- a/test/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_vahvistus_test.clj
+++ b/test/clj/harja/palvelin/palvelut/suunnittelu/uusi_kustannussuunnitelma_vahvistus_test.clj
@@ -213,8 +213,8 @@
                         :tehtavat_ja_maarat [{:tehtava 17345, :uusi? true, :maaramuutos 10, :hoitokauden_alkuvuosi 2025}
                                              {:tehtava 11235, :uusi? true, :maaramuutos 111, :hoitokauden_alkuvuosi 2025}
                                              {:tehtava 17350, :uusi? true, :maaramuutos 222, :hoitokauden_alkuvuosi 2026}
-                                             {:tehtava 6953, :uusi_maara 1100, :maaramuutos 111, :edellinen_maara 1000, :hoitokauden_alkuvuosi 2025}
-                                             {:tehtava 6953, :uusi_maara 1100, :maaramuutos 222, :edellinen_maara 1000, :hoitokauden_alkuvuosi 2026}],
+                                             {:tehtava 6953, :maaramuutos 111, :hoitokauden_alkuvuosi 2025}
+                                             {:tehtava 6953, :maaramuutos 222, :hoitokauden_alkuvuosi 2026}],
                         :kustannusvaikutukset [{:toimenpideinstanssi 129, :kustannuslaji "hankintakustannukset", :summa 1000, :hoitokauden_alkuvuosi 2025}
                                                {:toimenpideinstanssi 129, :kustannuslaji "hankintakustannukset", :summa 1000, :hoitokauden_alkuvuosi 2026}
                                                {:summa 1000, :kustannuslaji "hankintakustannukset", :toimenpideinstanssi 132, :hoitokauden_alkuvuosi 2025}

--- a/tietokanta/src/main/resources/db/migration/V1_1245__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1245__.sql
@@ -1,0 +1,9 @@
+-- Poista käyttämättömäksi jääneet edelinen_maara ja uusi_maara sarakkeet mhu_muutos_tehtava_ja_maaraluettelo taulusta
+
+ALTER TABLE mhu_muutos_tehtava_ja_maaraluettelo
+    DROP COLUMN edellinen_maara,
+    DROP COLUMN uusi_maara;
+
+ALTER TABLE mhu_muutos_tehtava_ja_maaraluettelo_historia
+    DROP COLUMN edellinen_maara,
+    DROP COLUMN uusi_maara;

--- a/tietokanta/testidata/muutos_testidata.sql
+++ b/tietokanta/testidata/muutos_testidata.sql
@@ -61,14 +61,12 @@ RETURNING id INTO muutos_id_3;
 INSERT INTO mhu_muutos_kustannusvaikutus(versio, muutos, kustannuslaji, toimenpideinstanssi, hoitokauden_alkuvuosi, summa)
 VALUES (_versio, muutos_id_3, 'hankintakustannukset',
         _toimenpideinstanssi_id_mhu_yllapito, ensimmainen_tayden_hkn_alkuvuosi, 1000);
-INSERT INTO mhu_muutos_tehtava_ja_maaraluettelo(versio, muutos, tehtava, hoitokauden_alkuvuosi, edellinen_maara, maaramuutos, uusi_maara)
+INSERT INTO mhu_muutos_tehtava_ja_maaraluettelo(versio, muutos, tehtava, hoitokauden_alkuvuosi, maaramuutos)
 VALUES (_versio, muutos_id_3, _tehtava_id_soratien_rummut_alle_600mm,
-        ensimmainen_tayden_hkn_alkuvuosi,
-        30, -30, 0);
-INSERT INTO mhu_muutos_tehtava_ja_maaraluettelo(versio, muutos, tehtava, hoitokauden_alkuvuosi, edellinen_maara, maaramuutos, uusi_maara)
+        ensimmainen_tayden_hkn_alkuvuosi, -30);
+INSERT INTO mhu_muutos_tehtava_ja_maaraluettelo(versio, muutos, tehtava, hoitokauden_alkuvuosi, maaramuutos)
 VALUES (_versio, muutos_id_3, _tehtava_id_soratien_rummut_600_1000mm,
-        ensimmainen_tayden_hkn_alkuvuosi,
-        40, -40, 0);
+        ensimmainen_tayden_hkn_alkuvuosi, -40);
 INSERT INTO liite (nimi, tyyppi, lahde, urakka, luotu, luoja)
 VALUES ('rumpu.jpg', 'image/png', 'harja-ui'::lahde,
         urakka_id, NOW(), kayttaja_id_tero)
@@ -114,10 +112,9 @@ FOR vuosi IN ensimmainen_tayden_hkn_alkuvuosi..viimeinen_tayden_hkn_alkuvuosi
         VALUES (_versio, muutos_id_1, 'hankintakustannukset',
                 _toimenpideinstanssi_id_paall_paikk, vuosi, 1000);
         -- Muutos 1: Päällysteiden paikkausta enemmän - tehtävä- ja määräluettelon muutokset
-        INSERT INTO mhu_muutos_tehtava_ja_maaraluettelo(versio, muutos, tehtava, hoitokauden_alkuvuosi, edellinen_maara,
-                                                        maaramuutos, uusi_maara)
-        VALUES (_versio, muutos_id_1, _tehtava_id_ab_paikkaus, vuosi,
-                1000, 100, 1100);
+        INSERT INTO mhu_muutos_tehtava_ja_maaraluettelo(versio, muutos, tehtava, hoitokauden_alkuvuosi,
+                                                        maaramuutos)
+        VALUES (_versio, muutos_id_1, _tehtava_id_ab_paikkaus, vuosi, 100);
 
         -- Muutos 5: Lisää paikkausta (aiemman hoitovuoden pysyvä muutos) - kustannusvaikutus
         --           HOX: Muutos on voimassa alkaen edellisen hoitokauden alusta, mutta kustannusvaikutusta lisätään
@@ -129,10 +126,9 @@ FOR vuosi IN ensimmainen_tayden_hkn_alkuvuosi..viimeinen_tayden_hkn_alkuvuosi
         -- Muutos 5: Lisää paikkausta (aiemman hoitovuoden pysyvä muutos) - tehtävä- ja määräluettelon muutokset
         --           HOX: Muutos on voimassa alkaen edellisen hoitokauden alusta, mutta määrämuutoksia lisätään
         --           seuraaville kokonaisille hoitovuosille
-        INSERT INTO mhu_muutos_tehtava_ja_maaraluettelo(versio, muutos, tehtava, hoitokauden_alkuvuosi, edellinen_maara,
-                                                        maaramuutos, uusi_maara)
-        VALUES (_versio, muutos_id_5, _tehtava_id_ab_paikkaus, vuosi,
-                1000, 100, 1100);
+        INSERT INTO mhu_muutos_tehtava_ja_maaraluettelo(versio, muutos, tehtava, hoitokauden_alkuvuosi,
+                                                        maaramuutos)
+        VALUES (_versio, muutos_id_5, _tehtava_id_ab_paikkaus, vuosi, 100);
 
     END LOOP;
 


### PR DESCRIPTION
Poistetaan mhu_muutos_tehtava_ja_maaraluettelo edellinen_maara ja uusi_maara sarakkeet
* Näitä sarakkeita käytettiin vain testeissä, ja ovat jääneet roikkumaan koodiin käyttämättöminä
* Keskusteltava myöhemmin mikä ratkaisumenetelmä otetaan käyttöön lopullisen muutokset sisältävän laskennallisen tehtävämäärän tallentamisessa ja kyseisen arvon ylläpidossa