### PR TITLE
HARJA-2489 Hae tilannekuvan urakat evk-numerolla

### DIFF
--- a/resources/api/api.raml
+++ b/resources/api/api.raml
@@ -6449,78 +6449,7 @@ types:
   /haku:
     description: Päivystäjätietojen haku
     is:
-      - secured
-    /puhelinnumerolla:
-      get:
-        is:
-          - secured
-        description: Päivystäjätietojen haku puhelinnumerolla.
-        responses:
-          '200':
-            body:
-              application/json:
-                example:
-                  paivystajatiedot:
-                    - urakka:
-                        tiedot:
-                          id: 123456789
-                          nimi: Oulun alueurakka
-                          urakoitsija:
-                            ytunnus: 123456-8
-                            nimi: Asfaltia
-                          vaylamuoto: tie
-                          tyyppi: hoito
-                          alkupvm: '2016-01-30T12:00:00+02:00'
-                          loppupvm: '2016-01-30T12:00:00+02:00'
-                        paivystykset:
-                          - paivystys:
-                              id: 1234
-                              paivystaja:
-                                id: 454653434
-                                etunimi: Päivi
-                                sukunimi: Päivystäjä
-                                email: paivi.paivystaja@test.i
-                                matkapuhelin: '4345455'
-                                tyopuhelin: '7849885769'
-                              alku: '2015-01-30T12:00:00+02:00'
-                              loppu: '2016-01-30T12:00:00+02:00'
-                              vastuuhenkilo: true
-                              varahenkilo: true
-                type: paivystajatietojen-haku-response
-                required: false
-          '400':
-            body:
-              application/json:
-                example:
-                  virheet:
-                    - virhe:
-                        koodi: Tuntematon urakka
-                        viesti: 'Annetulle id:lle ei löydy urakkaa.'
-                type: virhe-response
-                required: false
-          '500':
-            body:
-              application/json:
-                example:
-                  virheet:
-                    - virhe:
-                        koodi: Tuntematon urakka
-                        viesti: 'Annetulle id:lle ei löydy urakkaa.'
-                type: virhe-response
-                required: false
-        queryParameters:
-          puhelinnumero:
-            description: Puhelinnumero jolla haku suoritetaan. Haku tukee puhelinnumeroita maatunnuksella sekä ilman tunnusta. Huom. maatunnuksen plus-merkki täytyy escapeta muotoon %2B.
-            example: 0414332119
-            type: string
-          alkaen:
-            description: Päivystykset alkaen.
-            example: '2015-01-01'
-            type: date
-          paattyen:
-            description: Päivystykset päättyen.
-            example: '2015-01-01'
-            type: date
+      - secured    
     /sijainnilla:
       get:
         is:

--- a/src/clj/harja/kyselyt/tilannekuva.clj
+++ b/src/clj/harja/kyselyt/tilannekuva.clj
@@ -9,7 +9,7 @@
 (defqueries "harja/kyselyt/tilannekuva.sql"
   {:positional? true})
 
