### PR TITLE
HARJA-2204 - Päivitä harjadb image

### DIFF
--- a/.github/docker/docker-compose.yml
+++ b/.github/docker/docker-compose.yml
@@ -13,7 +13,8 @@ services:
   # Uusin saatavilla oleva testietiekannan konfiguraatio
   harjadb-latest:
     # Hae latest image GitHubin container registrystä
-    image: ghcr.io/finnishtransportagency/harja_harjadb:latest
+    #image: ghcr.io/finnishtransportagency/harja_harjadb:latest
+    image: ghcr.io/finnishtransportagency/harja_harjadb:15.18-3.3.3
 
     # Alla saatavilla olevia versioita
     # https://github.com/finnishtransportagency/harja/pkgs/container/harja_harjadb/versions

--- a/.github/docker/docker-compose.yml
+++ b/.github/docker/docker-compose.yml
@@ -13,8 +13,7 @@ services:
   # Uusin saatavilla oleva testietiekannan konfiguraatio
   harjadb-latest:
     # Hae latest image GitHubin container registrystä
-    #image: ghcr.io/finnishtransportagency/harja_harjadb:latest
-    image: ghcr.io/finnishtransportagency/harja_harjadb:15.18-3.3.3
+    image: ghcr.io/finnishtransportagency/harja_harjadb:latest
 
     # Alla saatavilla olevia versioita
     # https://github.com/finnishtransportagency/harja/pkgs/container/harja_harjadb/versions

--- a/.github/docker/docker-compose.yml
+++ b/.github/docker/docker-compose.yml
@@ -9,6 +9,7 @@ networks:
     enable_ipv6: false
 
 services:
+  # -- Harjadb --
   # Uusin saatavilla oleva testietiekannan konfiguraatio
   harjadb-latest:
     # Hae latest image GitHubin container registrystä
@@ -16,9 +17,8 @@ services:
 
     # Alla saatavilla olevia versioita
     # https://github.com/finnishtransportagency/harja/pkgs/container/harja_harjadb/versions
-    #image: ghcr.io/finnishtransportagency/harja_harjadb:15.4-3.3.3 (uusin vakaa)
-    #image: ghcr.io/finnishtransportagency/harja_harjadb:15.3-3.3.2
-    #image: ghcr.io/finnishtransportagency/harja_harjadb:13.11-3.3.2
+    #image: ghcr.io/finnishtransportagency/harja_harjadb:15.18-3.3.3 (uusin vakaa)
+    #image: ghcr.io/finnishtransportagency/harja_harjadb:15.4-3.3.3
 
     container_name: harjadb
     networks:
@@ -43,6 +43,32 @@ services:
   # Vanhempia testattavia imagen versiota varten on tehty tähän omia compose konfiguraatioita, koska
   # 'latest' imagen versioissa healthcheck, volumet ym. asetukset voivat muuttua.
 
+  # TODO: Version 13.x harjadb-imaget ovat yhteensopivia vanhojen testiympäristöjen kanssa
+  #       Näistä hankkiudutaan eroon, kun testiympäristöt menevät eläkkeelle, jolloin ei ole enää tarpeen
+  #       testata PR:iä myös PostgreSQL 13.x versiota vasten
+  harjadb-13.23-3.3.3:
+    image: ghcr.io/finnishtransportagency/harja_harjadb:13.23-3.3.3
+
+    container_name: harjadb
+    networks:
+      - harja_net
+    environment:
+      HARJA_TIETOKANTA_PORTTI: 5432
+    ports:
+      - "127.0.0.1:5432:5432"
+    # Estetään IPv6 käyttö, jotta testitietokannan migraatioiden ajossa ei tule yhteysongelmia
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=1
+    # Huom: Mountissa viitataan Harja-repon juuressa olevaan tietokanta-hakemistoon, jossa migraatiotiedostot ovat.
+    volumes:
+      - ../../tietokanta:/var/lib/postgresql/harja/tietokanta
+    healthcheck:
+      test: [ "CMD", "pg_isready", "-U", "harja", "-d", "harja" ]
+      interval: 10s
+      retries: 5
+      start_period: 20s
+      timeout: 10s
+
   harjadb-13.13-3.3.3:
     image: ghcr.io/finnishtransportagency/harja_harjadb:13.13-3.3.3
 
