### PR TITLE
HARJA-2660 - Päivitä gson kirjasto haavoittuvuuden vuoksi - CVE-2022-25647

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -178,7 +178,9 @@
 
                          ;; Ratkaise: https://security.snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518
                          ;;   Pakotetaan commons-codec korkeampaan versioon
-                         [commons-codec "1.22.0"]]
+                         [commons-codec "1.22.0"]
+                         ;; uudemmassa org.clojure/clojurescript voisi saada myös tähän päivityksen - Eli tarkista tämä kun clojurescript päivitetään
+                         [com.google.code.gson/gson "2.8.9"]]
 
   :profiles {:uberjar {:aot :all}
              :dev {:test2junit-run-ant ~(not jenkinsissa?)}}


### PR DESCRIPTION
## Mitä muutettiin
ks project.clj - pieni muutos

## Miksi
CVE-2022-25647

## Testaustapa
> lein deps :tree | grep -i gson
Pitäisi antaa: [com.google.code.gson/gson "2.8.9"]

## Huomioita
Päivittämällä clojurescript uusimpaan tämä voitaisiin ehkä välttää. Mutta clojurescriptin päivitys vaatii rajut testaustoimenpiteet, niin ajattelin, ettei lähdetä nyt siihen.
