### PR TITLE
HARJA-2580 - Korjaa verify-npm-security toiminta, pakota käyttöön NPM v11.18.x

### DIFF
--- a/.github/actions/setup-build-env-and-tools/action.yml
+++ b/.github/actions/setup-build-env-and-tools/action.yml
@@ -76,20 +76,12 @@ runs:
 #      with:
 #        #lein: 2.9.8
 
-
-    - name: Setup NodeJS
+    - name: Setup Node.js and NPM (versions defined in package.json "engines")
       if: ${{ inputs.setup-node == 'true' || inputs.install-node-deps == 'true' }}
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      uses: ./.github/actions/setup-node-and-npm
       with:
-        # Haetaan nodejs versio package.json "engines" kentästä
-        node-version-file: 'package.json'
         # Halutaan täysi kontrolli cachettamista, joten ei käytetä actionin omaa cachetusta
         package-manager-cache: false
-        #cache: 'npm'
-
-    - name: Verify NPM security settings
-      if: ${{ inputs.setup-node == 'true' || inputs.install-node-deps == 'true' }}
-      uses: ./.github/actions/verify-npm-security
 
     # https://www.voorhoede.nl/en/blog/super-fast-npm-install-on-github-actions/
     - name: Cache NPM packages

--- a/.github/actions/setup-node-and-npm/action.yml
+++ b/.github/actions/setup-node-and-npm/action.yml
@@ -1,0 +1,35 @@
+# Future improvements:
+#  * Allow defining package.json path as an input. Hardcoding the path is enough for now.
+#  * Validate, that NPM version was installed correctly. Printing the NPM version will suffice for now.
+
+name: 'Setup Node.js and NPM'
+description: 'Installs specific Node.js and NPM versions that are defined in package.json of this project. 
+Also verifies tha required NPM supply chain security settings are active.'
+
+inputs:
+  package-manager-cache:
+    description: 'Set to false to disable actions/setup-node automatic caching.'
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Node.js (version defined in package.json "engines")
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version-file: 'package.json'
+        package-manager-cache: ${{ inputs.package-manager-cache }}
+    - name: Setup NPM (version defined in package.json "engines")
+      run: |
+        NPM_VERSION=$(node -pe 'require("./package").engines.npm')
+
+        if [ -z "${NPM_VERSION}" ] || [ "${NPM_VERSION}" = "undefined" ]; then
+          echo "::error::NPM_VERSION is not defined in package.json 'engines.npm' setting. Cannot continue."
+          exit 1
+        fi
+
+        npm install -g npm@"${NPM_VERSION}"
+        echo "Installed NPM version: $(npm -v)"
+      shell: bash
+    - name: Verify NPM security settings
+      uses: ./.github/actions/verify-npm-security

--- a/.github/actions/verify-npm-security/action.yml
+++ b/.github/actions/verify-npm-security/action.yml
@@ -15,11 +15,11 @@ runs:
 
         ignore_scripts=$(npm config get ignore-scripts)
         allow_git=$(npm config get allow-git)
-        before=$(npm config get before)
+        min_release_age=$(npm config get min-release-age)
         
         echo "ignore-scripts = $ignore_scripts"
         echo "allow-git = $allow_git"
-        echo "before (derived from 'min-release-age') = $before"
+        echo "min-release-age = $min_release_age"
         
         errors=0
         
@@ -33,25 +33,15 @@ runs:
           errors=$((errors + 1))
         fi
         
-        if [ -z "$before" ] || [ "$before" = "null" ]; then
-          echo "::error::before (derived from 'min-release-age') has no value. Expected a date string, got '$before'. Check that 'min-release-age' is defined."
+        if [ -z "$min_release_age" ] || [ "$min_release_age" = "null" ] || [ "$min_release_age" = "undefined" ]; then
+          echo "::error::min-release-age has no value. expected a number of days, got '$min_release_age'."
           errors=$((errors + 1))
         else
-          before_seconds=$(date -d "$before" +%s 2>/dev/null)
-          current_seconds=$(date +%s)
-
-          if [ -z "$before_seconds" ]; then
-            echo "::error::Failed to transform 'before' date string into seconds."
-            errors=$((errors + 1))
+          if [[ "$min_release_age" =~ ^[0-9]+$ ]] && [ "$min_release_age" -gt 0 ]; then
+            echo "Validation successful: 'min-release-age' is configured to $min_release_age days."
           else
-            before_diff_seconds=$(( current_seconds - before_seconds ))
-
-            if [ "$before_diff_seconds" -gt 60 ]; then
-              echo "Validation successful: 'min-release-age' is greater than 0, got '$(( before_diff_seconds / 86400 ))' days."
-            else
-              echo "::error::min-release-age is <= 0."
-              errors=$((errors + 1))
-            fi
+            echo "::error::min-release-age is not a valid positive number, got '$min_release_age'."
+            errors=$((errors + 1))
           fi
         fi
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   },
   "engines": {
     "node": "^24.0.0",
-    "npm": "^11.10.0"
+    "npm": "^11.18.0"
   },
   "devDependencies": {
     "cypress": "10.2.0",


### PR DESCRIPTION
## Mitä muutettiin
* Pakotettu NPM v11.18.x versio asentumaan ci/cd putkessa
* Hyödynnetään uusimman NPM-version vakaampaa min-release-age asetuksen varmistamiseksi

## Miksi
NPM versiossa ^v11.13.0 on bugi, joka teki aiemmasta laskennallisen 'before' arvon verifioinnista epävakaan -> before arvoon tulee satunnaisesti null. Myöskään aiemmin ei ollut mahdollista hakea suoraan min-release-age asetuksen arvoa sisäänluetusta NPM config:sta, vaan se piti tehdä hankalasti kiertotietä hyödyntäen laskennallista 'before'-arvoa.
* -> Nyt uudempi NPM versio mahdollistaa suoraan sisäänluetun 'min-release-age' arvon validoinnin ja sallii 'before'-bugin kiertämisen.
* Before-bug on edelleen läsnä NPM:ssä, mutta se ei vaikuta enää meihin tämän muutoksen jälkeen