@@ -66,30 +92,8 @@ services:
       start_period: 20s
       timeout: 10s
 
-# Deprekoitu ActiveMQ Classic broker
-#  activemq-itmf:
-#    image: ghcr.io/finnishtransportagency/harja_activemq:latest
-#    container_name: activemq-itmf
-#    networks:
-#      - harja_net
-#    environment:
-#      TZ: "EET"
-#      TCP_PORT: 61616
-#      UI_PORT: 8161
-#    ports:
-#        - "127.0.0.1:61616:61616" # broker (admin:adminactivemq)(amq:amq)
-#        - "127.0.0.1:8161:8161"   # web    localhost:8161/admin/queues.jsp (admin:admin)
-#    # Estetään IPv6 käyttö, jotta testitietokannan migraatioiden ajossa ei tule yhteysongelmia
-#    sysctls:
-#      - net.ipv6.conf.all.disable_ipv6=1
-#    healthcheck:
-#     # https://stackoverflow.com/questions/52500782/how-to-check-if-activemq-is-working-properly
-#      test: /opt/activemq/bin/activemq query --objname type=Broker,brokerName=*,service=Health | grep Good
-#      interval: 10s
-#      retries: 5
-#      start_period: 20s
-#      timeout: 10s
 
+  # -- ActiveMQ --
   # Uusi ActiveMQ Artemis broker
   activemq-artemis-itmf:
     image: ghcr.io/finnishtransportagency/harja_activemq_artemis:latest

--- a/.github/docker/tietokanta/Dockerfile
+++ b/.github/docker/tietokanta/Dockerfile
@@ -15,6 +15,11 @@
 # https://github.com/postgis/docker-postgis
 # https://postgis.net/docs/manual-3.3/postgis_installation.html#install_requirements
 
+# -- PostgreSQL pohjaimagen versio:
+# https://hub.docker.com/_/postgres/tag
+#ARG POSTHRESQL_DOCKER_IMAGE_VERSION=postgres:15.18-bookworm
+ARG POSTGRESQL_DOCKER_IMAGE_VERSION=postgres:13.23-bookworm
+
 
 # -- Asennettava PostGIS-versio ja paketin MD5-hash
 # Tarkista versio ja hash: https://download.osgeo.org/postgis/source/
@@ -35,7 +40,8 @@ ARG MAVEN_SHA512="831a8591fe20c8243b1dbe7d71e3244f31d1665b0804b2e825e38cbbe5ce0c
 #------------------------------------------#
 
 # https://hub.docker.com/_/postgres/tags
-FROM postgres:15.18-bookworm AS postgis-builder
+FROM $POSTGRESQL_DOCKER_IMAGE_VERSION AS postgis-builder
+ARG POSTGRESQL_DOCKER_IMAGE_VERSION
 ARG POSTGIS_VERSION
 ARG POSTGIS_MD5
 
@@ -94,7 +100,8 @@ RUN cd postgis-${POSTGIS_VERSION} \
 #---------------------------------#
 #---- Lopullinen runtime-image ---#
 #---------------------------------#
-FROM postgres:15.18-bookworm AS final
+FROM $POSTGRESQL_DOCKER_IMAGE_VERSION AS final
+ARG POSTGRESQL_DOCKER_IMAGE_VERSION
 ARG MAVEN_VERSIO
 ARG MAVEN_SHA512
 

