### PR TITLE
HARJA-1611 tilaa monta paikkauskohdetta kerralla

### DIFF
--- a/dev-resources/less/pages/paikkauskohteet.less
+++ b/dev-resources/less/pages/paikkauskohteet.less
@@ -150,7 +150,7 @@ div.kohdelistaus {
 
   .valitut-maara {
     margin: 0;
-    font-size: 1rem;
+    font-size: 0.85rem;
     color: @black-light;
   }
 

--- a/dev-resources/less/pages/paikkauskohteet.less
+++ b/dev-resources/less/pages/paikkauskohteet.less
@@ -133,3 +133,43 @@ div.kohdelistaus {
   display: flex;
   justify-content: space-between;
 }
+
+.tilaa-kohteita-vihje {
+  background-color: @gray240;
+  border: 1px solid @gray230;
+  border-radius: 4px;
+  padding: @valistys-16 @valistys-24;
+  margin-bottom: @valistys-16;
+  margin-top: @valistys-16;
+
+  .otsikko {
+    margin: 0 0 @valistys-8 0;
+    color: @blue-darker;
+    font-weight: 600;
+  }
+
+  .valitut-maara {
+    margin: 0;
+    font-size: 1rem;
+    color: @black-light;
+  }
+
+  .napit {
+    margin-top: @valistys-12;
+    gap: @valistys-12;
+
+    button {
+      margin-left: 0;
+      margin-right: @valistys-12;
+    }
+  }
+}
+
+.tilaus-vahvistus-modal {
+  min-width: 600px;
+  max-width: 800px;
+
+  .grid-taulukko {
+    margin-top: @valistys-16;
+  }
+}

--- a/dev-resources/less/yleiset.less
+++ b/dev-resources/less/yleiset.less
@@ -36,6 +36,10 @@
   justify-content: right;
 }
 
+.poista-ajax-loader-valistykset {
+  padding: 0;
+}
+
 div.tietorivi {
   border-bottom: solid 1px lightGray;
 

--- a/src/clj/harja/palvelin/palvelut/yllapitokohteet/paikkauskohteet.clj
+++ b/src/clj/harja/palvelin/palvelut/yllapitokohteet/paikkauskohteet.clj
@@ -440,7 +440,10 @@
         urakka-sampo-id (urakat-q/hae-urakan-sampo-id db (:urakka-id kohde))
         ;; Tarkista pakolliset tiedot ja tietojen oikeellisuus
         validointivirheet (paikkauskohde-validi? db kohde vanha-kohde kayttajarooli) ;;rooli on null?
-        kohde (tarkista-tilamuutoksen-vaikutukset db fim email user kohde vanha-kohde urakka-sampo-id)
+        ;; Jos ei ole erikseen merkitty, että sähköposti skipataan, niin tarkista tilamuutoksen vaikutukset
+        kohde (if-not (:skip-sahkoposti kohde)
+                (tarkista-tilamuutoksen-vaikutukset db fim email user kohde vanha-kohde urakka-sampo-id)
+                kohde)
         ;; Mikäli paikkauskohde halutaan raportoida pot lomakkeella, tehdään samalla yllapitokohde tauluun merkintä
         kohde (tarkista-pot-raportointi db kohde vanha-kohde (:id user))
         ;; Kohteen valmistumispäivä kaivellaan pot raportoitavalla vähä eri tavalla
@@ -839,6 +842,73 @@
       ;; Normitilanteessa palautetaan jo löydetyt kohteet
       paikkauskohteet)))
 
+(defn laheta-massatilaus-sahkoposti
+  "Kun tilataan useampi paikkauskohde kerralla, lähetetään niistä yhteinen sähköposti urakoitsijalle."
+
+  [db fim email paikkauskohteet]
+  (let [kpl (count paikkauskohteet)
+        urakka-id (get-in (first paikkauskohteet) [:kohde :urakka-id])
+        ;; Haetaan urakan sampo-id sähköpostin lähetystä varten
+        sampo-id (urakat-q/hae-urakan-sampo-id db urakka-id)
+        urakan-nimi (-> (urakat-q/hae-yksittainen-urakka db {:urakka_id urakka-id})
+                      first
+                      :nimi)
+        otsikko (str "Paikkauskohteita tilattu" (count paikkauskohteet) "kpl")
+        roolit  #{"urakan vastuuhenkilö"}
+        ely-id (-> (urakat-q/hae-urakan-ely db {:urakkaid (:urakka-id (first paikkauskohteet))})
+                 first
+                 :id)
+        ;; Testausta varten jätetään mahdollisuus, että fimiä ei ole asennettu
+        vastaanottajat (try
+                         (when fim
+                           (fim/hae-urakan-kayttajat-jotka-roolissa fim sampo-id roolit))
+                         (catch Exception e
+                           (log/error e "Fimiin ei saatu yhteyttä.")))
+        viesti (html (into [:div]
+                       (keep identity)
+                       [[:p "Hei "]
+                        [:p (str "Urakan " urakan-nimi " paikkauskohteita tilattiin  " kpl " kpl. Alla lista paikkauskohteista:" )]
+                        (doseq [kohde paikkauskohteet]
+                          (let [{:keys [tie aosa aet let losa]} kohde]
+                            (when (and tie aosa aet let losa)
+                              [[:p (str "- " (:nimi kohde) " (" tie " - " aet "/" aosa " " let "/" losa ")")]])))
+
+
+                        [:p (str "Voit tarkastella paikkauskohteiden tilannetta tarkemmin https://harja.vaylapilvi.fi/#urakat/paikkaukset-yllapito?&hy=" ely-id "&u=" urakka-id)]
+                        [:p "Tämä on automaattinen viesti HARJA -järjestelmästä, älä vastaa tähän viestiin."]]))]
+    (if (empty? vastaanottajat)
+      (log/warn (str "Tilattaessa useampi paikkauskohde kerralla, paikkauskohteille ei löytynyt sähköpostin vastaanottajaa. Sähköposteja ei lähetetä."))
+      (laheta-sahkoposti fim email sampo-id
+        roolit
+        otsikko
+        viesti))))
+
+(defn tilaa-valitut-paikkauskohteet!
+  "Otetaan frontilta vastaan lista paikkauskohteista, joiden tila halutaan muuttaa tilattuun tilaan. Varmistetaan,
+  että käyttäjällä on oikeudet tilata kohteet. Kutsutaan sen jälkeen jo olemassa olevaa kohteen tallennusta."
+  [db fim email user kohteet]
+  (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-paikkaukset-paikkauskohteetkustannukset user (:urakka-id (first kohteet)))
+  (jdbc/with-db-transaction [db db]
+   (let [tulokset (mapv
+                    (fn [kohde]
+                      (try
+                        {:kohde kohde
+                         :tulos (tallenna-paikkauskohde! db fim email user
+                                  (assoc kohde :paikkauskohteen-tila "tilattu"
+                                    :skip-sahkoposti true))} ;; Lisää tämä lippu, jotta jokaisesta kohteesta ei lähetetä erikseen sähköpostia, vaan sähköposti lähetetään tilauksen jälkeen yhteenvetona
+                        (catch Exception e
+                          {:kohde kohde
+                           :virhe (.getMessage e)})))
+                    (:tilattavat-paikkauskohteet kohteet))
+         onnistuneet (filterv (complement :virhe) tulokset)
+         epaonnistuneet (filterv :virhe tulokset)]
+     ;; Lähetä YKSI yhteenvetosähköposti vain jos onnistuneita
+     (when (seq onnistuneet)
+       (laheta-massatilaus-sahkoposti db fim email onnistuneet))
+     {:onnistuneet (count onnistuneet)
+      :epaonnistuneet (count epaonnistuneet)
+      :virheet (mapv :virhe epaonnistuneet)})))
+
 (defrecord Paikkauskohteet []
   component/Lifecycle
   (start [this]
@@ -879,6 +949,9 @@
       (julkaise-palvelu http :hae-paikkauskohteiden-tyomenetelmat
                         (fn [user tiedot]
                           (paikkaus-q/hae-paikkauskohteiden-tyomenetelmat db user tiedot)))
+      (julkaise-palvelu http :tilaa-valitut-paikkauskohteet
+        (fn [user kohteet]
+          (tilaa-valitut-paikkauskohteet! db fim email user kohteet)))
       (julkaise-palvelu http :lue-urapaikkaukset-excelista
         (wrap-multipart-params (fn [req] (vastaanota-urem-excel db req)))
         {:ring-kasittelija? true})
@@ -899,6 +972,7 @@
       :poista-kasinsyotetty-paikkaus
       :hae-paikkauskohteen-tiemerkintaurakat
       :hae-paikkauskohteiden-tyomenetelmat
+      :tilaa-valitut-paikkauskohteet
       :lue-urapaikkaukset-excelista
       (when (:excel-vienti this)
         (excel-vienti/poista-excel-kasittelija! (:excel-vienti this) :paikkauskohteet-urakalle-excel)))

--- a/src/clj/harja/palvelin/palvelut/yllapitokohteet/paikkauskohteet.clj
+++ b/src/clj/harja/palvelin/palvelut/yllapitokohteet/paikkauskohteet.clj
@@ -864,17 +864,18 @@
                            (fim/hae-urakan-kayttajat-jotka-roolissa fim sampo-id roolit))
                          (catch Exception e
                            (log/error e "Fimiin ei saatu yhteyttä.")))
