### PR TITLE
HARJA-2635 - Päivitä jackson-core

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                  [org.clojure/core.async "1.7.701"]
                  ;; Transit tietomuoto asiakkaan ja palvelimen väliseen kommunikointiin
                  [com.cognitect/transit-cljs "0.8.280"]
-                 [com.cognitect/transit-clj "1.1.357"]
+                 [com.cognitect/transit-clj "1.1.363"]
                  ;; Pätevä yksinkertainen työkalu esimerkiksi config-tiedostojen mergeämiseen
                  [meta-merge "1.0.0"]
 
@@ -178,7 +178,9 @@
 
                          ;; Ratkaise: https://security.snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518
                          ;;   Pakotetaan commons-codec korkeampaan versioon
-                         [commons-codec "1.22.0"]]
+                         [commons-codec "1.22.0"]
+                         ;; jackson-core tulee gt-shapefilen mukana (versio 3.1.2, jossa haavoittuvuus) uudempaa ei ole tarjolla. Joten niin pakotetaan se uudempi mukaan.
+                         [tools.jackson.core/jackson-core "3.2.1"]]
 
   :profiles {:uberjar {:aot :all}
              :dev {:test2junit-run-ant ~(not jenkinsissa?)}}


### PR DESCRIPTION
## Mitä muutettiin
Päivitetään jackson-core 3.1.2 -> 3.2.1

## Miksi
ackson-core: Async parser maxNumberLength bypass via chunked digit accumulation (incomplete fix for GHSA-72hv-8253-57qq)
Package: tools.jackson.core:jackson-core
Installed Version: 3.1.2
Vulnerability GHSA-r7wm-3cxj-wff9
Severity: HIGH
Fixed Version: 3.1.4, 3.2.1
Link: [GHSA-r7wm-3cxj-wff9](https://github.com/advisories/GHSA-r7wm-3cxj-wff9)

## Testaustapa
Riittää, että cypress ja yksikkötestit toimii.

## Huomioita
-