--- a/.github/docker/tietokanta/Dockerfile
+++ b/.github/docker/tietokanta/Dockerfile
@@ -16,32 +16,36 @@
 # https://postgis.net/docs/manual-3.3/postgis_installation.html#install_requirements
 ARG POSTGIS_VERSION=3.3.3
 
+# -- Asennettava maven-versio ja paketin SHA
+# Tarkista uusin saatavilla oleva maven: https://downloads.apache.org/maven/maven-3
+# Maven pitää arkistoissaan ainoastaan viimeisimmän version, vanhoja versioita ei ole saatavilla.
+ARG MAVEN_VERSIO=3.9.16
+# https://downloads.apache.org/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz.sha512
+ARG MAVEN_SHA512="831a8591fe20c8243b1dbe7d71e3244f31d1665b0804b2e825e38cbbe5ce0cafb8338851f90780735568773e0a6cd07bbec107cda0b896b008b861075358b6f6"
 
-#-------------------------------#
-#----- Rakenna pohja-image -----#
-#-------------------------------#
+
+#------------------------------------------#
+#----- PostGIS builder -stage (käännös) ---#
+#------------------------------------------#
 
 # https://hub.docker.com/_/postgres/tags
-FROM postgres:15.18-bookworm AS base
-# https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+FROM postgres:15.18-bookworm AS postgis-builder
 ARG POSTGIS_VERSION
 
-# --- Asenna riippuvuudet --- #
-
-# Asenna työkaluja
-RUN apt-get update && apt-get install -y wget
-
-
-RUN wget "https://download.osgeo.org/postgis/source/postgis-${POSTGIS_VERSION}.tar.gz" \
+# Lataa PostGIS-lähdekoodi
+RUN apt-get update && apt-get install -y wget \
+    && wget "https://download.osgeo.org/postgis/source/postgis-${POSTGIS_VERSION}.tar.gz" \
     && tar -xvzf "postgis-${POSTGIS_VERSION}.tar.gz" \
     && rm "postgis-${POSTGIS_VERSION}.tar.gz"
 
-# Asenna PostGISin buildaamiseen vaadittavat riippuvuudet (https://docs.docker.com/build/cache/#use-the-dedicated-run-cache)
+# Asenna PostGISin buildaamiseen vaadittavat riippuvuudet
 RUN --mount=type=cache,target=/var/cache/apt \
     set -ex \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-      libgdal-dev libgeos-dev libproj-dev \
+      libgdal-dev \
+      libgeos-dev \
+      libproj-dev \
       postgresql-server-dev-$PG_MAJOR \
       autoconf \
       automake \
@@ -54,16 +58,11 @@ RUN --mount=type=cache,target=/var/cache/apt \
       g++ \
       git \
       llvm-dev \
-      libboost-all-dev \
-      libcgal-dev \
       libcurl4-gnutls-dev \
-      libgmp-dev \
       libjson-c-dev \
-      libmpfr-dev \
       libpcre3-dev \
       libprotobuf-c-dev \
       libsqlite3-dev \
-      libtiff-dev \
       libtool \
       libxml2-dev \
       make \
@@ -71,24 +70,54 @@ RUN --mount=type=cache,target=/var/cache/apt \
       protobuf-c-compiler \
       xsltproc
 
