### PR TITLE
HARJA-2393 - Tietokantamuutos toteuma_* taulujen nopeuttamiseksi

### DIFF
--- a/tietokanta/src/main/resources/db/migration/V1_1260__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1260__.sql
@@ -1,0 +1,157 @@
+-- Nopeutetaan toteumahakuja lisäämällä hoitokauden alkuvuosi toteuma_tehtava- ja toteuma_materiaali-tauluihin, jotta voidaan hyödyntää indeksejä paremmin.
+-- Mikäli tosielämässä tämäkään ei riitä, niin partitioidaan taulut hoitokauden alkavuoden mukaan, mutta toistaiseksi kokeillaan tätä kevyempää ratkaisua.
+ALTER TABLE toteuma_tehtava
+ ADD COLUMN hoitokauden_alkuvuosi INTEGER;
+
+ALTER TABLE toteuma_materiaali
+    ADD COLUMN hoitokauden_alkuvuosi INTEGER;
+
+
+CREATE INDEX idx_toteuma_tehtava_urakka_hk
+    ON toteuma_tehtava (urakka_id, hoitokauden_alkuvuosi, toimenpidekoodi)
+    INCLUDE (maara, toteuma)
+    WHERE poistettu = FALSE;
+
+CREATE INDEX idx_toteuma_materiaali_urakka_hk
+    ON toteuma_materiaali (materiaalikoodi, urakka_id, hoitokauden_alkuvuosi)
+    INCLUDE (maara, toteuma)
+    WHERE poistettu = FALSE;
+
+-- Viedään tuotantoon valmiksii stored proceduuri, jolla päivitetään hoitokauden alkavuosi toteuma_tehtava- ja toteuma_materiaali-tauluihin.
+-- Tämä voidaan laittaa esim screenissä pyörimään
+CREATE OR REPLACE PROCEDURE paivita_hoitokauden_alkuvuosi_toteumittain(
+    erakoko      INTEGER DEFAULT 50000,
+    aloitus_id   BIGINT  DEFAULT NULL,
+    lopetus_id   BIGINT  DEFAULT NULL
+)
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    min_id                         BIGINT;
+    max_id                         BIGINT;
+    nykyinen_id                    BIGINT;
+    seuraava_id                    BIGINT;
+    todellinen_max                 BIGINT;
+    kokonaismaara                  BIGINT;
+    aloitusaika                    TIMESTAMP;
+    kulunut_sekunteina             NUMERIC;
+    arvio_jaljella_s               NUMERIC;
+    prosentin_osuus                NUMERIC;
+    kasitelty_id_maara             BIGINT;
+    koko_id_alue                   BIGINT;
+    eranumero                      INTEGER := 0;
+    paivitetyt_tehtavat_era        INTEGER;
+    paivitetyt_materiaalit_era     INTEGER;
+    paivitetyt_tehtavat_yhteensa   BIGINT := 0;
+    paivitetyt_materiaalit_yhteensa BIGINT := 0;
+BEGIN
+    SELECT MIN(id), MAX(id), COUNT(*)
+    INTO min_id, max_id, kokonaismaara
+    FROM toteuma;
+
+    IF min_id IS NULL OR max_id IS NULL THEN
+        RAISE NOTICE 'Taulu toteuma on tyhjä, ei päivitettävää.';
+        RETURN;
+    END IF;
+
+    nykyinen_id    := COALESCE(aloitus_id, min_id);
+    todellinen_max := COALESCE(lopetus_id, max_id);
+    aloitusaika    := clock_timestamp();
+
+    IF nykyinen_id > todellinen_max THEN
+        RAISE NOTICE 'Aloitus-id (%) on suurempi kuin lopetus-id (%), ei päivitettävää.',
+            nykyinen_id, todellinen_max;
+        RETURN;
+    END IF;
+
+    koko_id_alue := todellinen_max - nykyinen_id + 1;
+
+    RAISE NOTICE '=== Aloitetaan hoitokauden_alkuvuosi-päivitys toteumittain ===';
+    RAISE NOTICE 'Toteuma-id alue taulussa: % - %, ajettava alue: % - %, eräkoko: %, toteumia yhteensä: %',
+        min_id, max_id, nykyinen_id, todellinen_max, erakoko, kokonaismaara;
+
+    LOOP
+        eranumero := eranumero + 1;
+        seuraava_id := LEAST(nykyinen_id + erakoko, todellinen_max + 1);
+
+        WITH toteumat_erassa AS (
+            SELECT
+                t.id,
+                CASE
+                    WHEN EXTRACT(MONTH FROM t.alkanut) >= 10
+                        THEN EXTRACT(YEAR FROM t.alkanut)::INTEGER
+                    ELSE EXTRACT(YEAR FROM t.alkanut)::INTEGER - 1
+                    END AS hoitokauden_alkuvuosi
+            FROM toteuma t
+            WHERE t.id >= nykyinen_id
+              AND t.id <  seuraava_id
+        ),
+             paivitetyt_tehtavat AS (
+                 UPDATE toteuma_tehtava tt
+                     SET hoitokauden_alkuvuosi = te.hoitokauden_alkuvuosi
+                     FROM toteumat_erassa te
+                     WHERE tt.toteuma = te.id
+                         AND tt.hoitokauden_alkuvuosi IS DISTINCT FROM te.hoitokauden_alkuvuosi
+                     RETURNING 1
+             ),
+             paivitetyt_materiaalit AS (
+                 UPDATE toteuma_materiaali tm
+                     SET hoitokauden_alkuvuosi = te.hoitokauden_alkuvuosi
+                     FROM toteumat_erassa te
+                     WHERE tm.toteuma = te.id
+                         AND tm.hoitokauden_alkuvuosi IS DISTINCT FROM te.hoitokauden_alkuvuosi
+                     RETURNING 1
+             )
+        SELECT
+            (SELECT COUNT(*) FROM paivitetyt_tehtavat),
+            (SELECT COUNT(*) FROM paivitetyt_materiaalit)
+        INTO paivitetyt_tehtavat_era, paivitetyt_materiaalit_era;
+
+        paivitetyt_tehtavat_yhteensa    := paivitetyt_tehtavat_yhteensa + paivitetyt_tehtavat_era;
+        paivitetyt_materiaalit_yhteensa := paivitetyt_materiaalit_yhteensa + paivitetyt_materiaalit_era;
+
+        kulunut_sekunteina := EXTRACT(EPOCH FROM clock_timestamp() - aloitusaika);
+        kasitelty_id_maara := seuraava_id - COALESCE(aloitus_id, min_id);
+
+        IF koko_id_alue > 0 THEN
+            prosentin_osuus := ROUND((kasitelty_id_maara::NUMERIC / koko_id_alue::NUMERIC) * 100, 2);
+        ELSE
+            prosentin_osuus := 100;
+        END IF;
+
+        IF kasitelty_id_maara > 0 AND kulunut_sekunteina > 0 AND prosentin_osuus < 100 THEN
+            arvio_jaljella_s := ROUND(
+                (kulunut_sekunteina / kasitelty_id_maara::NUMERIC)
+                    * (todellinen_max - seuraava_id + 1),
+                0
+                                );
+        ELSE
+            arvio_jaljella_s := 0;
+        END IF;
+
+        RAISE NOTICE 'Erä #% | toteuma-id % - % | tehtäviä päivitetty % (yht. %) | materiaaleja päivitetty % (yht. %) | %.2f %% | kulunut % s | arvio jäljellä % s',
+            eranumero,
+            nykyinen_id,
+            seuraava_id - 1,
+            paivitetyt_tehtavat_era,
+            paivitetyt_tehtavat_yhteensa,
+            paivitetyt_materiaalit_era,
+            paivitetyt_materiaalit_yhteensa,
+            prosentin_osuus,
+            ROUND(kulunut_sekunteina),
+            arvio_jaljella_s;
+
+        COMMIT;
+
+        nykyinen_id := seuraava_id;
+
+        EXIT WHEN nykyinen_id > todellinen_max;
+    END LOOP;
+
+    RAISE NOTICE '=== Päivitys valmis === tehtäviä päivitetty yhteensä % | materiaaleja päivitetty yhteensä % | kokonaisaika % s',
+        paivitetyt_tehtavat_yhteensa,
+        paivitetyt_materiaalit_yhteensa,
+        ROUND(EXTRACT(EPOCH FROM clock_timestamp() - aloitusaika));
+END;
+$$;

