### PR TITLE
HARJA-2158 siivoa integraatiologilta henkilotietoja ja muita bugeja

### DIFF
--- a/src/clj/harja/palvelin/integraatiot/integraatioloki.clj
+++ b/src/clj/harja/palvelin/integraatiot/integraatioloki.clj
@@ -1,5 +1,6 @@
 (ns harja.palvelin.integraatiot.integraatioloki
-  (:require [taoensso.timbre :as log]
+  (:require [clojure.data.json :as json]
+            [taoensso.timbre :as log]
             [harja.palvelin.tyokalut.ajastettu-tehtava :as ajastettu-tehtava]
             [harja.kyselyt.integraatioloki :as integraatioloki]
             [clj-time.core :refer [weeks months ago]]
@@ -69,6 +70,39 @@
    :otsikko nil
    :parametrit nil})
 
+(defn siivoa-henkilotiedot-viestista
+  "Poistaa henkilötiedot (Name, email) MIAM-järjestelmän 'hae-kayttajan-roolit' -integraation JSON-vastauksesta.
+
+  Funktio parsii JSON-viestin ja käy läpi Table1-taulukon jokaisen rivin, poistaen Name- ja email-kentät
+  GDPR-vaatimusten mukaisesti ennen lokitusta tietokantaan.
+
+  Parametrit:
+  - viesti: JSON-merkkijono, joka sisältää MIAM-järjestelmän vastauksen
+  - jarjestelma: Integraation järjestelmätunnus (esim. 'miam')
+  - integraation-nimi: Integraation nimi (esim. 'hae-kayttajan-roolit')
+
+  Palauttaa:
+  - Siivotun JSON-merkkijonon, jossa Name ja email -kentät on poistettu, jos ehdot täyttyvät
+  - Alkuperäisen viestin muuttumattomana, jos järjestelmä ei ole 'miam' tai integraatio ei ole 'hae-kayttajan-roolit'
+
+  Esimerkki:
+  (siivoa-henkilotiedot-viestista
+    \"{\\\"Table1\\\": [{\\\"Name\\\":\\\"Testi Käyttäjä\\\",\\\"email\\\":\\\"testi@example.com\\\"}]}\"
+    \"miam\"
+    \"hae-kayttajan-roolit\")
+  => \"{\\\"Table1\\\":[{...}]}\" ; Name ja email poistettu"
+  [viesti jarjestelma integraation-nimi]
+  (if (and (= jarjestelma "miam") (= integraation-nimi "hae-kayttajan-roolit"))
+    (let [data (json/read-str viesti :key-fn keyword)
+          table1 (get data :Table1)
+          siivottu-json-data (if (and table1 (sequential? table1))
+                               (let [siivottu-table1 (mapv #(dissoc % :Name :email) table1)
+                                     siivottu-data (assoc data :Table1 siivottu-table1)]
+                                 (json/write-str siivottu-data))
+                               (json/write-str data))]
+      siivottu-json-data)
+    viesti))
+
 (defn kirjaa-viesti [db tapahtumaid {:keys [osoite suunta sisaltotyyppi siirtotyyppi
                                             sisalto otsikko parametrit]}]
   (let [kasitteleva-palvelin (fmt/leikkaa-merkkijono 512
@@ -79,7 +113,8 @@
 
 (defn luo-alkanut-integraatio [db jarjestelma nimi ulkoinen-id viesti]
   (try
-    (let [tapahtumaid (:id (integraatioloki/luo-integraatiotapahtuma<! db jarjestelma nimi ulkoinen-id))]
+    (let [tapahtumaid (:id (integraatioloki/luo-integraatiotapahtuma<! db jarjestelma nimi ulkoinen-id))
+          viesti (siivoa-henkilotiedot-viestista viesti jarjestelma nimi)]
       (when viesti
         (kirjaa-viesti db tapahtumaid viesti))
       tapahtumaid)

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/paatosnakyvyyskone.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/paatosnakyvyyskone.clj
@@ -252,6 +252,20 @@
             tavoitehinta-ennen (- oikaistu-tavoitehinta muutosten-summa)
             hoitokauden-lopun-indeksikorjaus (* tavoitehinta-ennen (/ indeksikorotuksen-prosenttiosuus 100))
             tavoitehinnan-muutos (apply + (map :summa tavoitehinnan-muutokset))
+            ;; Lisätään mahdolliset puuttuvat kuukaudet UI:n Pistelukujen keskiarvon laskenta listaukseen.
+            puuttuvat-kuukaudet (filter #(not (some (fn [kuukausi] (= (:kuukausi kuukausi) (:kuukausi %))) hoitokauden-indeksikuukaudet))
+                                  [{:kuukausi (str hoitokauden-alkuvuosi " Lokakuu") :indeksiluku 0}
+                                   {:kuukausi (str hoitokauden-alkuvuosi " Marraskuu") :indeksiluku 0}
+                                   {:kuukausi (str hoitokauden-alkuvuosi " Joulukuu") :indeksiluku 0}
+                                   {:kuukausi (str (+ hoitokauden-alkuvuosi 1) " Tammikuu") :indeksiluku 0}
+                                   {:kuukausi (str (+ hoitokauden-alkuvuosi 1) " Helmikuu") :indeksiluku 0}
+                                   {:kuukausi (str (+ hoitokauden-alkuvuosi 1) " Maaliskuu") :indeksiluku 0}
+                                   {:kuukausi (str (+ hoitokauden-alkuvuosi 1) " Huhtikuu") :indeksiluku 0}
+                                   {:kuukausi (str (+ hoitokauden-alkuvuosi 1) " Toukokuu") :indeksiluku 0}
+                                   {:kuukausi (str (+ hoitokauden-alkuvuosi 1) " Kesäkuu") :indeksiluku 0}
+                                   {:kuukausi (str (+ hoitokauden-alkuvuosi 1) " Heinäkuu") :indeksiluku 0}
+                                   {:kuukausi (str (+ hoitokauden-alkuvuosi 1) " Elokuu") :indeksiluku 0}
+                                   {:kuukausi (str (+ hoitokauden-alkuvuosi 1) " Syyskuu") :indeksiluku 0}])
             ;; Korvataan koneelta saatu päätös tässä valistellulta
             indeksipaatos (first (filter #(when (= (:nimi %) "Hoitovuoden lopun indeksikorjaus") %) paatokset))
             indeksipaatos (-> indeksipaatos
@@ -259,6 +273,7 @@
                             (assoc :tavoitehinnan_muutokset tavoitehinnan-muutos)
                             (assoc :tavoitehinta_ennen tavoitehinta-ennen)
                             (assoc :hoitokauden_kuukaudet hoitokauden-indeksikuukaudet)
+                            (assoc :puuttuvat_kuukaudet puuttuvat-kuukaudet)
                             (assoc :kuukausien_keskiarvo piste-keskiarvo)
                             (assoc :alkuperainen_pisteluku alkuperainen-pisteluku)
                             (assoc :alkuperaisen_pisteluvun_kuukausi alkuperaisen-pisteluvun-kuukausi)

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/paatosnakyvyyskone.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/paatosnakyvyyskone.clj
@@ -411,6 +411,7 @@
   ;; Kustannussuunnitelma vahvistettu
   ;; Tavoitehinnan muutokset tallennettu,
   ;; Hoitovuoden lopun tavoitehintapäätös tallennettu
+  ;; Ja vielä lisäksi: Tavoitehinnan ylityspäätös tallennettu
   (if-not (and hoitovuoden-lopun-kattohinta kustannukset (> kustannukset hoitovuoden-lopun-kattohinta))
     (lisaa-paatos-virheellisena paatokset "Kattohinnan ylitys" "Poistetaan vain koko päätös." false 7)
 
@@ -430,6 +431,12 @@
       (and validoinnit-kaytossa? (>= urakan-alkuvuosi 2021) (<= 2024 kuluva-hoitovuosi)
         (not (paatos-tallennettu-tietokantaan? tietokanta-paatokset "Hoitovuoden lopun tavoite- ja kattohinta")))
       (lisaa-paatos-virheellisena paatokset "Kattohinnan ylitys" "Hoitovuoden lopun tavoite- ja kattohinta -päätös on vielä tekemättä." true 7)
+
+      ;; Vaaditaan Tavoitehinnan ylitys päätös, pitää olla tallennettuna
+      ;; Ja, jos urakka on alkanut 2021 tai myöhemmin
+      (and validoinnit-kaytossa? (>= urakan-alkuvuosi 2021)
+        (not (paatos-tallennettu-tietokantaan? tietokanta-paatokset "Tavoitehinnan ylitys")))
+      (lisaa-paatos-virheellisena paatokset "Kattohinnan ylitys" "Tavoitehinnan ylitys -päätös on vielä tekemättä." true 7)
 
       (and hoitovuoden-lopun-kattohinta kustannukset (> kustannukset hoitovuoden-lopun-kattohinta))
       (let [urakan-parametrit (first (urakka-kyselyt/hae-urakan-parametrit db {:urakkaid urakkaid}))

--- a/src/cljs/harja/tiedot/urakka/suunnittelu/tehtavat_maarat_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/suunnittelu/tehtavat_maarat_tiedot.cljs
@@ -54,16 +54,17 @@
 
 (defn validoi-ja-filtteroi-tehtavat
   "Validoi hakuehdon ja filtteröi tehtävät. Näytä virheviesti, jos hakuehto on liian lyhyt (alle 2 merkkiä)."
-  [hakuehto app]
+  [hakuehto kaikki-tehtavat app]
   ;; Kun hakuehto on alle 2 merkkiä, näytetään kaikki tehtävät
   (if (>= (count hakuehto) 2)
-    (let [tehtavat (:tehtavat-ja-maarat app)
-          f-tehtavat (filtteroi-tehtavat hakuehto tehtavat)]
+    (let [f-tehtavat (filtteroi-tehtavat hakuehto kaikki-tehtavat)]
       (-> app
         (assoc :haku hakuehto)
-        (assoc :tehtavat-ja-maarat f-tehtavat)))
+        (assoc :tehtavat-ja-maarat f-tehtavat)
+        (assoc :kaikki-tehtavat kaikki-tehtavat)))
     (-> app
-      (assoc :tehtavat-ja-maarat (:kaikki-tehtavat app))
+      (assoc :tehtavat-ja-maarat kaikki-tehtavat)
+      (assoc :kaikki-tehtavat kaikki-tehtavat)
       (assoc :haku hakuehto))))
 
 (def ^:private puuttuva-tarjousmaara-viesti
@@ -101,12 +102,10 @@
 
   HaeTehtavatJaMaaratOnnistui
   (process-event [{vastaus :vastaus} app]
-    (let [app (validoi-ja-filtteroi-tehtavat (:haku app) app)]
+    (let [app (validoi-ja-filtteroi-tehtavat (:haku app) (:tehtavat vastaus) app)]
       (-> app
         (assoc :haku-kaynnissa? false)
         (assoc :haku (:haku app))
-        (assoc :tehtavat-ja-maarat (:tehtavat-ja-maarat app))
-        (assoc :kaikki-tehtavat (:tehtavat vastaus))
         (assoc :viimeisin-muokkaus (:viimeisin-muokkaus vastaus))
         (assoc :viimeisin-muokkaaja (:viimeisin-muokkaaja vastaus)))))
 
@@ -184,7 +183,7 @@
 
   FiltteroiTehtavat
   (process-event [{hakuehto :hakuehto} app]
-    (validoi-ja-filtteroi-tehtavat hakuehto app))
+    (validoi-ja-filtteroi-tehtavat hakuehto (:kaikki-tehtavat app) app))
 
   PeruutaTallennus
   (process-event [_ app]

--- a/src/cljs/harja/tiedot/urakka/suunnittelu/tehtavat_maarat_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/suunnittelu/tehtavat_maarat_tiedot.cljs
@@ -52,6 +52,20 @@
       tehtavat)
     tehtavat))
 
+(defn validoi-ja-filtteroi-tehtavat
+  "Validoi hakuehdon ja filtteröi tehtävät. Näytä virheviesti, jos hakuehto on liian lyhyt (alle 2 merkkiä)."
+  [hakuehto app]
+  ;; Kun hakuehto on alle 2 merkkiä, näytetään kaikki tehtävät
+  (if (>= (count hakuehto) 2)
+    (let [tehtavat (:tehtavat-ja-maarat app)
+          f-tehtavat (filtteroi-tehtavat hakuehto tehtavat)]
+      (-> app
+        (assoc :haku hakuehto)
+        (assoc :tehtavat-ja-maarat f-tehtavat)))
+    (-> app
+      (assoc :tehtavat-ja-maarat (:kaikki-tehtavat app))
+      (assoc :haku hakuehto))))
+
 (def ^:private puuttuva-tarjousmaara-viesti
   "Syötä määrä tai aseta 0. Tyhjää arvoa ei voi tallentaa.")
 
@@ -82,18 +96,19 @@
 
   HaeTehtavatJaMaarat
   (process-event [{parametrit :parametrit} app]
-    (js/console.log "HaeTehtavatJaMaarat :: parametrit " (pr-str parametrit))
     (hae-tehtavat-ja-maarat parametrit)
     (assoc app :haku-kaynnissa? true))
 
   HaeTehtavatJaMaaratOnnistui
   (process-event [{vastaus :vastaus} app]
-    (-> app
-      (assoc :haku-kaynnissa? false)
-      (assoc :tehtavat-ja-maarat (:tehtavat vastaus))
-      (assoc :kaikki-tehtavat (:tehtavat vastaus))
-      (assoc :viimeisin-muokkaus (:viimeisin-muokkaus vastaus))
-      (assoc :viimeisin-muokkaaja (:viimeisin-muokkaaja vastaus))))
+    (let [app (validoi-ja-filtteroi-tehtavat (:haku app) app)]
+      (-> app
+        (assoc :haku-kaynnissa? false)
+        (assoc :haku (:haku app))
+        (assoc :tehtavat-ja-maarat (:tehtavat-ja-maarat app))
+        (assoc :kaikki-tehtavat (:tehtavat vastaus))
+        (assoc :viimeisin-muokkaus (:viimeisin-muokkaus vastaus))
+        (assoc :viimeisin-muokkaaja (:viimeisin-muokkaaja vastaus)))))
 
   HaeTehtavatJaMaaratEpaonnistui
   (process-event [{vastaus :vastaus} app]
@@ -169,16 +184,7 @@
 
   FiltteroiTehtavat
   (process-event [{hakuehto :hakuehto} app]
-    ;; Kun hakuehto on alle 2 merkkiä, näytetään kaikki tehtävät
-    (if (>= (count hakuehto) 2)
-      (let [tehtavat (:tehtavat-ja-maarat app)
-            f-tehtavat (filtteroi-tehtavat hakuehto tehtavat)]
-        (-> app
-          (assoc :haku hakuehto)
-          (assoc :tehtavat-ja-maarat f-tehtavat)))
-      (-> app
-        (assoc :tehtavat-ja-maarat (:kaikki-tehtavat app))
-        (assoc :haku hakuehto))))
+    (validoi-ja-filtteroi-tehtavat hakuehto app))
 
   PeruutaTallennus
   (process-event [_ app]

--- a/src/cljs/harja/views/urakka/valikatselmus/indeksikorjaus.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/indeksikorjaus.cljs
@@ -12,8 +12,7 @@
 
 (defn- laskenta-modaali [paatos]
   (let [keskiarvo (js/parseFloat (str/replace (fmt/desimaaliluku-opt (:kuukausien_keskiarvo paatos) 1) "," "."))
-        alkuperainen (js/parseFloat (str/replace (fmt/desimaaliluku-opt (:alkuperainen_pisteluku paatos) 1) "," "."))
-        pistelukujen-muutos (fmt/desimaaliluku-opt (* 100 (/ (- keskiarvo alkuperainen) keskiarvo)) 1)]
+        alkuperainen (js/parseFloat (str/replace (fmt/desimaaliluku-opt (:alkuperainen_pisteluku paatos) 1) "," "."))]
     [:div
      [:div.flex-row
       [:p.laskenta-rivi "Hoitovuoden päätyttyä lasketaan hoitovuotta edeltävän syyskuun ja hoitovuoden elokuun välisten
@@ -32,6 +31,13 @@
        [:div.flex-row.kuukausi-rivi
         [:div (str/join " " (reverse (str/split (:kuukausi kuukausi) #"\s+")))]
         [:div (fmt/desimaaliluku-opt (:indeksiluku kuukausi) 1)]])
+
+     ;; Jos kaikkia indeksikuukausia ei ole vielä hallintaan lisätty, niin näytetään nolla arvoilla puuttuvat kuukaudet
+     (when (> (count (:puuttuvat_kuukaudet paatos)) 0)
+       (for* [kuukausi (:puuttuvat_kuukaudet paatos)]
+         [:div.flex-row.kuukausi-rivi
+          [:div (str/join " " (reverse (str/split (:kuukausi kuukausi) #"\s+")))]
+          [:div (fmt/desimaaliluku-opt (:indeksiluku kuukausi) 1)]]))
 
      (when (not= 12 (count (:hoitokauden_kuukaudet paatos)))
        [yleiset/info-laatikko :vahva-ilmoitus

--- a/test/clj/harja/palvelin/komponentit/todennus_test.clj
+++ b/test/clj/harja/palvelin/komponentit/todennus_test.clj
@@ -103,6 +103,19 @@
 (def semi-virheellinen-miam-vastaus "{\"Table1\": [{\"CompanyID\":\"2163026-3\",\"Company\":\"Destia Oy\",\"UserName\":\"LXXX\",\"Name\":\"Firma Oy\",\"Role\": \"\",\"StartDate\": \"9.4.2024 13:01:03\", \"EndDate\": \"31.3.2029 0:00:00\", \"Agreementname\": \"_Organisaatio peruste Destia Oy\",\"Appname\": \"HARJA\", \"email\": \"s.fi\" }
                          ,{\"CompanyID\":\"2163026-3\",\"Company\":\"Destia Oy\",\"UserName\":\"LXYY\",\"Name\":\"Destia Oy\", \"StartDate\": \"2016-10-14 09:57:23\", \"EndDate\": \"2027-12-30 17:00:00\", \"Agreementname\": \"E18 (Vt7) Koskenkylä-Kotka, kunnossapito, P\", \"Appname\": \"HARJA\", \"email\": \"...fi\" }]}")
 
+(deftest siivoa-roolit-rajapintavastauksesta-test
+  (let [data (json/read-str default-miam-vastaus :key-fn keyword)
+        table1 (get data :Table1)
+        siivottu-json-data (if (and table1 (sequential? table1))
+                             (let [siivottu-table1 (mapv #(dissoc % :Name :email) table1)
+                                   siivottu-data (assoc data :Table1 siivottu-table1)]
+                               (json/write-str siivottu-data))
+                             (json/write-str data))]
+    ;; Sisältää emailin
+    (is (re-find #"email" default-miam-vastaus))
+    ;; Ei sisällä emailia
+    (is (not (re-find #"email" siivottu-json-data)))))
+
 (deftest kayttajaroolit-rajapinnasta-test
   (is (= {:organisaatioroolit {26 #{"Paakayttaja"}}
           :roolit #{}


### PR DESCRIPTION
Tässä pr:ssä on korjattu useita bugeja. Kannattaa katselmoida committi kohtaisesti, niin näkee helposti, että mitkä muutokset liittyvät mihinkin bugiin.

1. Ensin tehtiin testi, jolla varmistettiin, että henkilötiedot poistuvat miam rajapinnasta saapuvasta jsonista.
2. Sitten tehtiin itse koodi, jolla jsonista poistetaan henkilötiedot ennen integraatiologille tallennusta (kantaan)
3. Tehtävät ja määrät sivun hakukenttä nollautu, kun hoitovuotta vaihdettiin. Nyt ei nollaudu enää ja filtteröity tehtävä jää näkyviin, vaikka hoitovuosi vaihtuu
4. Kattohintapäätös pystyttiin tekemään välikatselmuksessa, vaikka tavoitehintapäätöstä ei oltu vielä tehty.
5. Indeksikorjauspäätöksessä näytetiin esim vain 3 indeksikuukautta, jos sen verran niitä oltiin hallinnasta syötetty. nyt näytetään koko hoitovuoden kaikki kuukaudet, mutta indeksiarvot nollina, jos niitä ei ole vielä styötetty.

Eli kaiken kaikkiaan korjattiin 4 erillistä bugia.