-# Buildaa PostGIS
-RUN  cd postgis-${POSTGIS_VERSION} \
-        && ./configure \
-        && make clean \
-        # Anna Makelle saatavilla olevat prosessointiyksiköt
-        && make -j$(nproc) \
-        && make install
+# Buildaa PostGIS ilman rasteria ja sfcgal:ia, topology-plugin jää käyttöön
+RUN cd postgis-${POSTGIS_VERSION} \
+    && ./configure --without-raster --without-sfcgal \
+    && make clean \
+    # Anna Makelle saatavilla olevat prosessointiyksiköt \
+    && make -j$(nproc) \
+    && make install
 
 
-## Asenna maven
+#---------------------------------#
+#---- Lopullinen runtime-image ---#
+#---------------------------------#
+FROM postgres:15.18-bookworm AS final
+ARG MAVEN_VERSIO
+ARG MAVEN_SHA512
+
+# Yhdistä image harjan repositoryyn
+LABEL org.opencontainers.image.source=https://github.com/finnishtransportagency/harja
+LABEL org.opencontainers.image.description="PostGIS 3.3.3 extension with PostgreSQL 15.18 bookworm"
+
+# Kopioi PostGISin käännetyt artefaktit builder-stagesta
+COPY --from=postgis-builder /usr/lib/postgresql/ /usr/lib/postgresql/
+COPY --from=postgis-builder /usr/share/postgresql/ /usr/share/postgresql/
+
+# Asenna vain ajonaikaiset runtime-kirjastot (ei -dev paketteja, ei kääntäjiä)
+RUN --mount=type=cache,target=/var/cache/apt \
+    set -ex \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+      libgeos-c1v5 \
+      libgdal32 \
+      libproj25 \
+      libprotobuf-c1 \
+      libjson-c5 \
+      libxml2 \
+      libcurl3-gnutls \
+      libsqlite3-0 \
+      libpcre3 \
+      wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+## Asenna Maven (tarvitaan Flyway-migraatioiden ajamiseen)
 # HUOM: Maven pitää arkistoissaan ainoastaan viimeisimmän version, vanhoja versioita ei ole saatavilla.
 #       Eli, mikäli buildaat tämän imagen uudestaan ja build kaatuu tähän, tarkista mikä on uusin saatavilla oleva maven:
 #       https://downloads.apache.org/maven/maven-3
-ENV MAVEN_VERSIO=3.9.16
-# https://downloads.apache.org/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz.sha512
-ENV MAVEN_SHA512="831a8591fe20c8243b1dbe7d71e3244f31d1665b0804b2e825e38cbbe5ce0cafb8338851f90780735568773e0a6cd07bbec107cda0b896b008b861075358b6f6"
 
-RUN apt-get update && apt-get install -y openjdk-17-jdk \
+RUN apt-get update && apt-get install -y --no-install-recommends openjdk-17-jre-headless \
     && wget "https://downloads.apache.org/maven/maven-3/${MAVEN_VERSIO}/binaries/apache-maven-${MAVEN_VERSIO}-bin.tar.gz" \
     && if [ "$MAVEN_SHA512" != "$(sha512sum apache-maven-${MAVEN_VERSIO}-bin.tar.gz | awk '{print $1}')" ]; then \
                echo "Downloaded Maven SHA512: $(sha512sum apache-maven-${MAVEN_VERSIO}-bin.tar.gz | awk '{print $1}')"; \
@@ -96,30 +125,22 @@ RUN apt-get update && apt-get install -y openjdk-17-jdk \
                exit 1; \
            fi \
     && tar xzvf "apache-maven-${MAVEN_VERSIO}-bin.tar.gz" \
-    && rm "apache-maven-${MAVEN_VERSIO}-bin.tar.gz"
+    && rm "apache-maven-${MAVEN_VERSIO}-bin.tar.gz" \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Lisää maven bin kansio PATH:iin
 ENV PATH="/apache-maven-${MAVEN_VERSIO}/bin/:${PATH}"
 
-# Siivous
-RUN apt-get -y --purge autoremove  \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
 
-
-#---------------------------------#
-#---- Harjadb-imagen rakennus ----#
-#---------------------------------#
-FROM base
-
-# Yhdistä image harjan repositoryyn
-LABEL org.opencontainers.image.source=https://github.com/finnishtransportagency/harja
-LABEL org.opencontainers.image.description="PostGIS 3.3.2 extension with PostgreSQL 13.11 bullseye"
+#-----------------------------------------#
+#---- Harjadb-imagen konfigurointi -------#
+#-----------------------------------------#
 
 # Aseta Harjaan liittyvät default ympäristömuuttujat
 ENV HARJA_TIETOKANTA_PORTTI=5432
 
