### PR TITLE
HARJA-2397 talvisuolasanktio vain viimeselle hoitovuodelle

### DIFF
--- a/src/clj/harja/kyselyt/sanktiot.clj
+++ b/src/clj/harja/kyselyt/sanktiot.clj
@@ -4,7 +4,7 @@
             [harja.geo :as geo]))
 
 (declare hae-sanktiotyypit hae-sanktiotyypin-tiedot-koodilla hae-sanktio hae-urakan-sanktiot
-  hae-urakan-sanktiot-analytiikalle)
+  hae-urakan-sanktiot-analytiikalle hae-sanktiotyyppi-koodilla merkitse-maksuera-likaiseksi!)
 
 ;; Käytössä jeesql:ssä
 (defn muunna-urakan-sanktio

--- a/src/clj/harja/palvelin/palvelut/laadunseuranta.clj
+++ b/src/clj/harja/palvelin/palvelut/laadunseuranta.clj
@@ -215,6 +215,16 @@
         (throw (SecurityException. (str "Sanktio " sanktio-id " ei kuulu valittuun urakkaan "
                                      urakka-id " vaan urakkaan " sanktion-urakka)))))))
 
+(defn vaadi-talvisuolan-ylitys-ehdon-tayttymista
+  "Tarkistaa, että talvisuolan ylitys -sanktion ehdot täyttyvät:
+  sanktion laji on talvisuolan ylitys
+  ja sanktion käsittelyaika on urakan viimeisen hoitovuoden aikana."
+  [urakan-tiedot kasittelyaika]
+  (when-not (and
+              (pvm/valissa? kasittelyaika
+                (pvm/->pvm (str "01.10." (dec (-> urakan-tiedot :loppupvm pvm/vuosi))))
+                (-> urakan-tiedot :loppupvm)))
+    (throw (SecurityException. "Talvisuolan ylityksen ehdot eivät täyttyneet: Urakka ei ole teidenhoidon hoitourakka, tai sanktion perintäpäivä ei ole urakan viimeisen hoitovuoden aikana."))))
 (defn tallenna-laatupoikkeaman-sanktio
   [db user {:keys [id perintapvm laji tyyppi summa indeksi suorasanktio
                    toimenpideinstanssi vakiofraasi poistettu] :as sanktio} laatupoikkeama urakka]

--- a/src/clj/harja/palvelin/palvelut/laadunseuranta.clj
+++ b/src/clj/harja/palvelin/palvelut/laadunseuranta.clj
@@ -215,7 +215,7 @@
         (throw (SecurityException. (str "Sanktio " sanktio-id " ei kuulu valittuun urakkaan "
                                      urakka-id " vaan urakkaan " sanktion-urakka)))))))
 
-(defn vaadi-talvisuolan-ylitys-ehdon-tayttymista
+(defn vaadi-talvisuolan-ylitys-ehto
   "Tarkistaa, että talvisuolan ylitys -sanktion ehdot täyttyvät:
   sanktion laji on talvisuolan ylitys
   ja sanktion käsittelyaika on urakan viimeisen hoitovuoden aikana."
@@ -225,15 +225,18 @@
                 (pvm/->pvm (str "01.10." (dec (-> urakan-tiedot :loppupvm pvm/vuosi))))
                 (-> urakan-tiedot :loppupvm)))
     (throw (SecurityException. "Talvisuolan ylityksen ehdot eivät täyttyneet: Urakka ei ole teidenhoidon hoitourakka, tai sanktion perintäpäivä ei ole urakan viimeisen hoitovuoden aikana."))))
+
 (defn tallenna-laatupoikkeaman-sanktio
   [db user {:keys [id perintapvm laji tyyppi summa indeksi suorasanktio
-                   toimenpideinstanssi vakiofraasi poistettu] :as sanktio} laatupoikkeama urakka]
+                   toimenpideinstanssi vakiofraasi poistettu] :as sanktio} laatupoikkeama urakka kasittelyaika]
   (log/debug "TALLENNA sanktio: " sanktio ", urakka: " urakka ", tyyppi: " tyyppi ", laatupoikkeamaan " laatupoikkeama)
   (when (id-olemassa? id) (vaadi-sanktio-kuuluu-urakkaan db urakka id))