--- a/tietokanta/src/main/resources/db/migration/V1_1261__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1261__.sql
@@ -1,0 +1,37 @@
+-- Triggeri, joka päivittää hoitokauden_alkuvuosi-sarakkeen toteuma_tehtava- ja toteuma_materiaali-tauluihin
+-- kun toteuma-tauluun tehdään INSERT tai UPDATE.
+
+CREATE OR REPLACE FUNCTION paivita_hoitokauden_alkuvuosi_toteumalle()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    hk_alkuvuosi INTEGER;
+BEGIN
+    hk_alkuvuosi := CASE
+                        WHEN EXTRACT(MONTH FROM NEW.alkanut) >= 10
+                            THEN EXTRACT(YEAR FROM NEW.alkanut)::INTEGER
+                        ELSE EXTRACT(YEAR FROM NEW.alkanut)::INTEGER - 1
+                    END;
+
+    UPDATE toteuma_tehtava
+       SET hoitokauden_alkuvuosi = hk_alkuvuosi
+     WHERE toteuma = NEW.id
+       AND hoitokauden_alkuvuosi IS DISTINCT FROM hk_alkuvuosi;
+
+    UPDATE toteuma_materiaali
+       SET hoitokauden_alkuvuosi = hk_alkuvuosi
+     WHERE toteuma = NEW.id
+       AND hoitokauden_alkuvuosi IS DISTINCT FROM hk_alkuvuosi;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER tg_toteuma_hoitokauden_alkuvuosi
+    AFTER INSERT OR UPDATE OF alkanut
+    ON toteuma
+    FOR EACH ROW
+EXECUTE FUNCTION paivita_hoitokauden_alkuvuosi_toteumalle();
+

