### PR TITLE
HARJA 2465 - Estä Git-pohjaisten NPM-riippuvuuksien asennus, validoi NPM CI turva-asetukset, ja ota käyttöön deployment: false

### DIFF
--- a/.github/actions/setup-build-env-and-tools/action.yml
+++ b/.github/actions/setup-build-env-and-tools/action.yml
@@ -102,6 +102,7 @@ runs:
         #restore-keys: ${{ runner.os }}-npm-
 
     - name: Verify NPM security settings
+      if: ${{ inputs.install-node-deps == 'true' }}
       uses: ./.github/actions/verify-npm-security
 
     - name: Install node dependencies from package-lock.json (dependencies & devDependencies)

--- a/.github/actions/setup-build-env-and-tools/action.yml
+++ b/.github/actions/setup-build-env-and-tools/action.yml
@@ -101,6 +101,9 @@ runs:
         # Mikäli package-lock.json muuttuu, käytetään kuitenkin vanhentunutta npm-cachea pohjana uudelle cachelle
         #restore-keys: ${{ runner.os }}-npm-
 
+    - name: Verify NPM security settings
+      uses: ./.github/actions/verify-npm-security
+
     - name: Install node dependencies from package-lock.json (dependencies & devDependencies)
       if: ${{ inputs.install-node-deps == 'true' }}
       # NPM ci:tä pitää kutsua vaikka ~/.npm yleinen cache löytyykin. Komento npm ci asentaa package-lock.jsonissa

--- a/.github/actions/setup-build-env-and-tools/action.yml
+++ b/.github/actions/setup-build-env-and-tools/action.yml
@@ -2,7 +2,7 @@ name: 'Setup build environment and build tools'
 description: 'Asentaa clojure-kehitys ympäristön ja buildaamiseen liittyviä työkalua'
 
 inputs:
-  install-java:
+  setup-java:
     description: 'Asenna java? Javan versio määritellään .github/.java-version tiedostossa.'
     # Huom, composite actionit eivät tue tyyppimäärityksiä inputeille, joten boolean esitetään tässä stringinä.
     default: 'true'
@@ -12,6 +12,9 @@ inputs:
   install-clojure-deps:
     description: 'Asenna clojure dependencyt?'
     default: 'true'
+  setup-node:
+    description: 'Asennetaanko NodeJS? Käytettävä NodeJS-versio määritellään package.json "engines" kentässä.'
+    default: 'false'
   install-node-deps:
     description: 'Asennetaanko nodejs dependencyt? (less.js ym.)'
     default: 'false'
@@ -19,9 +22,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Prepare java
+    - name: Setup Java
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-      if: ${{ inputs.install-java == 'true' }}
+      if: ${{ inputs.setup-java == 'true' }}
       with:
         distribution: 'temurin'
         java-version-file: './.github/.java-version'
@@ -35,7 +38,7 @@ runs:
         path: /usr/local/bin/lein
         key: ${{ runner.os }}-lein-${{ inputs.install-leiningen }}
 
-    - name: Prepare leiningen
+    - name: Prepare Leiningen
       if: ${{ inputs.install-leiningen != 'false' && steps.cache-leiningen.outputs.cache-hit != 'true' }}
       env:
         LEIN_VERSION: ${{ inputs.install-leiningen }}
@@ -74,8 +77,8 @@ runs:
 #        #lein: 2.9.8
 
 
-    - name: Prepare nodejs
-      if: ${{ inputs.install-node-deps == 'true' }}
+    - name: Setup NodeJS
+      if: ${{ inputs.setup-node == 'true' || inputs.install-node-deps == 'true' }}
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         # Haetaan nodejs versio package.json "engines" kentästä
@@ -83,6 +86,10 @@ runs:
         # Halutaan täysi kontrolli cachettamista, joten ei käytetä actionin omaa cachetusta
         package-manager-cache: false
         #cache: 'npm'
+
+    - name: Verify NPM security settings
+      if: ${{ inputs.setup-node == 'true' || inputs.install-node-deps == 'true' }}
+      uses: ./.github/actions/verify-npm-security
 
     # https://www.voorhoede.nl/en/blog/super-fast-npm-install-on-github-actions/
     - name: Cache NPM packages