+        osoite (str "https://harja.vaylapilvi.fi/#urakat/paikkaukset-yllapito?&hy=" ely-id "&u=" urakka-id)
         viesti (html (into [:div]
                        (keep identity)
                        [[:p "Hei "]
-                        [:p (str "Urakan " urakan-nimi " paikkauskohteita tilattiin  " kpl " kpl. Alla lista paikkauskohteista:" )]
-                        (doseq [kohde paikkauskohteet]
-                          (let [{:keys [tie aosa aet let losa]} kohde]
-                            (when (and tie aosa aet let losa)
-                              [[:p (str "- " (:nimi kohde) " (" tie " - " aet "/" aosa " " let "/" losa ")")]])))
+                        [:p (str "Urakan: '" urakan-nimi "' paikkauskohteita tilattiin " kpl " kpl. <br> Alla lista paikkauskohteista:" )]
+                        (for [p paikkauskohteet]
+                          (let [kohde (:kohde p)]
+                            (when (:nimi kohde)
+                              [:p (str "- " (:nimi kohde) " (" (:tie kohde) " - " (:aet kohde) "/" (:aosa kohde) " " (:let kohde) "/" (:losa kohde) ")")])))
 
 
-                        [:p (str "Voit tarkastella paikkauskohteiden tilannetta tarkemmin https://harja.vaylapilvi.fi/#urakat/paikkaukset-yllapito?&hy=" ely-id "&u=" urakka-id)]
+                        [:p (str "Voit tarkastella paikkauskohteiden tilannetta tarkemmin <a href=\"" osoite "\" > tääältä. </a>")]
                         [:p "Tämä on automaattinen viesti HARJA -järjestelmästä, älä vastaa tähän viestiin."]]))]
     (if (empty? vastaanottajat)
       (log/warn (str "Tilattaessa useampi paikkauskohde kerralla, paikkauskohteille ei löytynyt sähköpostin vastaanottajaa. Sähköposteja ei lähetetä."))

--- a/src/clj/harja/palvelin/palvelut/yllapitokohteet/paikkauskohteet.clj
+++ b/src/clj/harja/palvelin/palvelut/yllapitokohteet/paikkauskohteet.clj
@@ -426,7 +426,6 @@
 (defn tallenna-paikkauskohde! [db fim email user kohde]
   (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-paikkaukset-paikkauskohteetkustannukset user (:urakka-id kohde))
 
-  ;; VAIHE 1: ESIKÄSITTELY JA VALIDOINTI
   (let [_ (log/info "tallenna-paikkauskohde! :: kohde " (pr-str (dissoc kohde :sijainti)))
         kayttajarooli (roolit/osapuoli user)
         kohde-id (:id kohde)
@@ -448,7 +447,6 @@
       (throw+ {:type "Validaatiovirhe"
                :virheet {:koodi "ERROR" :viesti validointivirheet}}))
 
-    ;; VAIHE 2: KÄSITTELE SIVUVAIKUTUKSET JA TILASIIRTYMÄT
     ;; (vain jos validointi meni läpi)
     (let [on-kustannusoikeudet? (oikeudet/voi-kirjoittaa?
                                  oikeudet/urakat-paikkaukset-paikkauskohteetkustannukset
@@ -469,7 +467,6 @@
                             nil)
           tiemerkinnan-tila (or (:tiemerkinnan-tila kohde) "ei-tiemerkintaa")
 
-          ;; VAIHE 3: MUODOSTA TALLENNETTAVA PAIKKAUSKOHDE
           paikkauskohde (merge
                          {:ulkoinen-id (konversio/konvertoi->int (:ulkoinen-id kohde))
                           :urakka-id (:urakka-id kohde)
@@ -518,7 +515,6 @@
                             :muokattu (pvm/nyt)
                             :muokkaaja-id (:id user)}))
 
-          ;; VAIHE 4: TALLENNA KANTAAN
           tallennettu-kohde (if (id-olemassa? (:id paikkauskohde))
                              (do
                                (paikkaus-q/paivita-paikkauskohde! db paikkauskohde)
@@ -527,8 +523,7 @@
                              (let [tallennettu (paikkaus-q/tallenna-paikkauskohde<! db paikkauskohde)]
                                (first (paikkaus-q/hae-paikkauskohde db {:id (:id tallennettu)
                                                                         :urakka-id (:urakka-id kohde)}))))
-
-          ;; VAIHE 5: PÄIVITÄ PK-LUOKKA
+          
           pkluokka (:paivita_paikkauskohteen_korjausluokka
                     (first (paikkaus-q/paivita-paikkauskohteen-korjausluokka db {:id (:id tallennettu-kohde)})))]
 

--- a/src/clj/harja/palvelin/palvelut/yllapitokohteet/paikkauskohteet.clj
+++ b/src/clj/harja/palvelin/palvelut/yllapitokohteet/paikkauskohteet.clj
@@ -425,102 +425,115 @@
 
 (defn tallenna-paikkauskohde! [db fim email user kohde]
   (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-paikkaukset-paikkauskohteetkustannukset user (:urakka-id kohde))
-  (let [_ (log/debug "tallenna-paikkauskohde! :: kohde " (pr-str (dissoc kohde :sijainti)))
+
+  ;; VAIHE 1: ESIKÄSITTELY JA VALIDOINTI
+  (let [_ (log/info "tallenna-paikkauskohde! :: kohde " (pr-str (dissoc kohde :sijainti)))
         kayttajarooli (roolit/osapuoli user)
-        on-kustannusoikeudet? (oikeudet/voi-kirjoittaa? oikeudet/urakat-paikkaukset-paikkauskohteetkustannukset (:urakka-id kohde) user)
         kohde-id (:id kohde)
-        vanha-kohde (when kohde-id (first (paikkaus-q/hae-paikkauskohde db {:id kohde-id
-                                                                            :urakka-id (:urakka-id kohde)})))
-        ;; Muutetaan tarvittaessa työmenetelmä teksistä ID:ksi.
+        vanha-kohde (when kohde-id
+                      (first (paikkaus-q/hae-paikkauskohde db {:id kohde-id
+                                                               :urakka-id (:urakka-id kohde)})))
+
+        ;; Muutetaan tarvittaessa työmenetelmä tekstistä ID:ksi
         annettu-tyomenetelma (:tyomenetelma kohde)
         kohde (if (string? annettu-tyomenetelma)
                 (assoc kohde :tyomenetelma (paikkaus-q/hae-tyomenetelman-id db annettu-tyomenetelma))
                 kohde)
-        ;; Haetaan urakan sampo-id sähköpostin lähetystä varten
-        urakka-sampo-id (urakat-q/hae-urakan-sampo-id db (:urakka-id kohde))
+
         ;; Tarkista pakolliset tiedot ja tietojen oikeellisuus
-        validointivirheet (paikkauskohde-validi? db kohde vanha-kohde kayttajarooli) ;;rooli on null?
-        ;; Jos ei ole erikseen merkitty, että sähköposti skipataan, niin tarkista tilamuutoksen vaikutukset
-        kohde (if-not (:skip-sahkoposti kohde)
-                (tarkista-tilamuutoksen-vaikutukset db fim email user kohde vanha-kohde urakka-sampo-id)
-                kohde)
-        ;; Mikäli paikkauskohde halutaan raportoida pot lomakkeella, tehdään samalla yllapitokohde tauluun merkintä
-        kohde (tarkista-pot-raportointi db kohde vanha-kohde (:id user))
-        ;; Kohteen valmistumispäivä kaivellaan pot raportoitavalla vähä eri tavalla
-        valmistumispvm (or (and (:pot? kohde) (:pot-valmistumispvm kohde)) (:valmistumispvm kohde) nil)
+        validointivirheet (paikkauskohde-validi? db kohde vanha-kohde kayttajarooli)]
 
-        tiemerkinnan-tila (or (:tiemerkinnan-tila kohde) "ei-tiemerkintaa")
-
-        paikkauskohde (merge
-                        {:ulkoinen-id (konversio/konvertoi->int (:ulkoinen-id kohde))
-                         :urakka-id (:urakka-id kohde)
-                         :luotu (pvm/nyt)
-                         :luoja-id (:id user)
-                         :nimi (:nimi kohde)
-                         :poistettu? (or (:poistettu kohde) false)
-                         :yhalahetyksen-tila (or (:yhalahetyksen-tila kohde) nil)
-                         :virhe (or (:virhe kohde) nil)
-                         :tarkistettu (or (:tarkistettu kohde) nil)
-                         :tarkistaja-id (or (:tarkistaja-id kohde) nil)
-                         :ilmoitettu-virhe (or (:ilmoitettu-virhe kohde) nil)
-                         :alkupvm (:alkupvm kohde)
-                         :loppupvm (:loppupvm kohde)
-                         :tyomenetelma (or (:tyomenetelma kohde) nil)
-                         :pot? (or (:pot? kohde) false)
-                         :paikkauskohteen-tila (:paikkauskohteen-tila kohde)
-                         :suunniteltu-maara (when (:suunniteltu-maara kohde)
-                                              (bigdec (:suunniteltu-maara kohde)))
-                         :yksikko (:yksikko kohde)
-                         :lisatiedot (or (:lisatiedot kohde) nil)
-                         :valmistumispvm valmistumispvm
-                         :tilattupvm (or (:tilattupvm kohde) nil)
-                         :toteutunut-hinta (when (:toteutunut-hinta kohde)
-                                             (bigdec (:toteutunut-hinta kohde)))
-                         :tiemerkintaa-tuhoutunut? (or (:tiemerkintaa-tuhoutunut? kohde) nil)
-                         ;; Asetetaan suorittava tiemerkintäurakka ja varmistetaan että ei nollata - Välitetään kulujen kirjauksen paikkausosiolle 
-                         :suorittava-tiemerkintaurakka (if (and (nil? (:tiemerkintapvm vanha-kohde))
-                                                               (:tiemerkintaa-tuhoutunut? kohde))
-                                                         (:tiemerkinta-urakka kohde)
-                                                         (:suorittava-tiemerkintaurakka vanha-kohde))
-                         :takuuaika (when (:takuuaika kohde) (bigdec (:takuuaika kohde)))
-                         :tiemerkintapvm (when (:tiemerkintaa-tuhoutunut? kohde) (pvm/nyt))
-                         :yllapitokohde-id (:yllapitokohde-id kohde)
-                         :tie (konversio/konvertoi->int (:tie kohde))
-                         :aosa (konversio/konvertoi->int (:aosa kohde))
-                         :aet (konversio/konvertoi->int (:aet kohde))
-                         :losa (konversio/konvertoi->int (:losa kohde))
-                         :let (konversio/konvertoi->int (:let kohde))
-                         :ajorata (konversio/konvertoi->int (or (:ajorata kohde) 0))
-                         :tiemerkinnan-tila tiemerkinnan-tila}
-                        (when on-kustannusoikeudet?
-                          {:suunniteltu-hinta (bigdec (or (:suunniteltu-hinta kohde) 0))})
-                        (when kohde-id
-                          {:id kohde-id
-                           :muokattu (pvm/nyt)
-                           :muokkaaja-id (:id user)}))
-        ;; Jos annetulla kohteella on olemassa id, niin päivitetään. Muuten tehdään uusi
-        kohde (when (empty? validointivirheet)
-                (let [p (if (id-olemassa? (:id paikkauskohde))
-                          (do
-                            (paikkaus-q/paivita-paikkauskohde! db paikkauskohde)
-                            (first (paikkaus-q/hae-paikkauskohde db {:id (:id paikkauskohde)
-                                                                     :urakka-id (:urakka-id kohde)})))
-                          (let [tallennettu-paikkauskohde (paikkaus-q/tallenna-paikkauskohde<! db paikkauskohde)
-                                haettu-paikkauskohde (first (paikkaus-q/hae-paikkauskohde db {:id (:id tallennettu-paikkauskohde)
-                                                                                              :urakka-id (:urakka-id kohde)}))]
-                            haettu-paikkauskohde))]
-                  p))
-
-        ;; Päivitetään paikkauskohteen PK-luokan laskenta aina päivityksen tai luonnin yhteydessä
-        kohde (when kohde
-                (let [pkluokka (:paivita_paikkauskohteen_korjausluokka
-                                 (first (paikkaus-q/paivita-paikkauskohteen-korjausluokka db {:id (:id kohde)})))]
-                  (assoc kohde :pkluokka pkluokka)))]
-
-    (if (empty? validointivirheet)
-      kohde
+    ;; Jos validointivirheitä, heitetään poikkeus heti
+    (when (seq validointivirheet)
       (throw+ {:type "Validaatiovirhe"
-               :virheet {:koodi "ERROR" :viesti validointivirheet}}))))
+               :virheet {:koodi "ERROR" :viesti validointivirheet}}))
+
+    ;; VAIHE 2: KÄSITTELE SIVUVAIKUTUKSET JA TILASIIRTYMÄT
+    ;; (vain jos validointi meni läpi)
+    (let [on-kustannusoikeudet? (oikeudet/voi-kirjoittaa?
+                                 oikeudet/urakat-paikkaukset-paikkauskohteetkustannukset
+                                 (:urakka-id kohde) user)
+          urakka-sampo-id (urakat-q/hae-urakan-sampo-id db (:urakka-id kohde))
+
+          ;; Tilamuutosten käsittely
+          kohde (if-not (:skip-sahkoposti kohde)
+                  (tarkista-tilamuutoksen-vaikutukset db fim email user kohde vanha-kohde urakka-sampo-id)
+                  kohde)
+
+          ;; POT-raportoinnin käsittely
+          kohde (tarkista-pot-raportointi db kohde vanha-kohde (:id user))
+
+          ;; Kohteen valmistumispäivä kaivellaan pot raportoitavalla vähän eri tavalla
+          valmistumispvm (or (and (:pot? kohde) (:pot-valmistumispvm kohde))
+                            (:valmistumispvm kohde)
+                            nil)
+          tiemerkinnan-tila (or (:tiemerkinnan-tila kohde) "ei-tiemerkintaa")
+
+          ;; VAIHE 3: MUODOSTA TALLENNETTAVA PAIKKAUSKOHDE
+          paikkauskohde (merge
+                         {:ulkoinen-id (konversio/konvertoi->int (:ulkoinen-id kohde))
+                          :urakka-id (:urakka-id kohde)
+                          :luotu (pvm/nyt)
+                          :luoja-id (:id user)
+                          :nimi (:nimi kohde)
+                          :poistettu? (or (:poistettu kohde) false)
+                          :yhalahetyksen-tila (or (:yhalahetyksen-tila kohde) nil)
+                          :virhe (or (:virhe kohde) nil)
+                          :tarkistettu (or (:tarkistettu kohde) nil)
+                          :tarkistaja-id (or (:tarkistaja-id kohde) nil)
+                          :ilmoitettu-virhe (or (:ilmoitettu-virhe kohde) nil)
+                          :alkupvm (:alkupvm kohde)
+                          :loppupvm (:loppupvm kohde)
+                          :tyomenetelma (or (:tyomenetelma kohde) nil)
+                          :pot? (or (:pot? kohde) false)
+                          :paikkauskohteen-tila (:paikkauskohteen-tila kohde)
+                          :suunniteltu-maara (when (:suunniteltu-maara kohde)
+                                               (bigdec (:suunniteltu-maara kohde)))
+                          :yksikko (:yksikko kohde)
+                          :lisatiedot (or (:lisatiedot kohde) nil)
+                          :valmistumispvm valmistumispvm
+                          :tilattupvm (or (:tilattupvm kohde) nil)
+                          :toteutunut-hinta (when (:toteutunut-hinta kohde)
+                                              (bigdec (:toteutunut-hinta kohde)))
+                          :tiemerkintaa-tuhoutunut? (or (:tiemerkintaa-tuhoutunut? kohde) nil)
+                          ;; Asetetaan suorittava tiemerkintäurakka ja varmistetaan että ei nollata - Välitetään kulujen kirjauksen paikkausosiolle
+                          :suorittava-tiemerkintaurakka (if (and (nil? (:tiemerkintapvm vanha-kohde))
+                                                                (:tiemerkintaa-tuhoutunut? kohde))
+                                                          (:tiemerkinta-urakka kohde)
+                                                          (:suorittava-tiemerkintaurakka vanha-kohde))
+                          :takuuaika (when (:takuuaika kohde) (bigdec (:takuuaika kohde)))
+                          :tiemerkintapvm (when (:tiemerkintaa-tuhoutunut? kohde) (pvm/nyt))
+                          :yllapitokohde-id (:yllapitokohde-id kohde)
+                          :tie (konversio/konvertoi->int (:tie kohde))
+                          :aosa (konversio/konvertoi->int (:aosa kohde))
+                          :aet (konversio/konvertoi->int (:aet kohde))
+                          :losa (konversio/konvertoi->int (:losa kohde))
+                          :let (konversio/konvertoi->int (:let kohde))
+                          :ajorata (konversio/konvertoi->int (or (:ajorata kohde) 0))
+                          :tiemerkinnan-tila tiemerkinnan-tila}
+                         (when on-kustannusoikeudet?
+                           {:suunniteltu-hinta (bigdec (or (:suunniteltu-hinta kohde) 0))})
+                         (when kohde-id
+                           {:id kohde-id
+                            :muokattu (pvm/nyt)
+                            :muokkaaja-id (:id user)}))
+
+          ;; VAIHE 4: TALLENNA KANTAAN
+          tallennettu-kohde (if (id-olemassa? (:id paikkauskohde))
+                             (do
+                               (paikkaus-q/paivita-paikkauskohde! db paikkauskohde)
+                               (first (paikkaus-q/hae-paikkauskohde db {:id (:id paikkauskohde)
+                                                                        :urakka-id (:urakka-id kohde)})))
+                             (let [tallennettu (paikkaus-q/tallenna-paikkauskohde<! db paikkauskohde)]
+                               (first (paikkaus-q/hae-paikkauskohde db {:id (:id tallennettu)
+                                                                        :urakka-id (:urakka-id kohde)}))))
+
+          ;; VAIHE 5: PÄIVITÄ PK-LUOKKA
+          pkluokka (:paivita_paikkauskohteen_korjausluokka
+                    (first (paikkaus-q/paivita-paikkauskohteen-korjausluokka db {:id (:id tallennettu-kohde)})))]
+
+      ;; Palauta lopullinen kohde PK-luokan kanssa
+      (assoc tallennettu-kohde :pkluokka pkluokka))))
 
 (defn poista-paikkauskohde! [db user kohde]
   (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-paikkaukset-paikkauskohteetkustannukset user (:urakka-id kohde))

--- a/src/cljs/harja/tiedot/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
+++ b/src/cljs/harja/tiedot/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
@@ -859,13 +859,14 @@
   AsetaToteumatyyppiKohteelle
   (process-event [{:keys [paikkauskohde toteumatyyppi]} app]
     ;; Vaihda tälle kohteelle toteumatyyppi halutuksi
-    (let [kohteet (:valitut-tilattavat-kohteet app)
-          kohteet (mapv (fn [kohde]
+    (let [kohteet (mapv (fn [kohde]
                             (if (= (:id kohde) (:id paikkauskohde))
-                              (assoc kohde :toteumatyyppi toteumatyyppi)
+                              (-> kohde
+                                (assoc :pot? (= toteumatyyppi :pot))
+                                (assoc :toteumatyyppi toteumatyyppi))
                               kohde))
-                        kohteet)]
-      (assoc app :valitut-tilattavat-kohteet kohteet)))
+                    (:paikkauskohteet app))]
+      (assoc app :paikkauskohteet kohteet)))
 
   TilaaValitutPaikkauskohteet
   (process-event [_ app]

--- a/src/cljs/harja/tiedot/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
+++ b/src/cljs/harja/tiedot/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
@@ -783,10 +783,12 @@
           kaanteinen? (if (= jarjestys vanha-jarjestys)
                         (not (get-in app [:jarjestys :kaanteinen?]))
                         false)]
-      (-> app
-        (assoc-in [:jarjestys :nimi] jarjestys)
-        (assoc-in [:jarjestys :kaanteinen?] kaanteinen?)
-        (assoc :paikkauskohteet (sort-by jarjestys (if kaanteinen? kaanteinen-jarjestaja compare) (:paikkauskohteet app))))))
+      (if jarjestys
+        (-> app
+          (assoc-in [:jarjestys :nimi] jarjestys)
+          (assoc-in [:jarjestys :kaanteinen?] kaanteinen?)
+          (assoc :paikkauskohteet (sort-by jarjestys (if kaanteinen? kaanteinen-jarjestaja compare) (:paikkauskohteet app))))
+        app)))
 
   AsetaToteumatyyppi
   (process-event [{uusi-tyyppi :uusi-tyyppi} app]

--- a/src/cljs/harja/tiedot/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
+++ b/src/cljs/harja/tiedot/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
@@ -47,11 +47,11 @@
 
 (defn lomakkeen-hash [lomake]
   (as-> lomake vertailtava-lomake
-        (lomake/ilman-lomaketietoja lomake)
-        (dissoc vertailtava-lomake ::tila/validius ::tila/validi? :tyyppi :alku-hash)
-        (assoc vertailtava-lomake :alkupvm (str (:alkupvm vertailtava-lomake)))
-        (assoc vertailtava-lomake :loppupvm (str (:loppupvm vertailtava-lomake)))
-        (hash vertailtava-lomake)))
+    (lomake/ilman-lomaketietoja lomake)
+    (dissoc vertailtava-lomake ::tila/validius ::tila/validi? :tyyppi :alku-hash)
+    (assoc vertailtava-lomake :alkupvm (str (:alkupvm vertailtava-lomake)))
+    (assoc vertailtava-lomake :loppupvm (str (:loppupvm vertailtava-lomake)))
+    (hash vertailtava-lomake)))
 
 (defn- fmt-aikataulu
   "Formatoi paikkauskohteen aikataulun."
@@ -133,10 +133,10 @@
 
 (defn- siivoa-ennen-lahetysta [lomake]
   (-> lomake
-      (update :ajorata (fn [nykyinen-arvo]
-                         (if (= "Ei ajorataa" nykyinen-arvo)
-                           nil
-                           nykyinen-arvo)))
+    (update :ajorata (fn [nykyinen-arvo]
+                       (if (= "Ei ajorataa" nykyinen-arvo)
+                         nil
+                         nykyinen-arvo)))
     (dissoc
       :sijainti
       :formatoitu-sijainti
@@ -168,15 +168,15 @@
                   (not (nil? (:let lomake)))
                   ;; Ja pituus on muuttunut
                   (or (not (nil? (first pituus-diff)))
-                      (not (nil? (second pituus-diff)))))
+                    (not (nil? (second pituus-diff)))))
             (do
               (reset! lomakkeen-pituuskentat nykyiset-pituuskentat)
               (tuck-apurit/post! :laske-paikkauskohteen-pituus
-                                 nykyiset-pituuskentat
-                                 {:onnistui ->LaskePituusOnnistui
-                                  :onnistui-parametrit parametrit
-                                  :epaonnistui ->LaskePituusEpaonnistui
-                                  :paasta-virhe-lapi? true})))]
+                nykyiset-pituuskentat
+                {:onnistui ->LaskePituusOnnistui
+                 :onnistui-parametrit parametrit
+                 :epaonnistui ->LaskePituusEpaonnistui
+                 :paasta-virhe-lapi? true})))]
     lomake))
 
 (defn hae-paikkauskohteet [urakka-id {:keys [valitut-tilat valittu-vuosi valitut-tyomenetelmat valitut-elyt hae-aluekohtaiset-paikkauskohteet?] :as app}]
@@ -208,7 +208,7 @@
                         (assoc :takuuaika (or (:valiaika-takuuaika paikkauskohde) (:takuuaika paikkauskohde))))
         paikkauskohde (siivoa-ennen-lahetysta paikkauskohde)]
     (k/post! :tallenna-paikkauskohde-urakalle
-             paikkauskohde)))
+      paikkauskohde)))
 
 (defn- tallenna-paikkauskohde
   ([paikkauskohde onnistui epaonnistui]
@@ -216,12 +216,12 @@
   ([paikkauskohde onnistui epaonnistui parametrit]
    (let [paikkauskohde (siivoa-ennen-lahetysta paikkauskohde)]
      (tuck-apurit/post! :tallenna-paikkauskohde-urakalle
-                        paikkauskohde
-                        {:onnistui onnistui
-                         :onnistui-parametrit parametrit
-                         :epaonnistui epaonnistui
-                         :epaonnistui-parametrit parametrit
-                         :paasta-virhe-lapi? true}))))
+       paikkauskohde
+       {:onnistui onnistui
+        :onnistui-parametrit parametrit
+        :epaonnistui epaonnistui
+        :epaonnistui-parametrit parametrit
+        :paasta-virhe-lapi? true}))))
 
 ;; Nämä validointi funktiot ajetaan vain kerran ja sinne annettu toteumalomake ei päivity.
 ;; Joten siirrytään käyttämään atomia, jossa on ajantasainen toteumalomake
