### PR TITLE
Korjaa virhe ajastetuissa e2e testeissa

### DIFF
--- a/.github/workflows/harja_test_extra_browsers_cron.yml
+++ b/.github/workflows/harja_test_extra_browsers_cron.yml
@@ -46,8 +46,10 @@ jobs:
       e2e-tests: 'true'
       build-harja: 'light'
       # Disabloidaan kaikki muut testit
+      scan-docker-image: 'false'
       deps-tree: 'false'
       lint-clj: 'false'
+      validate-oikeudet-edn: 'false'
       backend-tests: 'false'
       slow-tests: 'false'
       front-end-tests: 'false'

--- a/.github/workflows/reusable_run_app_tests.yml
+++ b/.github/workflows/reusable_run_app_tests.yml
@@ -45,6 +45,11 @@ on:
         default: 'true'
         type: string
         required: false
+      validate-oikeudet-edn:
+        description: 'Enabloi validate-oikeudet-edn job'
+        default: 'true'
+        type: string
+        required: false
       backend-tests:
         description: 'Enabloi back-tests job'
         default: 'true'
@@ -137,6 +142,7 @@ jobs:
 
   # Validoi että oikeudet EDN-tiedostot ovat ajan tasalla
   validate-oikeudet-edn:
+    if: ${{ inputs.validate-oikeudet-edn == 'true' }}
     name: "Validoi oikeudet EDN-tiedostot"
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Mitä muutettiin
Kytketty pois turhia testijobeja, joita ei kuulu ajaa tässä workflowssa:
   * validate-oikeudet-edn
   * scan-docker-image

## Miksi
Tarkoitus on ajaa vain E2E-testit "harvinaisemmilla selaimilla", ja ajaa vain E2E-testien tarvitsevat jobit, jotka tuottavat tarvitut artifactit testien ajamisen mahdollistamiseksi.
