### PR TITLE
HARJA-2615 - Libc päivitys - CVE-2026-5450

### DIFF
--- a/aws/fargate/Dockerfile
+++ b/aws/fargate/Dockerfile
@@ -27,6 +27,14 @@ RUN apt-get update \
     && ln -snf /usr/share/zoneinfo/Europe/Helsinki /etc/localtime \
     && echo "Europe/Helsinki" > /etc/timezone
 
+# Päivitä libc ja muut paketit
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -y install --only-upgrade \
+        libc6 \
+        libc-bin \
+        locales \
+    && rm -rf /var/lib/apt/lists/*
+
 # Asenna apurit
 RUN apt-get update && apt-get install -y \
     bash \


### PR DESCRIPTION
## Mitä muutettiin
Ota libc:stä uusimmat versiot, jotka korjaa haavoittuvuuden CVE-2026-5450

## Miksi
Kriittinen haavoittuvuus

## Testaustapa
Tee ensin uberjar omalla koneella
> lein uberjar
AJa sitten docker komennot ja varmista kirjastoversiot
> docker build --no-cache -f aws/fargate/Dockerfile -t harja:cve-after .
> docker run --rm --entrypoint /bin/sh harja:cve-after -c "dpkg -l libc6 libc-bin locales"

-> libc-bin 2.39-0ubuntu8.8 arm64 GNU C Library: Binaries

## Huomioita
Tässä tuli eteen se, että Dockerin buildausta voisi vielä optimoida käyttämällä " --no-install-recommends" mutta en vielä lisännyt sitä.