@@ -238,25 +238,25 @@
        :aet [tila/ei-nil tila/ei-tyhja tila/numero #(tila/maksimiarvo 90000 %)]
        :let [tila/ei-nil tila/ei-tyhja tila/numero #(tila/maksimiarvo 90000 %)
              (tila/silloin-kun #(not (nil? (:aet @lomake-atom)))
-                               (fn [arvo]
-                                 ;; Validointi vaatii "nil" vastauksen, kun homma on pielessä ja kentän arvon, kun kaikki on ok
-                                 (cond
-                                   ;; Jos alkuosa ja loppuosa on sama
-                                   ;; Ja alkuetäisyys on pienempi kuin loppuetäisyys)
-                                   (and (= (:aosa @lomake-atom) (:losa @lomake-atom)) (< (:aet @lomake-atom) arvo))
-                                   arvo
-                                   ;; Alkuetäisyys on suurempi kuin loppuetäisyys
-                                   (and (= (:aosa @lomake-atom) (:losa @lomake-atom)) (>= (:aet @lomake-atom) arvo))
-                                   nil
-                                   :else arvo)))]
+               (fn [arvo]
+                 ;; Validointi vaatii "nil" vastauksen, kun homma on pielessä ja kentän arvon, kun kaikki on ok
+                 (cond
+                   ;; Jos alkuosa ja loppuosa on sama
+                   ;; Ja alkuetäisyys on pienempi kuin loppuetäisyys)
+                   (and (= (:aosa @lomake-atom) (:losa @lomake-atom)) (< (:aet @lomake-atom) arvo))
+                   arvo
+                   ;; Alkuetäisyys on suurempi kuin loppuetäisyys
+                   (and (= (:aosa @lomake-atom) (:losa @lomake-atom)) (>= (:aet @lomake-atom) arvo))
+                   nil
+                   :else arvo)))]
        :alkupvm [tila/ei-nil tila/ei-tyhja tila/paivamaara]
        :loppupvm [tila/ei-nil tila/ei-tyhja tila/paivamaara
                   (tila/silloin-kun #(not (nil? (:alkupvm @lomake-atom)))
-                                    (fn [arvo]
-                                      ;; Validointi vaatii "nil" vastauksen, kun homma on pielessä ja kentän arvon, kun kaikki on ok
-                                      (when (or (pvm/sama-pvm? (:alkupvm @lomake-atom) arvo) ;; Joko sama päivä
-                                                (pvm/ennen? (:alkupvm @lomake-atom) arvo)) ;; Tai alkupäivämäärä tulee ennen loppupäivää
-                                        arvo)))]
+                    (fn [arvo]
+                      ;; Validointi vaatii "nil" vastauksen, kun homma on pielessä ja kentän arvon, kun kaikki on ok
+                      (when (or (pvm/sama-pvm? (:alkupvm @lomake-atom) arvo) ;; Joko sama päivä
+                              (pvm/ennen? (:alkupvm @lomake-atom) arvo)) ;; Tai alkupäivämäärä tulee ennen loppupäivää
+                        arvo)))]
        :suunniteltu-maara [tila/ei-nil tila/ei-tyhja tila/numero]
        :yksikko [tila/ei-nil tila/ei-tyhja]
        :suunniteltu-hinta [tila/ei-nil tila/ei-tyhja tila/numero]
@@ -283,38 +283,38 @@
 
 (defn- validoi-lomake [lomake]
   (apply tila/luo-validius-tarkistukset
-         (if-not (= :pot (:toteumatyyppi @lomake-atom))
-           [[:nimi] (validoinnit :nimi)
-            [:ulkoinen-id] (validoinnit :ulkoinen-id)
-            [:tyomenetelma] (validoinnit :tyomenetelma)
-            [:tie] (validoinnit :tie)
-            [:aosa] (validoinnit :aosa)
-            [:losa] (validoinnit :losa)
-            [:aet] (validoinnit :aet)
-            [:let] (validoinnit :let)
-            [:alkupvm] (validoinnit :alkupvm)
-            [:loppupvm] (validoinnit :loppupvm)
-            [:suunniteltu-maara] (validoinnit :suunniteltu-maara)
-            [:yksikko] (validoinnit :yksikko)
-            [:suunniteltu-hinta] (validoinnit :suunniteltu-hinta)]
-           ;; Pot raportoitavalla on erilaiset  validoinnit
-           [[:nimi] (validoinnit :nimi)
-            [:ulkoinen-id] (validoinnit :ulkoinen-id)
-            [:tyomenetelma] (validoinnit :tyomenetelma)
-            [:tie] (validoinnit :tie)
-            [:aosa] (validoinnit :aosa)
-            [:losa] (validoinnit :losa)
-            [:aet] (validoinnit :aet)
-            [:let] (validoinnit :let)
-            [:alkupvm] (validoinnit :alkupvm)
-            [:loppupvm] (validoinnit :loppupvm)
-            [:suunniteltu-maara] (validoinnit :suunniteltu-maara)
-            [:yksikko] (validoinnit :yksikko)
-            [:suunniteltu-hinta] (validoinnit :suunniteltu-hinta)
-            [:pot-tyo-alkoi] (validoinnit :pot-tyo-alkoi)
-            [:pot-tyo-paattyi] (validoinnit :pot-tyo-paattyi)
-            [:pot-valmistumispvm] (validoinnit :pot-valmistumispvm)]
-           )))
+    (if-not (= :pot (:toteumatyyppi @lomake-atom))
+      [[:nimi] (validoinnit :nimi)
+       [:ulkoinen-id] (validoinnit :ulkoinen-id)
+       [:tyomenetelma] (validoinnit :tyomenetelma)
+       [:tie] (validoinnit :tie)
+       [:aosa] (validoinnit :aosa)
+       [:losa] (validoinnit :losa)
+       [:aet] (validoinnit :aet)
+       [:let] (validoinnit :let)
+       [:alkupvm] (validoinnit :alkupvm)
+       [:loppupvm] (validoinnit :loppupvm)
+       [:suunniteltu-maara] (validoinnit :suunniteltu-maara)
+       [:yksikko] (validoinnit :yksikko)
+       [:suunniteltu-hinta] (validoinnit :suunniteltu-hinta)]
+      ;; Pot raportoitavalla on erilaiset  validoinnit
+      [[:nimi] (validoinnit :nimi)
+       [:ulkoinen-id] (validoinnit :ulkoinen-id)
+       [:tyomenetelma] (validoinnit :tyomenetelma)
+       [:tie] (validoinnit :tie)
+       [:aosa] (validoinnit :aosa)
+       [:losa] (validoinnit :losa)
+       [:aet] (validoinnit :aet)
+       [:let] (validoinnit :let)
+       [:alkupvm] (validoinnit :alkupvm)
+       [:loppupvm] (validoinnit :loppupvm)
+       [:suunniteltu-maara] (validoinnit :suunniteltu-maara)
+       [:yksikko] (validoinnit :yksikko)
+       [:suunniteltu-hinta] (validoinnit :suunniteltu-hinta)
+       [:pot-tyo-alkoi] (validoinnit :pot-tyo-alkoi)
+       [:pot-tyo-paattyi] (validoinnit :pot-tyo-paattyi)
+       [:pot-valmistumispvm] (validoinnit :pot-valmistumispvm)]
+      )))
 
 (defn- validoi-tiemerkintamodal-lomake [lomake]
   (apply tila/luo-validius-tarkistukset [[:tiemerkinta-urakka] (validoinnit :tiemerkinta-urakakka)
@@ -555,8 +555,8 @@
           ;; tallennettu uusi toteuma kohteelle. Joten haetaan app-statesta samalla id:llä olevan paikkauskohteen tiedot lomakkeelle
           app (if (:toteuma-lisatty? app)
                 (-> app
-                    ;; Jos paikkauskohdelomake oli raportointitilassa ja muokkaustilassa laitetaan sama tila päälle
-                    ;; :raportointila? true - appin juuressa
+                  ;; Jos paikkauskohdelomake oli raportointitilassa ja muokkaustilassa laitetaan sama tila päälle
+                  ;; :raportointila? true - appin juuressa
                   (assoc :lomake (some #(when (= (get-in app [:lomake :id]) (:id %))
                                           %) paikkauskohteet))
                   (assoc-in [:lomake :tyyppi] (:raportointi-tila? app))
@@ -859,14 +859,15 @@
   AsetaToteumatyyppiKohteelle
   (process-event [{:keys [paikkauskohde toteumatyyppi]} app]
     ;; Vaihda tälle kohteelle toteumatyyppi halutuksi
-    (let [kohteet (mapv (fn [kohde]
-                            (if (= (:id kohde) (:id paikkauskohde))
-                              (-> kohde
-                                (assoc :pot? (= toteumatyyppi :pot))
-                                (assoc :toteumatyyppi toteumatyyppi))
-                              kohde))
+    (let [kohteet (map (fn [kohde]
+                         (if (= (:id kohde) (:id paikkauskohde))
+                           (assoc kohde
+                             :pot? (= toteumatyyppi :pot)
+                             :toteumatyyppi toteumatyyppi)
+                           kohde))
                     (:paikkauskohteet app))]
       (assoc app :paikkauskohteet kohteet)))
+
 
   TilaaValitutPaikkauskohteet
   (process-event [_ app]
@@ -924,7 +925,7 @@
       (some (fn [rooli]
               (true?
                 (some #(= rooli %) urakoitsijaroolit)))
-            urakkaroolit)
+        urakkaroolit)
       true
       :else false)))
 

--- a/src/cljs/harja/tiedot/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
+++ b/src/cljs/harja/tiedot/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
@@ -1,5 +1,6 @@
 (ns harja.tiedot.urakka.yllapitokohteet.paikkaukset.paikkaukset-paikkauskohteet
-  (:require [reagent.core :refer [atom]]
+  (:require [harja.ui.napit :as napit]
+            [reagent.core :refer [atom]]
             [clojure.data :refer [diff]]
             [clojure.string :as str]
             [tuck.core :as tuck]
@@ -109,6 +110,14 @@
 (defrecord AsetaToteumatyyppi [uusi-tyyppi])
 (defrecord AvaaVihje [])
 (defrecord AsetaTiemerkinnanTila [tila paikkauskohde])
+(defrecord VahvistaRaportointitavatModalissa [])
+(defrecord TilaustilaAktivoituToggle [])
+(defrecord ValitsePaikkauskohde [paikkauskohde valittu?])
+(defrecord ValitseKaikkiPaikkauskohteet [valittu?])
+(defrecord AsetaToteumatyyppiKohteelle [paikkauskohde toteumatyyppi])
+(defrecord TilaaValitutPaikkauskohteet [])
+(defrecord TilaaValitutPaikkauskohteetOnnistui [vastaus])
+(defrecord TilaaValitutPaikkauskohteetEpaonnistui [vastaus])
 
 (defn- tilat-hakuun [tilat]
   (let [sql-tilat {"Kaikki" "kaikki",
@@ -126,16 +135,19 @@
                          (if (= "Ei ajorataa" nykyinen-arvo)
                            nil
                            nykyinen-arvo)))
-      (dissoc :sijainti
-              :pituus
-              :harja.tiedot.urakka.urakka/validi?
-              :harja.tiedot.urakka.urakka/validius
-              :valiaika-takuuaika
-              :valiaika-valmistumispvm
-              :paikkaustyo-valmis?
-              :erotus
-              :toteutus-alkuaika
-              :toteutus-loppuaika)))
+    (dissoc
+      :sijainti
+      :formatoitu-sijainti
+      :pituus
+      :harja.tiedot.urakka.urakka/validi?
+      :harja.tiedot.urakka.urakka/validius
+      :valiaika-takuuaika
+      :valiaika-valmistumispvm
+      :paikkaustyo-valmis?
+      :erotus
+      :toteutus-alkuaika
+      :toteutus-loppuaika
+      :alasveto-valinnat)))
 
 (defn laske-paikkauskohteen-pituus [lomake parametrit]
   (let [;; Tarkistetaan ensin, että onko pituuskentät muuttuneet, jos ei niin ei lasketa pituutta
@@ -793,7 +805,77 @@
         ->TallennaPaikkauskohdeOnnistui
         ->TallennaPaikkauskohdeEpaonnistui
         [(not (nil? (:id paikkauskohde)))])
-      (assoc app :haku-kaynnissa? true :paikkauskohteet nil))))
+      (assoc app :haku-kaynnissa? true :paikkauskohteet nil)))
+
+  TilaustilaAktivoituToggle
+  (process-event [_ app]
+    (let [uusi-tila (not (:tilaustila-aktiivinen? app))]
+      (-> app
+        (assoc :tilaustila-aktiivinen? uusi-tila)
+        ;; Tyhjennetään valitut kohteet kun tila muuttuu
+        (assoc :valitut-tilattavat-kohteet []))))
+
+  ValitsePaikkauskohde
+  (process-event [{:keys [paikkauskohde valittu?]} app]
+    (let [valitut (:valitut-tilattavat-kohteet app [])]
+      (assoc app :valitut-tilattavat-kohteet
+        (if valittu?
+          (conj valitut paikkauskohde)
+          (disj valitut paikkauskohde)))))
+
+  ValitseKaikkiPaikkauskohteet
+  (process-event [{:keys [valittu?]} app]
+    (let [ehdotetut (filter #(= "ehdotettu" (:paikkauskohteen-tila %)) (:paikkauskohteet app))]
+      (if valittu?
+        (assoc app :valitut-tilattavat-kohteet ehdotetut)
+        (assoc app :valitut-tilattavat-kohteet []))))
+
+  VahvistaRaportointitavatModalissa
+  (process-event [_ app]
+    (modal/piilota!)
+    ;; Avataan toinen modal, jossa pyydetään lopullinen vahvistus tilauksesta, ja jos vahvistetaan, niin tilataan kohteet
+    (assoc app :vahvista-tilaus-modal-auki? true))
+
+  AsetaToteumatyyppiKohteelle
+  (process-event [{:keys [paikkauskohde toteumatyyppi]} app]
+    ;; Vaihda tälle kohteelle toteumatyyppi halutuksi
+    (update app :valitut-tilattavat-kohteet
+      (fn [kohteet]
+        (mapv (fn [kohde]
+                (if (= (:id kohde) (:id paikkauskohde))
+                  (assoc kohde :toteumatyyppi toteumatyyppi)
+                  kohde))
+          kohteet))))
+
+  TilaaValitutPaikkauskohteet
+  (process-event [_ app]
+    (let [valitut-kohteet (:valitut-tilattavat-kohteet app)
+          ;; Merkitse kohteet tilatuiksi
+          tilattavat-kohteet (map (fn [kohde]
+                                    (-> kohde
+                                      (assoc :paikkauskohteen-tila "tilattu")
+                                      (siivoa-ennen-lahetysta)))
+                               valitut-kohteet)]
+
+      (tuck-apurit/post! :tilaa-valitut-paikkauskohteet
+        {:tilattavat-paikkauskohteet tilattavat-kohteet}
+        {:onnistui ->TilaaValitutPaikkauskohteetOnnistui
+         :epaonnistui ->TilaaValitutPaikkauskohteetEpaonnistui
+         :paasta-virhe-lapi? true})
+      app))
+
+  TilaaValitutPaikkauskohteetOnnistui
+  (process-event [{vastaus :vastaus} app]
+    (modal/piilota!)
+    (viesti/nayta-toast! (str "Tilattiin onnistuneesti" (vastaus :onnistuneet) " kpl kohteita"))
+    (hae-paikkauskohteet (-> @tila/yleiset :urakka :id) app))
+
+  TilaaValitutPaikkauskohteetEpaonnistui
+  (process-event [{vastaus :vastaus} app]
+    (modal/piilota!)
+    (viesti/nayta-toast! (str "Tilauksessa tapahtui virhe!")
+      :varoitus viesti/viestin-nayttoaika-aareton)
+    app))
 
 (defn kayttaja-on-urakoitsija? [urakkaroolit]
   (let [urakkaroolit (if (set? urakkaroolit)

--- a/src/cljs/harja/tiedot/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
+++ b/src/cljs/harja/tiedot/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
@@ -835,18 +835,19 @@
 
   ValitsePaikkauskohde
   (process-event [{:keys [paikkauskohde valittu?]} app]
-    (let [valitut (:valitut-tilattavat-kohteet app [])]
+    (let [valitut (set (:valitut-tilattavat-kohteet app))]
       (assoc app :valitut-tilattavat-kohteet
         (if valittu?
-          (conj valitut paikkauskohde)
-          (disj valitut paikkauskohde)))))
+          (conj valitut (:id paikkauskohde))
+          (disj valitut (:id paikkauskohde))))))
 
   ValitseKaikkiPaikkauskohteet
   (process-event [{:keys [valittu?]} app]
     (let [ehdotetut (filter #(= "ehdotettu" (:paikkauskohteen-tila %)) (:paikkauskohteet app))]
       (if valittu?
-        (assoc app :valitut-tilattavat-kohteet ehdotetut)
-        (assoc app :valitut-tilattavat-kohteet []))))
+        (assoc app :valitut-tilattavat-kohteet (set (map :id ehdotetut)))
+        (assoc app :valitut-tilattavat-kohteet #{}))))
+
 
   VahvistaRaportointitavatModalissa
   (process-event [_ app]
@@ -869,12 +870,15 @@
   TilaaValitutPaikkauskohteet
   (process-event [_ app]
     (let [valitut-kohteet (:valitut-tilattavat-kohteet app)
+          kaikki-kohteet (:paikkauskohteet app)
+
           ;; Merkitse kohteet tilatuiksi
-          tilattavat-kohteet (map (fn [kohde]
-                                    (-> kohde
-                                      (assoc :paikkauskohteen-tila "tilattu")
-                                      (siivoa-ennen-lahetysta)))
-                               valitut-kohteet)]
+          tilattavat-kohteet (->> kaikki-kohteet
+                               (filter #(contains? valitut-kohteet (:id %)))
+                               (map (fn [kohde]
+                                      (-> kohde
+                                        (assoc :paikkauskohteen-tila "tilattu")
+                                        (siivoa-ennen-lahetysta)))))]
 
       (tuck-apurit/post! :tilaa-valitut-paikkauskohteet
         {:tilattavat-paikkauskohteet tilattavat-kohteet}
@@ -882,8 +886,11 @@
          :epaonnistui ->TilaaValitutPaikkauskohteetEpaonnistui
          :paasta-virhe-lapi? true})
       (-> app
-        (assoc :vahvista-tilaus-modal-auki? false)
-        (assoc :tilaustila-aktiivinen? false))))
+        (assoc
+          :paikkauskohteet nil
+          :haku-kaynnissa? true
+          :tilaustila-aktiivinen? false
+          :vahvista-tilaus-modal-auki? false))))
 
   TilaaValitutPaikkauskohteetOnnistui
   (process-event [{vastaus :vastaus} app]

--- a/src/cljs/harja/tiedot/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
+++ b/src/cljs/harja/tiedot/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
@@ -524,7 +524,11 @@
           ;; Kun tullaan näkymään, aseta suodattimeen kuluva/viimeinen vuosi 
           app (if nakymaan?
                 (assoc app :valittu-vuosi vuosi)
-                app)]
+                app)
+          app (assoc app :tilaustila-aktiivinen? false
+                :vahvista-tilaus-modal-auki? false
+                :raportointimodal-aktiivinen? false
+                :valitut-tilattavat-kohteet [])]
 
       (hae-paikkauskohteet (-> @tila/yleiset :urakka :id) app)))
 
@@ -877,12 +881,13 @@
         {:onnistui ->TilaaValitutPaikkauskohteetOnnistui
          :epaonnistui ->TilaaValitutPaikkauskohteetEpaonnistui
          :paasta-virhe-lapi? true})
-      (assoc app :vahvista-tilaus-modal-auki? false)))
+      (-> app
+        (assoc :vahvista-tilaus-modal-auki? false)
+        (assoc :tilaustila-aktiivinen? false))))
 
   TilaaValitutPaikkauskohteetOnnistui
   (process-event [{vastaus :vastaus} app]
-    (modal/piilota!)
-    (viesti/nayta-toast! (str "Tilattiin onnistuneesti" (vastaus :onnistuneet) " kpl kohteita"))
+    (viesti/nayta-toast! (str "Kohteet " (vastaus :onnistuneet) " kpl tilattu"))
     (hae-paikkauskohteet (-> @tila/yleiset :urakka :id) app))
 
   TilaaValitutPaikkauskohteetEpaonnistui

