### PR TITLE
Harja 2636 laatupoikkeama api

### DIFF
--- a/src/clj/harja/kyselyt/laatupoikkeamat.clj
+++ b/src/clj/harja/kyselyt/laatupoikkeamat.clj
@@ -12,8 +12,9 @@
 (declare onko-olemassa-ulkoisella-idlla paivita-laatupoikkeaman-perustiedot<! luo-laatupoikkeama<!
   poista-laatupoikkeama! hae-bonuksen-liitteet hae-omat-laatupoikkeamat hae-kaikki-laatupoikkeamat
   hae-selvitysta-odottavat-laatupoikkeamat hae-kasitellyt-laatupoikkeamat hae-poikkeamaraportilliset-laatupoikkeamat
-  hae-laatupoikkeaman-urakka-id hae-bonuksen-liitteet hae-laatupoikkeaman-liitteet hae-urakan-laatupoikkeama-liitteet
-  hae-laatupoikkeaman-tiedot hae-laatupoikkeaman-kommentit liita-kommentti<! liita-liite<! kirjaa-laatupoikkeaman-paatos!)
+  hae-laatupoikkeaman-urakka-id hae-laatupoikkeaman-liitteet hae-urakan-laatupoikkeama-liitteet
+  hae-laatupoikkeaman-tiedot hae-laatupoikkeaman-kommentit liita-kommentti<! liita-liite<! kirjaa-laatupoikkeaman-paatos!
+  paivita-laatupoikkeama-ulkoisella-idlla<!)
 
 (defn onko-olemassa-ulkoisella-idlla? [db ulkoinen-id urakka-id]
   (:exists (first (onko-olemassa-ulkoisella-idlla db ulkoinen-id urakka-id))))

--- a/src/clj/harja/kyselyt/laatupoikkeamat.sql
+++ b/src/clj/harja/kyselyt/laatupoikkeamat.sql
@@ -432,6 +432,7 @@ SET
   tr_loppuosa      = :tr_loppuosa,
   tr_alkuetaisyys  = :tr_alkuetaisyys,
   tr_loppuetaisyys = :tr_loppuetaisyys,
+  yllapitokohde    = :yllapitokohde_id, -- kaikilla urakoilla ei ole ylläpitokohteita, joten voi olla null
   muokkaaja        = :muokkaaja,
   muokattu         = current_timestamp,
   "sisaltaa-poikkeamaraportin?" = :sisaltaa_poikkeamaraportin

--- a/src/clj/harja/kyselyt/liitteet.clj
+++ b/src/clj/harja/kyselyt/liitteet.clj
@@ -4,4 +4,4 @@
 (defqueries "harja/kyselyt/liitteet.sql"
   {:positional? true})
 
-(declare hae-liitteiden-tiedot hae-urakan-liite-id)
+(declare hae-liitteiden-tiedot hae-urakan-liite-id hae-liite-meta-tiedoilla)

--- a/src/clj/harja/kyselyt/yllapitokohteet.clj
+++ b/src/clj/harja/kyselyt/yllapitokohteet.clj
@@ -29,7 +29,7 @@
   hae-tiemerkinnan-suorittavat-urakat hae-kohteen-merkinta-ja-jyrsintatiedot merkitse-kohde-valmiiksi-tiemerkintaan<!
   tallenna-paallystyskohteen-aikataulu! tallenna-yllapitokohteen-suorittava-tiemerkintaurakka!
   tallenna-yllapitokohteen-kustannukset-yhaid! onko-olemassa-urakalla? hae-urakkaan-liittyvat-tiemerkintakohteet
-  hae-urakkaan-kuuluvat-yllapitokohteet paivita-yllapitokohteen-tiemerkintaaikataulu!
+  hae-urakkaan-kuuluvat-yllapitokohteet hae-yllapitokohde-urakan-nimella paivita-yllapitokohteen-tiemerkintaaikataulu!
   paivita-yllapitokohteen-paallystysilmoituksen-aikataulu<! hae-kaikki-urakan-yllapitokohteet
   hae-paikkauskohteen-paikkaukset-alueelle hae-paikkauskohteen-paikkaukset
   hae-yllapitokohteiden-tiedot-sahkopostilahetykseen)

--- a/src/clj/harja/kyselyt/yllapitokohteet.sql
+++ b/src/clj/harja/kyselyt/yllapitokohteet.sql
@@ -69,6 +69,16 @@ WHERE
   ypk.urakka = :urakka
   AND ypk.poistettu IS NOT TRUE;
 
+-- name: hae-yllapitokohde-urakan-nimella
+-- Hakee ylläpitokohteen id:n urakan ja nimen perusteella
+SELECT ypk.id,
+       ypk.nimi
+  FROM yllapitokohde ypk
+ WHERE ypk.urakka = :urakka
+   AND ypk.nimi = :nimi
+   AND ypk.poistettu IS NOT TRUE
+ LIMIT 1;
+
 -- name: hae-urakkaan-liittyvat-tiemerkintakohteet
 -- Hakee ylläpitokohteet, joihin on merkitty suorittajaksi kyseinen urakka
 SELECT ypk.id

--- a/src/clj/harja/palvelin/integraatiot/api/laatupoikkeamat.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/laatupoikkeamat.clj
@@ -9,6 +9,8 @@
             [harja.palvelin.integraatiot.api.tyokalut.validointi :as validointi]
             [harja.kyselyt.laatupoikkeamat :as laatupoikkeamat]
             [harja.kyselyt.kommentit :as kommentit]
+            [harja.kyselyt.urakat :as q-urakat]
+            [harja.kyselyt.yllapitokohteet :as q-yllapitokohteet]
             [harja.palvelin.komponentit.liitteet :refer [->Liitteet]]
             [harja.palvelin.integraatiot.api.tyokalut.liitteet :refer [tallenna-liitteet-laatupoikkeamalle]]
             [harja.palvelin.integraatiot.api.tyokalut.json :refer [aika-string->java-sql-date]]
@@ -20,43 +22,65 @@
   (tee-kirjausvastauksen-body {:ilmoitukset "Laatupoikkeama kirjattu onnistuneesti"
                                :varoitukset (when-not (empty? varoitukset) varoitukset)}))
 
