### PR TITLE
HARJA-2584 Päivitä siltatunnus kun sillan tiedot päivitetään

### DIFF
--- a/src/clj/harja/kyselyt/sillat.sql
+++ b/src/clj/harja/kyselyt/sillat.sql
@@ -13,6 +13,7 @@ VALUES
 UPDATE silta
 SET tyyppi          = :tyyppi,
     siltanimi       = :siltanimi,
+    siltatunnus     = :tunnus,
     alue            = ST_GeomFromText(:geometria) :: GEOMETRY,
     tr_numero       = :numero,
     tr_alkuosa      = :aosa,


### PR DESCRIPTION
Siltatunnuksen voi päivittää, koska se ei koskaan yksin yksilöi siltaa. Varsinainen sillan yksilöivä tieto on trex-oid.
Tunnus täytyy päivittää, koska elinvoimakeskusmuutoksen seurauksena tunnukset ovat muuttuneet.