-(declare hallintayksikoiden-urakat-ilman-valaistus-urakoita hae-tyokoneselitteet urakoitsijan-urakat hae-ilmoitukset
+(declare elinvoimakeskusten-urakat-ilman-valaistus-urakoita hae-tyokoneselitteet urakoitsijan-urakat hae-ilmoitukset
   hae-paikkaukset-nykytilanteeseen hae-paikkaukset-historiakuvaan hae-paikkauskohteet-tilannekuvaan
   hae-paallystysten-viimeisin-muokkaus hae-laatupoikkeamat hae-turvallisuuspoikkeamat hae-toimenpidekoodit
   hae-toteumat hae-tarkastukset hae-tyokonereitit-kartalle hae-paallystysten-reitit hae-tietyomaat

--- a/src/clj/harja/kyselyt/tilannekuva.sql
+++ b/src/clj/harja/kyselyt/tilannekuva.sql
@@ -676,12 +676,12 @@ FROM urakka u
   LEFT JOIN organisaatio urk ON u.urakoitsija = urk.id
 WHERE urk.id = :organisaatio;
 
--- name: hallintayksikoiden-urakat-ilman-valaistus-urakoita
-SELECT
-  u.id, u.hallintayksikko
+-- name: elinvoimakeskusten-urakat-ilman-valaistus-urakoita
+SELECT  
+  u.id, u.elinvoimakeskus_id
 FROM urakka u
-  LEFT JOIN organisaatio hal ON u.hallintayksikko = hal.id
-WHERE hal.id IN (:hallintayksikot)
+  LEFT JOIN organisaatio elv ON u.elinvoimakeskus_id = elv.id
+WHERE elv.id IN (:elinvoimakeskusnumerot)
   AND u.tyyppi != 'valaistus';
 
 -- name: elinvoimakeskusten-urakat

--- a/src/clj/harja/palvelin/integraatiot/api/paivystajatiedot.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/paivystajatiedot.clj
@@ -62,14 +62,6 @@
            :viesti (format "Alkupäivämäärä: %s on päättymispäivämäärän: %s jälkeen." alkaen paattyen)})
         [alkaen paattyen]))))
 
-(defn- suodata-puhelinnumerolla [puhelinnumero paivystajatiedot]
-  (into [] (filter (fn [paivystys]
-                     (or (= (fmt/trimmaa-puhelinnumero (:tyopuhelin paivystys))
-                            (fmt/trimmaa-puhelinnumero puhelinnumero))
-                         (= (fmt/trimmaa-puhelinnumero (:matkapuhelin paivystys))
-                            (fmt/trimmaa-puhelinnumero puhelinnumero))))
-                   paivystajatiedot)))
-
 (defn- tarkista-sijaintihaun-parametrit [parametrit]
   (parametrivalidointi/tarkista-parametrit
     parametrit
@@ -151,17 +143,6 @@
         vastaus (paivystajatiedot-sanoma/muodosta-vastaus-paivystajatietojen-haulle paivystajatiedot)]
     vastaus))
 
-(defn- hae-paivystajatiedot-puhelinnumerolla [db parametrit kayttaja]
-  (log/debug "Haetaan päivystäjätiedot puhelinnumerolla parametreillä: " parametrit)
-  (parametrivalidointi/tarkista-parametrit parametrit {:puhelinnumero "Puhelinnumero puuttuu"})
-  (validointi/tarkista-rooli kayttaja roolit/liikennepaivystaja)
-  (let [{puhelinnumero :puhelinnumero alkaen :alkaen paattyen :paattyen} parametrit
-        pvm-vali (parsi-aikaparametrit alkaen paattyen)
-        kaikki-paivystajatiedot (yhteyshenkilot-q/hae-kaikki-paivystajat db (first pvm-vali) (second pvm-vali))
-        paivystajatiedot-puhelinnumerolla (suodata-puhelinnumerolla puhelinnumero kaikki-paivystajatiedot)
-        vastaus (paivystajatiedot-sanoma/muodosta-vastaus-paivystajatietojen-haulle paivystajatiedot-puhelinnumerolla)]
-    vastaus))
-
 (defn- poista-paivystykset [db data parametrit kayttaja]
   (let [{:keys [paivystysidt]} data
         urakka-id (Integer/parseInt (:id parametrit))]
@@ -217,15 +198,6 @@
     :vastaus-skeema json-skeemat/paivystajatietojen-haku-vastaus
     :kasittely-fn (fn [parametrit _ kayttaja-id db]
                     (hae-paivystajatiedot-sijainnilla db
-                      (apurit/muuta-mapin-avaimet-keywordeiksi parametrit)
-                      kayttaja-id))}
-   {:palvelu :hae-paivystajatiedot-puhelinnumerolla
-    :api-oikeus :luku
-    :polku "/api/paivystajatiedot/haku/puhelinnumerolla"
-    :tyyppi :GET
-    :vastaus-skeema json-skeemat/paivystajatietojen-haku-vastaus
-    :kasittely-fn (fn [parametrit _ kayttaja-id db]
-                    (hae-paivystajatiedot-puhelinnumerolla db
                       (apurit/muuta-mapin-avaimet-keywordeiksi parametrit)
                       kayttaja-id))}
    {:palvelu :lisaa-paivystajatiedot

--- a/src/clj/harja/palvelin/palvelut/tilannekuva.clj
+++ b/src/clj/harja/palvelin/palvelut/tilannekuva.clj
@@ -165,14 +165,14 @@
                                        (set
                                          (map
                                            :id
-                                           (q/hallintayksikoiden-urakat-ilman-valaistus-urakoita
+                                           (q/elinvoimakeskusten-urakat-ilman-valaistus-urakoita
                                              db
-                                             {:hallintayksikot (map
-                                                                 :hallintayksikko
-                                                                 (filter
-                                                                   (fn [urakka]
-                                                                     (oikeudet/on-muu-oikeus? "oman-urakan-ely" oikeus-nakyma (:id urakka) user))
-                                                                   oman-organisaation-urakat))})))))
+                                             {:elinvoimakeskusnumerot (map
+                                                                       :elinvoimakeskus_id
+                                                                       (filter
+                                                                         (fn [urakka]
+                                                                           (oikeudet/on-muu-oikeus? "oman-urakan-ely" oikeus-nakyma (:id urakka) user))
+                                                                         oman-organisaation-urakat))})))))
 
                                    ;; Jos ei ole oman-urakan-ely oikeutta, otetaan vaan urakat, joihin
                                    ;; käyttäjällä on lukuoikeus