--- a/tietokanta/src/main/resources/db/migration/V1_1261__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1261__.sql
@@ -1,7 +1,7 @@
--- Triggeri, joka päivittää hoitokauden_alkuvuosi-sarakkeen toteuma_tehtava- ja toteuma_materiaali-tauluihin
--- kun toteuma-tauluun tehdään INSERT tai UPDATE.
+-- Triggerit, jotka päivittävät hoitokauden_alkuvuosi-sarakkeen toteuma_tehtava- ja toteuma_materiaali-tauluihin
+-- kun niihin tehdään INSERT tai UPDATE. Hoitokauden alkuvuosi lasketaan toteuma.alkanut-arvon perusteella.
 
-CREATE OR REPLACE FUNCTION paivita_hoitokauden_alkuvuosi_toteumalle()
+CREATE OR REPLACE FUNCTION paivita_hoitokauden_alkuvuosi_tehtavalle()
     RETURNS TRIGGER
     LANGUAGE plpgsql
 AS
@@ -9,29 +9,56 @@ $$
 DECLARE
     hk_alkuvuosi INTEGER;
 BEGIN
-    hk_alkuvuosi := CASE
-                        WHEN EXTRACT(MONTH FROM NEW.alkanut) >= 10
-                            THEN EXTRACT(YEAR FROM NEW.alkanut)::INTEGER
-                        ELSE EXTRACT(YEAR FROM NEW.alkanut)::INTEGER - 1
-                    END;
+    SELECT CASE
+               WHEN EXTRACT(MONTH FROM t.alkanut) >= 10
+                   THEN EXTRACT(YEAR FROM t.alkanut)::INTEGER
+               ELSE EXTRACT(YEAR FROM t.alkanut)::INTEGER - 1
+           END
+      INTO hk_alkuvuosi
+      FROM toteuma t
+     WHERE t.id = NEW.toteuma;
 
-    UPDATE toteuma_tehtava
-       SET hoitokauden_alkuvuosi = hk_alkuvuosi
-     WHERE toteuma = NEW.id
-       AND hoitokauden_alkuvuosi IS DISTINCT FROM hk_alkuvuosi;
-
-    UPDATE toteuma_materiaali
-       SET hoitokauden_alkuvuosi = hk_alkuvuosi
-     WHERE toteuma = NEW.id
-       AND hoitokauden_alkuvuosi IS DISTINCT FROM hk_alkuvuosi;
+    IF hk_alkuvuosi IS NOT NULL THEN
+        NEW.hoitokauden_alkuvuosi := hk_alkuvuosi;
+    END IF;
 
     RETURN NEW;
 END;
 $$;
 