-# Siirretään apuscriptit postgresl käyttäjän kotihakemistoon
+# Siirretään apuscriptit postgresql käyttäjän kotihakemistoon
 WORKDIR /var/lib/postgresql/
 
 ADD docker_aja-migraatiot.sh ./aja-migraatiot.sh
@@ -184,4 +205,3 @@ SHELL ["/bin/bash", "-c"]
 CMD sed -i "s/port = 5432/port = ${HARJA_TIETOKANTA_PORTTI}/g" ./data/postgresql.conf \
     && sed -i 's/#port =/port =/g' ./data/postgresql.conf \
     && pg_ctl start && tail -f /dev/null
-

--- a/.github/docker/tietokanta/Dockerfile
+++ b/.github/docker/tietokanta/Dockerfile
@@ -180,6 +180,7 @@ RUN pg_ctl start; \
 
 # Käynnistä postgresql ja pidä container käynnissä
 # Jos ympäristömuuttujaa HARJA_TIETOKANTA_PORTTI ei ole asetettu, käytä oletusarvoa.
+SHELL ["/bin/bash", "-c"]
 CMD sed -i "s/port = 5432/port = ${HARJA_TIETOKANTA_PORTTI}/g" ./data/postgresql.conf \
     && sed -i 's/#port =/port =/g' ./data/postgresql.conf \
     && pg_ctl start && tail -f /dev/null

--- a/.github/docker/tietokanta/Dockerfile
+++ b/.github/docker/tietokanta/Dockerfile
@@ -17,8 +17,8 @@
 
 # -- PostgreSQL pohjaimagen versio:
 # https://hub.docker.com/_/postgres/tag
-#ARG POSTHRESQL_DOCKER_IMAGE_VERSION=postgres:15.18-bookworm
-ARG POSTGRESQL_DOCKER_IMAGE_VERSION=postgres:13.23-bookworm
+ARG POSTHRESQL_DOCKER_IMAGE_VERSION=postgres:15.18-bookworm
+#ARG POSTGRESQL_DOCKER_IMAGE_VERSION=postgres:13.23-bookworm
 
 
 # -- Asennettava PostGIS-versio ja paketin MD5-hash

--- a/.github/docker/tietokanta/Dockerfile
+++ b/.github/docker/tietokanta/Dockerfile
@@ -22,7 +22,7 @@ ARG POSTGIS_VERSION=3.3.3
 #-------------------------------#
 
 # https://hub.docker.com/_/postgres/tags
-FROM postgres:15.4-bullseye as base
+FROM postgres:15.4-bullseye AS base
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG POSTGIS_VERSION
 
@@ -81,9 +81,12 @@ RUN  cd postgis-${POSTGIS_VERSION} \
 
 
 ## Asenna maven
-ENV MAVEN_VERSIO=3.9.6
-# https://downloads.apache.org/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz.sha512
-ENV MAVEN_SHA512="706f01b20dec0305a822ab614d51f32b07ee11d0218175e55450242e49d2156386483b506b3a4e8a03ac8611bae96395fd5eec15f50d3013d5deed6d1ee18224"
+# HUOM: Maven pitää arkistoissaan ainoastaan viimeisimmän version, vanhoja versioita ei ole saatavilla.
+#       Eli, mikäli buildaat tämän imagen uudestaan ja build kaatuu tähän, tarkista mikä on uusin saatavilla oleva maven:
+#       https://downloads.apache.org/maven/maven-3
+ENV MAVEN_VERSIO=3.9.16
+# https://downloads.apache.org/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz.sha512
+ENV MAVEN_SHA512="831a8591fe20c8243b1dbe7d71e3244f31d1665b0804b2e825e38cbbe5ce0cafb8338851f90780735568773e0a6cd07bbec107cda0b896b008b861075358b6f6"
 
 RUN apt-get update && apt-get install -y openjdk-17-jdk \
     && wget "https://downloads.apache.org/maven/maven-3/${MAVEN_VERSIO}/binaries/apache-maven-${MAVEN_VERSIO}-bin.tar.gz" \

