### PR TITLE
HARJA-1678 raporttien UI muutoksia

### DIFF
--- a/dev-resources/less/grid.less
+++ b/dev-resources/less/grid.less
@@ -810,6 +810,15 @@ tr.otsikko {
       position: absolute;
     }
   }
+  &.tyhja-rivi {
+    background-color: @gray250;
+    color: @black-lighter;
+
+    > td {
+      text-align: center;
+      vertical-align: middle;
+    }
+  }
 }
 
 .gridin-collapsoitava-valiotsikko {

--- a/src/clj/harja/palvelin/raportointi/raportit/muutos_ja_lisatyoraportti.clj
+++ b/src/clj/harja/palvelin/raportointi/raportit/muutos_ja_lisatyoraportti.clj
@@ -124,6 +124,7 @@
         ;; HTML raporttiin tulee hieno sininen tausta ja kaksi vierekkäistä laatikkoa
         [[:tyhja-rivi nil]
          [:otsikko-heading "Muutosten yhteenveto"]
+         [:tyhja-rivi nil]
          [:display-flex
           [:sininen-laatikko {:otsikko "Muutosten vaikutus tavoitehintaan"}
            [{:avain "Hoitovuoden alun indeksikorjattu tavoitehinta"
@@ -321,7 +322,8 @@
      [:tyhja-rivi nil]]))
 
 (defn muodosta-muutostoiden-kulukohdistukset [db urakka-id alkupvm loppupvm urakka-nimi kasittelija]
-  (let [muutostyot (hae-muutostoiden-kulukohdistukset db {:urakka-id urakka-id
+  (let [ei-excel? (not= kasittelija :excel)
+        muutostyot (hae-muutostoiden-kulukohdistukset db {:urakka-id urakka-id
                                                           :alkupvm alkupvm
                                                           :loppupvm loppupvm})
         muutostyorivit (mapv (fn [r]
@@ -336,35 +338,35 @@
                                   :korosta-hennosti? true
                                   :rivi (rivi "Yhteensä" "" "" "" muutostyot-yhteensa)}]
         otsikko-title [:otsikko-title "Muutostöiden kulukohdistukset"]
-        ajankohtakuvaus [:teksti (str urakka-nimi " | Aikaväli: " (pvm/pvm alkupvm) " - " (pvm/pvm loppupvm))]]
-    (if
-      ;; HTML ja PDF raporteille ei näytetä taulukkoa
-      (and (not (= kasittelija :excel)) (= 0 (count muutostyorivit)))
-      [[:jakaja nil]
-       (when-not (= kasittelija :excel) otsikko-title)
-       (when-not (= kasittelija :excel) ajankohtakuvaus)
-       [:tyhja-rivi nil]
-       [:tyhja-rivi nil]
-       [:teksti "Ei muutostöiden kulukohdistuksia." {:vari "#5C5C5C"}]
-       [:tyhja-rivi nil]]
+        ajankohtakuvaus [:teksti (str urakka-nimi " | Aikaväli: " (pvm/pvm alkupvm) " - " (pvm/pvm loppupvm))]
+        otsikon-alun-rivit (when ei-excel? [otsikko-title
+                                            ajankohtakuvaus
+                                            [:tyhja-rivi nil]
+                                            [:tyhja-rivi nil]])]
+    (if (and ei-excel? (empty? muutostyorivit))
+      (concat
+        [[:jakaja nil]]
+        otsikon-alun-rivit
+        [[:teksti "Ei muutostöiden kulukohdistuksia." {:vari "#5C5C5C"}]
+         [:tyhja-rivi nil]])
 
-      [(when-not (= kasittelija :excel) otsikko-title)
-       (when-not (= kasittelija :excel) ajankohtakuvaus)
-       [:taulukko {:otsikko (when-not (= kasittelija :excel) "Muutostyöt (erillisrahoitetut)")
-                   :viimeinen-rivi-yhteenveto? true
-                   :tyhja (when (empty? muutostyot) "Ei muutostöitä.")
-                   :sheet-nimi "Muutostöiden kulut"
-                   :excel-alkutekstit (when (= kasittelija :excel)
-                                        [otsikko-title
-                                         ajankohtakuvaus
-                                         [:teksti ""]
-                                         [:otsikko-heading "Muutostyöt (erillisrahoitetut)"]])}
-        [{:leveys 3 :otsikko "Lasku pvm"}
-         {:leveys 5 :otsikko "Muutostyö"}
-         {:leveys 5 :otsikko "Toimenpide"}
-         {:leveys 10 :otsikko "Muutoksen syy"}
-         {:leveys 5 :otsikko "Määrä (€)" :fmt :raha}]
-        (into [] (concat muutostyorivit (when-not (empty? muutostyot) muutostyot-yhteensarivi)))]])))
+      (concat
+        otsikon-alun-rivit
+        [[:taulukko {:otsikko (when ei-excel? "Muutostyöt (erillisrahoitetut)")
+                     :viimeinen-rivi-yhteenveto? true
+                     :tyhja (when (empty? muutostyot) "Ei muutostöitä.")
+                     :sheet-nimi "Muutostöiden kulut"
+                     :excel-alkutekstit (when (not ei-excel?)
+                                          [otsikko-title
+                                           ajankohtakuvaus
+                                           [:teksti ""]
+                                           [:otsikko-heading "Muutostyöt (erillisrahoitetut)"]])}
+          [{:leveys 3 :otsikko "Lasku pvm"}
+           {:leveys 5 :otsikko "Muutostyö"}
+           {:leveys 5 :otsikko "Toimenpide"}
+           {:leveys 10 :otsikko "Muutoksen syy"}
+           {:leveys 5 :otsikko "Määrä (€)" :fmt :raha}]
+          (into [] (concat muutostyorivit (when-not (empty? muutostyot) muutostyot-yhteensarivi)))]]))))
 
 (defn muodosta-tavoitehinnan-oikaisut [db urakka-id alkupvm loppupvm urakka-nimi kasittelija]
   (let [oikaisut (hae-tavoitehinnan-oikaisut db {:urakka-id urakka-id

--- a/src/cljs/harja/ui/grid/perus.cljs
+++ b/src/cljs/harja/ui/grid/perus.cljs
@@ -663,19 +663,23 @@
   (let [valiotsikko-id (get-in otsikko-record [:optiot :id])
         ;; mahdollistetaan komponentin rendaus myös otsikkorivin sisään
         komponentti-otsikon-sisaan (get-in otsikko-record [:optiot :komponentti-otsikon-sisaan])
-        otsikkokomponentit (get-in otsikko-record [:optiot :otsikkokomponentit])]
+        otsikkokomponentit (get-in otsikko-record [:optiot :otsikkokomponentit])
+        luokka (get-in otsikko-record [:optiot :luokka])]
     [:<>
-     [:tr.otsikko (when salli-valiotsikoiden-piilotus?
-                    {:class (str "gridin-collapsoitava-valiotsikko klikattava"
-                              (when (not (empty? otsikkokomponentit)) " grid-otsikkokomponentti"))
-                     :on-click #(toggle-valiotsikko valiotsikko-id
-                                  piilotetut-valiotsikot)
-                     :style (merge {}
-                              (when (not (empty? otsikkokomponentit))
-                                {:border-bottom "none"
-                                 :border-top "solid 0.1mm black"})
-                              (when (:otsikon-tyyli komponentti-otsikon-sisaan)
-                                (:otsikon-tyyli komponentti-otsikon-sisaan)))})
+     [:tr.otsikko
+      (merge
+        {:class (when luokka luokka)}
+       (when salli-valiotsikoiden-piilotus?
+         {:class (str "gridin-collapsoitava-valiotsikko klikattava"
+                   (when (not (empty? otsikkokomponentit)) " grid-otsikkokomponentti"))
+          :on-click #(toggle-valiotsikko valiotsikko-id
+                       piilotetut-valiotsikot)
+          :style (merge {}
+                   (when (not (empty? otsikkokomponentit))
+                     {:border-bottom "none"
+                      :border-top "solid 0.1mm black"})
+                   (when (:otsikon-tyyli komponentti-otsikon-sisaan)
+                     (:otsikon-tyyli komponentti-otsikon-sisaan)))}))
       [:td {:colSpan (if (empty? komponentti-otsikon-sisaan)
                        colspan
                        (- colspan (:col-span komponentti-otsikon-sisaan)))}

--- a/src/cljs/harja/ui/raportti.cljs
+++ b/src/cljs/harja/ui/raportti.cljs
@@ -242,7 +242,7 @@
                           elementti))))}))))
          sarakkeet))
      (if (empty? data)
-       [(grid/otsikko (or tyhja "Ei tietoja"))]
+       [(grid/otsikko (or tyhja "Ei tietoja") {:luokka "tyhja-rivi"})]
        (let [viimeinen-rivi (last data)]
          (into []
            (map-indexed (fn [index rivi]


### PR DESCRIPTION
## Mitä muutettiin
Muutos- ja lisätyöraporttiin lisättiin H2 elementtien alle tyhjiä rivejä, jotta ne näyttää html-raportissa enemmän speksin mukaiselta.

Koko harjaa koskevan taulukon eli grid-komponentin otsikointia muutettiin niin, että sille voidaan paremmin antaa parametrina luokka, jolla sen ulkoasua voi säätää. Raportti kontekstissa se otettiin hyötykäyttöön ja tyhjä rivi näyttää nyt nätimmältä.

## Miksi
Ui on tärkeää

## Testaustapa
Avaa esim Kittilä -25 urakka, niin näet tyhjiä rivejä (grid muutos)
Avaa Kajaani -25 urakka ja lisää sille pysyviä muutoksia ja niihin liittyvä kulu, niin näkyy kaikki otsikointimuutokset.

## Huomioita
Ei riskejä. Vain ui-korjauksia.