-CREATE TRIGGER tg_toteuma_hoitokauden_alkuvuosi
-    AFTER INSERT OR UPDATE OF alkanut
-    ON toteuma
-    FOR EACH ROW
-EXECUTE FUNCTION paivita_hoitokauden_alkuvuosi_toteumalle();
+CREATE OR REPLACE FUNCTION paivita_hoitokauden_alkuvuosi_materiaalille()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    hk_alkuvuosi INTEGER;
+BEGIN
+    SELECT CASE
+               WHEN EXTRACT(MONTH FROM t.alkanut) >= 10
+                   THEN EXTRACT(YEAR FROM t.alkanut)::INTEGER
+               ELSE EXTRACT(YEAR FROM t.alkanut)::INTEGER - 1
+           END
+      INTO hk_alkuvuosi
+      FROM toteuma t
+     WHERE t.id = NEW.toteuma;
 
+    IF hk_alkuvuosi IS NOT NULL THEN
+        NEW.hoitokauden_alkuvuosi := hk_alkuvuosi;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER tg_toteuma_tehtava_hoitokauden_alkuvuosi
+    BEFORE INSERT OR UPDATE
+    ON toteuma_tehtava
+    FOR EACH ROW
+EXECUTE FUNCTION paivita_hoitokauden_alkuvuosi_tehtavalle();
+
+CREATE TRIGGER tg_toteuma_materiaali_hoitokauden_alkuvuosi
+    BEFORE INSERT OR UPDATE
+    ON toteuma_materiaali
+    FOR EACH ROW
+EXECUTE FUNCTION paivita_hoitokauden_alkuvuosi_materiaalille();

--- a/tietokanta/src/main/resources/db/migration/V1_1261__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1261__.sql
@@ -66,7 +66,7 @@ EXECUTE FUNCTION paivita_hoitokauden_alkuvuosi_materiaalille();
 -- Triggeri toteuma-tauluun: kun alkanut muuttuu, päivitetään toteuma_tehtava ja toteuma_materiaali taulujen hoitokauden_alkuvuosi.
 -- Päivitys tehdään vain, jos uusi hoitokausi eroaa vanhasta.
 
-CREATE OR REPLACE FUNCTION paivita_lasten_hoitokauden_alkuvuosi_toteumalta()
+CREATE OR REPLACE FUNCTION paivita_hoitokauden_alkuvuosi_tehtava_ja_materiaalitauluista()
     RETURNS TRIGGER
     LANGUAGE plpgsql
 AS
@@ -94,9 +94,9 @@ BEGIN
 END;
 $$;
 
-CREATE TRIGGER tg_toteuma_alkanut_paivittaa_lasten_hoitokausi
+CREATE TRIGGER tg_toteuma_alkanut_paivitta_tehtavamateriaali_hoitokausi
     AFTER UPDATE OF alkanut
     ON toteuma
     FOR EACH ROW
     WHEN (OLD.alkanut IS DISTINCT FROM NEW.alkanut)
-EXECUTE FUNCTION paivita_lasten_hoitokauden_alkuvuosi_toteumalta();
+EXECUTE FUNCTION paivita_hoitokauden_alkuvuosi_tehtava_ja_materiaalitauluista();

--- a/tietokanta/src/main/resources/db/migration/V1_1261__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1261__.sql
@@ -9,10 +9,6 @@ $$
 DECLARE
     hk_alkuvuosi INTEGER;
 BEGIN
-    IF NEW.hoitokauden_alkuvuosi IS NOT NULL THEN
-        RETURN NEW;
-    END IF;
-
     SELECT CASE
                WHEN EXTRACT(MONTH FROM t.alkanut) >= 10
                    THEN EXTRACT(YEAR FROM t.alkanut)::INTEGER
@@ -38,10 +34,6 @@ $$
 DECLARE
     hk_alkuvuosi INTEGER;
 BEGIN
-    IF NEW.hoitokauden_alkuvuosi IS NOT NULL THEN
-        RETURN NEW;
-    END IF;
-
     SELECT CASE
                WHEN EXTRACT(MONTH FROM t.alkanut) >= 10
                    THEN EXTRACT(YEAR FROM t.alkanut)::INTEGER

