### PR TITLE
Käytä vakiintunutta Flyway-historiataulun nimeä myös testitietokannassa

### DIFF
--- a/.github/docker/tietokanta/docker_aja-migraatiot.sh
+++ b/.github/docker/tietokanta/docker_aja-migraatiot.sh
@@ -26,7 +26,7 @@ mvn -Dharja.tietokanta.port="${HARJA_TIETOKANTA_PORTTI:-5432}" -Dharja.tietokant
 
 ## Aja migraatiot alusta
 mvn -Dharja.tietokanta.port="${HARJA_TIETOKANTA_PORTTI:-5432}" -Dharja.tietokanta.host="${HARJA_TIETOKANTA_HOST:-localhost}" \
--DbaselineVersion="0" -DbaseLineOnMigrate="true" \
+-Dflyway.baselineVersion="0" -Dflyway.baselineOnMigrate="true" -Dflyway.table="schema_version" \
  flyway:migrate
 
 echo "Migraatio ajettu."

--- a/cypress/e2e/kalustoresurssit.cy.js
+++ b/cypress/e2e/kalustoresurssit.cy.js
@@ -35,8 +35,14 @@ function avaaUrakanSuunnittelu(alue, urakkaNimi) {
 }
 
 function asetaKalustoresurssi(dataCy, arvo) {
-		cy.get(`[data-cy="${dataCy}"]`, {timeout: timeout}).should('be.visible').and('not.be.disabled');
-		cy.get(`[data-cy="${dataCy}"]`).clear().type(arvo);
+    cy.get(`[data-cy="${dataCy}"]`, { timeout })
+        .should('be.visible')
+        .and('not.be.disabled');
+
+    cy.get(`[data-cy="${dataCy}"]`, { timeout })
+        .click()
+        .clear()
+        .type(arvo);
 }
 
 describe('Suunnittelu / Kalustoresurssit', function () {
@@ -53,7 +59,6 @@ describe('Suunnittelu / Kalustoresurssit', function () {
 
     it('MHU26-urakka voi tallentaa, tarkastella ja peruuttaa kalustoresurssit', function () {
         tyhjennaKalustoresurssit(MHU26_URAKKA);
-
         avaaUrakanSuunnittelu(ALUE, MHU26_URAKKA);
 
         // Avaa Kalustoresurssit-välilehti

--- a/tietokanta/pom.xml
+++ b/tietokanta/pom.xml
@@ -43,6 +43,13 @@
                 <artifactId>flyway-maven-plugin</artifactId>
                 <version>12.8.1</version>
                 <configuration>
+                    <!--
+                    Asetetaan Flywayn historiataulu saman nimiseksi kuin tuotannossa, jotta voidaan
+                    testata migraatioiden ajamista stg/prod-ympäristöjen toimintaa simuloiden.
+                    Default-asetuksella historiataulu on nimeltään: "flyway_schema_history",
+                    mutta tuotannossa se on "schema_version".
+                    -->
+                    <table>schema_version</table>
                     <baselineOnMigrate>true</baselineOnMigrate>
                     <baselineVersion>0</baselineVersion>
                     <!--


### PR DESCRIPTION
## Mitä muutettiin
Muutettu harjadb-testitietokannan Flyway-historiataulun nimi default-asetuksesta "schema_version"-nimiseksi

## Miksi
Historiataulu on nimetty samanimiseksi kuin tuotannossa, jotta voidaan testata migraatioiden ajamista stg/prod-ympäristöjen toimintaa simuloiden.

## Testaustapa
Historiataulun nimenmuutoksen voi todeta ajamalla devdb_restart.sh branchissä, ja varmistaa paikallisesta testitietokannasta että Flywayn historiataulu on nyt nimeltään "schema_version", eikä default "flyway_schema_history"

## Huomioita
Ei erityisiä riskejä tai huomioitavaa.
Ei vaadi uuden harjadb-imagen tuottamista. Rakennan uuden imagen muun harjadb-imagen päivityksen yhteydessä, joka on jo tehtävänä eri tiketillä myöhemmällä ajankohdalla.
