### PR TITLE
HARJA-2424 Lisää optionaalinen timeout HTTP-kutsuihin

### DIFF
--- a/src/clj/harja/palvelin/integraatiot/integraatiopisteet/http.clj
+++ b/src/clj/harja/palvelin/integraatiot/integraatiopisteet/http.clj
@@ -27,7 +27,7 @@
 
 (defn tee-http-kutsu [lokittaja tapahtuma-id url metodi otsikot
                       parametrit kayttajatunnus salasana kutsudata
-                      lomakedatana? httpkit-asetukset]
+                      lomakedatana? httpkit-asetukset & [timeout]]
   (try
     (let [kutsu (rakenna-http-kutsu {:metodi metodi
                                      :otsikot otsikot
@@ -37,7 +37,7 @@
                                      :kutsudata kutsudata
                                      :lomakedatana? lomakedatana?
                                      :httpkit-asetukset httpkit-asetukset
-                                     :timeout timeout-aika-ms})]
+                                     :timeout (or timeout timeout-aika-ms)})]
       (case metodi
         :post @(http/post url kutsu)
         :get @(http/get url kutsu)
@@ -88,17 +88,21 @@
 
 (defn laheta-kutsu
   [lokittaja tapahtuma-id url metodi otsikot parametrit
-   {:keys [kayttajatunnus salasana response->loki httpkit-asetukset]} lomakedatana? kutsudata]
+   {:keys [kayttajatunnus salasana response->loki httpkit-asetukset timeout]} lomakedatana? kutsudata]
   (log/info (format "Lähetetään HTTP %s -kutsu: osoite: %s, metodi: %s, data: %s, otsikkot: %s, parametrit: %s, lomakedatana?: %s"
-               metodi url metodi (fmt/merkkijonon-alku (str kutsudata) 800) otsikot parametrit lomakedatana?))
+              metodi url metodi (fmt/merkkijonon-alku (str kutsudata) 800) otsikot parametrit lomakedatana?))
 
   (let [sisaltotyyppi (get otsikot " Content-Type ")]
     (lokittaja :rest-viesti tapahtuma-id "ulos" url sisaltotyyppi kutsudata otsikot (str parametrit))
 
     (let [{:keys [status body error headers]}
-          (tee-http-kutsu lokittaja tapahtuma-id url metodi otsikot
-            parametrit kayttajatunnus salasana kutsudata
-            lomakedatana? httpkit-asetukset)
+          (if (some? timeout)
+            (tee-http-kutsu lokittaja tapahtuma-id url metodi otsikot
+              parametrit kayttajatunnus salasana kutsudata
+              lomakedatana? httpkit-asetukset timeout)
+            (tee-http-kutsu lokittaja tapahtuma-id url metodi otsikot
+              parametrit kayttajatunnus salasana kutsudata
+              lomakedatana? httpkit-asetukset))
           lokiviesti (integraatioloki/tee-rest-lokiviesti "sisään" url sisaltotyyppi body headers nil)]
 
       (if (or error

--- a/src/clj/harja/palvelin/integraatiot/integraatiopisteet/http.clj
+++ b/src/clj/harja/palvelin/integraatiot/integraatiopisteet/http.clj
@@ -96,13 +96,9 @@
     (lokittaja :rest-viesti tapahtuma-id "ulos" url sisaltotyyppi kutsudata otsikot (str parametrit))
 
     (let [{:keys [status body error headers]}
-          (if (some? timeout)
-            (tee-http-kutsu lokittaja tapahtuma-id url metodi otsikot
-              parametrit kayttajatunnus salasana kutsudata
-              lomakedatana? httpkit-asetukset timeout)
-            (tee-http-kutsu lokittaja tapahtuma-id url metodi otsikot
-              parametrit kayttajatunnus salasana kutsudata
-              lomakedatana? httpkit-asetukset))
+          (tee-http-kutsu lokittaja tapahtuma-id url metodi otsikot
+            parametrit kayttajatunnus salasana kutsudata
+            lomakedatana? httpkit-asetukset timeout)
           lokiviesti (integraatioloki/tee-rest-lokiviesti "sisään" url sisaltotyyppi body headers nil)]
 
       (if (or error

--- a/src/clj/harja/palvelin/integraatiot/integraatiopisteet/http.clj
+++ b/src/clj/harja/palvelin/integraatiot/integraatiopisteet/http.clj
@@ -28,6 +28,8 @@
 (defn tee-http-kutsu [lokittaja tapahtuma-id url metodi otsikot
                       parametrit kayttajatunnus salasana kutsudata
                       lomakedatana? httpkit-asetukset & [timeout]]
+  ;;timeout parametrilla voi korvata kovakoodatun 60000ms timeoutin. Harjan katkaisu näkyy integraatioväylällä virheenä, mutta käsittelyyn otetut viestit jatkavat prosessissa ilman paluuputkea.
+  ;;HUOM!! lyhyempi timeout Harjassa mahdollistaa tiheämmät kutsut rajapintaan ja voi kuormittaa integraatioväylää, älä lyhennä timeoutia harkitsematta vaikutusta integraation toiseen osapuoleen.
   (try
     (let [kutsu (rakenna-http-kutsu {:metodi metodi
                                      :otsikot otsikot
@@ -54,7 +56,7 @@
         {:type virheet/+ulkoinen-kasittelyvirhe-koodi+
          :virheet [{:koodi :poikkeus :viesti (str "HTTP-kutsukäsittelyssä tapahtui odottamaton virhe.")}]}))))
 
-(defn kasittele-virhe [lokittaja lokiviesti tapahtuma-id url error status]
+(defn kasittele-virhe [lokittaja lokiviesti tapahtuma-id url error status & [timeout]]
   (let [[jarjestelma integraation-nimi] (clj-str/split (lokittaja :avain) #"-" 2)
         integraatio-log-params {:tapahtuma-id tapahtuma-id
                                 :alkanut (pvm/pvm->iso-8601 (pvm/nyt-suomessa))
@@ -74,7 +76,8 @@
             (instance? TimeoutException error))
         (throw+ {:type virheet/+ulkoinen-kasittelyvirhe-koodi+
                  :virheet [{:koodi :ulkoinen-jarjestelma-palautti-virheen
-                            :viesti "Ulkoiseen järjestelmään ei saada yhteyttä."}]})
+                            :viesti (str "Ulkoiseen järjestelmään ei saada yhteyttä."
+                                         (when timeout (format " Timeout: %sms." timeout)))}]})
         :default
         (throw+ {:type virheet/+ulkoinen-kasittelyvirhe-koodi+
                  :virheet [{:koodi :ulkoinen-jarjestelma-palautti-virheen :viesti
@@ -103,7 +106,7 @@
 
       (if (or error
             (not (= 200 status)))
-        (kasittele-virhe lokittaja lokiviesti tapahtuma-id url (or error body) status)
+        (kasittele-virhe lokittaja lokiviesti tapahtuma-id url (or error body) status timeout)
         (kasittele-onnistunut-kutsu lokittaja lokiviesti tapahtuma-id url body headers status response->loki)))))
 
 (defprotocol HttpIntegraatiopiste

--- a/src/clj/harja/palvelin/integraatiot/vayla_rest/sahkoposti.clj
+++ b/src/clj/harja/palvelin/integraatiot/vayla_rest/sahkoposti.clj
@@ -70,7 +70,7 @@
 (defn laheta-sahkoposti-sahkopostipalveluun
   "Harjalla on lähetetty sähköpostit aiemmin laittamalla niistä jonoon ilmoitus, jonka Sähköpostipalvelin on käynyt
   lukemassa ja lähettänyt. Tämä fn lähettää samaiset sähköpostit suoralla api-rest kutsulla."
-  [db asetukset integraatioloki sahkoposti-xml http-otsikot liite?]
+  [db asetukset integraatioloki sahkoposti-xml http-otsikot liite? & [timeout]]
   (try+
     (let [_ (log/info "Lähetä rest-api sähköposti.")
           vastaus (integraatiotapahtuma/suorita-integraatio
@@ -84,7 +84,8 @@
                                                        {"Content-Type" "application/xml"}
                                                        http-otsikot)
                                             :kayttajatunnus (get-in asetukset [:api-sahkoposti :kayttajatunnus])
-                                            :salasana (get-in asetukset [:api-sahkoposti :salasana])}
+                                            :salasana (get-in asetukset [:api-sahkoposti :salasana])
+                                            :timeout timeout}
                             {body :body headers :headers status :status} (integraatiotapahtuma/laheta konteksti :http http-asetukset sahkoposti-xml)]
                         (if liite?
                           (kasittele-sahkoposti-ja-liite-vastaus status body db)
@@ -185,7 +186,7 @@
           ;; Validoidaan viesti
           virhe (validoi-sahkoposti viesti)]
       (if (nil? virhe)
-        (laheta-sahkoposti-sahkopostipalveluun (:db this) asetukset (:integraatioloki this) viesti headers false)
+        (laheta-sahkoposti-sahkopostipalveluun (:db this) asetukset (:integraatioloki this) viesti headers false 1000)
         (throw+ virhe))))
   (laheta-ulkoisella-jarjestelmalla-viesti! [this lahettaja vastaanottaja otsikko sisalto headers username password port]
     ;; Ei tee tarkoituksellisesti mitään, mutta toteuttaa Protokollan

--- a/src/clj/harja/palvelin/integraatiot/vayla_rest/sahkoposti.clj
+++ b/src/clj/harja/palvelin/integraatiot/vayla_rest/sahkoposti.clj
@@ -70,7 +70,7 @@
 (defn laheta-sahkoposti-sahkopostipalveluun
   "Harjalla on lähetetty sähköpostit aiemmin laittamalla niistä jonoon ilmoitus, jonka Sähköpostipalvelin on käynyt
   lukemassa ja lähettänyt. Tämä fn lähettää samaiset sähköpostit suoralla api-rest kutsulla."
-  [db asetukset integraatioloki sahkoposti-xml http-otsikot liite? & [timeout]]
+  [db asetukset integraatioloki sahkoposti-xml http-otsikot liite?]
   (try+
     (let [_ (log/info "Lähetä rest-api sähköposti.")
           vastaus (integraatiotapahtuma/suorita-integraatio
@@ -84,8 +84,7 @@
                                                        {"Content-Type" "application/xml"}
                                                        http-otsikot)
                                             :kayttajatunnus (get-in asetukset [:api-sahkoposti :kayttajatunnus])
-                                            :salasana (get-in asetukset [:api-sahkoposti :salasana])
-                                            :timeout timeout}
+                                            :salasana (get-in asetukset [:api-sahkoposti :salasana])}
                             {body :body headers :headers status :status} (integraatiotapahtuma/laheta konteksti :http http-asetukset sahkoposti-xml)]
                         (if liite?
                           (kasittele-sahkoposti-ja-liite-vastaus status body db)
@@ -186,7 +185,7 @@
           ;; Validoidaan viesti
           virhe (validoi-sahkoposti viesti)]
       (if (nil? virhe)
-        (laheta-sahkoposti-sahkopostipalveluun (:db this) asetukset (:integraatioloki this) viesti headers false 1000)
+        (laheta-sahkoposti-sahkopostipalveluun (:db this) asetukset (:integraatioloki this) viesti headers false)
         (throw+ virhe))))
   (laheta-ulkoisella-jarjestelmalla-viesti! [this lahettaja vastaanottaja otsikko sisalto headers username password port]
     ;; Ei tee tarkoituksellisesti mitään, mutta toteuttaa Protokollan

--- a/test/clj/harja/palvelin/integraatiot/tloik/sahkoposti_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/tloik/sahkoposti_test.clj
@@ -76,7 +76,7 @@
 (deftest tarkista-kuittauksen-vastaanotto-sahkopostilla
   (with-redefs
     [sahkoposti-api/muodosta-lahetys-uri (fn [_ _] "http://localhost:8084/api/sahkoposti")
-     integraatiopiste-http/tee-http-kutsu (fn [_ _ _ _ _ _ _ _ _ _ _]
+     integraatiopiste-http/tee-http-kutsu (fn [_ _ _ _ _ _ _ _ _ _ _ & _]
                                             {:status 200
                                              :header "jotain"
                                              :body onnistunut-kuittaus})]
@@ -154,7 +154,7 @@
 
     (with-redefs
       [sahkoposti-api/muodosta-lahetys-uri (fn [_ _] lokaali-sahkopostipalvelin)
-       integraatiopiste-http/tee-http-kutsu (fn [_ _ _ _ _ _ _ _ _ _ _]
+       integraatiopiste-http/tee-http-kutsu (fn [_ _ _ _ _ _ _ _ _ _ _ & _]
                                               {:status 200
                                                :header "jotain"
                                                :body onnistunut-kuittaus})

--- a/test/clj/harja/palvelin/integraatiot/vayla_rest/sahkoposti_api_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/vayla_rest/sahkoposti_api_test.clj
@@ -120,7 +120,7 @@
         ;; Lähetetään viesti ja tarkistetaan kuittaus
         viesti-id (str (UUID/randomUUID))
         vastaus (with-redefs [sahkoposti-api/muodosta-lahetys-uri (fn [_ _] "http://localhost:8084/api/sahkoposti")
-                              integraatiopiste-http/tee-http-kutsu (fn [_ _ _ _ _ _ _ _ _ _ _]
+                              integraatiopiste-http/tee-http-kutsu (fn [_ _ _ _ _ _ _ _ _ _ _ & _]
                                                                      {:status 200
                                                                       :header "jotain"
                                                                       :body (onnistunut-sahkopostikuittaus viesti-id)})]
@@ -151,7 +151,7 @@
         integraatio-id (integraatio-kyselyt/integraation-id (:db jarjestelma) "sahkoposti" "sahkoposti-lahetys")
         vastaus
         (try+ (future (with-redefs [sahkoposti-api/muodosta-lahetys-uri (fn [_ _] "http://localhost:8084/api/sahkoposti")
-                                    integraatiopiste-http/tee-http-kutsu (fn [_ _ _ _ _ _ _ _ _ _ _]
+                                    integraatiopiste-http/tee-http-kutsu (fn [_ _ _ _ _ _ _ _ _ _ _ & _]
                                                                            {:status 200
                                                                             :header "jotain"
                                                                             :body (onnistunut-sahkopostikuittaus viesti-id)})]
@@ -378,7 +378,7 @@
                            :vastuuhenkilo true
                            :varahenkilo true}))
                   sahkoposti-api/muodosta-lahetys-uri (fn [_ _] "http://localhost:8084/api/sahkoposti")
-                  integraatiopiste-http/tee-http-kutsu (fn [_ _ _ _ _ _ _ _ _ _ _]
+                  integraatiopiste-http/tee-http-kutsu (fn [_ _ _ _ _ _ _ _ _ _ _ & _]
                                                          {:status 200
                                                           :header "jotain"
                                                           :body (onnistunut-sahkopostikuittaus viesti-id)})]
@@ -486,7 +486,7 @@
 
 (deftest vastaanota-haro-sahkoposti-xml-api-rajapintaan
   (with-redefs [sahkoposti-api/muodosta-lahetys-uri (fn [_ _] "http://localhost:8084/api/sahkoposti")
-                integraatiopiste-http/tee-http-kutsu (fn [_ _ _ _ _ _ _ _ _ _ _]
+                integraatiopiste-http/tee-http-kutsu (fn [_ _ _ _ _ _ _ _ _ _ _ & _]
                                                        {:status 200
                                                         :header "jotain"
                                                         :body (onnistunut-sahkopostikuittaus nil)})]

--- a/test/clj/harja/palvelin/integraatiot/vayla_rest/sampo_api_vienti_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/vayla_rest/sampo_api_vienti_test.clj
@@ -56,7 +56,7 @@
   (let [maksueran-tiedot-alkuun (hae-maksueran-tiedot +testi-maksueran-numero+)
         ksuun-tiedot-alkuun (hae-kustannussuunnitelman-tiedot +testi-maksueran-numero+)
         integ-tapahtumat-alkuun (hae-integraatiotapahtumat-tietokannasta)
-        vastaus (with-redefs [integraatiopiste-http/tee-http-kutsu (fn [_ _ _ _ _ _ _ _ kutsudata _ _]
+        vastaus (with-redefs [integraatiopiste-http/tee-http-kutsu (fn [_ _ _ _ _ _ _ _ kutsudata _ _ & _]
                                                                      {:status 200
                                                                       :header "jotain"
                                                                       :body (if (str/includes? kutsudata "costPlan")
@@ -90,7 +90,7 @@
         maksueran-tiedot-alkuun (hae-maksueran-tiedot likainen-maksueranumero)
         ksuun-tiedot-alkuun (hae-kustannussuunnitelman-tiedot likainen-maksueranumero)
         integ-tapahtumat-alkuun (hae-integraatiotapahtumat-tietokannasta)
-        vastaus (with-redefs [integraatiopiste-http/tee-http-kutsu (fn [_ _ _ _ _ _ _ _ kutsudata _ _]
+        vastaus (with-redefs [integraatiopiste-http/tee-http-kutsu (fn [_ _ _ _ _ _ _ _ kutsudata _ _ & _]
                                                                      {:status 200
                                                                       :header "jotain"
                                                                       :body (if (str/includes? kutsudata "CostPlan")
@@ -128,7 +128,7 @@
         _ (u (format "UPDATE urakka_parametrit SET maksuera_lahetys_sampo = false WHERE urakkaid = %s" urakka-id))
         maksueran-tiedot-alkuun (hae-maksueran-tiedot maksueran-numero)
         vastaus (with-redefs [integraatiopiste-http/tee-http-kutsu
-                              (fn [_ _ _ _ _ _ _ _ kutsudata _ _]
+                              (fn [_ _ _ _ _ _ _ _ kutsudata _ _ & _]
                                 {:status 200
                                  :body onnistunut-maksuera-kuittaus})]
                   (sampo-api/laheta-maksuera-sampoon (:api-sampo jarjestelma) maksueran-numero))
@@ -152,7 +152,7 @@
         _ (u (format "UPDATE urakka_parametrit SET maksuera_lahetys_sampo = true WHERE urakkaid = %s" urakka-id))
         maksueran-tiedot-alkuun (hae-maksueran-tiedot maksueran-numero)
         vastaus (with-redefs [integraatiopiste-http/tee-http-kutsu
-                              (fn [_ _ _ _ _ _ _ _ kutsudata _ _]
+                              (fn [_ _ _ _ _ _ _ _ kutsudata _ _ & _]
                                 {:status 200
                                  :body (if (str/includes? kutsudata "costPlan")
                                          onnistunut-kustannussuunnitelma-kuittaus


### PR DESCRIPTION
Mahdollistetaan HTTP-kutsujen timeoutin määrittäminen tapauskohtaisesti, kovakoodatun 60000ms sijaan.