### PR TITLE
HARJA-2111 Kevennä jjh muutoksen validointia

### DIFF
--- a/cypress/e2e/nakymien_avaus.cy.js
+++ b/cypress/e2e/nakymien_avaus.cy.js
@@ -106,7 +106,7 @@ describe('MH-Urakan näkymien avaamiset', function () {
         cy.get('[data-cy=tabs-taso2-Suolarajoitukset]').click()
         cy.contains('Urakan suolarajoitukset hoitovuosittain').should('exist')
         cy.get('[data-cy="tabs-taso2-Tehtava- ja maaraluettelo"]').click()
-        cy.contains('Tehtävät ja määrät').should('exist')
+        cy.contains('Tehtävä ja määräluettelo').should('exist')
         //cy.get('[data-cy=tabs-taso2-Kustannussuunnitelma]').click()
         //cy.contains('Suunnitelluista kustannuksista muodostetaan summa Sampon kustannussuunnitelmaa varten.', {timeout: clickTimeout}).should('exist')
     })

--- a/cypress/e2e/tehtavat_ja_maarat.cy.js
+++ b/cypress/e2e/tehtavat_ja_maarat.cy.js
@@ -47,7 +47,7 @@ describe('Tehtävä- ja määräluettelo -näkymän testaus', () => {
         cy.get('img[src="images/ajax-loader.gif"]', {timeout: ladataanHarjaaTimeout}).should('not.exist');
 
         // Varmista että näkymä on varmasti valmis ennen testejä
-        cy.get('h1', {timeout: ladataanHarjaaTimeout}).contains('Tehtävät ja määrät').should('be.visible');
+        cy.get('h1', {timeout: ladataanHarjaaTimeout}).contains('Tehtävä ja määräluettelo').should('be.visible');
         cy.get('table.grid', {timeout: ladataanHarjaaTimeout}).should('exist');
         cy.get('[data-cy="btn-muokkaa-sopimuksen-maaria"]', {timeout: ladataanHarjaaTimeout}).should('exist');
     })

--- a/src/cljs/harja/views/urakka/muutokset/lomake/lomake_johto_hallinto.cljs
+++ b/src/cljs/harja/views/urakka/muutokset/lomake/lomake_johto_hallinto.cljs
@@ -35,22 +35,10 @@
        (merge
          (yhteiset/+rivi-muutos-voimassa+ urakan-hoitokaudet valittu-hoitokausi)
          {:aseta (fn [rivi arvo]
-                   (let [jjh-muutokset (:johto-ja-hallintokorvaukset rivi)
-                         jjh-muutokset (reduce-kv (fn [acc k v]
-                                                    ;; Jos rivi ei osu voimassa alkaen pvm, nollaa tavoitehinnan muutos
-                                                    ;; Tämä poistaa myös kirjatun kulun, jos sellainen on kirjattu 
-                                                    (assoc acc k (if (and
-                                                                       (not= 0 (:tavoitehinnan-muutos v))
-                                                                       (pvm/ennen? (:pvm v) arvo))
-                                                                   (assoc v :tavoitehinnan-muutos 0)
-                                                                   v)))
-                                         {}
-                                         jjh-muutokset)]
-
-                     (-> rivi
-                       (assoc :voimassa_alkaen arvo)
-                       (assoc :mahdolliset-hoitovuodet-lomakkeella urakan-hoitokaudet)
-                       (assoc :johto-ja-hallintokorvaukset jjh-muutokset))))}))
+                   (-> rivi
+                     (assoc :voimassa_alkaen arvo)
+                     (assoc :mahdolliset-hoitovuodet-lomakkeella urakan-hoitokaudet)
+                     (assoc :johto-ja-hallintokorvaukset (:johto-ja-hallintokorvaukset rivi))))}))
 
      (first (yhteiset/liite-kentta e! app))
 
@@ -98,12 +86,7 @@
               :fmt fmt/euro-opt
               :tasaa :oikea
               :leveys 8
-              :muokattava? (fn [r]
-                             ;; Ei ole muokattava, jos ei osu voimassa alkaen sisään
-                             (let [voimassa (:voimassa_alkaen muokattava-muutos)
-                                   rivi-voimassa? (boolean (when voimassa
-                                                             (pvm/ennen? voimassa (:pvm r))))]
-                               rivi-voimassa?))}]
+              :muokattava? (constantly true)}]
             rivit-atom]
 
            [yleiset/info-laatikko :neutraali


### PR DESCRIPTION
Johto ja hallintokorvauksen kuluihin ei haluttu näin tiukkaa lomakevalidointia. 
Se siis revertattu. Kulut toimii muuten samalla lailla (testattu)