--- a/.github/docker/tietokanta/Dockerfile
+++ b/.github/docker/tietokanta/Dockerfile
@@ -22,7 +22,7 @@ ARG POSTGIS_VERSION=3.3.3
 #-------------------------------#
 
 # https://hub.docker.com/_/postgres/tags
-FROM postgres:15.4-bullseye AS base
+FROM postgres:15.18-bookworm AS base
 # https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG POSTGIS_VERSION
 

--- a/.github/docker/tietokanta/Dockerfile
+++ b/.github/docker/tietokanta/Dockerfile
@@ -14,9 +14,15 @@
 # Muuta materiaalia:
 # https://github.com/postgis/docker-postgis
 # https://postgis.net/docs/manual-3.3/postgis_installation.html#install_requirements
-ARG POSTGIS_VERSION=3.3.3
 
-# -- Asennettava maven-versio ja paketin SHA
+
+# -- Asennettava PostGIS-versio ja paketin MD5-hash
+# Tarkista versio ja hash: https://download.osgeo.org/postgis/source/
+ARG POSTGIS_VERSION=3.3.3
+# https://download.osgeo.org/postgis/source/postgis-3.3.3.tar.gz.md5
+ARG POSTGIS_MD5="d94b48dfc7c106c2722844bfc611f180"
+
+# -- Asennettava maven-versio ja paketin SHA-hash
 # Tarkista uusin saatavilla oleva maven: https://downloads.apache.org/maven/maven-3
 # Maven pitää arkistoissaan ainoastaan viimeisimmän version, vanhoja versioita ei ole saatavilla.
 ARG MAVEN_VERSIO=3.9.16
@@ -31,10 +37,16 @@ ARG MAVEN_SHA512="831a8591fe20c8243b1dbe7d71e3244f31d1665b0804b2e825e38cbbe5ce0c
 # https://hub.docker.com/_/postgres/tags
 FROM postgres:15.18-bookworm AS postgis-builder
 ARG POSTGIS_VERSION
+ARG POSTGIS_MD5
 
 # Lataa PostGIS-lähdekoodi
 RUN apt-get update && apt-get install -y wget \
     && wget "https://download.osgeo.org/postgis/source/postgis-${POSTGIS_VERSION}.tar.gz" \
+    && if [ "$POSTGIS_MD5" != "$(md5sum postgis-${POSTGIS_VERSION}.tar.gz | awk '{print $1}')" ]; then \
+               echo "Downloaded PostGIS MD5: $(md5sum postgis-${POSTGIS_VERSION}.tar.gz | awk '{print $1}')"; \
+               echo "PostGIS package md5 values don't match! exiting."; \
+               exit 1; \
+           fi \
     && tar -xvzf "postgis-${POSTGIS_VERSION}.tar.gz" \
     && rm "postgis-${POSTGIS_VERSION}.tar.gz"
 

--- a/.github/docker/tietokanta/README.md
+++ b/.github/docker/tietokanta/README.md
@@ -5,12 +5,9 @@ https://github.com/finnishtransportagency/harja/pkgs/container/harja_harjadb
 ## Uusin vakaa (latest)
 * harja_harjadb:15.18-3.3.3
     * PostgreSQL 15.18 + PostGIS 3.3.3
-    * Pienempi, stageissa buildattu image
+    * Pienempi, stageissa buildattu image (< 1 GB, ent. > 3 GB)
 
 ## Kokeilut
-* harja_harjadb:15.18-3.3.3
-    * PostgreSQL 15.18 + PostGIS 3.3.3
-    * Pienempi, stageissa buildattu image (< 1 GB, ent. > 3 GB)
 * harja_harjadb:13.23-3.3.3
     * PostgreSQL 13.23 + PostGIS 3.3.3
     * PostgreSQL 13.x imaget ovat yhteensopia vanhojen testiympäristöjen kanssa