-  (let [summa (if (decimal? summa)
+
+  (let [urakan-tiedot (first (urakat/hae-urakka db urakka))
+        _ (when (= :talvisuolan_ylitys laji) (vaadi-talvisuolan-ylitys-ehto urakan-tiedot kasittelyaika))
+        summa (if (decimal? summa)
                 (double summa)            ;; Math/abs ei kestä BigDecimaalia, joten varmistetaan, ettei sitä käytetä
                 summa)
-        urakan-tiedot (first (urakat/hae-urakka db urakka))
         ;; MHU-urakoissa joiden alkuvuosi 2021 tai myöhemmin, ei koskaan sidota indeksiin
         indeksi (when-not (and
                             (= (:tyyppi urakan-tiedot) "teiden-hoito")
@@ -324,10 +327,10 @@
         (name paatos) perustelu
         (name kasittelytapa) muukasittelytapa
         (:id user)
-        id))
-    (when (= :sanktio (:paatos (:paatos laatupoikkeama)))
-      (doseq [sanktio (:sanktiot laatupoikkeama)]
-        (tallenna-laatupoikkeaman-sanktio db user sanktio id urakka)))))
+        id)
+      (when (= :sanktio (:paatos (:paatos laatupoikkeama)))
+        (doseq [sanktio (:sanktiot laatupoikkeama)]
+          (tallenna-laatupoikkeaman-sanktio db user sanktio id urakka kasittelyaika))))))
 
 (defn tallenna-laatupoikkeama [{:keys [db user fim email sms laatupoikkeama]}]
   (let [urakka-id (:urakka laatupoikkeama)]
@@ -408,7 +411,7 @@
               (name kasittelytapa) muukasittelytapa
               (:id user)
               id)
-          sanktio-id (tallenna-laatupoikkeaman-sanktio c user sanktio id urakka)
+          sanktio-id (tallenna-laatupoikkeaman-sanktio c user sanktio id urakka kasittelyaika)
           _ (tallenna-laatupoikkeaman-liitteet c laatupoikkeama id)]
       sanktio-id)))
 