-(defn tallenna-laatupoikkeama [db urakka-id kirjaaja data tr-osoite geometria]
+(def yllapitokohdeurakkatyypit #{:paallystys :paikkaus :tiemerkinta})
+
+(defn yllapitokohdeurakka? [urakkatyyppi]
+  (contains? yllapitokohdeurakkatyypit urakkatyyppi))
+
+(defn hae-urakan-tyyppi [db urakka-id]
+  (keyword (:tyyppi (first (q-urakat/hae-urakan-tyyppi db urakka-id)))))
+
+(defn hae-laatupoikkeamalle-yllapitokohde
+  "Ylläpitourakalle etsitään ylläpitokohde annetun kohde kentän perusteella. Ylläpitokohde oletetaan löytyvän urakan ja nimen perusteella.
+  Jos tämä on huono, niin myöhemmi voidaan päivittää hakuun myös ylläpitokohdenumero, joka yksilöi kohteen tarkemmin.
+  Palauttaa ylläpitokohteen id:n, jos löytyy. Jos ei löydy, se ei haittaa. Kohde voi olla nil."
+  [db urakka-id kohde-nimi]
+  (let [tulos (first (q-yllapitokohteet/hae-yllapitokohde-urakan-nimella db {:urakka urakka-id :nimi kohde-nimi}))]
+    ;; Jätetaään virheellisen kohteen käsittely myöhemmäksi. Jos kohde ei löydy, niin se ei ole virhe, vaan kohde voi olla nil.
+    #_ (when-not tulos
+      (virheet/heita-viallinen-apikutsu-poikkeus
+        {:koodi virheet/+tuntematon-yllapitokohde+
+         :viesti (format "Kohdetta: %s ei löydy" kohde-nimi)}))
+    (:id tulos)))
+
+(defn tallenna-laatupoikkeama [db urakka-id kirjaaja data tr-osoite geometria yllapitokohde-id]
   (let [{:keys [tunniste kuvaus kohde aika sisaltaa-poikkeamaraportin]} data]
     (if (laatupoikkeamat/onko-olemassa-ulkoisella-idlla? db (:id tunniste) urakka-id)
       (:id (laatupoikkeamat/paivita-laatupoikkeama-ulkoisella-idlla<!
              db
-             (aika-string->java-sql-date aika)
-             kohde
-             kuvaus
-             geometria
-             (:tie tr-osoite)
-             (:aosa tr-osoite)
-             (:losa tr-osoite)
-             (:aet tr-osoite)
-             (:let tr-osoite)
-             (:id kirjaaja)
-             sisaltaa-poikkeamaraportin
-             (:id tunniste)
-             urakka-id))
+             {:aika (aika-string->java-sql-date aika)
+              :kohde kohde
+              :kuvaus kuvaus
+              :sijainti geometria
+              :tr_numero (:tie tr-osoite)
+              :tr_alkuosa (:aosa tr-osoite)
+              :tr_loppuosa (:losa tr-osoite)
+              :tr_alkuetaisyys (:aet tr-osoite)
+              :tr_loppuetaisyys (:let tr-osoite)
+              :yllapitokohde_id yllapitokohde-id
+              :muokkaaja (:id kirjaaja)
+              :sisaltaa_poikkeamaraportin sisaltaa-poikkeamaraportin
+              :ulkoinen_id (:id tunniste)
+              :urakka-id urakka-id}))
       (:id (laatupoikkeamat/luo-laatupoikkeama<!
-             db
-             "harja-api"
-             urakka-id
-             (aika-string->java-sql-date aika)
-             "urakoitsija"
-             kohde
-             true
-             (:id kirjaaja)
-             kuvaus
-             geometria
-             (:numero tr-osoite)
-             (:aosa tr-osoite)
-             (:losa tr-osoite)
-             (:aet tr-osoite)
-             (:let tr-osoite)
-             nil
-             sisaltaa-poikkeamaraportin
-             (:id tunniste))))))
+               db
+               {:lahde "harja-api"
+                :urakka urakka-id,
+                :aika (aika-string->java-sql-date aika),
+                :tekija "urakoitsija",
+                :kohde kohde,
+                :selvitys true,
+                :luoja (:id kirjaaja),
+                :kuvaus kuvaus,
+                :sijainti geometria,
+                :tr_numero (:tie tr-osoite),
+                :tr_alkuosa (:aosa tr-osoite),
+                :tr_loppuosa (:losa tr-osoite),
+                :tr_alkuetaisyys (:aet tr-osoite),
+                :tr_loppuetaisyys (:let tr-osoite),
+                :yllapitokohde yllapitokohde-id,
+                :sisaltaa_laatupoikkeaman sisaltaa-poikkeamaraportin,
+                :ulkoinen_id (:id tunniste)})))))
 
 (defn tallenna-kommentit [db laatupoikkeama-id kirjaaja kommentit]
   (doseq [kommentin-data kommentit]
@@ -65,16 +89,19 @@
       (laatupoikkeamat/liita-kommentti<! db laatupoikkeama-id kommentti-id))))
 
 (defn tallenna [liitteiden-hallinta db urakka-id kirjaaja data]
-  (let [tr-osoite (sijainnit/hae-tierekisteriosoite db (:alkusijainti data) (:loppusijainti data))
+  (let [urakkatyyppi (hae-urakan-tyyppi db urakka-id)
+        yllapitokohde-id (when (yllapitokohdeurakka? urakkatyyppi)
+                           (hae-laatupoikkeamalle-yllapitokohde db urakka-id (:kohde data)))
+        tr-osoite (sijainnit/hae-tierekisteriosoite db (:alkusijainti data) (:loppusijainti data))
         geometria (sijainnit/tee-geometria (:alkusijainti data) (:loppusijainti data))]
     (jdbc/with-db-transaction [db db]
-      (let [laatupoikkeama-id (tallenna-laatupoikkeama db urakka-id kirjaaja data tr-osoite geometria)
+      (let [laatupoikkeama-id (tallenna-laatupoikkeama db urakka-id kirjaaja data tr-osoite geometria yllapitokohde-id)
             kommentit (:kommentit data)
             liitteet (:liitteet data)]
         (tallenna-kommentit db laatupoikkeama-id kirjaaja kommentit)
         (tallenna-liitteet-laatupoikkeamalle db liitteiden-hallinta urakka-id laatupoikkeama-id kirjaaja liitteet)))
     (when-not tr-osoite (format "Annetulla sijainnilla ei voitu päätellä sijaintia tieverkolla (alku: %s, loppu %s)."
-                                (:alkusijainti data) (:loppusijainti data)))))
+                          (:alkusijainti data) (:loppusijainti data)))))
 
 (defn kirjaa-laatupoikkeama [liitteiden-hallinta db {id :id} data kirjaaja]
   (let [urakka-id (Integer/parseInt id)]
@@ -89,10 +116,10 @@
       http :lisaa-laatupoikkeama
       (POST "/api/urakat/:id/laatupoikkeama" request
         (kasittele-kutsu db integraatioloki
-                         :lisaa-laatupoikkeama request
-                         json-skeemat/laatupoikkeaman-kirjaus json-skeemat/kirjausvastaus
-                         (fn [parametrit data kayttaja db]
-                           (kirjaa-laatupoikkeama liitteiden-hallinta db parametrit data kayttaja))
+          :lisaa-laatupoikkeama request
+          json-skeemat/laatupoikkeaman-kirjaus json-skeemat/kirjausvastaus
+          (fn [parametrit data kayttaja db]
+            (kirjaa-laatupoikkeama liitteiden-hallinta db parametrit data kayttaja))
           :kirjoitus)))
     this)
   (stop [{http :http-palvelin :as this}]

--- a/src/clj/harja/palvelin/integraatiot/api/laatupoikkeamat.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/laatupoikkeamat.clj
@@ -63,24 +63,24 @@
               :ulkoinen_id (:id tunniste)
               :urakka-id urakka-id}))
       (:id (laatupoikkeamat/luo-laatupoikkeama<!
-               db
-               {:lahde "harja-api"
-                :urakka urakka-id,
-                :aika (aika-string->java-sql-date aika),
-                :tekija "urakoitsija",
-                :kohde kohde,
-                :selvitys true,
-                :luoja (:id kirjaaja),
-                :kuvaus kuvaus,
-                :sijainti geometria,
-                :tr_numero (:tie tr-osoite),
-                :tr_alkuosa (:aosa tr-osoite),
-                :tr_loppuosa (:losa tr-osoite),
-                :tr_alkuetaisyys (:aet tr-osoite),
-                :tr_loppuetaisyys (:let tr-osoite),
-                :yllapitokohde yllapitokohde-id,
-                :sisaltaa_laatupoikkeaman sisaltaa-poikkeamaraportin,
-                :ulkoinen_id (:id tunniste)})))))
+             db
+             {:lahde "harja-api"
+              :urakka urakka-id,
+              :aika (aika-string->java-sql-date aika),
+              :tekija "urakoitsija",
+              :kohde kohde,
+              :selvitys true,
+              :luoja (:id kirjaaja),
+              :kuvaus kuvaus,
+              :sijainti geometria,
+              :tr_numero (:tie tr-osoite),
+              :tr_alkuosa (:aosa tr-osoite),
+              :tr_loppuosa (:losa tr-osoite),
+              :tr_alkuetaisyys (:aet tr-osoite),
+              :tr_loppuetaisyys (:let tr-osoite),
+              :yllapitokohde yllapitokohde-id,
+              :sisaltaa_laatupoikkeaman sisaltaa-poikkeamaraportin,
+              :ulkoinen_id (:id tunniste)})))))
 
 (defn tallenna-kommentit [db laatupoikkeama-id kirjaaja kommentit]
   (doseq [kommentin-data kommentit]

--- a/src/clj/harja/palvelin/palvelut/debug.clj
+++ b/src/clj/harja/palvelin/palvelut/debug.clj
@@ -355,6 +355,15 @@
        :viesti (.getMessage e)
        :virhe (pr-str e)})))
 
