### PR TITLE
HARJA-1152 karttanakyman sivupaneeliongelma

### DIFF
--- a/src/clj/harja/kyselyt/talvihoitoreitit.clj
+++ b/src/clj/harja/kyselyt/talvihoitoreitit.clj
@@ -145,7 +145,7 @@
                                        hoitoluokat (group-by :ryhma hoitoluokat)
                                        rivi (-> rivi
                                               (assoc :reitit reitit)
-                                               (assoc :laskettu_pituus (round2 2 (reduce + (map :laskettu_pituus reitit))))
+                                               (assoc :laskettu_pituus (round2 3 (reduce + (map :laskettu_pituus reitit))))
                                               (assoc :hoitoluokat hoitoluokat)
                                               (dissoc :muokkaaja :muokattu :luotu :luoja))]
                                    rivi))

--- a/src/clj/harja/kyselyt/talvihoitoreitit.clj
+++ b/src/clj/harja/kyselyt/talvihoitoreitit.clj
@@ -6,7 +6,8 @@
             [harja.domain.tierekisteri :as tr]
             [harja.domain.laadunseuranta.talvihoitoreitit-domain :as talvihoitoreitit-domain]
             [taoensso.timbre :as log]
-            [harja.domain.tierekisteri.validointi :as tr-validointi]))
+            [harja.domain.tierekisteri.validointi :as tr-validointi]
+            [harja.tyokalut.yleiset :refer [round2]]))
 
 (defqueries "harja/kyselyt/talvihoitoreitit.sql"
   {:positional? true})
@@ -144,7 +145,7 @@
                                        hoitoluokat (group-by :ryhma hoitoluokat)
                                        rivi (-> rivi
                                               (assoc :reitit reitit)
-                                              (assoc :laskettu_pituus (reduce + (map :laskettu_pituus reitit)))
+                                               (assoc :laskettu_pituus (round2 2 (reduce + (map :laskettu_pituus reitit))))
                                               (assoc :hoitoluokat hoitoluokat)
                                               (dissoc :muokkaaja :muokattu :luotu :luoja))]
                                    rivi))

--- a/src/cljs/harja/views/urakka/laadunseuranta/laatupoikkeamat.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/laatupoikkeamat.cljs
@@ -140,6 +140,7 @@
                                                          (reset! laatupoikkeamat/valittu-laatupoikkeama-id
                                                            (:id (vastaava-laatupoikkeama lp))))
                                              :teksti "Valitse laatupoikkeama"}})
+                         (kartta-tiedot/piilota-infopaneeli!)
                          (nav/vaihda-kartan-koko! :M))
       #(do (nav/vaihda-kartan-koko! @nav/kartan-edellinen-koko)
          (kartta-tiedot/kasittele-infopaneelin-linkit! nil)))

--- a/src/cljs/harja/views/urakka/laadunseuranta/siltatarkastukset.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/siltatarkastukset.cljs
@@ -585,7 +585,8 @@
     (komp/sisaan-ulos #(do
                          (kartta-tasot/taso-paalle! :sillat)
                          (reset! nav/kartan-edellinen-koko @nav/kartan-koko)
-                         (nav/vaihda-kartan-koko! :L))
+                         (nav/vaihda-kartan-koko! :L)
+                         (kartta-tiedot/piilota-infopaneeli!))
       #(do
          (kartta-tasot/taso-pois! :sillat)
          (nav/vaihda-kartan-koko! @nav/kartan-edellinen-koko)

--- a/src/cljs/harja/views/urakka/laadunseuranta/talvihoitoreitit_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/talvihoitoreitit_nakyma.cljs
@@ -11,6 +11,7 @@
             [harja.ui.varmista-kayttajalta :as varmista-kayttajalta]
             [harja.tiedot.navigaatio :as nav]
             [harja.tiedot.urakka.laadunseuranta.talvihoitoreitit-tiedot :as tiedot]
+            [harja.tiedot.kartta :as kartta-tiedot]
             [harja.ui.grid :as grid]
             [harja.ui.yleiset :refer [ajax-loader] :as yleiset]
             [harja.ui.ikonit :as ikonit]
@@ -212,6 +213,7 @@
       #(do
          (reset! nav/kartan-edellinen-koko @nav/kartan-koko)
          (nav/vaihda-kartan-koko! :M)
+         (kartta-tiedot/piilota-infopaneeli!)
 
          (reset! tiedot/valitut-kohteet-atom #{})
          (e! (tiedot/->HaeTalvihoitoreitit))

--- a/src/cljs/harja/views/urakka/laadunseuranta/tarkastukset.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/tarkastukset.cljs
@@ -525,7 +525,8 @@
                            {:tarkastus {:toiminto (fn [klikattu-tarkastus] ;; asiat-pisteessa -asia joka on tyypiltään tarkastus
                                                     (reset! tiedot/valittu-tarkastus (vastaava-tarkastus klikattu-tarkastus)))
                                         :teksti "Valitse tarkastus"}})
-                         (nav/vaihda-kartan-koko! :M))
+                         (nav/vaihda-kartan-koko! :M)
+                         (kartta-tiedot/piilota-infopaneeli!))
       #(do
          (nav/vaihda-kartan-koko! @nav/kartan-edellinen-koko)
          (reset! tarkastukset-kartalla/karttataso-tarkastukset false)