@@ -100,10 +107,6 @@ runs:
         #       ole tapahtunut vuoteen kun "restore-keys" asetus on ollut käytössä.
         # Mikäli package-lock.json muuttuu, käytetään kuitenkin vanhentunutta npm-cachea pohjana uudelle cachelle
         #restore-keys: ${{ runner.os }}-npm-
-
-    - name: Verify NPM security settings
-      if: ${{ inputs.install-node-deps == 'true' }}
-      uses: ./.github/actions/verify-npm-security
 
     - name: Install node dependencies from package-lock.json (dependencies & devDependencies)
       if: ${{ inputs.install-node-deps == 'true' }}

--- a/.github/actions/verify-npm-security/action.yml
+++ b/.github/actions/verify-npm-security/action.yml
@@ -1,0 +1,64 @@
+# Composite action to verify that NPM supply chain security settings from .npmrc are active.
+# This action should be called before any `npm ci` or `npm install` command in workflows.
+# It fails the workflow if the expected security settings are not in effect.
+
+name: 'Verify NPM Security Settings'
+description: 'Verifies that .npmrc supply chain protection settings (ignore-scripts, allow-git) are active'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Verify NPM security settings (For NPM v11.10.x and later)
+      shell: bash
+      run: |
+        echo "::group::NPM Supply Chain Security Settings"
+
+        ignore_scripts=$(npm config get ignore-scripts)
+        allow_git=$(npm config get allow-git)
+        before=$(npm config get before)
+        
+        echo "ignore-scripts = $ignore_scripts"
+        echo "allow-git = $allow_git"
+        echo "before (derived from 'min-release-age') = $before"
+        
+        errors=0
+        
+        if [[ "$ignore_scripts" != "true" ]]; then
+          echo "::error::ignore-scripts is not enabled! Expected 'true', got '$ignore_scripts'"
+          errors=$((errors + 1))
+        fi
+        
+        if [[ "$allow_git" != "none" ]]; then
+          echo "::error::allow-git is not restricted! Expected 'none', got '$allow_git'"
+          errors=$((errors + 1))
+        fi
+        
+        if [ -z "$before" ] || [ "$before" = "null" ]; then
+          echo "::error::before (derived from 'min-release-age') has no value. Expected a date string, got '$before'. Check that 'min-release-age' is defined."
+          errors=$((errors + 1))
+        else
+          before_seconds=$(date -d "$before" +%s 2>/dev/null)
+          current_seconds=$(date +%s)
+
+          if [ -z "$before_seconds" ]; then
+            echo "::error::Failed to transform 'before' date string into seconds."
+            errors=$((errors + 1))
+          else
+            before_diff_seconds=$(( current_seconds - before_seconds ))
+
+            if [ "$before_diff_seconds" -gt 60 ]; then
+              echo "Validation successful: 'min-release-age' is greater than 0, got '$(( before_diff_seconds / 86400 ))' days."
+            else
+              echo "::error::min-release-age is <= 0."
+              errors=$((errors + 1))
+            fi
+          fi
+        fi
+
+        if [[ $errors -gt 0 ]]; then
+          echo "::error::NPM security settings verification failed. Check that .npmrc is present and correctly configured."
+          exit 1
+        fi
+        
+        echo "✅ All NPM supply chain security settings verified"
+        echo "::endgroup::"

--- a/.github/workflows/infra_restart_fargate_tasks.yml
+++ b/.github/workflows/infra_restart_fargate_tasks.yml
@@ -27,7 +27,10 @@ jobs:
   restart-fargate-tasks:
     name: "Restart Fargate tasks"
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
+    environment:
+      name: ${{ inputs.environment }}
+      # Käytä ympäristökohtaisia salaisuuksia, mutta estä GitHub deployment-objektin luonti, jotta ei synny turhaa kohinaa.
+      deployment: false
 
     # README: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:

--- a/.github/workflows/infra_shutdown_fargate_tasks.yml
+++ b/.github/workflows/infra_shutdown_fargate_tasks.yml
@@ -27,7 +27,10 @@ jobs:
   shutdown-fargate-tasks:
     name: "Shutdown Fargate tasks"
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
+    environment:
+      name: ${{ inputs.environment }}
+      # Käytä ympäristökohtaisia salaisuuksia, mutta estä GitHub deployment-objektin luonti, jotta ei synny turhaa kohinaa.
+      deployment: false
 
     # README: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:

--- a/.github/workflows/infra_start_fargate_tasks.yml
+++ b/.github/workflows/infra_start_fargate_tasks.yml
@@ -27,7 +27,10 @@ jobs:
   start-fargate-tasks:
     name: "Start Fargate tasks"
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
+    environment:
+      name: ${{ inputs.environment }}
+      # Käytä ympäristökohtaisia salaisuuksia, mutta estä GitHub deployment-objektin luonti, jotta ei synny turhaa kohinaa.
+      deployment: false
 
     # README: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:

--- a/.github/workflows/reusable_run_app_tests.yml
+++ b/.github/workflows/reusable_run_app_tests.yml
@@ -575,15 +575,15 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           service-name: ${{ env.TEST_DB_SERVICE }}
 
-      # Asenna pelkkä Java
+      # Asenna pelkkä Java- ja NodeJS-ympäristö ilman riippuvuuksia
       - name: Setup environment
         uses: ./.github/actions/setup-build-env-and-tools
         with:
-          install-java: true
+          setup-java: true
+          setup-node: true
           install-leiningen: false
           install-clojure-deps: false
           install-node-deps: false
-
 
       - name: Get the build artifact name
         id: artifact-name

--- a/.npmrc
+++ b/.npmrc
@@ -4,11 +4,15 @@
 # HUOM: Tämä estää myös Cypressin binäärin automaattisen latauksen.
 # Cypressin binääri täytyy asentaa erikseen komennolla: `npx cypress install` ennen cypressin käyttöä.
 # Katso: kaynnista_cypress.sh
-
+# https://docs.npmjs.com/cli/v11/commands/npm-install#ignore-scripts
 ignore-scripts=true
 
+# Supply chain -suojaus: Estetään git-viitteistä asennettavien riippuvuuksien asentaminen (NPM versio vähintään v11.10.x)
+# https://docs.npmjs.com/cli/v11/commands/npm-install#allow-git
+allow-git=none
 
-# Supply chain -suojaus: Estetään liian uusien pakettien asentaminen
+
+# Supply chain -suojaus: Estetään liian uusien pakettien asentaminen (NPM versio vähintään v11.10.x)
 # Huom: Varmista, että Depandabot/Renovate-asetuksissa min-release-age-asetusta vastaava asetus on määritelty
 #       samaan arvoon, jotta automaattiset PR:t eivät turhaan epäonnistu liian uusien pakettien vuoksi.
 min-release-age=3

--- a/sh/tietoturva/local-github-actions-scan.sh
+++ b/sh/tietoturva/local-github-actions-scan.sh
@@ -46,6 +46,8 @@ pull_image() {
 }
 
 run_zizmor() {
+    local mount_opts=""
+
     # Jos ei olla fix-tilassa, mountataan read-only
     # Tämä lisää tietoturvaa, koska skannauksessa ei tarvita kirjoitusoikeuksia.
     if [[ -z "$FIX_MODE" ]]; then


### PR DESCRIPTION
* Estä NPM riippuvuuksien asentaminen git-referensseistä
* Varmista NPM tietoturva-asetukset workflowssa ennen NPM-komennon ajamista uudella composite-actionilla
* Estä turhan GitHub deployment objektin luominen deployment-historiaan Build and Diff workflowssa
  * Uusi GitHub Actions asetus `deployment: false` mahdollistaa environment-salaisuuksien hyödyntämisen, mutta mahdollistaa "deploymentin luomisen" estämisen. Tämä vähentää turhaa kohinaa deployment historiassa, ja sinne menee oikeasti asiat jotka on puskettu AWS ympäristöön asti.
  * Ennen vanhaan deployment objekti luotiin väkisten automaattisesti GitHubin toimesta aina kun environment-asetusta käytettiin missä tahansa workflowissa.
  
* Korjattu myös pieni bugi Zizmor-skannerin ajavassa scriptissä 
  