--- a/tietokanta/src/main/resources/db/migration/V1_1261__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1261__.sql
@@ -62,3 +62,41 @@ CREATE TRIGGER tg_toteuma_materiaali_hoitokauden_alkuvuosi
     ON toteuma_materiaali
     FOR EACH ROW
 EXECUTE FUNCTION paivita_hoitokauden_alkuvuosi_materiaalille();
+
+-- Triggeri toteuma-tauluun: kun alkanut muuttuu, päivitetään toteuma_tehtava ja toteuma_materiaali taulujen hoitokauden_alkuvuosi.
+-- Päivitys tehdään vain, jos uusi hoitokausi eroaa vanhasta.
+
+CREATE OR REPLACE FUNCTION paivita_lasten_hoitokauden_alkuvuosi_toteumalta()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    uusi_hk INTEGER;
+BEGIN
+    uusi_hk := CASE
+                   WHEN EXTRACT(MONTH FROM NEW.alkanut) >= 10
+                       THEN EXTRACT(YEAR FROM NEW.alkanut)::INTEGER
+                   ELSE EXTRACT(YEAR FROM NEW.alkanut)::INTEGER - 1
+        END;
+
+    UPDATE toteuma_tehtava
+    SET hoitokauden_alkuvuosi = uusi_hk
+    WHERE toteuma = NEW.id
+      AND hoitokauden_alkuvuosi IS DISTINCT FROM uusi_hk;
+
+    UPDATE toteuma_materiaali
+    SET hoitokauden_alkuvuosi = uusi_hk
+    WHERE toteuma = NEW.id
+      AND hoitokauden_alkuvuosi IS DISTINCT FROM uusi_hk;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER tg_toteuma_alkanut_paivittaa_lasten_hoitokausi
+    AFTER UPDATE OF alkanut
+    ON toteuma
+    FOR EACH ROW
+    WHEN (OLD.alkanut IS DISTINCT FROM NEW.alkanut)
+EXECUTE FUNCTION paivita_lasten_hoitokauden_alkuvuosi_toteumalta();

--- a/tietokanta/src/main/resources/db/migration/V1_1261__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1261__.sql
@@ -9,6 +9,10 @@ $$
 DECLARE
     hk_alkuvuosi INTEGER;
 BEGIN
+    IF NEW.hoitokauden_alkuvuosi IS NOT NULL THEN
+        RETURN NEW;
+    END IF;
+
     SELECT CASE
                WHEN EXTRACT(MONTH FROM t.alkanut) >= 10
                    THEN EXTRACT(YEAR FROM t.alkanut)::INTEGER
@@ -34,6 +38,10 @@ $$
 DECLARE
     hk_alkuvuosi INTEGER;
 BEGIN
+    IF NEW.hoitokauden_alkuvuosi IS NOT NULL THEN
+        RETURN NEW;
+    END IF;
+
     SELECT CASE
                WHEN EXTRACT(MONTH FROM t.alkanut) >= 10
                    THEN EXTRACT(YEAR FROM t.alkanut)::INTEGER


### PR DESCRIPTION
Lisätään toteumatauluihin hoitokauden_alkuvuosi ja uudet indeksit ja triggeri.

1. Tämä on ensimmäinen vaihe muutoksesta. 
- Tässä lisätään hoitokauden_alkuvuosi kolumni toteuma_tehtava ja toteuma_materiaali -tauluihin.
- Tälle uudelle kolumnille lisätään indeksi jo valmiiksi. 
2. Kolumin data pitää lisätä erikseen tietokanta-ajona, joka kestää ainakin 8h. Se tehdään erillään.
- Triggeri huolehtii siitä, että siirron jälkeen data pysyy kunnossa, vaikka kolmatta vaihetta ei ole vielä tehtykään.
3. Kolmannessa vaiheessa mergetään branchi, jossa on uutta kolumnia hyödyntävät tietokantahaut. Sen jälkeen saadaan tietää, että kuinka paljon kolumnin ja indeksien lisäys on nopeuttanut hakuja.

Ja jos tämä ei riitä, niin sitten partitioidaan taulut. Mutta mennään tällä ensin tuotantoon ja kokeillaan miten käy.