--- a/.github/docker/tietokanta/README.md
+++ b/.github/docker/tietokanta/README.md
@@ -3,14 +3,23 @@
 https://github.com/finnishtransportagency/harja/pkgs/container/harja_harjadb
 
 ## Uusin vakaa (latest)
-* harja_harjadb:15.4-3.3.3
-    * PostgreSQL 15.4 + PostGIS 3.3.3
-    * Flyway v10 yhteensopiva
+* harja_harjadb:15.18-3.3.3
+    * PostgreSQL 15.18 + PostGIS 3.3.3
+    * Pienempi, stageissa buildattu image
 
 ## Kokeilut
-* 
+* harja_harjadb:15.18-3.3.3
+    * PostgreSQL 15.18 + PostGIS 3.3.3
+    * Pienempi, stageissa buildattu image (< 1 GB, ent. > 3 GB)
+* harja_harjadb:13.23-3.3.3
+    * PostgreSQL 13.23 + PostGIS 3.3.3
+    * PostgreSQL 13.x imaget ovat yhteensopia vanhojen testiympäristöjen kanssa
+    * Pienempi, stageissa buildattu image (< 1 GB, ent. > 3 GB)
 
 ## Vanhat
+* harja_harjadb:15.4-3.3.3
+    * PostgreSQL 15.4 + PostGIS 3.3.3
+    * Flyway v10 yhteensopiva tästä alkaen
 * harja_harjadb:13.13-3.3.3
     * PostgreSQL 13.13 + PostGIS 3.3.3
     * Uudempi Java 17, Flyway v10 yhteensopiva

--- a/.github/workflows/harja_test_pr.yml
+++ b/.github/workflows/harja_test_pr.yml
@@ -35,9 +35,7 @@ jobs:
       # Katso saatavilla olevat harjadb servicet docker-compose.yml:stä
       # Testataan vanhempaa PostgreSQL versiota vasten vanhojen testipalvelimien yhteensopivuuden varmistamiseksi.
       # TODO: Käytä harjadb-latest, kun vanhempien versioiden tuesta voidaan luopua.
-      #test-db-service: harjadb-13.13-3.3.3
-
-      test-db-service: harjadb-latest
+      test-db-service: harjadb-13.23-3.3.3
       e2e-browsers: "['chrome']"
       # PR-testeissä ajetaan vain kevyt build ja testauksen kannalta epärelevantit osat on jätetty pois.
       build-harja: 'light'

--- a/.github/workflows/harja_test_pr.yml
+++ b/.github/workflows/harja_test_pr.yml
@@ -35,7 +35,9 @@ jobs:
       # Katso saatavilla olevat harjadb servicet docker-compose.yml:stä
       # Testataan vanhempaa PostgreSQL versiota vasten vanhojen testipalvelimien yhteensopivuuden varmistamiseksi.
       # TODO: Käytä harjadb-latest, kun vanhempien versioiden tuesta voidaan luopua.
-      test-db-service: harjadb-13.13-3.3.3
+      #test-db-service: harjadb-13.13-3.3.3
+
+      test-db-service: harjadb-latest
       e2e-browsers: "['chrome']"
       # PR-testeissä ajetaan vain kevyt build ja testauksen kannalta epärelevantit osat on jätetty pois.
       build-harja: 'light'


### PR DESCRIPTION
## Mitä muutettiin
* Harjadb-imagen variantit 15.x ja 13.x päivitetty uudempiin minor-versioihin, sekä otettu käyttöön uudempi Debian pohjalle
* Myös build-prosessia muutettu niin, että lopullinen Harjadb-image on huomattavasti pienempi, jolloin testitietokannan käynnistysaika putoaa jopa 30 sec 