--- a/src/cljs/harja/views/urakka/pot1_lomake.cljs
+++ b/src/cljs/harja/views/urakka/pot1_lomake.cljs
@@ -1,6 +1,7 @@
 (ns harja.views.urakka.pot1-lomake
 
-  (:require [reagent.core :refer [atom] :as r]
+  (:require [harja.tiedot.kartta :as kartta-tiedot]
+            [reagent.core :refer [atom] :as r]
             [tuck.core :as tuck]
             [cljs.core.async :refer [<! chan]]
             [cljs.spec.alpha :as s]
@@ -609,6 +610,7 @@
       (komp/lukko lukon-id)
       (komp/sisaan #(do
                       (nav/vaihda-kartan-koko! :S)
+                      (kartta-tiedot/piilota-infopaneeli!)
                       (e! (paallystys/->MuutaTila [:paallystysilmoitus-lomakedata :historia] '()))
                       (e! (paallystys/->HaeTrOsienPituudet tr-numero tr-alkuosa tr-loppuosa))
                       (e! (paallystys/->HaeTrOsienTiedot tr-numero tr-alkuosa tr-loppuosa))))

--- a/src/cljs/harja/views/urakka/pot2/pot2_lomake.cljs
+++ b/src/cljs/harja/views/urakka/pot2/pot2_lomake.cljs
@@ -1,6 +1,7 @@
 (ns harja.views.urakka.pot2.pot2-lomake
 "POT2-lomake"
   (:require
+    [harja.tiedot.kartta :as kartta-tiedot]
     [reagent.core :refer [atom] :as r]
     [harja.asiakas.kommunikaatio :as k]
     [harja.domain.oikeudet :as oikeudet]
@@ -300,7 +301,8 @@
                                  (yllapitokohteet-domain/jarjesta-yllapitokohteet)
                                  (yllapitokohteet-domain/indeksoi-kohdeosat)))
                      (reset! pot2-tiedot/lisatiedot-atom (:lisatiedot paallystysilmoitus-lomakedata))
-                     (nav/vaihda-kartan-koko! :S)))
+                     (nav/vaihda-kartan-koko! :S)
+                     (kartta-tiedot/piilota-infopaneeli!)))
       (fn [e! {:keys [paallystysilmoitus-lomakedata massat murskeet materiaalikoodistot
                       pot2-massa-lomake pot2-murske-lomake paikkauskohteet?] :as app}]
         (let [lukittu? (lukko/nakyma-lukittu? lukko)

--- a/src/cljs/harja/views/urakka/toteumat.cljs
+++ b/src/cljs/harja/views/urakka/toteumat.cljs
@@ -1,6 +1,7 @@
 (ns harja.views.urakka.toteumat
   "Urakan 'Toteumat' välilehti:"
-  (:require [harja.ui.bootstrap :as bs]
+  (:require [harja.tiedot.kartta :as kartta-tiedot]
+            [harja.ui.bootstrap :as bs]
             [harja.views.urakka.toteumat.yksikkohintaiset-tyot :as yks-hint-tyot]
             [harja.views.urakka.toteumat.kokonaishintaiset-tyot :as kokonaishintaiset-tyot]
             [harja.views.urakka.toteumat.muut-tyot :as muut-tyot]
@@ -27,7 +28,8 @@
     (komp/luo
       (komp/sisaan-ulos #(do
                            (reset! nav/kartan-edellinen-koko @nav/kartan-koko)
-                           (nav/vaihda-kartan-koko! :S))
+                           (nav/vaihda-kartan-koko! :S)
+                           (kartta-tiedot/piilota-infopaneeli!))
                         #(nav/vaihda-kartan-koko! @nav/kartan-edellinen-koko))
       (fn [{:keys [id] :as ur}]
         [bs/tabs {:style :tabs :classes "tabs-taso2"

--- a/src/cljs/harja/views/urakka/turvallisuuspoikkeamat.cljs
+++ b/src/cljs/harja/views/urakka/turvallisuuspoikkeamat.cljs
@@ -569,7 +569,8 @@
       #(kartta-tiedot/kasittele-infopaneelin-linkit! nil))
     (komp/sisaan #(do
                     (reset! nav/kartan-edellinen-koko @nav/kartan-koko)
-                    (nav/vaihda-kartan-koko! :M)))
+                    (nav/vaihda-kartan-koko! :M)
+                    (kartta-tiedot/piilota-infopaneeli!)))
     (komp/ulos (kartta-tiedot/kuuntele-valittua! tiedot/valittu-turvallisuuspoikkeama))
     (fn [urakka]
       [:span


### PR DESCRIPTION
Useammalla sivulla kartalla näytettiin edellisen sivun kartan sivupaneelin tiedot.
Nyt ne suljetaan, kun näkymään saavutaan. Kun kartalta valitaan jotain uutta, niin se avaa sivupaneelin uudestaan uusilla tiedoilla ja ongelma on korjaantunut.

Samalla korjasin yhden pyöristysongelman.