--- a/src/cljs/harja/tiedot/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
+++ b/src/cljs/harja/tiedot/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
@@ -112,6 +112,8 @@
 (defrecord AsetaTiemerkinnanTila [tila paikkauskohde])
 (defrecord VahvistaRaportointitavatModalissa [])
 (defrecord TilaustilaAktivoituToggle [])
+(defrecord RaportointitapaModalToggle [])
+(defrecord TilaaModalToggle [])
 (defrecord ValitsePaikkauskohde [paikkauskohde valittu?])
 (defrecord ValitseKaikkiPaikkauskohteet [valittu?])
 (defrecord AsetaToteumatyyppiKohteelle [paikkauskohde toteumatyyppi])
@@ -817,6 +819,16 @@
         ;; Tyhjennetään valitut kohteet kun tila muuttuu
         (assoc :valitut-tilattavat-kohteet []))))
 
+  RaportointitapaModalToggle
+  (process-event [_ app]
+    (let [uusi-tila (not (:raportointimodal-aktiivinen? app))]
+      (assoc app :raportointimodal-aktiivinen? uusi-tila)))
+
+  TilaaModalToggle
+  (process-event [_ app]
+    (let [uusi-tila (not (:vahvista-tilaus-modal-auki? app))]
+      (assoc app :vahvista-tilaus-modal-auki? uusi-tila)))
+
   ValitsePaikkauskohde
   (process-event [{:keys [paikkauskohde valittu?]} app]
     (let [valitut (:valitut-tilattavat-kohteet app [])]
@@ -834,20 +846,21 @@
 
   VahvistaRaportointitavatModalissa
   (process-event [_ app]
-    (modal/piilota!)
-    ;; Avataan toinen modal, jossa pyydetään lopullinen vahvistus tilauksesta, ja jos vahvistetaan, niin tilataan kohteet
-    (assoc app :vahvista-tilaus-modal-auki? true))
+    (-> app
+      (assoc :raportointimodal-aktiivinen? false)
+      ;; Avataan toinen modal, jossa pyydetään lopullinen vahvistus tilauksesta, ja jos vahvistetaan, niin tilataan kohteet
+      (assoc :vahvista-tilaus-modal-auki? true)))
 
   AsetaToteumatyyppiKohteelle
   (process-event [{:keys [paikkauskohde toteumatyyppi]} app]
     ;; Vaihda tälle kohteelle toteumatyyppi halutuksi
-    (update app :valitut-tilattavat-kohteet
-      (fn [kohteet]
-        (mapv (fn [kohde]
-                (if (= (:id kohde) (:id paikkauskohde))
-                  (assoc kohde :toteumatyyppi toteumatyyppi)
-                  kohde))
-          kohteet))))
+    (let [kohteet (:valitut-tilattavat-kohteet app)
+          kohteet (mapv (fn [kohde]
+                            (if (= (:id kohde) (:id paikkauskohde))
+                              (assoc kohde :toteumatyyppi toteumatyyppi)
+                              kohde))
+                        kohteet)]
+      (assoc app :valitut-tilattavat-kohteet kohteet)))
 
   TilaaValitutPaikkauskohteet
   (process-event [_ app]
@@ -864,7 +877,7 @@
         {:onnistui ->TilaaValitutPaikkauskohteetOnnistui
          :epaonnistui ->TilaaValitutPaikkauskohteetEpaonnistui
          :paasta-virhe-lapi? true})
-      app))
+      (assoc app :vahvista-tilaus-modal-auki? false)))
 
   TilaaValitutPaikkauskohteetOnnistui
   (process-event [{vastaus :vastaus} app]

--- a/src/cljs/harja/ui/napit.cljs
+++ b/src/cljs/harja/ui/napit.cljs
@@ -91,7 +91,7 @@
             (when data-cy
               {:data-cy data-cy}))
 
