### PR TITLE
HARJA-2247 Poista urakkamäärärajoitus

### DIFF
--- a/resources/api/schemas/urakoiden-haku-response.schema.json
+++ b/resources/api/schemas/urakoiden-haku-response.schema.json
@@ -7,7 +7,6 @@
     "urakat": {
       "id": "urn:harja/urakat",
       "type": "array",
-      "maxItems" : 700,
       "items": {
         "id": "http://example.com/item-schema",
         "type": "object",


### PR DESCRIPTION
Kun haetaan urakat väyläviraston järjestelmätunnuksilla rajaamatta urakkatyyppiä, palautuu kaikki Harjan tietokannasta löytyvät urakat. Määrä on taas kasvanut. Rajoittaminen on oikeasti tarpeetonta, koska palautuva data on kevyttä (ei palauteta geometrioita).