+(defn hae-tierekisteriosoite-koordinaateista
+  "Palauttaa tierekisteriosoitteen annetuista alkusijainti/loppusijainti-koordinaateista.
+  Käyttää samaa päättelylogiikkaa kuin integraatioiden laatupoikkeama-API."
+  [db {:keys [alkusijainti loppusijainti]}]
+  (let [tr-osoite (sijainnit/hae-tierekisteriosoite db alkusijainti loppusijainti)]
+    {:tr-osoite tr-osoite
+     :alkusijainti alkusijainti
+     :loppusijainti loppusijainti}))
+
 (defn vaadi-jvh! [palvelu-fn]
   (fn [user payload]
     (if-not (roolit/jvh? user)
@@ -410,7 +419,9 @@
       :debug-hae-pkluokkageometriat
       (vaadi-jvh! (partial #'hae-pkluokkageometriat db))
       :debug-ilmoitus-xml
-      (vaadi-jvh! (partial #'ilmoitus-xml db)))
+      (vaadi-jvh! (partial #'ilmoitus-xml db))
+      :debug-hae-tierekisteriosoite-koordinaateista
+      (vaadi-jvh! (partial #'hae-tierekisteriosoite-koordinaateista db)))
     this)
 
   (stop [{http :http-palvelin :as this}]
@@ -433,5 +444,6 @@
       :debug-hae-tieturvalliusuus-geometriat
       :debug-hae-yllapitokohteen-geometriat
       :debug-hae-pkluokkageometriat
-      :debug-ilmoitus-xml)
+      :debug-ilmoitus-xml
+      :debug-hae-tierekisteriosoite-koordinaateista)
     this))

--- a/src/cljs/harja/tiedot/hallinta/tyokalut/laatupoikkeamasanktiotyokalu_tiedot.cljs
+++ b/src/cljs/harja/tiedot/hallinta/tyokalut/laatupoikkeamasanktiotyokalu_tiedot.cljs
@@ -1,0 +1,250 @@
+(ns harja.tiedot.hallinta.tyokalut.laatupoikkeamasanktiotyokalu-tiedot
+  "Hallinnan sanktiotyokalun ui controlleri."
+  (:require [reagent.core :refer [atom]]
+            [tuck.core :as tuck]
+            [cljs.core.async :refer [<!]]
+            [cljs-http.client :as http]
+            [harja.pvm :as pvm]
+            [harja.tyokalut.tuck :as tuck-apurit]
+            [harja.domain.laadunseuranta.sanktio :as sanktio-domain]
+            [harja.ui.viesti :as viesti]
+            [harja.tiedot.navigaatio :as nav]
+            [harja.asiakas.kommunikaatio :as k])
+  (:require-macros [cljs.core.async.macros :refer [go]]))
+
+(def +sanktiolajit+
+  [:muistutus :A :B :C :arvonvahennyssanktio])
+
+(defn sanktiotyypit-lajille [app sanktio]
+  (let [urakan-alkupvm (or (get-in sanktio [:valittu-urakka :alkupvm])
+                         (get-in @nav/valittu-urakka [:alkupvm])
+                         (pvm/nyt))]
+    (vec (sanktio-domain/sanktiolaji->sanktiotyypit
+           (:laji sanktio)
+           (:sanktiotyypit app)
+           urakan-alkupvm))))
+
+(defn- paivita-tyyppi [app sanktio]
+  (let [valinnat (sanktiotyypit-lajille app sanktio)
+        valittu-id (get-in sanktio [:tyyppi :id])
+        tyyppi-loytyy? (some #(= (:id %) valittu-id) valinnat)]
+    (cond
+      (empty? valinnat)
+      (assoc sanktio :tyyppi nil)
+
+      tyyppi-loytyy?
+      sanktio
+
+      :else
+      (assoc sanktio :tyyppi (first valinnat)))))
+
+(defn- koordinaatit-annettu?
+  [{:keys [alku-x alku-y]}]
+  (and (number? alku-x) (number? alku-y)))
+
+(defn- muodosta-alkusijainti
+  [{:keys [alku-x alku-y] :as sanktio}]
+  (when (koordinaatit-annettu? sanktio)
+    {:x alku-x :y alku-y}))
+
+(defn- muodosta-loppusijainti
+  [{:keys [loppu-x loppu-y]}]
+  (when (and (number? loppu-x) (number? loppu-y))
+    {:x loppu-x :y loppu-y}))
+
+(def alkutila
+  {:sanktio {:valittu-hallintayksikko nil
+             :valittu-urakka nil
+             :sanktiomuoto :suorasanktio
+             :laji :A
+             :tyyppi nil
+             :summa 1000
+             :perintapvm (pvm/nyt)
+             :maarattypvm (pvm/nyt)
+             :paivamaara (pvm/nyt)
+             :kasittelyaika (pvm/nyt)
+             :kasittelytapa :valikatselmus
+             :alku-x 430746
+             :alku-y 7199055
+             :loppu-x nil
+             :loppu-y nil
+             :kohde "Leppäjärven ramppi"
+             :kuvaus "Laatupoikkeaman kuvaus"
+             :perustelu "Sanktion perustelu"
+             :liitteet []}
+   :sanktiotyypit []
+   :sanktiotyypit-haku-kaynnissa? false
+   :tieosoitteen-haku-kaynnissa? false
+   :haettu-tr-osoite nil
+   :lahetys-kaynnissa? false
+   :mahdolliset-urakat []})
+
+(def data (atom alkutila))
+(def nakymassa? (atom false))
+
+(defn koosta-json-map [app]
+  {:otsikko {
+             :lahettaja {
+                         :jarjestelma "Urakoitsijan järjestelmä",
+                         :organisaatio {
+                                        :nimi "Urakoitsija",
+                                        :ytunnus "1234567-8"}},
+             :viestintunniste {:id 123},
+             :lahetysaika (pvm/aika->str-iso8601-UTC (get-in app [:sanktio :kasittelyaika]))},
+   :tunniste {:id 123},
+   :alkusijainti {:x (get-in app [:sanktio :alku-x]),
+                  :y (get-in app [:sanktio :alku-y])},
+   :kuvaus (get-in app [:sanktio :kuvaus]),
+   :kohde (get-in app [:sanktio :kohde]),
+   :kirjaaja {:id 54697481,
+              :etunimi "Ville",
+              :sukunimi "Vaara"},
+   :aika (pvm/aika->str-iso8601-UTC (get-in app [:sanktio :kasittelyaika])),
+   :sisaltaa-poikkeamaraportin true,
+   :liitteet (or (get-in app [:sanktio :liitteet]) []),
+   :kommentit []})
+
+(defrecord Muokkaa [sanktio])
+(defrecord Laheta [sanktio])
+(defrecord LahetysOnnistui [vastaus])
+(defrecord LahetysEpaonnistui [vastaus])
+
+(defrecord HaeHallintayksikonUrakatOnnistui [vastaus])
+(defrecord HaeHallintayksikonUrakatEpaonnistui [vastaus])
+(defrecord HaeSanktiotyypit [])
+(defrecord HaeSanktiotyypitOnnistui [vastaus])
+(defrecord HaeSanktiotyypitEpaonnistui [vastaus])
+(defrecord HaeTieosoite [])
+(defrecord HaeTieosoiteOnnistui [vastaus])
+(defrecord HaeTieosoiteEpaonnistui [vastaus])
+
+(defn- hae-hallintayksikon-urakat [hallintayksikko]
+  (when hallintayksikko
+    (tuck-apurit/post! :hallintayksikon-urakat
+      (:id hallintayksikko)
+      {:onnistui ->HaeHallintayksikonUrakatOnnistui
+       :epaonnistui ->HaeHallintayksikonUrakatEpaonnistui
+       :paasta-virhe-lapi? true})))
+
+(extend-protocol tuck/Event
+  Muokkaa
+  (process-event [{sanktio :sanktio} app]
+    (let [hallintayksikko-vaihtui? (not= (get-in app [:sanktio :valittu-hallintayksikko])
+                                     (:valittu-hallintayksikko sanktio))
+          koordinaatit-muuttuivat? (not= (select-keys (get-in app [:sanktio]) [:alku-x :alku-y :loppu-x :loppu-y])
+                                     (select-keys sanktio [:alku-x :alku-y :loppu-x :loppu-y]))
+          sanktio (if hallintayksikko-vaihtui?
+                    (do
+                      (hae-hallintayksikon-urakat (:valittu-hallintayksikko sanktio))
+                      (assoc sanktio :valittu-urakka nil))
+                    sanktio)
+          sanktio (if (= :muistutus (:laji sanktio))
+                    (assoc sanktio :summa nil)
+                    sanktio)
+          sanktio (paivita-tyyppi app sanktio)]
+      (cond-> (assoc app :sanktio sanktio)
+        koordinaatit-muuttuivat?
+        (assoc :haettu-tr-osoite nil))))
+
+  HaeTieosoite
+  (process-event [_ app]
+    (let [sanktio (:sanktio app)
+          alkusijainti (muodosta-alkusijainti sanktio)
+          loppusijainti (muodosta-loppusijainti sanktio)]
+      (if-not alkusijainti
+        (do
+          (viesti/nayta-toast! "Anna ensin alkusijainnin x- ja y-koordinaatit" :varoitus)
+          app)
+        (do
+          (tuck-apurit/post! :debug-hae-tierekisteriosoite-koordinaateista
+            {:alkusijainti alkusijainti
+             :loppusijainti loppusijainti}
+            {:onnistui ->HaeTieosoiteOnnistui
+             :epaonnistui ->HaeTieosoiteEpaonnistui
+             :paasta-virhe-lapi? true})
+          (assoc app :tieosoitteen-haku-kaynnissa? true)))))
+
+  HaeTieosoiteOnnistui
+  (process-event [{vastaus :vastaus} app]
+    (let [tr-osoite (:tr-osoite vastaus)]
+      (if tr-osoite
+        (viesti/nayta-toast! "Tieosoite löytyi koordinaateista" :onnistui)
+        (viesti/nayta-toast! "Tieosoitetta ei löytynyt annetuista koordinaateista" :varoitus))
+      (-> app
+        (assoc :haettu-tr-osoite tr-osoite)
+        (assoc :tieosoitteen-haku-kaynnissa? false))))
+
+  HaeTieosoiteEpaonnistui
+  (process-event [{vastaus :vastaus} app]
+    (viesti/nayta-toast! (or (k/virheviesti vastaus)
+                           "Tieosoitteen haku epäonnistui")
+      :varoitus
+      viesti/viestin-nayttoaika-pitka)
+    (assoc app :tieosoitteen-haku-kaynnissa? false))
+
+  Laheta
+  (process-event [{sanktio :sanktio} app]
+    (let [tulos! (tuck/send-async! ->LahetysOnnistui)
+          virhe! (tuck/send-async! ->LahetysEpaonnistui)
+          urakka-id (get-in sanktio [:valittu-urakka :id])
+          payload (koosta-json-map app)
+          url (str "api/urakat/" urakka-id "/laatupoikkeama")]
+      (if-not urakka-id
+        (do
+          (viesti/nayta-toast! "Urakka pitää valita ennen lähetystä" :varoitus)
+          (assoc app :lahetys-kaynnissa? false))
+        (do
+          (go
+            (let [params {:body (.stringify js/JSON (clj->js payload))
+                          :content-type :json
+                          :accept :json
+                          :headers {"X-CSRF-Token" (k/get-csrf-token)}}
+                  vastaus (<! (http/post url params))]
+              (if (or (k/virhe? vastaus) (false? (:success vastaus)))
+                (virhe! vastaus)
+                (tulos! vastaus))))
+          (assoc app :lahetys-kaynnissa? true)))))
+
+  LahetysOnnistui
+  (process-event [_ app]
+    (viesti/nayta-toast! "Sanktion lähetys onnistui" :onnistui)
+    (assoc app :lahetys-kaynnissa? false))
+
+  LahetysEpaonnistui
+  (process-event [{vastaus :vastaus} app]
+    (viesti/nayta-toast! (or (k/virheviesti vastaus)
+                           "Sanktion lähetys epäonnistui")
+      :varoitus
+      viesti/viestin-nayttoaika-pitka)
+    (assoc app :lahetys-kaynnissa? false))
+
+  HaeHallintayksikonUrakatOnnistui
+  (process-event [{vastaus :vastaus} app]
+    (assoc app :mahdolliset-urakat vastaus))
+
+  HaeHallintayksikonUrakatEpaonnistui
+  (process-event [_ app]
+    (viesti/nayta-toast! "Urakoiden haku epäonnistui" :varoitus viesti/viestin-nayttoaika-pitka)
+    app)
+
+  HaeSanktiotyypit
+  (process-event [_ app]
+    (tuck-apurit/get! :hae-sanktiotyypit
+      {:onnistui ->HaeSanktiotyypitOnnistui
+       :epaonnistui ->HaeSanktiotyypitEpaonnistui
+       :paasta-virhe-lapi? true})
+    (assoc app :sanktiotyypit-haku-kaynnissa? true))
+
+  HaeSanktiotyypitOnnistui
+  (process-event [{vastaus :vastaus} app]
+    (let [app (-> app
+                (assoc :sanktiotyypit vastaus)
+                (assoc :sanktiotyypit-haku-kaynnissa? false))
+          paivitetty (paivita-tyyppi app (:sanktio app))]
+      (assoc app :sanktio paivitetty)))
+
+  HaeSanktiotyypitEpaonnistui
+  (process-event [_ app]
+    (viesti/nayta-toast! "Sanktiotyyppien haku epäonnistui" :varoitus viesti/viestin-nayttoaika-pitka)
+    (assoc app :sanktiotyypit-haku-kaynnissa? false)))
+

--- a/src/cljs/harja/views/hallinta.cljs
+++ b/src/cljs/harja/views/hallinta.cljs
@@ -22,6 +22,7 @@
             [harja.views.hallinta.tyokalut.tieosoitteet-nakyma :as tieosoitteet-nakyma]
             [harja.views.hallinta.tyokalut.ajastukset-nakyma :as ajastukset-nakyma]
             [harja.views.hallinta.tyokalut.raporttityokalu-nakyma :as raporttityokalu-nakyma]
+            [harja.views.hallinta.tyokalut.laatupoikkeamasanktiotyokalu-nakyma :as laatupoikkeamasanktiotyokalu-nakyma]
             [harja.views.hallinta.koulutusvideot :as koulutusvideot]
             [harja.views.hallinta.palauteluokitukset :as pl]
             [harja.views.hallinta.viestitestaus-nakyma :as viestinakyma]
@@ -262,6 +263,13 @@
             (oikeudet/voi-kirjoittaa? oikeudet/hallinta-toteumatyokalu))
       ^{:key "raporttityokalut"}
       [raporttityokalu-nakyma/nayta-raporttityokalut])
+
+    "Sanktiotyökalu"
+    :sanktiotyokalu
+    (when (and (istunto/ominaisuus-kaytossa? :toteumatyokalu)
+            (oikeudet/voi-kirjoittaa? oikeudet/hallinta-toteumatyokalu))
+      ^{:key "sanktiotyokalu"}
+      [laatupoikkeamasanktiotyokalu-nakyma/laheta-sanktio])
 
     "Viestitestaus"
     :viestitestaus

--- a/src/cljs/harja/views/hallinta/tyokalut/laatupoikkeamasanktiotyokalu_nakyma.cljs
+++ b/src/cljs/harja/views/hallinta/tyokalut/laatupoikkeamasanktiotyokalu_nakyma.cljs
@@ -1,0 +1,206 @@
+(ns harja.views.hallinta.tyokalut.laatupoikkeamasanktiotyokalu-nakyma
+  "Työkalu laatupoikkeamien lähettämiseen APIn kautta."
+  (:require [tuck.core :refer [tuck]]
+            [harja.domain.oikeudet :as oikeudet]
+            [harja.domain.laadunseuranta.sanktio :as sanktio-domain]
+            [harja.ui.komponentti :as komp]
+            [harja.ui.debug :as debug]
+            [harja.ui.lomake :as lomake]
+            [harja.ui.napit :as napit]
+            [harja.ui.viesti :as viesti]
+            [harja.tiedot.hallintayksikot :as hal]
+            [harja.tiedot.hallinta.tyokalut.laatupoikkeamasanktiotyokalu-tiedot :as tiedot])
+  (:require-macros [cljs.core.async.macros :refer [go]]))
+
+(defn- tyyppi-valinnat [app]
+  (tiedot/sanktiotyypit-lajille app (:sanktio app)))
+
+(defn- voi-lahettaa? [sanktio]
+  (and (:valittu-hallintayksikko sanktio)
+    (:valittu-urakka sanktio)
+    (:laji sanktio)
+    (:paivamaara sanktio)
+    (:kasittelyaika sanktio)
+    (:maarattypvm sanktio)
+    (:perintapvm sanktio)
+    (:kohde sanktio)
+    (:perustelu sanktio)
+    (:kasittelytapa sanktio)
+    (:tyyppi sanktio)
+    (or (not (sanktio-domain/muu-kuin-muistutus? sanktio))
+      (number? (:summa sanktio)))))
+
+(defn- tieosoite-tekstina [tr-osoite]
+  (when tr-osoite
+    (str "Tie " (:tie tr-osoite)
+      ", alkuosa " (:aosa tr-osoite)
+      ", alkuetäisyys " (:aet tr-osoite)
+      ", loppuosa " (:losa tr-osoite)
+      ", loppuetäisyys " (:let tr-osoite))))
+
+(defn- data-url->base64 [data-url]
+  (second (re-find #"^data:.*;base64,(.*)$" data-url)))
+
+(defn- lue-liite! [sanktio e! tiedosto]
+  (let [lukija (js/FileReader.)]
+    (set! (.-onload lukija)
+      (fn [e]
+        (let [data-url (-> e .-target .-result)
+              sisalto (data-url->base64 data-url)
+              liite {:liite {:nimi (.-name tiedosto)
+                             :tyyppi (or (.-type tiedosto) "application/octet-stream")
+                             :kuvaus "Liitetiedosto"
+                             :sisalto sisalto}}]
+          (if sisalto
+            (e! (tiedot/->Muokkaa (assoc sanktio :liitteet [liite])))
+            (viesti/nayta-toast! "Liitteen lukeminen epäonnistui" :varoitus)))))
+    (set! (.-onerror lukija)
+      (fn [_]
+        (viesti/nayta-toast! "Liitteen lukeminen epäonnistui" :varoitus)))
+    (.readAsDataURL lukija tiedosto)))
+
+(defn sanktiolomake [e! {:keys [sanktio] :as app}]
+  (let [tyypit (tyyppi-valinnat app)
+        voi-lahettaa? (voi-lahettaa? sanktio)
+        liite (first (:liitteet sanktio))]
+    [:div.yhteydenpito
+     [:h3 "Sanktiotyökalu"]
+     [:p "Lähetä laatupoikkeama. Lomake ei vielä tue sanktioita tai bonuksia tai arvonvähennyksiä. Vain laatupoikkeamia. API ei tue vielä muita."]
+     [lomake/lomake
+      {:ei-borderia? true
+       :tarkkaile-ulkopuolisia-muutoksia? true
+       :footer-fn (fn [sanktio]
+                    [:div
+                     [napit/tallenna "Hae tieosoite koordinaateista"
+                      #(e! (tiedot/->HaeTieosoite))
+                      {:disabled (:tieosoitteen-haku-kaynnissa? app)}]
+                     [napit/tallenna "Lähetä"
+                      #(e! (tiedot/->Laheta sanktio))
+                      {:disabled (not voi-lahettaa?)
+                       :paksu? true}]])
+       :muokkaa! #(e! (tiedot/->Muokkaa %))}
+      [{:nimi :valittu-hallintayksikko
+        :otsikko "Valitse hallintayksikkö"
+        :tyyppi :valinta
+        :valinnat @hal/vaylamuodon-hallintayksikot
+        :valinta-nayta :nimi
+        :pakollinen? true}
+       {:id (hash (:mahdolliset-urakat app))
+        :nimi :valittu-urakka
+        :otsikko "Valitse urakka"
+        :tyyppi :valinta
+        :valinnat (:mahdolliset-urakat app)
+        :valinta-nayta :nimi
+        :pakollinen? true}
+       {:nimi :sanktiomuoto
+        :otsikko "Sanktion muoto"
+        :tyyppi :radio-group
+        :vaihtoehdot [:suorasanktio :laatupoikkeaman-sanktio]
+        :vaihtoehto-nayta (fn [arvo]
+                            ({:suorasanktio "Suorasanktio"
+                              :laatupoikkeaman-sanktio "Laatupoikkeaman normaali sanktio"}
+                             arvo))}
+       {:nimi :laji
+        :otsikko "Sanktion laji"
+        :tyyppi :valinta
+        :valinnat tiedot/+sanktiolajit+
+        :valinta-nayta #(or (sanktio-domain/sanktiolaji->teksti %) "Valitse laji")
+        :pakollinen? true}
+       {:nimi :tyyppi
+        :otsikko "Sanktiotyyppi"
+        :tyyppi :valinta
+        :valinta-arvo identity
+        :valinnat tyypit
+        :valinta-nayta #(or (:nimi %) "Valitse sanktiotyyppi")
+        :pakollinen? true}
+       {:nimi :summa
+        :otsikko "Sanktion suuruus"
+        :tyyppi :numero
+        :pakollinen? (sanktio-domain/muu-kuin-muistutus? sanktio)
+        :napiton? (not (sanktio-domain/muu-kuin-muistutus? sanktio))}
+       {:nimi :paivamaara
+        :otsikko "Havaittu"
+        :tyyppi :pvm
+        :pakollinen? true}
+       {:nimi :kasittelyaika
+        :otsikko "Käsitelty"
+        :tyyppi :pvm
+        :pakollinen? true}
+       {:nimi :maarattypvm
+        :otsikko "Määrätty"
+        :tyyppi :pvm
+        :pakollinen? true}
+       {:nimi :perintapvm
+        :otsikko "Perintäpäivä"
+        :tyyppi :pvm
+        :pakollinen? true}
+       {:nimi :alku-x
+        :otsikko "Alkusijainti x"
+        :tyyppi :numero}
+       {:nimi :alku-y
+        :otsikko "Alkusijainti y"
+        :tyyppi :numero}
+       {:nimi :loppu-x
+        :otsikko "Loppusijainti x (valinnainen)"
+        :tyyppi :numero}
+       {:nimi :loppu-y
+        :otsikko "Loppusijainti y (valinnainen)"
+        :tyyppi :numero}
+       {:nimi :kasittelytapa
+        :otsikko "Käsittelytapa"
+        :tyyppi :valinta
+        :valinnat sanktio-domain/kasittelytavat
+        :valinta-nayta #(or (sanktio-domain/kasittelytapa->teksti %) "Valitse käsittelytapa")
+        :pakollinen? true}
+       {:nimi :kohde
+        :otsikko "Kohde"
+        :tyyppi :string
+        :pakollinen? true}
+       {:nimi :kuvaus
+        :otsikko "Kuvaus"
+        :tyyppi :text
+        :koko [60 6]}
+       {:nimi :perustelu
+        :otsikko "Perustelu"
+        :tyyppi :text
+        :koko [60 6]
+        :pakollinen? true}]
+      sanktio]
+     [:div.form-group
+      [:label.control-label
+       [:span.kentan-label "Liitetiedosto (valinnainen) - HOX! asetukset.edn:stä pitää vaihtaa virustarkistus url nilliksi, jotta tämä voi toimia lokaalisti"]]
+      [:input {:type "file"
+               :class "form-control"
+               :on-change #(let [tiedosto (aget (.. % -target -files) 0)]
+                             (when tiedosto
+                               (lue-liite! sanktio e! tiedosto)))}]
+      (when liite
+        [:div {:style {:margin-top "8px"}}
+         [:span (str "Valittu liite: " (get-in liite [:liite :nimi]))]
+         [napit/yleinen-toissijainen
+          "Poista liite"
+          #(e! (tiedot/->Muokkaa (assoc sanktio :liitteet [])))
+          {:luokka "margin-left-16"}]])]
+     (when (:haettu-tr-osoite app)
+       [:p [:b "Haettu tieosoite: "] (tieosoite-tekstina (:haettu-tr-osoite app))])
+     [debug/debug app]]))
+
+(defn laheta-sanktio* []
+  (komp/luo
+    (komp/sisaan-ulos
+      #(go
+         (reset! tiedot/nakymassa? true)
+         (reset! tiedot/data tiedot/alkutila))
+      #(reset! tiedot/nakymassa? false))
+    (fn [e! app]
+      (if (oikeudet/voi-kirjoittaa? oikeudet/hallinta-toteumatyokalu)
+        (when @tiedot/nakymassa?
+          (when (and (empty? (:sanktiotyypit app))
+                  (not (:sanktiotyypit-haku-kaynnissa? app)))
+            (e! (tiedot/->HaeSanktiotyypit)))
+          (sanktiolomake e! app))
+        "Puutteelliset käyttöoikeudet"))))
+
+(defn laheta-sanktio []
+  [tuck tiedot/data laheta-sanktio*])
+

--- a/test/clj/harja/palvelin/integraatiot/api/laatupoikkeaman_kirjaus_test.clj
+++ b/test/clj/harja/palvelin/integraatiot/api/laatupoikkeaman_kirjaus_test.clj
@@ -4,7 +4,6 @@
             [clojure.data :refer [diff]]
             [harja.palvelin.komponentit.liitteet :as liitteet]
             [com.stuartsierra.component :as component]
-            [taoensso.timbre :as log]
             [harja.palvelin.integraatiot.api.laatupoikkeamat :as api-laatupoikkeamat]
             [harja.palvelin.integraatiot.api.tyokalut :as api-tyokalut]
             [cheshire.core :as cheshire]))
@@ -22,14 +21,15 @@
 
 (use-fixtures :once jarjestelma-fixture)
 
-(deftest tallenna-laatupoikkeama
+(deftest api-tallenna-laatupoikkeama-hoito-urakalle-toimii
   (let [laatupoikkeamat-kannassa-ennen-pyyntoa (ffirst (q (str "SELECT COUNT(*) FROM laatupoikkeama;")))
         liitteiden-maara-ennen (first (first (q "select count(id) FROM liite")))
         _ (anna-kirjoitusoikeus kayttaja)
         _ (anna-kirjoitusoikeus kayttaja-jvh)
-        vastaus (api-tyokalut/post-kutsu ["/api/urakat/" urakka "/laatupoikkeama"] kayttaja portti
+        urakka-id (hae-urakan-id-nimella "Oulun alueurakka 2005-2012")
+        vastaus (api-tyokalut/post-kutsu ["/api/urakat/" urakka-id "/laatupoikkeama"] kayttaja portti
                                          (-> "test/resurssit/api/laatupoikkeama.json" slurp))
-        vastaus2 (api-tyokalut/post-kutsu ["/api/urakat/" urakka "/laatupoikkeama"] kayttaja-jvh portti
+        vastaus2 (api-tyokalut/post-kutsu ["/api/urakat/" urakka-id "/laatupoikkeama"] kayttaja-jvh portti
                   (-> "test/resurssit/api/laatupoikkeama.json" slurp))
         liitteiden-maara-jalkeen (first (first (q "select count(id) FROM liite")))]
     (is (contains? (cheshire/decode (:body vastaus) true) :ilmoitukset))
@@ -45,15 +45,44 @@
 
     (let [laatupoikkeamat-kannassa-pyynnon-jalkeen (ffirst (q (str "SELECT COUNT(*) FROM laatupoikkeama;")))
           liite-id (ffirst (q (str "SELECT id FROM liite WHERE nimi = 'testihavainto36934853.jpg';")))
-          laatupoikkeama-id (ffirst (q (str "SELECT id FROM laatupoikkeama WHERE kohde = 'testikohde36934853';")))
+          laatupoikkeama-db (first (q-map (str "SELECT id, tr_numero FROM laatupoikkeama WHERE kohde = 'testikohde36934853';")))
           kommentti-id (ffirst (q (str "SELECT id FROM kommentti WHERE kommentti = 'Testikommentti323353435';")))]
-      ;(log/debug "liite-id: " liite-id)
-      ;(log/debug "laatupoikkeama-id: " laatupoikkeama-id)
-      ;(log/debug "kommentti-id: " kommentti-id)
 
       (is (= (+ laatupoikkeamat-kannassa-ennen-pyyntoa 1) laatupoikkeamat-kannassa-pyynnon-jalkeen))
       (is (number? liite-id))
-      (is (number? laatupoikkeama-id))
+      (is (number? (:id laatupoikkeama-db)))
+      (is (number? (:tr_numero laatupoikkeama-db)))
+      (is (number? kommentti-id))
+
+      (u "DELETE FROM laatupoikkeama_kommentti WHERE laatupoikkeama = (SELECT id FROM laatupoikkeama WHERE kohde = 'testikohde36934853') ;")
+      (u "DELETE FROM laatupoikkeama_liite WHERE laatupoikkeama = (SELECT id FROM laatupoikkeama WHERE kohde = 'testikohde36934853');")
+      (u "DELETE FROM laatupoikkeama WHERE id = (SELECT id FROM laatupoikkeama WHERE kohde = 'testikohde36934853');"))))
+
+(deftest api-tallenna-laatupoikkeama-yllapito-urakalle-toimii
+  (let [laatupoikkeamat-kannassa-ennen-pyyntoa (ffirst (q (str "SELECT COUNT(*) FROM laatupoikkeama;")))
+        _ (anna-kirjoitusoikeus kayttaja-jvh)
+        urakka-id (hae-urakan-id-nimella "Tienpäällystysurakka KAS ELY 1 2015")
+        ;; Haetaan yllapitokohde-id, jotta voidaan varmistaa, että laatupoikkeama tallentuu oikein yllapitokohteelle
+        yllapitokohde (first (q-map (format "SELECT id, nimi FROM yllapitokohde WHERE urakka = %s", urakka-id)))
+        yllapitokohde-nimi (:nimi yllapitokohde)
+        yllapitokohde-id (:id yllapitokohde)
+        laatupoikkeama-json (-> "test/resurssit/api/laatupoikkeama.json"
+                              slurp
+                              (.replace "testikohde36934853" yllapitokohde-nimi)
+                              (.replace "123456" "654321"))
+        vastaus (api-tyokalut/post-kutsu ["/api/urakat/" urakka-id "/laatupoikkeama"] kayttaja-jvh portti laatupoikkeama-json)]
+    (is (contains? (cheshire/decode (:body vastaus) true) :ilmoitukset))
+
+    (is (= 200 (:status vastaus)))
+
+    (let [laatupoikkeamat-kannassa-pyynnon-jalkeen (ffirst (q (str "SELECT COUNT(*) FROM laatupoikkeama;")))
+          laatupoikkeama-db (first (q-map (format "SELECT id, tr_numero, yllapitokohde FROM laatupoikkeama WHERE yllapitokohde = %s; " yllapitokohde-id)))
+          kommentti-id (ffirst (q (str "SELECT id FROM kommentti WHERE kommentti = 'Testikommentti323353435';")))]
+
+      (is (= (+ laatupoikkeamat-kannassa-ennen-pyyntoa 1) laatupoikkeamat-kannassa-pyynnon-jalkeen))
+      (is (number? (:id laatupoikkeama-db)))
+      (is (number? (:tr_numero laatupoikkeama-db)))
+      (is (= yllapitokohde-id (:yllapitokohde laatupoikkeama-db)))
       (is (number? kommentti-id))
 
       (u "DELETE FROM laatupoikkeama_kommentti WHERE laatupoikkeama = (SELECT id FROM laatupoikkeama WHERE kohde = 'testikohde36934853') ;")


### PR DESCRIPTION
## Mitä muutettiin
Laatupoikkeama rajapintaan lähetettävä json ei löytänyt ylläpitourakoille kohdetta ja tienumeroa ei tallennettu oikein.
Muutin kohteen haun nimellä toimivaksi ja korjasin tienumerointi tallennuksen

Lisäksi tein työkalun hallintapaneeliin, jolla toiminnan voi testata.
## Miksi
Palaute asiakkaalta

## Testaustapa
Lähetä hallintapaneelista laatupoikkeama ylläpitourakalle ja varmista, että annetusta x -y -koordinaatista löytyy tienumero tietokannasta ja ui:lta tietenkin

## Huomioita
Hallintapaneeliin lisätty työkalu ei ole täydellinen. Jotta se toimii jvh käyttäjällä, niin joudut lisäämään {kirjoitus} oikeudet tietokantaan käyttäjälle.