-          (if (and @kysely-kaynnissa? ikoni) [y/ajax-loader] ikoni) (when ikoni (str " ")) teksti]
+          (if (and @kysely-kaynnissa? ikoni) [y/ajax-loader nil {:luokka (:ajax-luokka asetukset)}] ikoni) (when ikoni (str " ")) teksti]
          (when (and @nayta-virheviesti? asetukset-nayta-virheviesti?)
            (case virheen-esitystapa
              :flash (do

--- a/src/cljs/harja/ui/yleiset.cljs
+++ b/src/cljs/harja/ui/yleiset.cljs
@@ -51,7 +51,7 @@
   ([] (ajax-loader nil))
   ([viesti] (ajax-loader viesti nil))
   ([viesti {:keys [luokka sama-rivi?] :as opts}]
-   [:div {:class (str "ajax-loader-valistys ajax-loader " (when (:luokka opts) (:luokka opts)))}
+   [:div {:class (str "ajax-loader-valistys ajax-loader " (when luokka luokka))}
     [:img {:alt "Ladataan sisältöä." :src "images/ajax-loader.gif"}]
     (when viesti
       (if sama-rivi?

--- a/src/cljs/harja/views/urakka/pot2/materiaalikirjasto.cljs
+++ b/src/cljs/harja/views/urakka/pot2/materiaalikirjasto.cljs
@@ -40,7 +40,7 @@
       :rivi-klikattu #(e! (mk-tiedot/->ValitseMassaTaiMurske (::pot2-domain/massa-id %) :massat))
       :tunniste :harja.domain.pot2/massa-id}
      [{:otsikko-komp (fn []
-                       [kentat/raksiboksi {:disabled false
+                       [kentat/raksiboksi {:disabled? false
                                            :toiminto #(e! (mk-tiedot/->ValitseKaikkiMassatTaiMurskeet :massat))}
                         (mk-tiedot/materiaalien-ruksin-tila (:massat materiaalit-toisesta-urakasta))])
        :tyyppi :komponentti
@@ -66,12 +66,12 @@
       :rivi-klikattu #(e! (mk-tiedot/->ValitseMassaTaiMurske (::pot2-domain/murske-id %) :murskeet))
       :tunniste ::pot2-domain/murske-id}
      [{:otsikko-komp (fn []
-                       [kentat/raksiboksi {:disabled false
+                       [kentat/raksiboksi {:disabled? false
                                            :toiminto #(e! (mk-tiedot/->ValitseKaikkiMassatTaiMurskeet :murskeet))}
                         (mk-tiedot/materiaalien-ruksin-tila (:murskeet materiaalit-toisesta-urakasta))])
        :tyyppi :komponentti
        :komponentti (fn [rivi]
-                      [kentat/raksiboksi {:disabled false
+                      [kentat/raksiboksi {:disabled? false
                                           :toiminto #(e! (mk-tiedot/->ValitseMassaTaiMurske (::pot2-domain/murske-id rivi) :murskeet))}
                        (:valittu? rivi)])
        :leveys 2}

--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_apurit.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_apurit.cljs
@@ -22,71 +22,67 @@
                  (paikkaus/levittimella-tehty? lomake tyomenetelmat))]
     nayta?))
 
-(defn nayta-tilaa-paikkauskohteet-modal! [e! valitut-tilattavat-kohteet]
-  (modal/nayta!
-    {:otsikko (str "Tilataanko " (count valitut-tilattavat-kohteet) " kpl kohteita?")
-     :footer [:div
-              [:div.pull-left
-               [napit/yleinen-ensisijainen (if (= 1 (count valitut-tilattavat-kohteet)) "Tilaa kohde" "Tilaa kohteet")
-                #(e! (t-paikkauskohteet/->TilaaValitutPaikkauskohteet))
-                {:paksu? true}]]
-              [:div.pull-right
-               [napit/yleinen-toissijainen "Kumoa" (fn [] (modal/piilota!)) {:paksu? true}]]]}
-    [:div.tilaus-vahvistus-modal
-     [:p "Urakoitsija saa sähköpostiin ilmoituksen kohteen tilauksesta."]]))
+(defn tilaa-paikkauskohteet-modal! [e! {:keys [valitut-tilattavat-kohteet vahvista-tilaus-modal-auki?] :as app}]
+  [modal/modal
+   {:nakyvissa? vahvista-tilaus-modal-auki?
+    :otsikko (str "Tilataanko " (count valitut-tilattavat-kohteet) " kpl kohteita?")
+    :footer [:div
+             [:div.pull-left
+              [napit/yleinen-ensisijainen (if (= 1 (count valitut-tilattavat-kohteet)) "Tilaa kohde" "Tilaa kohteet")
+               #(e! (t-paikkauskohteet/->TilaaValitutPaikkauskohteet))
+               {:paksu? true}]]
+             [:div.pull-right
+              [napit/yleinen-toissijainen "Kumoa" #(e! (t-paikkauskohteet/->TilaaModalToggle)) {:paksu? true}]]]}
+   [:div.tilaus-vahvistus-modal
+    [:p "Urakoitsija saa sähköpostiin ilmoituksen kohteen tilauksesta."]]])
 
-(defn nayta-tilaus-vahvistus-modal!
+(defn raportointi-modal!
   "Näyttää modalin, jossa käyttäjä voi vahvistaa valittujen paikkauskohteiden raportointitavan.
    Parametrit:
    - valitut-kohteet: Vektori paikkauskohteita, jotka käyttäjä on valinnut tilaukseen"
   [e! app]
   (let [valitut-kohteet (:valitut-tilattavat-kohteet app)
-        raportointitapa-teksti (fn [kohde]
-                                 (case (:toteumatyyppi kohde)
-                                   :pot "POT-lomake"
-                                   :normaali "Toteumat"
-                                   "Ei määritetty"))
         tyomenetelmat (get-in app [:valinnat :tyomenetelmat])]
-    (modal/nayta!
-      {:otsikko "Vahvista raportointitapa seuraaville kohteille"
-       :footer [:div
-                [:div.pull-left
-                 [napit/yleinen-ensisijainen "Vahvista"
-                  #(nayta-tilaa-paikkauskohteet-modal! e! valitut-kohteet)
-                  #_(e! (t-paikkauskohteet/->VahvistaRaportointitavatModalissa))
-                  {:paksu? true}]]
-                [:div.pull-right
-                 [napit/yleinen-toissijainen "Kumoa" (fn [] (modal/piilota!)) {:paksu? true}]]]}
-      [:div.tilaus-vahvistus-modal
-       [:p (str "Osa kohteista (" (count valitut-kohteet) ") vaatii raportointitavan vahvistamisen ennen tilaamista.")]
-       [grid/grid
-        {:otsikko "Valitut kohteet"
-         :tunniste :id
-         :tyhja "Ei valittuja kohteita"
-         :voi-muokata? false}
-        [{:otsikko "Nro"
-          :nimi :id
-          :tyyppi :string
-          :leveys 1}
-         {:otsikko "Nimi"
-          :nimi :nimi
-          :tyyppi :string
-          :leveys 3}
-         {:otsikko "Raportointitapa"
-          :leveys 3
-          :tyyppi :komponentti
-          :komponentti (fn [rivi]
-                         (if (nayta-pot-valinta? rivi tyomenetelmat)
-                           [kentat/tee-kentta {:tyyppi :radio-group
-                                               :nimi :toteumatyyppi
-                                               :otsikko ""
-                                               :vaihtoehdot [:normaali :pot]
-                                               :nayta-rivina? true
-                                               :vayla-tyyli? true
-                                               :vaihtoehto-nayta {:pot "POT-lomake"
-                                                                  :normaali "Toteumat"}
-                                               :valitse-fn #(e! (t-paikkauskohteet/->AsetaToteumatyyppiKohteelle rivi %))}
-                            (r/atom (:toteumatyyppi rivi))]
-                           "Toteumat"))}]
-        valitut-kohteet]])))
+    [modal/modal
+     {:nakyvissa? (:raportointimodal-aktiivinen? app)
+      :otsikko "Vahvista raportointitapa seuraaville kohteille"
+      :footer [:div
+               [:div.pull-left
+                [napit/yleinen-ensisijainen "Vahvista"
+                 #(e! (t-paikkauskohteet/->VahvistaRaportointitavatModalissa))
+                 {:paksu? true}]]
+               [:div.pull-right
+                [napit/yleinen-toissijainen "Kumoa" #(e! (t-paikkauskohteet/->RaportointitapaModalToggle)) {:paksu? true}]]]}
+     [:div.tilaus-vahvistus-modal
+      [:p (str "Osa kohteista (" (count valitut-kohteet) ") vaatii raportointitavan vahvistamisen ennen tilaamista.")]
+      [grid/grid
+       {:otsikko "Valitut kohteet"
+        :tunniste :id
+        :tyhja "Ei valittuja kohteita"
+        :voi-muokata? false}
+       [{:otsikko "Nro"
+         :nimi :id
+         :tyyppi :string
+         :leveys 1}
+        {:otsikko "Nimi"
+         :nimi :nimi
+         :tyyppi :string
+         :leveys 3}
+        {:otsikko "Raportointitapa"
+         :leveys 3
+         :tyyppi :komponentti
+         :komponentti (fn [rivi]
+                        (if (nayta-pot-valinta? rivi tyomenetelmat)
+                          [kentat/tee-kentta {:tyyppi :radio-group
+                                              :nimi :toteumatyyppi
+                                              :otsikko ""
+                                              :vaihtoehdot [:normaali :pot]
+                                              :nayta-rivina? true
+                                              :vayla-tyyli? true
+                                              :vaihtoehto-nayta {:pot "POT-lomake"
+                                                                 :normaali "Toteumat"}
+                                              :valitse-fn #(e! (t-paikkauskohteet/->AsetaToteumatyyppiKohteelle rivi %))}
+                           (r/atom (:toteumatyyppi rivi))]
+                          "Toteumat"))}]
+       valitut-kohteet]]]))
 

--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_apurit.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_apurit.cljs
@@ -25,7 +25,9 @@
 (defn tilaa-paikkauskohteet-modal! [e! {:keys [valitut-tilattavat-kohteet vahvista-tilaus-modal-auki?] :as app}]
   [modal/modal
    {:nakyvissa? vahvista-tilaus-modal-auki?
-    :otsikko (str "Tilataanko " (count valitut-tilattavat-kohteet) " kpl kohteita?")
+    :otsikko (if (= 1 (count valitut-tilattavat-kohteet))
+               (str "Tilataanko kohde \"" (:nimi (first valitut-tilattavat-kohteet)) "\"?")
+               (str "Tilataanko " (count valitut-tilattavat-kohteet) " kpl kohteita?"))
     :footer [:div
              [:div.pull-left
               [napit/yleinen-ensisijainen (if (= 1 (count valitut-tilattavat-kohteet)) "Tilaa kohde" "Tilaa kohteet")

--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_apurit.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_apurit.cljs
@@ -22,7 +22,7 @@
                  (paikkaus/levittimella-tehty? lomake tyomenetelmat))]
     nayta?))
 
-(defn tilaa-paikkauskohteet-modal! [e! {:keys [valitut-tilattavat-kohteet vahvista-tilaus-modal-auki?] :as app}]
+(defn tilaa-paikkauskohteet-modal! [e! {:keys [valitut-tilattavat-kohteet vahvista-tilaus-modal-auki? paikkauskohteet] :as app}]
   (let [valitut-kohteet (filter #(contains? valitut-tilattavat-kohteet (:id %)) paikkauskohteet)]
     [modal/modal
      {:nakyvissa? vahvista-tilaus-modal-auki?

--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_apurit.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_apurit.cljs
@@ -1,11 +1,26 @@
 (ns harja.views.urakka.yllapitokohteet.paikkaukset.paikkaukset-apurit
   (:require [reagent.core :as r]
+            [harja.domain.roolit :as roolit]
+            [harja.domain.paikkaus :as paikkaus]
             [harja.ui.kentat :as kentat]
-            [tuck.core :as tuck]
             [harja.ui.grid :as grid]
             [harja.ui.napit :as napit]
             [harja.ui.modal :as modal]
+            [harja.tiedot.istunto :as istunto]
+            [harja.tiedot.urakka.urakka :as tila]
             [harja.tiedot.urakka.yllapitokohteet.paikkaukset.paikkaukset-paikkauskohteet :as t-paikkauskohteet]))
+
+(defn- nayta-pot-valinta?
+  "Tilaajalle näytetään kolmen työmenetelmän kohdalla erillinen pot/toteuma radiobutton valinta.
+  Mikäli tilaaja valitsee pot vaihtoehdon, toteumia ei kirjata normaaliprossin mukaan, vaan pot-lomakkeelta
+  Kolme työmenetelmää ovat: AB-paikkaus levittäjällä, PAB-paikkaus levittäjällä, SMA-paikkaus levittäjällä"
+  [lomake tyomenetelmat]
+  (let [nayta? (and (roolit/kayttaja-on-laajasti-ottaen-tilaaja?
+                      (roolit/urakkaroolit @istunto/kayttaja (-> @tila/tila :yleiset :urakka :id))
+                      @istunto/kayttaja)
+                 (= "ehdotettu" (:paikkauskohteen-tila lomake))
+                 (paikkaus/levittimella-tehty? lomake tyomenetelmat))]
+    nayta?))
 
 (defn nayta-tilaa-paikkauskohteet-modal! [e! valitut-tilattavat-kohteet]
   (modal/nayta!
@@ -24,12 +39,14 @@
   "Näyttää modalin, jossa käyttäjä voi vahvistaa valittujen paikkauskohteiden raportointitavan.
    Parametrit:
    - valitut-kohteet: Vektori paikkauskohteita, jotka käyttäjä on valinnut tilaukseen"
-  [e! valitut-kohteet]
-  (let [raportointitapa-teksti (fn [kohde]
+  [e! app]
+  (let [valitut-kohteet (:valitut-tilattavat-kohteet app)
+        raportointitapa-teksti (fn [kohde]
                                  (case (:toteumatyyppi kohde)
                                    :pot "POT-lomake"
                                    :normaali "Toteumat"
-                                   "Ei määritetty"))]
+                                   "Ei määritetty"))
+        tyomenetelmat (get-in app [:valinnat :tyomenetelmat])]
     (modal/nayta!
       {:otsikko "Vahvista raportointitapa seuraaville kohteille"
        :footer [:div
@@ -59,15 +76,17 @@
           :leveys 3
           :tyyppi :komponentti
           :komponentti (fn [rivi]
-                         [kentat/tee-kentta {:tyyppi :radio-group
-                                             :nimi :toteumatyyppi
-                                             :otsikko ""
-                                             :vaihtoehdot [:normaali :pot]
-                                             :nayta-rivina? true
-                                             :vayla-tyyli? true
-                                             :vaihtoehto-nayta {:pot "POT-lomake"
-                                                                :normaali "Toteumat"}
-                                             :valitse-fn #(e! (t-paikkauskohteet/->AsetaToteumatyyppiKohteelle rivi %))}
-                          (r/atom (:toteumatyyppi rivi))])}]
+                         (if (nayta-pot-valinta? rivi tyomenetelmat)
+                           [kentat/tee-kentta {:tyyppi :radio-group
+                                               :nimi :toteumatyyppi
+                                               :otsikko ""
+                                               :vaihtoehdot [:normaali :pot]
+                                               :nayta-rivina? true
+                                               :vayla-tyyli? true
+                                               :vaihtoehto-nayta {:pot "POT-lomake"
+                                                                  :normaali "Toteumat"}
+                                               :valitse-fn #(e! (t-paikkauskohteet/->AsetaToteumatyyppiKohteelle rivi %))}
+                            (r/atom (:toteumatyyppi rivi))]
+                           "Toteumat"))}]
         valitut-kohteet]])))
 

--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_apurit.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_apurit.cljs
@@ -1,0 +1,73 @@
+(ns harja.views.urakka.yllapitokohteet.paikkaukset.paikkaukset-apurit
+  (:require [reagent.core :as r]
+            [harja.ui.kentat :as kentat]
+            [tuck.core :as tuck]
+            [harja.ui.grid :as grid]
+            [harja.ui.napit :as napit]
+            [harja.ui.modal :as modal]
+            [harja.tiedot.urakka.yllapitokohteet.paikkaukset.paikkaukset-paikkauskohteet :as t-paikkauskohteet]))
+
+(defn nayta-tilaa-paikkauskohteet-modal! [e! valitut-tilattavat-kohteet]
+  (modal/nayta!
+    {:otsikko (str "Tilataanko " (count valitut-tilattavat-kohteet) " kpl kohteita?")
+     :footer [:div
+              [:div.pull-left
+               [napit/yleinen-ensisijainen (if (= 1 (count valitut-tilattavat-kohteet)) "Tilaa kohde" "Tilaa kohteet")
+                #(e! (t-paikkauskohteet/->TilaaValitutPaikkauskohteet))
+                {:paksu? true}]]
+              [:div.pull-right
+               [napit/yleinen-toissijainen "Kumoa" (fn [] (modal/piilota!)) {:paksu? true}]]]}
+    [:div.tilaus-vahvistus-modal
+     [:p "Urakoitsija saa sähköpostiin ilmoituksen kohteen tilauksesta."]]))
+
+(defn nayta-tilaus-vahvistus-modal!
+  "Näyttää modalin, jossa käyttäjä voi vahvistaa valittujen paikkauskohteiden raportointitavan.
+   Parametrit:
+   - valitut-kohteet: Vektori paikkauskohteita, jotka käyttäjä on valinnut tilaukseen"
+  [e! valitut-kohteet]
+  (let [raportointitapa-teksti (fn [kohde]
+                                 (case (:toteumatyyppi kohde)
+                                   :pot "POT-lomake"
+                                   :normaali "Toteumat"
+                                   "Ei määritetty"))]
+    (modal/nayta!
+      {:otsikko "Vahvista raportointitapa seuraaville kohteille"
+       :footer [:div
+                [:div.pull-left
+                 [napit/yleinen-ensisijainen "Vahvista"
+                  #(nayta-tilaa-paikkauskohteet-modal! e! valitut-kohteet)
+                  #_(e! (t-paikkauskohteet/->VahvistaRaportointitavatModalissa))
+                  {:paksu? true}]]
+                [:div.pull-right
+                 [napit/yleinen-toissijainen "Kumoa" (fn [] (modal/piilota!)) {:paksu? true}]]]}
+      [:div.tilaus-vahvistus-modal
+       [:p (str "Osa kohteista (" (count valitut-kohteet) ") vaatii raportointitavan vahvistamisen ennen tilaamista.")]
+       [grid/grid
+        {:otsikko "Valitut kohteet"
+         :tunniste :id
+         :tyhja "Ei valittuja kohteita"
+         :voi-muokata? false}
+        [{:otsikko "Nro"
+          :nimi :id
+          :tyyppi :string
+          :leveys 1}
+         {:otsikko "Nimi"
+          :nimi :nimi
+          :tyyppi :string
+          :leveys 3}
+         {:otsikko "Raportointitapa"
+          :leveys 3
+          :tyyppi :komponentti
+          :komponentti (fn [rivi]
+                         [kentat/tee-kentta {:tyyppi :radio-group
+                                             :nimi :toteumatyyppi
+                                             :otsikko ""
+                                             :vaihtoehdot [:normaali :pot]
+                                             :nayta-rivina? true
+                                             :vayla-tyyli? true
+                                             :vaihtoehto-nayta {:pot "POT-lomake"
+                                                                :normaali "Toteumat"}
+                                             :valitse-fn #(e! (t-paikkauskohteet/->AsetaToteumatyyppiKohteelle rivi %))}
+                          (r/atom (:toteumatyyppi rivi))])}]
+        valitut-kohteet]])))
+

--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_apurit.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_apurit.cljs
@@ -10,7 +10,7 @@
             [harja.tiedot.urakka.urakka :as tila]
             [harja.tiedot.urakka.yllapitokohteet.paikkaukset.paikkaukset-paikkauskohteet :as t-paikkauskohteet]))
 
-(defn- nayta-pot-valinta?
+(defn nayta-pot-valinta?
   "Tilaajalle näytetään kolmen työmenetelmän kohdalla erillinen pot/toteuma radiobutton valinta.
   Mikäli tilaaja valitsee pot vaihtoehdon, toteumia ei kirjata normaaliprossin mukaan, vaan pot-lomakkeelta
   Kolme työmenetelmää ovat: AB-paikkaus levittäjällä, PAB-paikkaus levittäjällä, SMA-paikkaus levittäjällä"
@@ -23,27 +23,28 @@
     nayta?))
 
 (defn tilaa-paikkauskohteet-modal! [e! {:keys [valitut-tilattavat-kohteet vahvista-tilaus-modal-auki?] :as app}]
-  [modal/modal
-   {:nakyvissa? vahvista-tilaus-modal-auki?
-    :otsikko (if (= 1 (count valitut-tilattavat-kohteet))
-               (str "Tilataanko kohde \"" (:nimi (first valitut-tilattavat-kohteet)) "\"?")
-               (str "Tilataanko " (count valitut-tilattavat-kohteet) " kpl kohteita?"))
-    :footer [:div
-             [:div.pull-left
-              [napit/yleinen-ensisijainen (if (= 1 (count valitut-tilattavat-kohteet)) "Tilaa kohde" "Tilaa kohteet")
-               #(e! (t-paikkauskohteet/->TilaaValitutPaikkauskohteet))
-               {:paksu? true}]]
-             [:div.pull-right
-              [napit/yleinen-toissijainen "Kumoa" #(e! (t-paikkauskohteet/->TilaaModalToggle)) {:paksu? true}]]]}
-   [:div.tilaus-vahvistus-modal
-    [:p "Urakoitsija saa sähköpostiin ilmoituksen kohteen tilauksesta."]]])
+  (let [valitut-kohteet (filter #(contains? valitut-tilattavat-kohteet (:id %)) paikkauskohteet)]
+    [modal/modal
+     {:nakyvissa? vahvista-tilaus-modal-auki?
+      :otsikko (if (= 1 (count valitut-kohteet))
+                 (str "Tilataanko kohde \"" (:nimi (first valitut-kohteet)) "\"?")
+                 (str "Tilataanko " (count valitut-kohteet) " kpl kohteita?"))
+      :footer [:div
+               [:div.pull-left
+                [napit/yleinen-ensisijainen (if (= 1 (count valitut-kohteet)) "Tilaa kohde" "Tilaa kohteet")
+                 #(e! (t-paikkauskohteet/->TilaaValitutPaikkauskohteet))
+                 {:paksu? true}]]
+               [:div.pull-right
+                [napit/yleinen-toissijainen "Kumoa" #(e! (t-paikkauskohteet/->TilaaModalToggle)) {:paksu? true}]]]}
+     [:div.tilaus-vahvistus-modal
+      [:p "Urakoitsija saa sähköpostiin ilmoituksen kohteen tilauksesta."]]]))
 
 (defn raportointi-modal!
-  "Näyttää modalin, jossa käyttäjä voi vahvistaa valittujen paikkauskohteiden raportointitavan.
-   Parametrit:
-   - valitut-kohteet: Vektori paikkauskohteita, jotka käyttäjä on valinnut tilaukseen"
+  "Näyttää modalin, jossa käyttäjä voi vahvistaa valittujen paikkauskohteiden raportointitavan."
   [e! app]
   (let [valitut-kohteet (:valitut-tilattavat-kohteet app)
+        kaikki-kohteet (:paikkauskohteet app)
+        valitut-kohteet (filter #(contains? valitut-kohteet (:id %)) kaikki-kohteet)
         tyomenetelmat (get-in app [:valinnat :tyomenetelmat])]
     [modal/modal
      {:nakyvissa? (:raportointimodal-aktiivinen? app)

--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohdelomake.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohdelomake.cljs
@@ -21,6 +21,7 @@
             [harja.tiedot.urakka.yllapitokohteet.paikkaukset.paikkaukset-toteumalomake :as t-toteumalomake]
             [harja.views.urakka.yllapitokohteet.paikkaukset.paikkaukset-toteumalomake :as v-toteumalomake]
             [harja.views.urakka.yllapitokohteet.paikkaukset.paikkaukset-pmrlomake :as v-pmrlomake]
+            [harja.views.urakka.yllapitokohteet.paikkaukset.paikkaukset-apurit :as apurit]
             [harja.ui.varmista-kayttajalta :as varmista-kayttajalta]
             [harja.domain.tierekisteri :as tr-domain]))
 
@@ -628,19 +629,6 @@
                 sijainti
                 suunnitelma)))))
 
-(defn- nayta-pot-valinta?
-  " Tilaajalle näytetään kolmen työmenetelmän kohdalla erillinen pot/toteuma radiobutton valinta.
-  Mikäli tilaaja valitsee pot vaihtoehdon, toteumia ei kirjata normaaliprossin mukaan, vaan pot-lomakkeelta
-  Kolme työmenetelmää ovat: AB-paikkaus levittäjällä, PAB-paikkaus levittäjällä, SMA-paikkaus levittäjällä"
-  [lomake tyomenetelmat]
-  (let [
-        nayta? (and (roolit/kayttaja-on-laajasti-ottaen-tilaaja?
-                      (roolit/urakkaroolit @istunto/kayttaja (-> @tila/tila :yleiset :urakka :id))
-                      @istunto/kayttaja)
-                    (= "ehdotettu" (:paikkauskohteen-tila lomake))
-                    (paikkaus/levittimella-tehty? lomake tyomenetelmat))]
-    nayta?))
-
 (defn- lomake-otsikko [lomake]
   [:<>
    [:div {:style {:padding-left "16px" :padding-top "32px"}}
@@ -1026,7 +1014,7 @@
                          ;; Tilaajalle näytetään kolmen työmenetelmän kohdalla erillinen pot/toteuma radiobutton valinta.
                          ;; Mikäli tilaaja valitsee pot vaihtoehdon, toteumia ei kirjata normaaliprossin mukaan, vaan pot-lomakkeelta
                         (when (and (not muokkaustila?)
-                                (nayta-pot-valinta? lomake tyomenetelmat))
+                                (apurit/nayta-pot-valinta? lomake tyomenetelmat))
                           [:div.row {:style {:background-color "#F0F0F0" :margin-bottom "24px" :padding-bottom "8px"}}
                            [:div.row
                             [:div.col-xs-12

--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohdelomake.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohdelomake.cljs
@@ -904,6 +904,7 @@
              "Peru tilaus"
              #(t-paikkauskohteet/tallenna-tilamuutos! (assoc (lomake/ilman-lomaketietoja lomake) :paikkauskohteen-tila "ehdotettu"))
              {:paksu? true
+              :ajax-luokka "poista-ajax-loader-valistykset"
               :ikoni (ikonit/check)
               :kun-onnistuu (fn [vastaus] (e! (t-paikkauskohteet/->PeruPaikkauskohteenTilausOnnistui vastaus)))
               :kun-virhe (fn [vastaus] (e! (t-paikkauskohteet/->PeruPaikkauskohteenTilausEpaonnistui vastaus)))}]

--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohdelomake.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohdelomake.cljs
@@ -871,6 +871,7 @@
                                                              (dissoc :toteumatyyppi)))
                                                          lomake)))
             {:paksu? true
+             :ajax-luokka "poista-ajax-loader-valistykset"
              :ikoni (ikonit/check)
              :kun-onnistuu (fn [vastaus] (e! (t-paikkauskohteet/->TilaaPaikkauskohdeOnnistui vastaus)))
              :kun-virhe (fn [vastaus] (e! (t-paikkauskohteet/->TilaaPaikkauskohdeEpaonnistui vastaus)))}]

--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
@@ -9,8 +9,10 @@
             [harja.fmt :as fmt]
             [harja.asiakas.kommunikaatio :as komm]
             [harja.transit :as transit]
+            [harja.ui.debug :as debug]
             [harja.ui.grid :as grid]
             [harja.ui.ikonit :as ikonit]
+            [harja.ui.kentat :as kentat]
             [harja.ui.valinnat :as valinnat]
             [harja.ui.napit :as napit]
             [harja.ui.komponentti :as komp]
@@ -27,7 +29,8 @@
             [harja.views.kartta.tasot :as kartta-tasot]
             [harja.views.urakka.yllapitokohteet.yhteyshenkilot :as yllapito-yhteyshenkilot]
             [harja.views.kartta :as kartta]
-            [harja.views.urakka.yllapitokohteet.paikkaukset.paikkaukset-paikkauskohdelomake :as paikkauskohdelomake]))
+            [harja.views.urakka.yllapitokohteet.paikkaukset.paikkaukset-paikkauskohdelomake :as paikkauskohdelomake]
+            [harja.views.urakka.yllapitokohteet.paikkaukset.paikkaukset-apurit :as paikkaukset-apurit]))
 
 (def paikkauskohteiden-tilat
   [{:nimi "Kaikki"} {:nimi "Ehdotettu"} {:nimi "Hylätty"} {:nimi "Tilattu"} {:nimi "Valmis"}])
@@ -55,157 +58,183 @@
       nakyvissa?
       toggle-fn]]))
 
-(defn- paikkauskohteet-taulukko [e! {:keys [haku-kaynnissa? nayta-vihje?] :as app}]
+(defn luo-taulukon-skeema [e! {:keys [tilaustila-aktiivinen? hae-aluekohtaiset-paikkauskohteet? valitut-tilattavat-kohteet
+                                      haku-kaynnissa?] :as app}]
   (let [urakkatyyppi (-> @tila/tila :yleiset :urakka :tyyppi)
         tyomenetelmat (get-in app [:valinnat :tyomenetelmat])
         nayta-hinnat? (and
                         (or (= urakkatyyppi :paallystys)
                           (and (or (= urakkatyyppi :hoito) (= urakkatyyppi :teiden-hoito))
+                            (not hae-aluekohtaiset-paikkauskohteet?)))
+                        (oikeudet/urakat-paikkaukset-paikkauskohteetkustannukset (-> @tila/tila :yleiset :urakka :id)))
+        kaikki-valittu? (= (count valitut-tilattavat-kohteet) (count (filter #(= "ehdotettu" (:paikkauskohteen-tila %)) (:paikkauskohteet app))))]
+    [(when tilaustila-aktiivinen?
+       {:otsikko-komp (fn []
+                        [kentat/raksiboksi {:disabled? false
+                                            :toiminto #(e! (t-paikkauskohteet/->ValitseKaikkiPaikkauskohteet (-> % .-target .-checked)))}
+                         kaikki-valittu?])
+        :leveys 0.6
+        :tyyppi :komponentti
+        :komponentti (fn [rivi]
+                       [kentat/raksiboksi {:disabled? (not= "ehdotettu" (:paikkauskohteen-tila rivi))
+                                           :toiminto #(e! (t-paikkauskohteet/->ValitsePaikkauskohde rivi (-> % .-target .-checked)))}
+                        (boolean (some #(= (:id %) (:id rivi)) valitut-tilattavat-kohteet))
+                        #_ (contains? (or valitut-tilattavat-kohteet #{}) (:id rivi))])})
+     (cond
+       ;; Tiemerkintäurakoitsijalle näytetään valmistusmipäivä, eikä muokkauspäivää
+       (= (-> @tila/tila :yleiset :urakka :tyyppi) :tiemerkinta)
+       {:otsikko "Valmistuminen"
+        :leveys 2.5
+        :nimi :loppupvm-arvio
+        :otsikkorivi-luokka "klikattava"}
+       ;; Tilaajalle näytetään ja päällysteurakalle näytetään muokkauspäivä. Mutta urakanvalvoja esiintyy myös
+       ;; päällystysurkoitsijana joten tarkistetaan myös urakkaroolit
+       ;; Aluekohtaisia paikkauskohteita hakiessa, eli hoitourakan urakanvalvojana, alueen muita kohteita katsellessa,
+       ;; ei näytetä muokkaustietoa.
+       (and (not (:hae-aluekohtaiset-paikkauskohteet? app))
+         (or (roolit/kayttaja-on-laajasti-ottaen-tilaaja?
+               (roolit/urakkaroolit @istunto/kayttaja (-> @tila/tila :yleiset :urakka :id))
+               @istunto/kayttaja)
+           (and (= (-> @tila/tila :yleiset :urakka :tyyppi) :paallystys)
+             (t-paikkauskohteet/kayttaja-on-urakoitsija? (roolit/urakkaroolit @istunto/kayttaja (-> @tila/tila :yleiset :urakka :id))))))
+       {:otsikko "Muokattu"
+        :leveys 1.7
+        :nimi :paivays
+        :fmt (fn [arvo]
+               [:span {:style {:color "#646464"}} (pvm/pvm-aika-opt arvo)])
+        :otsikkorivi-luokka "klikattava"}
+       ;; Defaulttina eli esim alueurakoitsijalle ei näytetä koko kenttää
+       :else nil)
+
+     {:otsikko "NRO"
+      :leveys 1.2
+      :nimi :ulkoinen-id
+      :otsikkorivi-luokka "klikattava"}
+     {:otsikko "Nimi"
+      :leveys 3.5
+      :nimi :nimi
+      :otsikkorivi-luokka "klikattava"}
+     {:otsikko "Tila"
+      :leveys 2
+      :nimi :paikkauskohteen-tila
+      :fmt (fn [arvo]
+             [yleiset/tila-indikaattori arvo {:fmt-fn paikkaus/fmt-tila}])
+      :solun-luokka (fn [arvo _]
+                      (str arvo "-bg"))
+      :otsikkorivi-luokka "klikattava"}
+
+     ;; Tiemerkinnän tilan indikointi
+     {:otsikko-komp (fn [_ _]
+                      [:div.tiemerkrinta-vihje.klikattava
+                       {:on-click #(e! (t-paikkauskohteet/->AvaaVihje))}
+                       "Tiemerkinnän tila " [yleiset/vihje ""]])
+      :leveys 3
+      :nimi :tiemerkinnan-tila
+      ;; Tiemerkinnällä tämä on alasveto, tasaa se vasemmalle
+      ;; Muilla urakoilla tämä on vaan teksti
+      :tasaa (if (not= urakkatyyppi :tiemerkinta) :vasen :oikea)
+      :solun-luokka (fn [arvo _rivi]
+                      ;; Korosta "käsittelemättä" sarake paikkaus urakoille
+                      (when (and
+                              (= arvo "kasittelematta")
+                              (not= urakkatyyppi :tiemerkinta))
+                        "ehdotettu-bg"))
+      :tyyppi :komponentti
+      :komponentti (fn [{:keys [tiemerkinnan-tila
+                                alasveto-valinnat paikkauskohteen-tila] :as rivi}]
+                     ;;
+                     ;; ==== Jos ei olla tiemerkintä urakassa, näytä vaan tila  ====
+                     (if (not= urakkatyyppi :tiemerkinta)
+                       [yleiset/tila-indikaattori tiemerkinnan-tila {:fmt-fn #(get t-paikkauskohteet/tiemerkinta-tila-valinnat (keyword %))}]
+
+                       ;;
+                       ;; ==== Tiemerkintä urakat voi asettaa tiemerkinnän tilan ====
+                       [:div {:on-click #(.stopPropagation %)} ;; Älä avaa lomaketta kun inffonappia painetaan
+                        [valinnat/checkbox-pudotusvalikko
+
+                         ;; Alasvedon valinnat, vectorissa, esim   [{:nimi Käsittelemättä, :arvo :kasittelematta, :valittu? false}]
+                         (remove #(= (:arvo %) :ei-tiemerkintaa) alasveto-valinnat)
+                         (fn [tila _valittu?]
+                           (e! (t-paikkauskohteet/->AsetaTiemerkinnanTila tila rivi))) ;; Muokkaa fn
+                         (get t-paikkauskohteet/tiemerkinta-tila-valinnat (keyword tiemerkinnan-tila)) ;; Alasvedon teksti
+                         ;; Komponentin optiot
+                         {:vayla-tyyli? true :disabled (or
+                                                         haku-kaynnissa?
+                                                         ;; Jos tiemerkintää ei tehdä, disabloidaan alasveto
+                                                         (= tiemerkinnan-tila "ei-tiemerkintaa")
+                                                         ;; Jos paikkauskohde ei ole valmis, ei voida asettaa tiemerkinnän tilaa vielä
+                                                         (not= paikkauskohteen-tila "valmis"))}]]))}
+
+     {:otsikko "Menetelmä"
+      :leveys 4
+      :nimi :tyomenetelma
+      :fmt #(paikkaus/tyomenetelma-id->nimi % tyomenetelmat)
+      :solun-luokka (fn [arvo _]
+                      ;; On olemassa niin pitkiä työmenetelmiä, että ne eivät mahdu soluun
+                      ;; Joten lisätään näille pitkille menetelmille class joka saa ne mahtumaan
+                      ;; soluun rivitettynä
+                      (when (> (count (paikkaus/tyomenetelma-id->nimi arvo tyomenetelmat)) 40)
+                        "grid-solulle-2-rivia"))
+      :otsikkorivi-luokka "klikattava"}
+     {:otsikko "Aikataulu"
+      :leveys 2.1
+      :nimi :formatoitu-aikataulu
+      :fmt (fn [arvo]
+             [:span {:class (if (str/includes? arvo "arv")
+                              "prosessi-kesken"
+                              "")} arvo])
+      :otsikkorivi-luokka "klikattava"}
+     {:otsikko "Sijainti"
+      :leveys 2.3
+      :nimi :formatoitu-sijainti
+      :otsikkorivi-luokka "klikattava"}
+     ;; Jos ei ole oikeuksia nähdä hintatietoja, niin ei näytetä niitä
+     ;; Alueurakoitsijat ja tiemerkkarit näkevät listassa muiden urakoiden tietoja
+     ;; Niimpä varmistetaan, että käyttäjällä on kustannusoikeudet paikkauskohteisiin
+     (when nayta-hinnat?
+       {:otsikko "Suunn. hinta"
+        :leveys 1.8
+        :nimi :suunniteltu-hinta
+        :fmt fmt/euro-opt
+        :tasaa :oikea
+        :otsikkorivi-luokka "klikattava"})
+     ;; Jos ei ole oikeuksia nähdä hintatietoja, niin ei näytetä niitä
+     (when nayta-hinnat?
+       {:otsikko "Tot. hinta"
+        :leveys 1.8
+        :nimi :toteutunut-hinta
+        :fmt fmt/euro-opt
+        :tasaa :oikea
+        :otsikkorivi-luokka "klikattava"})
+     ;; Jos ei ole oikeuksia nähdä hintatietoja, niin näytetään yhteystiedot
+     (when (not nayta-hinnat?)
+       {:otsikko "Yh\u00ADte\u00ADys\u00ADtie\u00ADdot"
+        :leveys 3
+        :nimi :yhteystiedot
+        :tasaa :keskita
+        :tyyppi :komponentti
+        :komponentti (fn [rivi]
+                       [:span
+                        [:span {:style {:padding-right "24px"}}
+                         (:urakoitsija rivi)]
+                        [napit/yleinen-toissijainen ""
+                         #(yllapito-yhteyshenkilot/nayta-paikkauskohteen-yhteyshenkilot-modal! (:urakka-id rivi))
+                         {:ikoni (ikonit/user)
+                          :luokka "btn-xs"}]])
+        :otsikkorivi-luokka "klikattava"})]))
+
+
+(defn- paikkauskohteet-taulukko [e! {:keys [haku-kaynnissa? nayta-vihje? tilaustila-aktiivinen? valitut-tilattavat-kohteet] :as app}]
+  (let [urakkatyyppi (-> @tila/tila :yleiset :urakka :tyyppi)
+        nayta-hinnat? (and
+                        (or (= urakkatyyppi :paallystys)
+                          (and (or (= urakkatyyppi :hoito) (= urakkatyyppi :teiden-hoito))
                             (not (:hae-aluekohtaiset-paikkauskohteet? app))))
                         (oikeudet/urakat-paikkaukset-paikkauskohteetkustannukset (-> @tila/tila :yleiset :urakka :id)))
-        skeema [(cond
-                  ;; Tiemerkintäurakoitsijalle näytetään valmistusmipäivä, eikä muokkauspäivää
-                  (= (-> @tila/tila :yleiset :urakka :tyyppi) :tiemerkinta)
-                  {:otsikko "Valmistuminen"
-                   :leveys 2.5
-                   :nimi :loppupvm-arvio
-                   :otsikkorivi-luokka "klikattava"}
-                  ;; Tilaajalle näytetään ja päällysteurakalle näytetään muokkauspäivä. Mutta urakanvalvoja esiintyy myös
-                  ;; päällystysurkoitsijana joten tarkistetaan myös urakkaroolit
-                  ;; Aluekohtaisia paikkauskohteita hakiessa, eli hoitourakan urakanvalvojana, alueen muita kohteita katsellessa,
-                  ;; ei näytetä muokkaustietoa.
-                  (and (not (:hae-aluekohtaiset-paikkauskohteet? app))
-                    (or (roolit/kayttaja-on-laajasti-ottaen-tilaaja?
-                          (roolit/urakkaroolit @istunto/kayttaja (-> @tila/tila :yleiset :urakka :id))
-                          @istunto/kayttaja)
-                      (and (= (-> @tila/tila :yleiset :urakka :tyyppi) :paallystys)
-                        (t-paikkauskohteet/kayttaja-on-urakoitsija? (roolit/urakkaroolit @istunto/kayttaja (-> @tila/tila :yleiset :urakka :id))))))
-                  {:otsikko "Muokattu"
-                   :leveys 1.7
-                   :nimi :paivays
-                   :fmt (fn [arvo]
-                          [:span {:style {:color "#646464"}} (pvm/pvm-aika-opt arvo)])
-                   :otsikkorivi-luokka "klikattava"}
-                  ;; Defaulttina eli esim alueurakoitsijalle ei näytetä koko kenttää
-                  :else nil)
 
-                {:otsikko "NRO"
-                 :leveys 1.5
-                 :nimi :ulkoinen-id
-                 :otsikkorivi-luokka "klikattava"}
-                {:otsikko "Nimi"
-                 :leveys 3.5
-                 :nimi :nimi
-                 :otsikkorivi-luokka "klikattava"}
-                {:otsikko "Tila"
-                 :leveys 2
-                 :nimi :paikkauskohteen-tila
-                 :fmt (fn [arvo]
-                        [yleiset/tila-indikaattori arvo {:fmt-fn paikkaus/fmt-tila}])
-                 :solun-luokka (fn [arvo _]
-                                 (str arvo "-bg"))
-                 :otsikkorivi-luokka "klikattava"}
-
-                ;; Tiemerkinnän tilan indikointi
-                {:otsikko-komp (fn [_ _]
-                                 [:div.tiemerkrinta-vihje.klikattava
-                                  {:on-click #(e! (t-paikkauskohteet/->AvaaVihje))}
-                                  "Tiemerkinnän tila " [yleiset/vihje ""]])
-                 :leveys 4
-                 :nimi :tiemerkinnan-tila
-                 ;; Tiemerkinnällä tämä on alasveto, tasaa se vasemmalle
-                 ;; Muilla urakoilla tämä on vaan teksti 
-                 :tasaa (if (not= urakkatyyppi :tiemerkinta) :vasen :oikea)
-                 :solun-luokka (fn [arvo _rivi]
-                                 ;; Korosta "käsittelemättä" sarake paikkaus urakoille
-                                 (when (and
-                                         (= arvo "kasittelematta")
-                                         (not= urakkatyyppi :tiemerkinta))
-                                   "ehdotettu-bg"))
-                 :tyyppi :komponentti
-                 :komponentti (fn [{:keys [tiemerkinnan-tila
-                                           alasveto-valinnat paikkauskohteen-tila] :as rivi}]
-                                ;;
-                                ;; ==== Jos ei olla tiemerkintä urakassa, näytä vaan tila  ====
-                                (if (not= urakkatyyppi :tiemerkinta)
-                                  [yleiset/tila-indikaattori tiemerkinnan-tila {:fmt-fn #(get t-paikkauskohteet/tiemerkinta-tila-valinnat (keyword %))}]
-
-                                  ;;
-                                  ;; ==== Tiemerkintä urakat voi asettaa tiemerkinnän tilan ====
-                                  [:div {:on-click #(.stopPropagation %)} ;; Älä avaa lomaketta kun inffonappia painetaan
-                                   [valinnat/checkbox-pudotusvalikko
-
-                                    ;; Alasvedon valinnat, vectorissa, esim   [{:nimi Käsittelemättä, :arvo :kasittelematta, :valittu? false}]
-                                    (remove #(= (:arvo %) :ei-tiemerkintaa) alasveto-valinnat)
-                                    (fn [tila _valittu?]
-                                      (e! (t-paikkauskohteet/->AsetaTiemerkinnanTila tila rivi))) ;; Muokkaa fn 
-                                    (get t-paikkauskohteet/tiemerkinta-tila-valinnat (keyword tiemerkinnan-tila)) ;; Alasvedon teksti
-                                    ;; Komponentin optiot
-                                    {:vayla-tyyli? true :disabled (or
-                                                                    haku-kaynnissa?
-                                                                    ;; Jos tiemerkintää ei tehdä, disabloidaan alasveto
-                                                                    (= tiemerkinnan-tila "ei-tiemerkintaa")
-                                                                    ;; Jos paikkauskohde ei ole valmis, ei voida asettaa tiemerkinnän tilaa vielä 
-                                                                    (not= paikkauskohteen-tila "valmis"))}]]))}
-
-                {:otsikko "Menetelmä"
-                 :leveys 4
-                 :nimi :tyomenetelma
-                 :fmt #(paikkaus/tyomenetelma-id->nimi % tyomenetelmat)
-                 :solun-luokka (fn [arvo _]
-                                 ;; On olemassa niin pitkiä työmenetelmiä, että ne eivät mahdu soluun
-                                 ;; Joten lisätään näille pitkille menetelmille class joka saa ne mahtumaan
-                                 ;; soluun rivitettynä
-                                 (when (> (count (paikkaus/tyomenetelma-id->nimi arvo tyomenetelmat)) 40)
-                                   "grid-solulle-2-rivia"))
-                 :otsikkorivi-luokka "klikattava"}
-                {:otsikko "Aikataulu"
-                 :leveys 2.3
-                 :nimi :formatoitu-aikataulu
-                 :fmt (fn [arvo]
-                        [:span {:class (if (str/includes? arvo "arv")
-                                         "prosessi-kesken"
-                                         "")} arvo])
-                 :otsikkorivi-luokka "klikattava"}
-                {:otsikko "Sijainti"
-                 :leveys 2.5
-                 :nimi :formatoitu-sijainti
-                 :otsikkorivi-luokka "klikattava"}
-                ;; Jos ei ole oikeuksia nähdä hintatietoja, niin ei näytetä niitä
-                ;; Alueurakoitsijat ja tiemerkkarit näkevät listassa muiden urakoiden tietoja
-                ;; Niimpä varmistetaan, että käyttäjällä on kustannusoikeudet paikkauskohteisiin
-                (when nayta-hinnat?
-                  {:otsikko "Suunn. hinta"
-                   :leveys 1.7
-                   :nimi :suunniteltu-hinta
-                   :fmt fmt/euro-opt
-                   :tasaa :oikea
-                   :otsikkorivi-luokka "klikattava"})
-                ;; Jos ei ole oikeuksia nähdä hintatietoja, niin ei näytetä niitä
-                (when nayta-hinnat?
-                  {:otsikko "Tot. hinta"
-                   :leveys 1.7
-                   :nimi :toteutunut-hinta
-                   :fmt fmt/euro-opt
-                   :tasaa :oikea
-                   :otsikkorivi-luokka "klikattava"})
-                ;; Jos ei ole oikeuksia nähdä hintatietoja, niin näytetään yhteystiedot
-                (when (not nayta-hinnat?)
-                  {:otsikko "Yh\u00ADte\u00ADys\u00ADtie\u00ADdot"
-                   :leveys 3
-                   :nimi :yhteystiedot
-                   :tasaa :keskita
-                   :tyyppi :komponentti
-                   :komponentti (fn [rivi]
-                                  [:span
-                                   [:span {:style {:padding-right "24px"}}
-                                    (:urakoitsija rivi)]
-                                   [napit/yleinen-toissijainen ""
-                                    #(yllapito-yhteyshenkilot/nayta-paikkauskohteen-yhteyshenkilot-modal! (:urakka-id rivi))
-                                    {:ikoni (ikonit/user)
-                                     :luokka "btn-xs"}]])
-                   :otsikkorivi-luokka "klikattava"})]
+        skeema (luo-taulukon-skeema e! app)
         paikkauskohteet (:paikkauskohteet app)
+        skeema-filteroitu (filter some? skeema)
         yht-suunniteltu-hinta (reduce (fn [summa kohde]
                                         (+ summa (:suunniteltu-hinta kohde)))
                                 0
@@ -226,42 +255,66 @@
               :tunniste :id
               :otsikko [:div
                         (when-not aluekohtaisissa?
-                          [:div.flex-row.tasaa-alas
-                           (when-not haku-kaynnissa?
-                             [:h2 {:style {:white-space "nowrap"}} (str kohteet-count (if (= kohteet-count 1) " paikkauskohde" " paikkauskohdetta"))])
-                           (when (and
-                                   (not= (-> @tila/tila :yleiset :urakka :tyyppi) :tiemerkinta) ;; Tiemerkintäurakoitsijalle ei näytetä nappeja
-                                   (oikeudet/urakat-paikkaukset-paikkauskohteetkustannukset (-> @tila/tila :yleiset :urakka :id)))
-                             [:div.flex-row {:style {:justify-content "flex-end"}}
-                              (when loytyi-kohteita?
-                                [:span.inline-block
-                                 [:form {:style {:margin-left "auto"}
-                                         :target "_blank" :method "POST"
-                                         :action (komm/excel-url :paikkauskohteet-urakalle-excel)}
-                                  [:input {:type "hidden" :name "parametrit"
-                                           :value (transit/clj->transit {:urakka-id (-> @tila/tila :yleiset :urakka :id)
-                                                                         :tila (:valittu-tila app)
-                                                                         :elyt (:valitut-elyt app)
-                                                                         :alkupvm (pvm/->pvm (str "1.1." (:valittu-vuosi app)))
-                                                                         :loppupvm (pvm/->pvm (str "31.12." (:valittu-vuosi app)))
-                                                                         :tyomenetelmat #{(:valittu-tyomenetelma app)}})}]
-                                  [:button {:type "submit"
-                                            :class #{"nappi-toissijainen"}}
-                                   [ikonit/ikoni-ja-teksti (ikonit/livicon-download) "Tallenna Excel"]]]])
+                          [:div
+                           [:div.flex-row.tasaa-alas
+                            (when-not haku-kaynnissa?
+                              [:h2 {:style {:white-space "nowrap"}} (str kohteet-count (if (= kohteet-count 1) " paikkauskohde" " paikkauskohdetta"))])
+                            (when (and
+                                    (not= (-> @tila/tila :yleiset :urakka :tyyppi) :tiemerkinta) ;; Tiemerkintäurakoitsijalle ei näytetä nappeja
+                                    (oikeudet/urakat-paikkaukset-paikkauskohteetkustannukset (-> @tila/tila :yleiset :urakka :id)))
+                              [:div.flex-row {:style {:justify-content "flex-end"}}
+                               (when loytyi-kohteita?
+                                 [:span.inline-block
+                                  [:form {:style {:margin-left "auto"}
+                                          :target "_blank" :method "POST"
+                                          :action (komm/excel-url :paikkauskohteet-urakalle-excel)}
+                                   [:input {:type "hidden" :name "parametrit"
+                                            :value (transit/clj->transit {:urakka-id (-> @tila/tila :yleiset :urakka :id)
+                                                                          :tila (:valittu-tila app)
+                                                                          :elyt (:valitut-elyt app)
+                                                                          :alkupvm (pvm/->pvm (str "1.1." (:valittu-vuosi app)))
+                                                                          :loppupvm (pvm/->pvm (str "31.12." (:valittu-vuosi app)))
+                                                                          :tyomenetelmat #{(:valittu-tyomenetelma app)}})}]
+                                   [:button {:type "submit"
+                                             :class #{"nappi-toissijainen"}}
+                                    [ikonit/ikoni-ja-teksti (ikonit/livicon-download) "Tallenna Excel"]]]])
 
-                              [liitteet/lataa-tiedosto
-                               {:urakka-id (-> @tila/tila :yleiset :urakka :id)}
-                               {:nappi-teksti "Tuo kohteet Excelistä"
-                                :url "lue-paikkauskohteet-excelista"
-                                :lataus-epaonnistui #(e! (t-paikkauskohteet/->TiedostoLadattu %))
-                                :tiedosto-ladattu #(e! (t-paikkauskohteet/->TiedostoLadattu %))}]
-                              [yleiset/tiedoston-lataus-linkki
-                               "Lataa Excel-pohja"
-                               "/excel/harja_paikkauskohteet_pohja.xlsx"
-                               {:luokat ["padding-top-8"]}]
-                              [napit/uusi "Lisää kohde" #(e! (t-paikkauskohteet/->AvaaLomake {:tyyppi :uusi-paikkauskohde}))
-                               {:paksu? true
-                                :data-attributes {:data-cy "lisaa-paikkauskohde"}}]])])
+                               [liitteet/lataa-tiedosto
+                                {:urakka-id (-> @tila/tila :yleiset :urakka :id)}
+                                {:nappi-teksti "Tuo kohteet Excelistä"
+                                 :url "lue-paikkauskohteet-excelista"
+                                 :lataus-epaonnistui #(e! (t-paikkauskohteet/->TiedostoLadattu %))
+                                 :tiedosto-ladattu #(e! (t-paikkauskohteet/->TiedostoLadattu %))}]
+                               [yleiset/tiedoston-lataus-linkki
+                                "Lataa Excel-pohja"
+                                "/excel/harja_paikkauskohteet_pohja.xlsx"
+                                {:luokat ["padding-top-8"]}]
+                               [napit/yleinen-toissijainen
+                                (if tilaustila-aktiivinen? "Peruuta tilaus" "Tilaa kohteita")
+                                #(e! (t-paikkauskohteet/->TilaustilaAktivoituToggle))
+                                {:paksu? true
+                                 :data-attributes {:data-cy "tilaa-paikkauskohteita"}}]
+                               [napit/uusi "Lisää kohde" #(e! (t-paikkauskohteet/->AvaaLomake {:tyyppi :uusi-paikkauskohde}))
+                                {:paksu? true
+                                 :data-attributes {:data-cy "lisaa-paikkauskohde"}}]])]
+                           ;; Vihje tilaustilan ollessa päällä
+                           (when tilaustila-aktiivinen?
+                             [:div.tilaa-kohteita-vihje {:id "tilaa-kohteita-vihje"}
+                              [:h3.otsikko "Tilaa kohteita"]
+                              [:div.flex-row.alkuun
+                               [:p.valitut-maara
+                                (str "Kohteita valittu yhteensä "
+                                     (count valitut-tilattavat-kohteet)
+                                     " kpl.")]]
+                              [:div.flex-row.alkuun.napit
+                               [napit/yleinen-ensisijainen "Tee tilaus"
+                                #(paikkaukset-apurit/nayta-tilaus-vahvistus-modal! e! (:valitut-tilattavat-kohteet app))
+                                {:paksu? true
+                                 :disabled (zero? (count valitut-tilattavat-kohteet))
+                                 :data-attributes {:data-cy "tee-tilaus"}}]
+                               [napit/peruuta "Peruuta"
+                                #(e! (t-paikkauskohteet/->TilaustilaAktivoituToggle))
+                                {:paksu? true}]]])])
                         ;; Gridin päällä oleva vihje tiemerkinnöille
                         [tiemerkinta-tila-vihje nayta-vihje? urakkatyyppi #(e! (t-paikkauskohteet/->AvaaVihje))]]
               :tyhja (if haku-kaynnissa?
@@ -314,7 +367,9 @@
         (when (> (count paikkauskohteet) 0)
           {:rivi-jalkeen-fn (fn [_rivit]
                               ^{:luokka "yhteenveto"}
-                              [{:teksti "Yht."}
+                              [(when tilaustila-aktiivinen?
+                                 {:teksti ""})
+                               {:teksti "Yht."}
                                {:teksti ""}
                                {:teksti (str (count paikkauskohteet) " kohdetta")}
                                (cond
@@ -341,7 +396,7 @@
                                  {:teksti [:div.tasaa-oikealle {:style {:margin-right "-12px"}} (fmt/euro-opt yht-suunniteltu-hinta)]})
                                (when nayta-hinnat?
                                  {:teksti [:div.tasaa-oikealle {:style {:margin-right "-12px"}} (fmt/euro-opt yht-tot-hinta)]})])}))
-      skeema
+      skeema-filteroitu
       paikkauskohteet]]))
 
 (defn- filtterit [e! {:keys [haku-kaynnissa?] :as app}]
@@ -441,7 +496,8 @@
          (e! (t-paikkauskohteet/->SuljeLomake))))
     (fn [e! app]
       [:div.row
-       [paikkauskohteet-sivu e! app]])))
+       [paikkauskohteet-sivu e! app]
+       [debug/debug app]])))
 
 (defn paikkauskohteet [e! app-state]
   (swap! tila/paikkauskohteet assoc :hae-aluekohtaiset-paikkauskohteet? false)

--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
@@ -308,7 +308,7 @@
                                      " kpl.")]]
                               [:div.flex-row.alkuun.napit
                                [napit/yleinen-ensisijainen "Tee tilaus"
-                                #(paikkaukset-apurit/nayta-tilaus-vahvistus-modal! e! (:valitut-tilattavat-kohteet app))
+                                #(paikkaukset-apurit/nayta-tilaus-vahvistus-modal! e! app)
                                 {:paksu? true
                                  :disabled (zero? (count valitut-tilattavat-kohteet))
                                  :data-attributes {:data-cy "tee-tilaus"}}]

--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
@@ -250,6 +250,8 @@
     ;; Riippuen vähän roolista, taulukossa on enemmän dataa tai vähemmän dataa.
     ;; Niinpä kavennetaan sitä hieman, jos siihen tulee vähemmän dataa, luettavuuden parantamiseksi
     [:div.col-xs-12.col-md-12.col-lg-12.paikkauskohde-nakyma
+     [paikkaukset-apurit/raportointi-modal! e! app]
+     [paikkaukset-apurit/tilaa-paikkauskohteet-modal! e! app]
      [grid/grid
       (merge {:sivuta 25
               :tunniste :id
@@ -290,9 +292,10 @@
                                 "/excel/harja_paikkauskohteet_pohja.xlsx"
                                 {:luokat ["padding-top-8"]}]
                                [napit/yleinen-toissijainen
-                                (if tilaustila-aktiivinen? "Peruuta tilaus" "Tilaa kohteita")
+                                "Tilaa kohteita"
                                 #(e! (t-paikkauskohteet/->TilaustilaAktivoituToggle))
                                 {:paksu? true
+                                 :disabled tilaustila-aktiivinen?
                                  :data-attributes {:data-cy "tilaa-paikkauskohteita"}}]
                                [napit/uusi "Lisää kohde" #(e! (t-paikkauskohteet/->AvaaLomake {:tyyppi :uusi-paikkauskohde}))
                                 {:paksu? true
@@ -304,11 +307,11 @@
                               [:div.flex-row.alkuun
                                [:p.valitut-maara
                                 (str "Kohteita valittu yhteensä "
-                                     (count valitut-tilattavat-kohteet)
-                                     " kpl.")]]
+                                  (count valitut-tilattavat-kohteet)
+                                  " kpl.")]]
                               [:div.flex-row.alkuun.napit
                                [napit/yleinen-ensisijainen "Tee tilaus"
-                                #(paikkaukset-apurit/nayta-tilaus-vahvistus-modal! e! app)
+                                #(e! (t-paikkauskohteet/->RaportointitapaModalToggle))
                                 {:paksu? true
                                  :disabled (zero? (count valitut-tilattavat-kohteet))
                                  :data-attributes {:data-cy "tee-tilaus"}}]

--- a/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet/paikkaukset/paikkaukset_paikkauskohteet.cljs
@@ -78,8 +78,7 @@
         :komponentti (fn [rivi]
                        [kentat/raksiboksi {:disabled? (not= "ehdotettu" (:paikkauskohteen-tila rivi))
                                            :toiminto #(e! (t-paikkauskohteet/->ValitsePaikkauskohde rivi (-> % .-target .-checked)))}
-                        (boolean (some #(= (:id %) (:id rivi)) valitut-tilattavat-kohteet))
-                        #_ (contains? (or valitut-tilattavat-kohteet #{}) (:id rivi))])})
+                        (boolean (some #(= % (:id rivi)) valitut-tilattavat-kohteet))])})
      (cond
        ;; Tiemerkintäurakoitsijalle näytetään valmistusmipäivä, eikä muokkauspäivää
        (= (-> @tila/tila :yleiset :urakka :tyyppi) :tiemerkinta)

--- a/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
+++ b/test/clj/harja/palvelin/palvelut/yllapitokohteet/paallystys_test.clj
@@ -1326,7 +1326,7 @@
     (poista-paallystysilmoitus-paallystyskohtella paallystyskohde-id)))
 
 ;; Jossain tilanteessa heitettiin virhe Liian herkästi muun kohteen päällekkäisyydestä vaikka ei ollut
-(deftest tallenna-pot2-jossa-on-alikohde-muulla-tiella-validointi-ottaa-tie-huomioon.
+(deftest tallenna-pot2-jossa-on-alikohde-muulla-tiella-validointi-ottaa-tie-huomioon
   (let [urakka-id (hae-urakan-id-nimella "Utajärven päällystysurakka")
         sopimus-id (hae-utajarven-paallystysurakan-paasopimuksen-id)
         paallystyskohde-id (hae-yllapitokohteen-id-nimella "Tärkeä kohde mt20")

--- a/test/clj/harja/palvelin/palvelut/yllapitokohteet/paikkauskohteet_test.clj
+++ b/test/clj/harja/palvelin/palvelut/yllapitokohteet/paikkauskohteet_test.clj
@@ -773,3 +773,34 @@
     ;; Tarkistetaan yhteenvetorivi
     (let [yhteenveto (first (drop 1 rivit))]
       (is (= "Yhteensä:" (nth yhteenveto 12)) "Yhteensä-teksti pitäisi olla oikeassa kohdassa"))))
+
+(deftest tilaa-monta-paikkauskohdetta-test
+  (let [urakka-id @kemin-alueurakan-2019-2023-id
+        kohde1 (merge {:urakka-id urakka-id}
+                (default-paikkauskohde (rand-int 999999)))
+        kohde1 (assoc kohde1 :paikkauskohteen-tila "tilattu")
+        kohde2 (merge {:urakka-id urakka-id}
+                 (default-paikkauskohde (rand-int 999999)))
+        kohde2 (assoc kohde2 :paikkauskohteen-tila "tilattu")
+        vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
+            :tilaa-valitut-paikkauskohteet
+            +kayttaja-jvh+
+            {:tilattavat-paikkauskohteet (vector kohde1 kohde2)})]
+
+     (is (= vastaus {:onnistuneet 2, :epaonnistuneet 0, :virheet []}))))
+
+(deftest tilaa-monta-paikkauskohdetta-test
+  (let [urakka-id @kemin-alueurakan-2019-2023-id
+        kohde1 (merge {:urakka-id urakka-id}
+                 (default-paikkauskohde 1))
+        kohde1 (assoc kohde1 :paikkauskohteen-tila "tilattu")
+        kohde2 (merge {:urakka-id urakka-id}
+                 (default-paikkauskohde 1))
+        kohde2 (assoc kohde2 :paikkauskohteen-tila "tilattu")
+        vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
+                  :tilaa-valitut-paikkauskohteet
+                  +kayttaja-jvh+
+                  {:tilattavat-paikkauskohteet (vector kohde1 kohde2)})]
+
+    (is (= vastaus {:onnistuneet 1, :epaonnistuneet 1, :virheet ["throw+: {:type \"Validaatiovirhe\", :virheet {:koodi \"ERROR\", :viesti #{\"Paikkauskohteen Nro: '1' on jo käytössä.\\n        Numeron täytyy olla yksilöllinen.\\n        Samalla numerolla löytyy kohde: 'testinimi' alkanut: 01.01.2020\"}}}"]}))))
+

--- a/test/clj/harja/palvelin/palvelut/yllapitokohteet/paikkauskohteet_test.clj
+++ b/test/clj/harja/palvelin/palvelut/yllapitokohteet/paikkauskohteet_test.clj
@@ -5,6 +5,12 @@
             [com.stuartsierra.component :as component]
             [clojure.data.json :as json]
             [cheshire.core :as cheshire]
+            [harja.jms-test :refer [feikki-jms]]
+            [harja.palvelin.komponentit.fim :as fim]
+            [harja.palvelin.komponentit.fim-test :refer [+testi-fim+]]
+            [harja.integraatio :as integraatio]
+            [harja.palvelin.integraatiot.integraatioloki :as integraatioloki]
+            [harja.palvelin.integraatiot.vayla-rest.sahkoposti :as sahkoposti-api]
             [harja.palvelin.palvelut.yllapitokohteet.paikkauskohteet :as paikkauskohteet]
             [harja.palvelin.palvelut.yllapitokohteet.paikkauskohteet-excel :as p-excel]
             [harja.kyselyt.tieverkko :as tieverkko-kyselyt]
@@ -15,7 +21,9 @@
             [dk.ative.docjure.spreadsheet :as xls]
             [clojure.java.io :as io]
             [harja.kyselyt.paikkaus :as paikkaus-q]
-            [harja.kyselyt.konversio :as konv]))
+            [harja.kyselyt.konversio :as konv])
+  (:use org.httpkit.fake)
+  (:import (java.util UUID)))
 
 (declare thrown?)
 
@@ -26,9 +34,20 @@
                       (component/system-map
                         :db (tietokanta/luo-tietokanta testitietokanta)
                         :http-palvelin (testi-http-palvelin)
+                        :fim (component/using
+                               (fim/->FIM {:url +testi-fim+})
+                               [:db :integraatioloki])
+                        :integraatioloki (component/using
+                                           (integraatioloki/->Integraatioloki nil)
+                                           [:db])
+                        :itmf (feikki-jms "itmf")
+                        :api-sahkoposti (component/using
+                                          (sahkoposti-api/->ApiSahkoposti {:api-sahkoposti integraatio/api-sahkoposti-asetukset
+                                                                           :tloik {:toimenpidekuittausjono "Harja.HarjaToT-LOIK.Ack"}})
+                                          [:http-palvelin :db :integraatioloki :itmf])
                         :paikkauskohteet (component/using
                                            (paikkauskohteet/->Paikkauskohteet)
-                                           [:http-palvelin :db])))))
+                                           [:http-palvelin :db :fim :api-sahkoposti])))))
 
   (testit)
   (alter-var-root #'jarjestelma component/stop))
@@ -782,14 +801,19 @@
         kohde2 (merge {:urakka-id urakka-id}
                  (default-paikkauskohde (rand-int 999999)))
         kohde2 (assoc kohde2 :paikkauskohteen-tila "tilattu")
-        vastaus (kutsu-palvelua (:http-palvelin jarjestelma)
-            :tilaa-valitut-paikkauskohteet
-            +kayttaja-jvh+
-            {:tilattavat-paikkauskohteet (vector kohde1 kohde2)})]
+
+        fim-vastaus [{:sahkoposti "testityyppi@example.com" :nimi "Testi Testinen"}]
+        vastaus (with-redefs [fim/hae-urakan-kayttajat-jotka-roolissa (fn [x y z]
+                                                                        (println "kutsuttiin fakettua fim-vastausta")
+                                                                        fim-vastaus)]
+                 (kutsu-palvelua (:http-palvelin jarjestelma)
+                   :tilaa-valitut-paikkauskohteet
+                   +kayttaja-jvh+
+                   {:tilattavat-paikkauskohteet (vector kohde1 kohde2)}))]
 
      (is (= vastaus {:onnistuneet 2, :epaonnistuneet 0, :virheet []}))))
 
-(deftest tilaa-monta-paikkauskohdetta-test
+(deftest tilaa-monta-paikkauskohdetta-samalla-numerolla-test
   (let [urakka-id @kemin-alueurakan-2019-2023-id
         kohde1 (merge {:urakka-id urakka-id}
                  (default-paikkauskohde 1))
@@ -803,4 +827,48 @@
                   {:tilattavat-paikkauskohteet (vector kohde1 kohde2)})]
 
     (is (= vastaus {:onnistuneet 1, :epaonnistuneet 1, :virheet ["throw+: {:type \"Validaatiovirhe\", :virheet {:koodi \"ERROR\", :viesti #{\"Paikkauskohteen Nro: '1' on jo käytössä.\\n        Numeron täytyy olla yksilöllinen.\\n        Samalla numerolla löytyy kohde: 'testinimi' alkanut: 01.01.2020\"}}}"]}))))
+
+(deftest tilaa-useampi-paikkauskohde-fim-integraatiolla
+  (let [urakka-id @kemin-alueurakan-2019-2023-id
+        ;; Luodaan kaksi eri paikkauskohetta eri numeroilla
+        kohde1 (merge {:urakka-id urakka-id}
+                 (default-paikkauskohde (rand-int 999999)))
+        kohde1 (assoc kohde1 :paikkauskohteen-tila "tilattu")
+        kohde2 (merge {:urakka-id urakka-id}
+                 (default-paikkauskohde (rand-int 999999)))
+        kohde2 (assoc kohde2 :paikkauskohteen-tila "tilattu")
+        ;; FIM XML-vastaus jossa on urakan vastuuhenkilö
+        fim-xml (str "<Members>"
+                  "<member>"
+                  "<AccountName>A000001</AccountName>"
+                  "<FirstName>Testi</FirstName>"
+                  "<LastName>Testinen</LastName>"
+                  "<DisplayName>Testinen Testi</DisplayName>"
+                  "<Email>testi.testinen@example.com</Email>"
+                  "<MobilePhone>0401234567</MobilePhone>"
+                  "<Company>ELY</Company>"
+                  "<Role>1337133-LAP1_vastuuhenkilo</Role>"
+                  "<Disabled>false</Disabled>"
+                  "</member>"
+                  "<member>"
+                  "<AccountName>A000002</AccountName>"
+                  "<FirstName>Toinen</FirstName>"
+                  "<LastName>Henkilö</LastName>"
+                  "<DisplayName>Henkilö Toinen</DisplayName>"
+                  "<Email>toinen.henkilo@example.com</Email>"
+                  "<MobilePhone>0409876543</MobilePhone>"
+                  "<Company>ELY</Company>"
+                  "<Role>1337133-LAP1_vastuuhenkilo</Role>"
+                  "<Disabled>false</Disabled>"
+                  "</member>"
+                  "</Members>")
+        vastaus (with-fake-http
+                  [+testi-fim+ fim-xml]
+                  (kutsu-palvelua (:http-palvelin jarjestelma)
+                    :tilaa-valitut-paikkauskohteet
+                    +kayttaja-jvh+
+                    {:tilattavat-paikkauskohteet (vector kohde1 kohde2)}))]
+
+    ;; Tarkistetaan että molemmat kohteet tilattiin onnistuneesti
+    (is (= vastaus {:onnistuneet 2, :epaonnistuneet 0, :virheet []}))))
 


### PR DESCRIPTION
Käyttöliittymästä voi muutamalla napinpainalluksella tilata useita paikkauskohteita.
Niistä ei lähetetä yksittäisiä sähköposteja vaan niistä koostetaan yksi sähköposti urakoitsijalle.

Tätä ei ole vielä näytetty kenellekään, joten ui:hin tulee muutoksia. Siksi DRAFT vielä.