--- a/test/clj/harja/palvelin/integraatiot/api/paivystajat_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/paivystajat_test.clj
@@ -118,30 +118,6 @@
   (is (not= (fmt/trimmaa-puhelinnumero "+358500-123-123") (fmt/trimmaa-puhelinnumero "+358400 123 123")))
   (is (not= (fmt/trimmaa-puhelinnumero "+0400-123-123") (fmt/trimmaa-puhelinnumero "358400 123 123"))))
 
-(deftest hae-paivystajatiedot-puhelinnumerolla-aikavalilla
-  (let [_ (anna-lukuoikeus kayttaja-jvh)
-        vastaus (api-tyokalut/get-kutsu
-                  ["/api/paivystajatiedot/haku/puhelinnumerolla?alkaen=2029-01-30T12:00:00Z&paattyen=2030-01-30T12:00:00Z&puhelinnumero=0505555555"]
-                  kayttaja-jvh portti)
-        encoodattu-body (cheshire/decode (:body vastaus) true)]
-    (is (= 200 (:status vastaus)))
-    (is (= (count (:paivystajatiedot encoodattu-body)) 0))))
-
-(deftest hae-paivystajatiedot-puhelinnumerolla
-  (let [urakka-id (hae-oulun-alueurakan-2014-2019-id)
-        _ (luo-urakalle-voimassa-oleva-paivystys urakka-id)
-        _ (anna-lukuoikeus kayttaja-jvh)
-        vastaus (api-tyokalut/get-kutsu ["/api/paivystajatiedot/haku/puhelinnumerolla?puhelinnumero=0505555555"] kayttaja-jvh portti)
-        encoodattu-body (cheshire/decode (:body vastaus) true)]
-    (is (= 200 (:status vastaus)))
-    (is (= (count (:paivystajatiedot encoodattu-body)) 1))
-    (is (= (count (:paivystykset (:urakka (first (:paivystajatiedot encoodattu-body))))) 1))))
-
-(deftest esta-hae-paivystajatiedot-puhelinnumerolla-ilman-oikeuksia
-  (let [_ (anna-lukuoikeus kayttaja-yit)
-        vastaus (api-tyokalut/get-kutsu ["/api/paivystajatiedot/haku/puhelinnumerolla?alkaen=2000-01-30T12:00:00Z&paattyen=2030-01-30T12:00:00Z&puhelinnumero=0505555555"] kayttaja-yit portti)]
-    (is (= 400 (:status vastaus)))))
-
 (deftest hae-paivystajatiedot-sijainnilla-kayttaen-lyhytta-aikavalia
 
   (let [urakka-id (hae-urakan-id-nimella "Rovaniemen MHU testiurakka (1. hoitovuosi)")
@@ -271,21 +247,6 @@
            (:body vastaus))))
 
   (let [vastaus (api-tyokalut/get-kutsu ["/api/paivystajatiedot/haku/sijainnilla?urakkatyyppi=hoito&x=453271&y=7188395&alkaen=2016-09-30&paattyen=2016-01-02"] kayttaja-yit portti)]
-    (is (= 400 (:status vastaus)))
-    (is (= "{\"virheet\":[{\"virhe\":{\"koodi\":\"virheellinen-paivamaara\",\"viesti\":\"Alkupäivämäärä: 2016-09-30 00:00:00.0 on päättymispäivämäärän: 2016-01-02 00:00:00.0 jälkeen.\"}}]}"
-           (:body vastaus))))
-
-  (let [vastaus (api-tyokalut/get-kutsu ["/api/paivystajatiedot/haku/puhelinnumerolla?puhelinnumero=0505555555&alkaen=rikki&paattyen=2016-09-30"] kayttaja-jvh portti)]
-    (is (= 400 (:status vastaus)))
-    (is (= "{\"virheet\":[{\"virhe\":{\"koodi\":\"virheellinen-paivamaara\",\"viesti\":\"Päivämäärää: rikki ei voi parsia. Anna päivämäärä muodossa: YYYY-MM-DD.\"}}]}"
-           (:body vastaus))))
-
-  (let [vastaus (api-tyokalut/get-kutsu ["/api/paivystajatiedot/haku/puhelinnumerolla?puhelinnumero=0505555555&alkaen=2016-09-30&paattyen=rikki"] kayttaja-jvh portti)]
-    (is (= 400 (:status vastaus)))
-    (is (= "{\"virheet\":[{\"virhe\":{\"koodi\":\"virheellinen-paivamaara\",\"viesti\":\"Päivämäärää: rikki ei voi parsia. Anna päivämäärä muodossa: YYYY-MM-DD.\"}}]}"
-           (:body vastaus))))
-
-  (let [vastaus (api-tyokalut/get-kutsu ["/api/paivystajatiedot/haku/puhelinnumerolla?puhelinnumero=0505555555&alkaen=2016-09-30&paattyen=2016-01-02"] kayttaja-jvh portti)]
     (is (= 400 (:status vastaus)))
     (is (= "{\"virheet\":[{\"virhe\":{\"koodi\":\"virheellinen-paivamaara\",\"viesti\":\"Alkupäivämäärä: 2016-09-30 00:00:00.0 on päättymispäivämäärän: 2016-01-02 00:00:00.0 jälkeen.\"}}]}"
            (:body vastaus)))))

--- a/tietokanta/src/main/resources/db/migration/V1_1277__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1277__.sql
@@ -1,0 +1,1 @@
+DELETE FROM integraatio WHERE jarjestelma = 'api' AND nimi = 'hae-paivystajatiedot-puhelinnumerolla';


### PR DESCRIPTION
## Mitä muutettiin
HARJA-2489:
Tilannekuvassa käytetään hallinta-yksikköä urakoiden hakuun -> Päivitetään käyttämään elinvoimakeskusnumeroa.

HARJA-1588:
Poistetaan käyttämätön rajapinta /api/paivystajatiedot/haku/puhelinnumerolla siivotaan myös testit,dokumentaatio ja integraation lokitus 

## Miksi
Hallinta-yksikkö liittyy ELY-keskuksiin, nykyään käytössä elinvoimakeskusnumero. Tekninen velka.