--- a/src/cljc/harja/pvm.cljc
+++ b/src/cljc/harja/pvm.cljc
@@ -875,10 +875,14 @@
 #?(:cljs
    (defn hoitokauden-alkuvuosi
      ([pvm]
-      (let [aika (parsi (luo-format "yyyy-MM-dd'T'HH:mm:ss'Z'") pvm)
-            vuosi (t/year aika)
-            kuukausi (t/month aika)]
-        (hoitokauden-alkuvuosi vuosi kuukausi)))
+      (if (instance? goog.date.DateTime pvm)
+        (let [vuosi (.getFullYear pvm)
+              kuukausi (inc (.getMonth pvm))] ;; JS:ssä kuukaudet 0-11, meidän funktioissa 1-12
+          (hoitokauden-alkuvuosi vuosi kuukausi))
+        (let [aika (parsi (luo-format "yyyy-MM-dd'T'HH:mm:ss'Z'") pvm)
+              vuosi (t/year aika)
+              kuukausi (t/month aika)]
+          (hoitokauden-alkuvuosi vuosi kuukausi))))
      ([vuosi kuukausi]
       (if (<= 10 kuukausi)
         vuosi

--- a/src/cljs/harja/tiedot/urakka/laadunseuranta/sanktiot.cljs
+++ b/src/cljs/harja/tiedot/urakka/laadunseuranta/sanktiot.cljs
@@ -21,7 +21,8 @@
 (defn uusi-sanktio [urakkatyyppi]
   (let [nyt (pvm/nyt)
         default-perintapvm (pvm/luo-pvm-dec-kk (pvm/vuosi nyt) (pvm/kuukausi nyt) 15)]
-    {:suorasanktio true
+    {:harja.ui.lomake/muokatut #{:kasittelyaika}
+     :suorasanktio true
      :laji (cond
              (u-domain/mh-tai-hoitourakka? urakkatyyppi) :A
              (u-domain/vesivaylaurakkatyyppi? urakkatyyppi) :vesivayla_sakko

--- a/src/cljs/harja/views/urakka/laadunseuranta/sanktiot_lomake.cljs
+++ b/src/cljs/harja/views/urakka/laadunseuranta/sanktiot_lomake.cljs
@@ -50,6 +50,14 @@
                                      toimenpideinstanssit)
     toimenpideinstanssit))
 
+(defn- viimeinen-hoitokausi-nykyhetkella?
+  [urakan-tiedot pvm]
+  (when (and urakan-tiedot pvm)
+    (let [loppuvuosi (pvm/vuosi (:loppupvm urakan-tiedot))
+          viimeinen (dec loppuvuosi) ; viimeisen hoitokauden alkuvuosi
+          kauden-alku (pvm/hoitokauden-alkuvuosi pvm)]
+      (= kauden-alku viimeinen))))
+
 (defn sanktio-lomake
   [sivupaneeli-auki?-atom lukutila? voi-muokata?]
   (let [muokattu (atom @tiedot/valittu-sanktio)
@@ -172,6 +180,17 @@
             :valinnat (vec mahdolliset-sanktiolajit)
             :valinta-nayta #(or (sanktio-domain/sanktiolaji->teksti %) "- valitse laji -")
             :validoi [[:ei-tyhja "Valitse laji"]]})
+
+         ;; Näytetään mahdollisesti Talvisuolan kokonaiskäytön ylitys sanktiosta tuleva ilmoitus
+          (when (and (not lukutila?) (= :talvisuolan_ylitys (:laji @muokattu)))
+            {:otsikko ""
+             :nimi :talvisuolan-kokonaiskayton-ylitys
+             ::lomake/col-luokka "col-xs-12"
+             :tyyppi :komponentti
+             :komponentti (fn [rivi]
+                            [yleiset/info-laatikko :neutraali
+                             [:span "Talvisuolan kokonaiskäytön ylitys -sanktio käsitellään urakan päätteeksi vastaanottotarkastuksessa ja sen voi kirjata Harjaan vasta viimeisenä hoitovuonna."]])})
+
          (when-not (or yllapitourakka? vesivaylaurakka?)
            (if (not lukutila?)
              {:otsikko "Tyyppi" :tyyppi :valinta
@@ -321,7 +340,12 @@
                                      true
                                      (assoc-in [:laatupoikkeama :paatos :kasittelyaika] arvo)))
             :fmt pvm/pvm-opt :tyyppi :pvm
-            :validoi [[:ei-tyhja "Valitse päivämäärä"]]}
+            :validoi [[:ei-tyhja "Valitse päivämäärä"]
+                      (fn [arvo sanktio]
+                        (when (and (not (nil? arvo))
+                                (= :talvisuolan_ylitys (:laji sanktio))
+                                (not (viimeinen-hoitokausi-nykyhetkella? @nav/valittu-urakka arvo)))
+                          (str "Sanktio voidaan määrätä ainostaan urakan viimeiselle hoitovuodelle " (pvm/vuosi (:loppupvm @nav/valittu-urakka)) ".")))]}
 
            (if (and voi-muokata? (not lukutila?))
              {:otsikko "Laskutuskuukausi"

--- a/test/clj/harja/palvelin/palvelut/laadunseuranta_test.clj
+++ b/test/clj/harja/palvelin/palvelut/laadunseuranta_test.clj
@@ -1,5 +1,6 @@
 (ns harja.palvelin.palvelut.laadunseuranta-test
   (:require [clojure.test :refer :all]
+            [slingshot.slingshot :refer [throw+]]
             [taoensso.timbre :as log]
             [clojure.java.jdbc :as jdbc]
             [harja.palvelin.komponentit.tietokanta :as tietokanta]
@@ -1586,9 +1587,96 @@
       (is (not-any? #(= :laskutus_yli_laskutusrajan (:laji %)) (:lajit mhu25-laatupoikkeama-konteksti))
         "MHU25-profiilin laatupoikkeama-kontekstissa ei pidä olla laskutusrajalajia"))))
 
-(deftest vaadi-talvisuolan-ylitys-ehdon-tayttymista-hyvaksyy-oikean-kasittelyajan
+(deftest vaadi-talvisuolan-ylitys-ehto
   (let [urakan-tiedot {:loppupvm (pvm/->pvm "30.09.2026")}]
     (is (nil? (ls/vaadi-talvisuolan-ylitys-ehdon-tayttymista urakan-tiedot (pvm/->pvm "15.09.2026"))))
     (is (nil? (ls/vaadi-talvisuolan-ylitys-ehdon-tayttymista urakan-tiedot (pvm/->pvm "15.10.2025"))))
     (is (thrown? SecurityException (ls/vaadi-talvisuolan-ylitys-ehdon-tayttymista urakan-tiedot (pvm/->pvm "15.09.2022"))))
     (is (thrown? SecurityException (ls/vaadi-talvisuolan-ylitys-ehdon-tayttymista urakan-tiedot (pvm/->pvm "15.10.2026"))))))
+
+
+(deftest suorasanktio-talvisuolan-ylitys-toimii
+  (let [urakka-id (hae-urakan-id-nimella "Kittilän MHU 2025-2030")
+        perustelu "testaus-perustelu"
+        perintapvm (pvm/->pvm-aika "2.6.2030 22:00:00")
+        sanktio {:suorasanktio true
+                 :laji :talvisuolan_ylitys
+                 :summa 5000
+                 :perintapvm perintapvm}
+        laatupoikeama {:tekijanimi "testaus-tekija"
+                       :paatos {:paatos "sanktio"
+                                :kasittelyaika (pvm/->pvm-aika "2.6.2030 22:00:00")
+                                :kasittelytapa :kommentit
+                                :perustelu perustelu}
+                       :aika (pvm/->pvm-aika "2.6.2030 08:00:00")
+                       :urakka urakka-id}
+        hk-alkupvm (pvm/->pvm "01.10.2029")
+        hk-loppupvm (pvm/->pvm "30.09.2030")]
+    (testing "Talvisuolan ylitys -sanktio saadaan tallennettua"
+      (let [sanktio-id (palvelukutsu-tallenna-suorasanktio
+                         +kayttaja-jvh+ sanktio laatupoikeama hk-alkupvm hk-loppupvm)]
+        (is (number? sanktio-id) "Sanktion id:n tulee olla numero")))))
+
+
+(deftest suorasanktio-talvisuolan-ylitys-ei-toimi
+  (let [urakka-id (hae-urakan-id-nimella "Kittilän MHU 2025-2030")
+        perustelu "testaus-perustelu"
+        perintapvm (pvm/->pvm-aika "2.6.2028 22:00:00")
+        sanktio {:suorasanktio true
+                 :laji :talvisuolan_ylitys
+                 :summa 5000
+                 :perintapvm perintapvm}
+        laatupoikeama {:tekijanimi "testaus-tekija"
+                       :paatos {:paatos "sanktio"
+                                :kasittelyaika (pvm/->pvm-aika "1.6.2028 22:00:00")
+                                :kasittelytapa :kommentit
+                                :perustelu perustelu}
+                       :aika (pvm/->pvm-aika "01.6.2029 08:00:00")
+                       :urakka urakka-id}
+        hk-alkupvm (pvm/->pvm "01.10.2029")
+        hk-loppupvm (pvm/->pvm "30.09.2030")]
+    (testing "Talvisuolan ylitys antaa virheen vääränä hoitovuotena"
+      (is (thrown? SecurityException (palvelukutsu-tallenna-suorasanktio
+                                       +kayttaja-jvh+ sanktio laatupoikeama hk-alkupvm hk-loppupvm))
+        "Sanktion tallennus ei onnistu"))))
+
+(deftest laatupoikkeama-talvisuolan-ylitys-testi
+  (let [urakka-id (hae-urakan-id-nimella "Kittilän MHU 2025-2030")
+        laatupoikkeama {:yllapitokohde nil
+                        :sijainti {:type :point
+                                   :coordinates [382554.0523636384 6675978.549765582]}
+                        :kuvaus "Kuvaus"
+                        :aika #inst "2030-09-15T09:00:01.000-00:00"
+                        :tr {:alkuosa 1
+                             :numero 1
+                             :alkuetaisyys 1
+                             :loppuetaisyys 2
+                             :loppuosa 2}
+                        :urakka urakka-id
+                        :sanktiot nil
+                        :tekija :tilaaja
+                        :kohde "Kohde"}
+
+        uusi-sanktio {:perintapvm #inst "2030-09-15T09:00:01.000-00:00"
+                      :laji :talvisuolan_ylitys
+                      :summa 100
+                      :indeksi "MAKU 2010"
+                      :suorasanktio false
+                      :toimenpideinstanssi 4
+                      :vakiofraasi nil}
+        paatos {:paatos :sanktio
+                :kasittelytapa :puhelin
+                :kasittelyaika #inst "2030-09-15T09:00:01.000-00:00"
+                :perustelu "Testi"}]
+
+    (testing "sanktiollisen-laatupoikkeaman-tallennus"
+      (let [_ (kutsu-http-palvelua :tallenna-laatupoikkeama +kayttaja-jvh+ laatupoikkeama)
+            vastaus (kutsu-http-palvelua :tallenna-laatupoikkeama +kayttaja-jvh+
+                      (assoc laatupoikkeama
+                        :paatos paatos
+                        :sanktiot [uusi-sanktio]))]
+        (is (number? (:id vastaus)) "Tallennus palauttaa uuden id:n")
+        (is (= 1 (count (:sanktiot vastaus))) "Uudella laatupoikkeamalla pitäisi olla yksi sanktio")))
+    
+    ;; Siivoa roskat
+    (testidatan-kaytto/poista-sanktio-perustelulla "Testi")))

--- a/test/clj/harja/palvelin/palvelut/laadunseuranta_test.clj
+++ b/test/clj/harja/palvelin/palvelut/laadunseuranta_test.clj
@@ -1586,3 +1586,9 @@
       (is (not-any? #(= :laskutus_yli_laskutusrajan (:laji %)) (:lajit mhu25-laatupoikkeama-konteksti))
         "MHU25-profiilin laatupoikkeama-kontekstissa ei pidä olla laskutusrajalajia"))))
 
+(deftest vaadi-talvisuolan-ylitys-ehdon-tayttymista-hyvaksyy-oikean-kasittelyajan
+  (let [urakan-tiedot {:loppupvm (pvm/->pvm "30.09.2026")}]
+    (is (nil? (ls/vaadi-talvisuolan-ylitys-ehdon-tayttymista urakan-tiedot (pvm/->pvm "15.09.2026"))))
+    (is (nil? (ls/vaadi-talvisuolan-ylitys-ehdon-tayttymista urakan-tiedot (pvm/->pvm "15.10.2025"))))
+    (is (thrown? SecurityException (ls/vaadi-talvisuolan-ylitys-ehdon-tayttymista urakan-tiedot (pvm/->pvm "15.09.2022"))))
+    (is (thrown? SecurityException (ls/vaadi-talvisuolan-ylitys-ehdon-tayttymista urakan-tiedot (pvm/->pvm "15.10.2026"))))))

--- a/test/clj/harja/palvelin/palvelut/laadunseuranta_test.clj
+++ b/test/clj/harja/palvelin/palvelut/laadunseuranta_test.clj
@@ -1589,10 +1589,10 @@
 
 (deftest vaadi-talvisuolan-ylitys-ehto
   (let [urakan-tiedot {:loppupvm (pvm/->pvm "30.09.2026")}]
-    (is (nil? (ls/vaadi-talvisuolan-ylitys-ehdon-tayttymista urakan-tiedot (pvm/->pvm "15.09.2026"))))
-    (is (nil? (ls/vaadi-talvisuolan-ylitys-ehdon-tayttymista urakan-tiedot (pvm/->pvm "15.10.2025"))))
-    (is (thrown? SecurityException (ls/vaadi-talvisuolan-ylitys-ehdon-tayttymista urakan-tiedot (pvm/->pvm "15.09.2022"))))
-    (is (thrown? SecurityException (ls/vaadi-talvisuolan-ylitys-ehdon-tayttymista urakan-tiedot (pvm/->pvm "15.10.2026"))))))
+    (is (nil? (ls/vaadi-talvisuolan-ylitys-ehto urakan-tiedot (pvm/->pvm "15.09.2026"))))
+    (is (nil? (ls/vaadi-talvisuolan-ylitys-ehto urakan-tiedot (pvm/->pvm "15.10.2025"))))
+    (is (thrown? SecurityException (ls/vaadi-talvisuolan-ylitys-ehto urakan-tiedot (pvm/->pvm "15.09.2022"))))
+    (is (thrown? SecurityException (ls/vaadi-talvisuolan-ylitys-ehto urakan-tiedot (pvm/->pvm "15.10.2026"))))))
 
 
 (deftest suorasanktio-talvisuolan-ylitys-toimii


### PR DESCRIPTION
Sallitaan talvisuolan ylityssanktio vain viimeisenä hoitovuotena

Testausohjeet:
- Tee Talvisuolan ylitys -sanktio, jollekin eri vuodelle, kuin viimeiselle vuodelle. Ei pitäisi onnistua.