### PR TITLE
HARJA-2158 esta npe integraatiologituksessa

### DIFF
--- a/src/clj/harja/palvelin/integraatiot/integraatioloki.clj
+++ b/src/clj/harja/palvelin/integraatiot/integraatioloki.clj
@@ -92,15 +92,24 @@
     \"hae-kayttajan-roolit\")
   => \"{\\\"Table1\\\":[{...}]}\" ; Name ja email poistettu"
   [viesti jarjestelma integraation-nimi]
-  (if (and (= jarjestelma "miam") (= integraation-nimi "hae-kayttajan-roolit"))
-    (let [data (json/read-str viesti :key-fn keyword)
-          table1 (get data :Table1)
-          siivottu-json-data (if (and table1 (sequential? table1))
-                               (let [siivottu-table1 (mapv #(dissoc % :Name :email) table1)
-                                     siivottu-data (assoc data :Table1 siivottu-table1)]
-                                 (json/write-str siivottu-data))
-                               (json/write-str data))]
-      siivottu-json-data)
+  (if (and
+        (not (nil? viesti))
+        (not (nil? jarjestelma))
+        (not (nil? integraation-nimi))
+        (= jarjestelma "miam")
+        (= integraation-nimi "hae-kayttajan-roolit"))
+    (try
+     (let [data (json/read-str viesti :key-fn keyword)
+           table1 (get data :Table1)
+           siivottu-json-data (if (and table1 (sequential? table1))
+                                (let [siivottu-table1 (mapv #(dissoc % :Name :email) table1)
+                                      siivottu-data (assoc data :Table1 siivottu-table1)]
+                                  (json/write-str siivottu-data))
+                                (json/write-str data))]
+       siivottu-json-data)
+      (catch Exception e
+        (log/error e "Virhe siivottaessa henkilötietoja MIAM-vastauksesta, palautetaan alkuperäinen viesti")
+        viesti))
     viesti))
 
 (defn kirjaa-viesti [db tapahtumaid {:keys [osoite suunta sisaltotyyppi siirtotyyppi
@@ -114,8 +123,7 @@
 (defn luo-alkanut-integraatio [db jarjestelma nimi ulkoinen-id viesti]
   (try
     (let [tapahtumaid (:id (integraatioloki/luo-integraatiotapahtuma<! db jarjestelma nimi ulkoinen-id))
-          ;viesti (siivoa-henkilotiedot-viestista viesti jarjestelma nimi)
-          ]
+          viesti (siivoa-henkilotiedot-viestista viesti jarjestelma nimi)]
       (when viesti
         (kirjaa-viesti db tapahtumaid viesti))
       tapahtumaid)

--- a/test/clj/harja/palvelin/integraatiot/integraatioloki_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/integraatioloki_test.clj
@@ -1,9 +1,10 @@
 (ns harja.palvelin.integraatiot.integraatioloki-test
-  (:require [clojure.test :refer [deftest is use-fixtures]]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.data.json :as json]
             [com.stuartsierra.component :as component]
             [harja.testi :refer :all]
             [harja.palvelin.komponentit.tietokanta :as tietokanta]
-            [harja.palvelin.integraatiot.integraatioloki :refer [->Integraatioloki] :as integraatioloki]))
+            [harja.palvelin.integraatiot.integraatioloki :refer [->Integraatioloki siivoa-henkilotiedot-viestista] :as integraatioloki]))
 
 (def +testiviesti+ {:suunta "ulos" :sisaltotyyppi "application/xml" :siirtotyyppi "jms" :sisalto "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" :otsikko nil :parametrit nil})
 
@@ -41,3 +42,77 @@
   (let [tapahtuma-id (integraatioloki/kirjaa-alkanut-integraatio (:integraatioloki jarjestelma) "sampo-api" "sisaanluku" nil +testiviesti+)]
     (is (= 1 (count (q "SELECT id FROM integraatioviesti WHERE integraatiotapahtuma = " tapahtuma-id ";"))))
     (poista-testitapahtuma tapahtuma-id)))
+;; =============================================================================
+;; siivoa-henkilotiedot-viestista -funktion testit
+;; =============================================================================
+
+(def +miam-jarjestelma+ "miam")
+(def +miam-integraatio+ "hae-kayttajan-roolit")
+
+(def +miam-vastaus-yksi-kayttaja+
+  "{\"Table1\": [{\"CompanyID\": \"1234567-8\", \"Company\": \"Testi Oy\", \"UserName\": \"testi123\", \"Name\": \"Testi Käyttäjä\", \"Role\": \"1234567-8_Paakayttaja\", \"StartDate\": \"9.4.2024 13:01:03\", \"EndDate\": \"31.3.2029 0:00:00\", \"Agreementname\": \"_Organisaatio peruste Testi Oy\", \"Appname\": \"HARJA\", \"email\": \"testi@example.com\"}]}")
+
+(def +miam-vastaus-useita-kayttajia+
+  "{\"Table1\": [{\"CompanyID\": \"1234567-8\", \"Name\": \"Käyttäjä 1\", \"email\": \"kayttaja1@example.com\", \"Role\": \"Rooli1\"}, {\"CompanyID\": \"9876543-2\", \"Name\": \"Käyttäjä 2\", \"email\": \"kayttaja2@example.com\", \"Role\": \"Rooli2\"}]}")
+
+(deftest siivoa-henkilotiedot-viestista-poistaa-name-ja-email-kentat
+  (testing "Poistaa Name ja email kentät MIAM-vastauksesta"
+    (let [siivottu (siivoa-henkilotiedot-viestista +miam-vastaus-yksi-kayttaja+ +miam-jarjestelma+ +miam-integraatio+)
+          parsed (json/read-str siivottu :key-fn keyword)
+          table1 (first (:Table1 parsed))]
+      (is (some? siivottu) "Siivottu viesti ei saa olla nil")
+      (is (nil? (:Name table1)) "Name-kenttä on poistettu")
+      (is (nil? (:email table1)) "email-kenttä on poistettu")
+      (is (= "1234567-8" (:CompanyID table1)) "Muut kentät säilyvät")
+      (is (= "Testi Oy" (:Company table1)) "Company-kenttä säilyy")
+      (is (= "testi123" (:UserName table1)) "UserName-kenttä säilyy")
+      (is (= "1234567-8_Paakayttaja" (:Role table1)) "Role-kenttä säilyy")))
+
+  (testing "Poistaa Name ja email kentät kaikilta käyttäjiltä"
+    (let [siivottu (siivoa-henkilotiedot-viestista +miam-vastaus-useita-kayttajia+ +miam-jarjestelma+ +miam-integraatio+)
+          parsed (json/read-str siivottu :key-fn keyword)
+          table1 (:Table1 parsed)]
+      (is (= 2 (count table1)) "Molemmat käyttäjät säilyvät")
+      (doseq [kayttaja table1]
+        (is (nil? (:Name kayttaja)) "Name-kenttä on poistettu")
+        (is (nil? (:email kayttaja)) "email-kenttä on poistettu")))))
+
+(deftest siivoa-henkilotiedot-viestista-ei-muokkaa-muita-jarjestelmia-tai-integraatioita
+  (testing "Muiden järjestelmien ja integraatioiden viestejä ei muokata"
+    (let [viesti +miam-vastaus-yksi-kayttaja+]
+      ;; Eri järjestelmät
+      (doseq [jarjestelma ["sampo-api" "turi" "labyrintti" "tloik" nil ""]]
+        (is (= viesti (siivoa-henkilotiedot-viestista viesti jarjestelma +miam-integraatio+))
+          (str "Järjestelmän '" jarjestelma "' viesti palautetaan muuttumattomana")))
+      ;; Eri integraatiot
+      (doseq [integraatio ["jokin-muu" "hae-sopimukset" nil ""]]
+        (is (= viesti (siivoa-henkilotiedot-viestista viesti +miam-jarjestelma+ integraatio))
+          (str "Integraation '" integraatio "' viesti palautetaan muuttumattomana"))))))
+
+(deftest siivoa-henkilotiedot-viestista-virhetilanteet
+  (testing "Nil-parametrit eivät aiheuta NullPointerExceptionia"
+    (is (nil? (siivoa-henkilotiedot-viestista nil +miam-jarjestelma+ +miam-integraatio+))
+      "Nil-viesti palautetaan nil:nä")
+    (is (nil? (siivoa-henkilotiedot-viestista nil nil nil))
+      "Kaikki parametrit nil palauttaa nil"))
+
+  (testing "Invalidi tai tyhjä JSON palauttaa alkuperäisen viestin"
+    (is (= "" (siivoa-henkilotiedot-viestista "" +miam-jarjestelma+ +miam-integraatio+))
+      "Tyhjä string palautetaan sellaisenaan")
+    (let [invalidi "tämä ei ole json"]
+      (is (= invalidi (siivoa-henkilotiedot-viestista invalidi +miam-jarjestelma+ +miam-integraatio+))
+        "Invalidi JSON palautetaan sellaisenaan")))
+
+  (testing "Erikoistapaukset Table1-kentässä käsitellään oikein"
+    ;; JSON ilman Table1
+    (let [json-ilman "{\"other\": \"data\"}"
+          tulos (siivoa-henkilotiedot-viestista json-ilman +miam-jarjestelma+ +miam-integraatio+)]
+      (is (= "data" (:other (json/read-str tulos :key-fn keyword)))))
+    ;; Tyhjä Table1
+    (let [tyhja "{\"Table1\": []}"
+          tulos (siivoa-henkilotiedot-viestista tyhja +miam-jarjestelma+ +miam-integraatio+)]
+      (is (= [] (:Table1 (json/read-str tulos :key-fn keyword)))))
+    ;; Table1 ei ole lista (null tai objekti)
+    (doseq [erikois ["{\"Table1\": null}" "{\"Table1\": {\"Name\": \"test\"}}"]]
+      (let [tulos (siivoa-henkilotiedot-viestista erikois +miam-jarjestelma+ +miam-integraatio+)]
+        (is (string? tulos) "Tulos on merkkijono")))))


### PR DESCRIPTION
Henkilötietojen siivous aiheutti npe ongelman tuotannossa ja testiserverillä.
Se ensin otettiin pois ja vietiin testiympäristöön, jossa voitiin varmistua, että näin tosiaan on.

Tässä se laitetaan takaisin, mutta varmistetaan, että mikään npe ongelma ei aiheuta ognelmia jatkoketjussa. Eli jos viesti, järjestelmä tai jokin siihen liittyvä falskaa, niin integraatiologitus toimii, kuten pitääkin.