### PR TITLE
HARJA-2391 Urakoiden tilanne -näkymän päivittäminen

### DIFF
--- a/src/clj/harja/kyselyt/kojelauta.sql
+++ b/src/clj/harja/kyselyt/kojelauta.sql
@@ -1,37 +1,37 @@
 -- name: hae-hoidon-urakat-kojelautaan
 SELECT u.id,
-       COALESCE(u.lyhyt_nimi, u.nimi) AS nimi,
-       u.elinvoimakeskus_id as evk_id,
-       EXTRACT (YEAR FROM u.alkupvm) AS urakan_alkuvuosi,
-       :hoitokauden_alkuvuosi as hoitokauden_alkuvuosi,
+       COALESCE(u.lyhyt_nimi, u.nimi)               AS nimi,
+       u.elinvoimakeskus_id                         AS evk_id,
+       EXTRACT (YEAR FROM u.alkupvm)                AS urakan_alkuvuosi,
+       :hoitokauden_alkuvuosi                       AS hoitokauden_alkuvuosi,
        urakan_kustannussuunnitelman_tila(u.id::INTEGER,
                                          monesko_hoitokausi(u.alkupvm, u.loppupvm,
                                                             :hoitokauden_alkuvuosi::INTEGER))       AS ks_tila,
-       (SELECT 'tavoitehinnan-alitus' as tyyppi
+       (SELECT 'tavoitehinnan-alitus'               AS tyyppi
         FROM paatos_tavoitehinta_alitus p
         WHERE p.urakkaid = u.id
           AND p.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
           AND p.poistettu IS FALSE
-          LIMIT 1) AS tavoitehintaalituspaatos,
-       (SELECT 'tavoitehinnan-ylitys' as tyyppi
+          LIMIT 1)                                  AS tavoitehintaalituspaatos,
+       (SELECT 'tavoitehinnan-ylitys'               AS tyyppi
         FROM paatos_tavoitehinta_ylitys p
         WHERE p.urakkaid = u.id
           AND p.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
           AND p.poistettu IS FALSE
         LIMIT 1) AS tavoitehintaylityspaatos,
-       (SELECT 'kattohinnan-ylitys' as tyyppi
+       (SELECT 'kattohinnan-ylitys'                 AS tyyppi
         FROM paatos_kattohinta p
         WHERE p.urakkaid = u.id
           AND p.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
           AND p.poistettu IS FALSE
         LIMIT 1) AS kattohintapaatos,
-       (SELECT 'tavoitehinnan-muutokset' as tyyppi
+       (SELECT 'tavoitehinnan-muutokset'            AS tyyppi
         FROM paatos_tavoitehinnan_muutos p
         WHERE p.urakkaid = u.id
           AND p.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
           AND p.poistettu IS FALSE
         LIMIT 1) AS tavoitehinnan_muutospaatos,
-       (SELECT tyyppi::TEXT as tyyppi
+       (SELECT tyyppi::TEXT                         AS tyyppi
          FROM paatos_lupaus p
          WHERE p.urakkaid = u.id
            AND p.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
@@ -68,11 +68,12 @@ SELECT u.id,
      (:evkt_annettu IS NOT TRUE OR u.elinvoimakeskus_id IN (:evk_idt))
  ORDER BY COALESCE(u.lyhyt_nimi, u.nimi);
 
+
 -- name: hae-paallystysurakat-kojelautaan
 SELECT u.id,
        u.nimi,
-       u.elinvoimakeskus_id as evk_id,
-       :vuosi as hoitokauden_alkuvuosi, -- Käytetään UIn vuoksi tässä samaa termiä kuin hoidossa vaikka kyseessä on vuosi
+       u.elinvoimakeskus_id AS evk_id,
+       :vuosi AS hoitokauden_alkuvuosi, -- Käytetään UIn vuoksi tässä samaa termiä kuin hoidossa vaikka kyseessä on vuosi
        COUNT(*) FILTER (WHERE y.id IS NOT NULL) AS yllapitokohteiden_lkm,
        COUNT(*) FILTER (WHERE pot2.tila IN ('valmis', 'lukittu')) AS valmis_hyvaksytty,
        COUNT(*) FILTER (WHERE y.lahetetty IS NOT NULL AND pot2.tila IN ('valmis', 'lukittu')
@@ -105,5 +106,3 @@ WHERE
     (:evkt_annettu IS NOT TRUE OR u.elinvoimakeskus_id IN (:evk_idt))
 GROUP BY u.id, u.nimi, u.elinvoimakeskus_id, hoitokauden_alkuvuosi
 ORDER BY u.nimi;
-
-

--- a/src/clj/harja/kyselyt/kojelauta.sql
+++ b/src/clj/harja/kyselyt/kojelauta.sql
@@ -1,55 +1,24 @@
 -- name: hae-hoidon-urakat-kojelautaan
 SELECT u.id,
-       COALESCE(u.lyhyt_nimi, u.nimi)               AS nimi,
-       u.elinvoimakeskus_id                         AS evk_id,
-       EXTRACT (YEAR FROM u.alkupvm)                AS urakan_alkuvuosi,
-       :hoitokauden_alkuvuosi                       AS hoitokauden_alkuvuosi,
+       COALESCE(u.lyhyt_nimi, u.nimi)                           AS nimi,
+       u.elinvoimakeskus_id                                     AS evk_id,
+       EXTRACT (YEAR FROM u.alkupvm)                            AS urakan_alkuvuosi,
+       :hoitokauden_alkuvuosi                                   AS hoitokauden_alkuvuosi,
        urakan_kustannussuunnitelman_tila(u.id::INTEGER,
                                          monesko_hoitokausi(u.alkupvm, u.loppupvm,
                                                             :hoitokauden_alkuvuosi::INTEGER))       AS ks_tila,
-       (SELECT 'tavoitehinnan-alitus'               AS tyyppi
-        FROM paatos_tavoitehinta_alitus p
-        WHERE p.urakkaid = u.id
-          AND p.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
-          AND p.poistettu IS FALSE
-          LIMIT 1)                                  AS tavoitehintaalituspaatos,
-       (SELECT 'tavoitehinnan-ylitys'               AS tyyppi
-        FROM paatos_tavoitehinta_ylitys p
-        WHERE p.urakkaid = u.id
-          AND p.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
-          AND p.poistettu IS FALSE
-        LIMIT 1) AS tavoitehintaylityspaatos,
-       (SELECT 'kattohinnan-ylitys'                 AS tyyppi
-        FROM paatos_kattohinta p
-        WHERE p.urakkaid = u.id
-          AND p.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
-          AND p.poistettu IS FALSE
-        LIMIT 1) AS kattohintapaatos,
-       (SELECT 'tavoitehinnan-muutokset'            AS tyyppi
-        FROM paatos_tavoitehinnan_muutos p
-        WHERE p.urakkaid = u.id
-          AND p.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
-          AND p.poistettu IS FALSE
-        LIMIT 1) AS tavoitehinnan_muutospaatos,
-       (SELECT tyyppi::TEXT                         AS tyyppi
-         FROM paatos_lupaus p
-         WHERE p.urakkaid = u.id
-           AND p.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
-           AND p.poistettu IS FALSE
-           AND p.tyyppi IN ('bonus', 'sanktio', 'taytetty')) AS lupauspaatos,
        (SELECT p.luvatut_pisteet
         FROM paatos_lupaus p
         WHERE p.urakkaid = u.id
           AND p.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
           AND p.poistettu IS FALSE
-          AND p.tyyppi IN ('bonus', 'sanktio', 'taytetty')) AS luvatut_pisteet,
+          AND p.tyyppi IN ('bonus', 'sanktio', 'taytetty'))     AS luvatut_pisteet,
        (SELECT p.toteutuneet_pisteet
         FROM paatos_lupaus p
         WHERE p.urakkaid = u.id
           AND p.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
           AND p.poistettu IS FALSE
-          AND p.tyyppi IN ('bonus', 'sanktio', 'taytetty')) AS toteutuneet_pisteet,
-
+          AND p.tyyppi IN ('bonus', 'sanktio', 'taytetty'))     AS toteutuneet_pisteet,
        (SELECT count(*) FROM laatupoikkeama lp WHERE lp.urakka = u.id AND lp.paatos IS NULL AND lp.poistettu IS FALSE AND
            lp.aika BETWEEN make_date(:hoitokauden_alkuvuosi::INTEGER, 10, 1) AND
                make_date(:hoitokauden_alkuvuosi::INTEGER + 1, 9, 30) + interval '23 hours 59 minutes 59 seconds') AS avoimet_laatupoikkeamat,

--- a/src/clj/harja/palvelin/palvelut/urakkatilanne/kojelauta.clj
+++ b/src/clj/harja/palvelin/palvelut/urakkatilanne/kojelauta.clj
@@ -63,7 +63,7 @@
                  (mapv
                    (fn [urakka]
                      (let [paatokset
-                           (v/palauta-kaikki-mahdolliset-ja-tehdyt-paatokset
+                           (v/palauta-kaikki-mahdolliset-ja-tehdyt-paatokset-kojelautaan
                              db kayttaja
                              {:urakkaid (:id urakka)
                               :kuluva-hoitovuosi hoitokauden-alkuvuosi})]

--- a/src/clj/harja/palvelin/palvelut/urakkatilanne/kojelauta.clj
+++ b/src/clj/harja/palvelin/palvelut/urakkatilanne/kojelauta.clj
@@ -1,34 +1,40 @@
 (ns harja.palvelin.palvelut.urakkatilanne.kojelauta
   (:require [clojure.set :as set]
             [com.stuartsierra.component :as component]
-            [harja.domain.oikeudet :as oikeudet]
-            [harja.kyselyt.konversio :as konv]
-            [harja.palvelin.komponentit.http-palvelin :refer [julkaise-palvelu poista-palvelut]]
+
             [harja.kyselyt.kojelauta :as q]
-            [harja.palvelin.palvelut.budjettisuunnittelu :as budjettisuunnittelu]))
+            [harja.kyselyt.konversio :as konv]
+            [harja.domain.oikeudet :as oikeudet]
+            [harja.palvelin.palvelut.valikatselmus.valikatselmukset :as v]
+            [harja.palvelin.palvelut.budjettisuunnittelu :as budjettisuunnittelu]
+            [harja.palvelin.komponentit.http-palvelin :refer [julkaise-palvelu poista-palvelut]]))
+
 
 (defn- liita-indeksikertoimet
   "Liitetään urakka- ja hoitovuosikohtaiseen riviin ko. vuoden indeksikerroin, jos saatavilla.
-
   Tätä tietoa voidaan hyödyntää kojelautanäkymässä päättelemään, onko kustannussuunnitelmien vahvistaminen pahasti myöhässä,
   vai esimerkiksi indeksitietojen puuttumisen vuoksi ei vielä edes mahdollista."
   [db kayttaja {:keys [hoitokauden_alkuvuosi id] :as rivi}]
   (let [urakan-vuoden-indeksikerroin (:indeksikerroin
-                                    (first
-                                      (filter
-                                        #(= hoitokauden_alkuvuosi (:vuosi %))
-                                        (budjettisuunnittelu/hae-urakan-indeksikertoimet db kayttaja {:urakka-id id}))))]
+                                       (first
+                                         (filter
+                                           #(= hoitokauden_alkuvuosi (:vuosi %))
+                                           (budjettisuunnittelu/hae-urakan-indeksikertoimet db kayttaja {:urakka-id id}))))]
     (assoc rivi :indeksikerroin urakan-vuoden-indeksikerroin)))
 
-(defn hae-urakat-kojelautaan [db kayttaja {:keys [urakkatyyppi hoitokauden-alkuvuosi urakka-idt evk-idt] :as hakuehdot}]
+
+(defn hae-urakat-kojelautaan
+  [db kayttaja {:keys [urakkatyyppi hoitokauden-alkuvuosi urakka-idt evk-idt] :as hakuehdot}]
   (oikeudet/vaadi-lukuoikeus oikeudet/urakkatilanne kayttaja)
   (let [params {:hoitokauden_alkuvuosi hoitokauden-alkuvuosi
                 :urakat_annettu (boolean (seq urakka-idt))
                 :urakka_idt urakka-idt
                 :evkt_annettu (boolean (seq evk-idt))
                 :evk_idt evk-idt}
+
         urakat (cond
-                 (= urakkatyyppi :hoito)                    ;; tässä kohti hoito = MHU, vanhoja alueurakoita ei tueta
+                 ;; tässä kohti hoito = MHU, vanhoja alueurakoita ei tueta
+                 (= urakkatyyppi :hoito)
                  (into []
                    (mapv
                      (comp
@@ -50,8 +56,29 @@
                                     :kohdenimi :string
                                     :lahetysvirhe :string)
                                  (konv/pgarray->vector kohteet))))))
-                   (q/hae-paallystysurakat-kojelautaan db (set/rename-keys params {:hoitokauden_alkuvuosi :vuosi}))))]
+                   (q/hae-paallystysurakat-kojelautaan db (set/rename-keys params {:hoitokauden_alkuvuosi :vuosi}))))
+
+        ;; Lisätään vielä välikatselmuksen päätöksien määrä
+        urakat (if (= urakkatyyppi :hoito)
+                 (mapv
+                   (fn [urakka]
+                     (let [paatokset
+                           (v/palauta-kaikki-mahdolliset-ja-tehdyt-paatokset
+                             db kayttaja
+                             {:urakkaid (:id urakka)
+                              :kuluva-hoitovuosi hoitokauden-alkuvuosi})]
+
+                       (assoc urakka
+                         :tehdyt-paatokset-count
+                         (count (:tietokanta-paatokset paatokset))
+
+                         :mahdolliset-paatokset-count
+                         (count (:mahdolliset-paatokset paatokset)))))
+                   urakat)
+                 ;; Ylläpitourakoille ei haeta välikatselmuksen päätöksiä
+                 urakat)]
     urakat))
+
 
 (defrecord KojelautaHallinta []
   component/Lifecycle
@@ -60,7 +87,7 @@
       (fn [kayttaja hakuehdot]
         (hae-urakat-kojelautaan db kayttaja hakuehdot)))
     this)
+
   (stop [{:keys [http-palvelin] :as this}]
-    (poista-palvelut http-palvelin
-      :hae-urakat-kojelautaan)
+    (poista-palvelut http-palvelin :hae-urakat-kojelautaan)
     this))

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
@@ -43,7 +43,7 @@
   [hoitokaudet]
   (mapv (fn [{:keys [alkupvm loppupvm]}]
           [alkupvm loppupvm])
-        hoitokaudet))
+    hoitokaudet))
 
 (defn heita-virhe [viesti]
   (throw+ viesti))
@@ -923,10 +923,9 @@
         tietokanta-paatokset (remove (fn [rivi] (= (:nimi rivi) "Välikatselmuspöytäkirjaan liitettävät raportit")) tietokanta-paatokset)]
     tietokanta-paatokset))
 
-(defn onko-paatoksia-tekematta
-  "Päätellään onko jokin päätös vielä tekemättä. Esim. raporttipäätös voi olla tekemättä ja tämä palauttaa true."
+(defn hae-urakan-mahdolliset-paatokset
+  "Yhteinen päätöstenhakufunktio"
   [db kayttaja {:keys [urakkaid kuluva-hoitovuosi]}]
-  (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-lupaukset kayttaja urakkaid)
   (let [urakan-tiedot (first (q-urakat/hae-urakan-tiedot db urakkaid))
         urakan-alkuvuosi (-> urakan-tiedot :alkupvm pvm/vuosi)
         urakan-loppuvuosi (dec (-> urakan-tiedot :loppupvm pvm/vuosi)) ;; Viimeisen hoitovuoden alkuvuosi käytännössä
@@ -943,19 +942,56 @@
         ;; Otetaan käytyn hoitovuoden budjetti
         budjettitavoite-vuodelle (some #(when (= (:hoitokauden-alkuvuosi %) kuluva-hoitovuosi) %) budjettitavoite)
         hoitovuoden-lopun-kattohinta (:kattohinta-oikaistu budjettitavoite-vuodelle)
-        hoitovuoden-lopun-tavoitehinta (maarita-hv-lopun-indeksikorjattu-tavoitehinta db kayttaja kuluva-hoitovuosi valittu-hoitokausi urakkaid urakan-alkuvuosi budjettitavoite-vuodelle)
+        hoitovuoden-lopun-tavoitehinta (maarita-hv-lopun-indeksikorjattu-tavoitehinta
+                                         db kayttaja
+                                         kuluva-hoitovuosi
+                                         valittu-hoitokausi
+                                         urakkaid
+                                         urakan-alkuvuosi
+                                         budjettitavoite-vuodelle)
 
         ; Haetaan ensin kaikki mahdolliset päätökset
-        mahdolliset-paatokset (paatoskone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi kuluva-hoitovuosi)
-        mahdolliset-paatokset (paatoskone/filtteroi-mahdolliset-paatokset mahdolliset-paatokset toteutuneet-kustannukset hoitovuoden-lopun-kattohinta hoitovuoden-lopun-tavoitehinta)
+        mahdolliset-paatokset (paatoskone/kaikki-mahdolliset-paatokset
+                                mhu-tyyppi
+                                urakan-alkuvuosi
+                                urakan-loppuvuosi
+                                kuluva-hoitovuosi)
+        mahdolliset-paatokset (paatoskone/filtteroi-mahdolliset-paatokset
+                                mahdolliset-paatokset
+                                toteutuneet-kustannukset
+                                hoitovuoden-lopun-kattohinta
+                                hoitovuoden-lopun-tavoitehinta)]
+    mahdolliset-paatokset))
+
+(defn palauta-kaikki-mahdolliset-ja-tehdyt-paatokset
+  "Palauttaa urakalle mahdolliset, sekä kaikki tehdyt päätökset. Ei poissulje mitään."
+  [db kayttaja {:keys [urakkaid kuluva-hoitovuosi] :as tiedot}]
+  (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-lupaukset kayttaja urakkaid)
+  (let [mahdolliset-paatokset (hae-urakan-mahdolliset-paatokset db kayttaja tiedot)
+        ;; Haetaan tietokantaan mahdollisesti tallennetut päätökset
+        tietokanta-paatokset (paatos-kyselyt/hae-paatokset db mahdolliset-paatokset urakkaid kuluva-hoitovuosi)
+        ;; Muodostetaan vastaus
+        vastaus {:mahdolliset-paatokset mahdolliset-paatokset
+                 :tietokanta-paatokset tietokanta-paatokset}]
+    vastaus))
+
+(defn onko-paatoksia-tekematta
+  "Päätellään onko jokin päätös vielä tekemättä, mikä voi vaikuttaa lukituksiin. 
+  HOX jotkin päätökset lasketaan tästä pois."
+  [db kayttaja {:keys [urakkaid kuluva-hoitovuosi] :as tiedot}]
+  (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-lupaukset kayttaja urakkaid)
+  (let [mahdolliset-paatokset (hae-urakan-mahdolliset-paatokset db kayttaja tiedot)
 
         ;; Poistetaan mahdollinen raporttipäätös
         mahdolliset-paatokset (remove (fn [rivi] (= (:nimi rivi) "Välikatselmuspöytäkirjaan liitettävät raportit")) mahdolliset-paatokset)
         ;; Haetaan tietokantaan mahdollisesti tallennetut päätökset
         tietokanta-paatokset (paatos-kyselyt/hae-paatokset db mahdolliset-paatokset urakkaid kuluva-hoitovuosi)
         ;; Poistetaan mahdollinen raporttipäätös
-        tietokanta-paatokset (remove (fn [rivi] (= (:nimi rivi) "Välikatselmuspöytäkirjaan liitettävät raportit")) tietokanta-paatokset)]
-    (not (or (= (count mahdolliset-paatokset) (count tietokanta-paatokset)) false))))
+        tietokanta-paatokset (remove (fn [rivi] (= (:nimi rivi) "Välikatselmuspöytäkirjaan liitettävät raportit")) tietokanta-paatokset)
+
+        ;; Muodostetaan vastaus
+        vastaus (not (or (= (count mahdolliset-paatokset) (count tietokanta-paatokset)) false))]
+    vastaus))
 
 (defrecord Valikatselmukset []
   component/Lifecycle

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
@@ -963,10 +963,11 @@
                                 hoitovuoden-lopun-tavoitehinta)]
     mahdolliset-paatokset))
 
-(defn palauta-kaikki-mahdolliset-ja-tehdyt-paatokset
+(defn palauta-kaikki-mahdolliset-ja-tehdyt-paatokset-kojelautaan
   "Palauttaa urakalle mahdolliset, sekä kaikki tehdyt päätökset. Ei poissulje mitään."
   [db kayttaja {:keys [urakkaid kuluva-hoitovuosi] :as tiedot}]
-  (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-lupaukset kayttaja urakkaid)
+  ;; Huomaa, että tämä on oikeutettu urakkatilanne näkymään
+  (oikeudet/vaadi-lukuoikeus oikeudet/urakkatilanne kayttaja)
   (let [mahdolliset-paatokset (hae-urakan-mahdolliset-paatokset db kayttaja tiedot)
         ;; Haetaan tietokantaan mahdollisesti tallennetut päätökset
         tietokanta-paatokset (paatos-kyselyt/hae-paatokset db mahdolliset-paatokset urakkaid kuluva-hoitovuosi)

--- a/src/cljs/harja/views/urakkatilanne/kojelauta.cljs
+++ b/src/cljs/harja/views/urakkatilanne/kojelauta.cljs
@@ -1,27 +1,34 @@
 (ns harja.views.urakkatilanne.kojelauta
-  (:require [harja.pvm :as pvm]
-            [harja.tiedot.hallintayksikot :as hal]
-            [harja.domain.kulut.kustannusten-seuranta :as kustannusten-seuranta-tiedot]
-            [harja.tiedot.navigaatio :as nav]
-            [harja.tiedot.palaute :as palaute-tiedot]
-            [harja.tiedot.urakka.siirtymat :as siirtymat]
-            [harja.ui.grid :as grid]
-            [harja.ui.kentat :as kentat]
-            [harja.views.urakka.pot-yhteinen :as pot-yhteinen]
-            [reagent.core :as r]
+  (:require [reagent.core :as r]
             [tuck.core :refer [tuck]]
-            [harja.ui.yleiset :refer [ajax-loader] :as yleiset]
-            [harja.ui.debug :as debug]
-            [harja.ui.komponentti :as komp]
-            [harja.tiedot.urakkatilanne.kojelauta :as tiedot])
-  (:require-macros [harja.tyokalut.ui :refer [for*]]))
 
-(def hoitokausia-taaksepain 4)
-(def hoitokausia-eteenpain 6)
+            [harja.pvm :as pvm]
+            [harja.ui.kentat :as kentat]
+            [harja.ui.yleiset :as yleiset]
+            [harja.ui.komponentti :as komp]
+            [harja.tiedot.navigaatio :as nav]
+            [harja.tiedot.hallintayksikot :as hal]
+            [harja.tiedot.palaute :as palaute-tiedot]
+            [harja.tiedot.urakkatilanne.kojelauta :as tiedot]
+            [harja.views.urakkatilanne.taulukko-hoito :refer [taulukko-hoitourakat]]
+            [harja.views.urakkatilanne.taulukko-yllapito :refer [taulukko-paallystysurakat]]))
+
+(def
+  ^{:doc "Näytetään uuden ominaisuuden vihjetekstiä jonkin aikaa, että käyttäjät oppivat mistä asiassa on kyse."}
+  vihjeteksti-uudesta-ominaisuudesta
+  [:p "Tämä on uusi osio, jonka tarkoituksena on parantaa tiedon läpinäkyvyyttä Harjan sisällä.
+       Tässä vaiheessa osio näkyy vain pääkäyttäjille sekä Elinvoimakeskusten pääkäyttäjille ja urakanvalvojille.
+       Myöhemmin laajennamme mahdollisesti tiedon näkyvyyttä myös urakoitsijoille heidän omien urakoidensa osalta. 
+       Jos löydät tiedoista virheitä tai sinulla on muita toiveita tämän osion kehittämiseksi, voit "
+   [:a.klikattava.alleviivaa {:href (palaute-tiedot/mailto-kehitystiimi)} "laittaa meille viestiä osoitteeseen harjapalaute@solita.fi"]])
+
 
 (defn- mahdolliset-hoitokauden-alkuvuodet [pvm-nyt]
-  (range (- (pvm/vuosi pvm-nyt) hoitokausia-taaksepain)
-    (+ hoitokausia-eteenpain (pvm/vuosi pvm-nyt))))
+  (let [hoitokausia-taaksepain 4
+        hoitokausia-eteenpain 6]
+    (range (- (pvm/vuosi pvm-nyt) hoitokausia-taaksepain)
+      (+ hoitokausia-eteenpain (pvm/vuosi pvm-nyt)))))
+
 
 (defn suodattimet [e! {:keys [valinnat evkhaku urakkahaku haku-kaynnissa?] :as app}]
   [:div
@@ -87,253 +94,10 @@
        :disabled? haku-kaynnissa?}
       (r/wrap (:urakat valinnat) #(e! (tiedot/->AsetaSuodatin :urakat %)))]]]])
 
-(defn avoimet-poikkeamat-sarake
-  [rivi]
-  (let [{:keys [avoimet_laatupoikkeamat avoimet_turvallisuuspoikkeamat]} rivi]
-    [:span.avoimet-poikkeamat
-     [yleiset/wrap-if true
-      [yleiset/tooltip {} :% "Siirry laatupoikkeamiin"]
-      [:a.klikattava.alleviivaa {:href (str "/#urakat/laadunseuranta/laatupoikkeamat?&hy=" (:evk_id rivi) "&u=" (:id rivi))
-                                 :on-click #(siirtymat/siirry-annettuun-valilehteen (:evk_id rivi) (:id rivi) {:taso1 :urakat
-                                                                                                               :taso2 :laadunseuranta
-                                                                                                               :taso3 :laatupoikkeamat})}
-       (if (> avoimet_laatupoikkeamat 0)
-         (yleiset/tila-indikaattori "hylatty" {:fmt-fn (constantly (str "Avoimia laatupoikkeamia: " avoimet_laatupoikkeamat))})
-         (yleiset/tila-indikaattori "valmis" {:fmt-fn (constantly "Ei avoimia laatupoikkeamia")}))]]
-     [yleiset/wrap-if true
-      [yleiset/tooltip {} :% "Siirry turvallisuuspoikkeamiin"]
-      [:a.klikattava.alleviivaa {:href (str "/#urakat/turvallisuuspoikkeamat?&hy=" (:evk_id rivi) "&u=" (:id rivi))
-                                 :on-click #(siirtymat/siirry-annettuun-valilehteen (:evk_id rivi) (:id rivi) {:taso1 :urakat
-                                                                                                               :taso2 :turvallisuuspoikkeamat
-                                                                                                               :taso3 nil})}
-       (if (> avoimet_turvallisuuspoikkeamat 0)
-         (yleiset/tila-indikaattori "hylatty" {:fmt-fn (constantly (str "Avoimia turvallisuuspoikkeamia: " avoimet_turvallisuuspoikkeamat))})
-         (yleiset/tila-indikaattori "valmis" {:fmt-fn (constantly "Ei avoimia turvallisuuspoikkeamia")}))]]]))
-
-(defn lupauspisteet-sarake
-  [rivi]
-  (let [{:keys [luvatut_pisteet toteutuneet_pisteet hoitokauden_alkuvuosi]} rivi]
-    [yleiset/wrap-if true
-     [yleiset/tooltip {} :% "Siirry lupausnäkymään"]
-     [:a.klikattava.alleviivaa {:href (str "/#urakat/valitavoitteet/lupaukset?&hy=" (:evk_id rivi) "&u=" (:id rivi))
-                                :on-click #(siirtymat/avaa-lupaukset-valitussa-urakassa (:evk_id rivi) (:id rivi) hoitokauden_alkuvuosi)}
-      [:div.lupauspisteet
-       (if (or (nil? luvatut_pisteet) (nil? toteutuneet_pisteet))
-         (yleiset/tila-indikaattori "hylatty" {:fmt-fn (constantly "Ei tavoitepistemäärää")})
-         (yleiset/tila-indikaattori "valmis" {:fmt-fn (constantly "Ok")}))]]]))
-
-(defn valikatselmus-sarake
-  [rivi]
-  (let [{:keys [urakan_alkuvuosi tavoitehintaalituspaatos tavoitehintaylityspaatos kattohintapaatos
-                lupauspaatos hoitokauden_alkuvuosi tavoitehinnan_muutospaatos]} rivi
-        edellisen-hoitokauden-alkuvuosi (- (pvm/vuosi (first (pvm/paivamaaran-hoitokausi (pvm/nyt)))) 1)
-        ;; 15.11. on takaraja, milloin edellisen hoitokauden välikatselmus pitää olla tehtynä (edellinen --> kuluva hk -1)
-        valikatselmuksen-takaraja-ohi? (or
-                                         (< hoitokauden_alkuvuosi edellisen-hoitokauden-alkuvuosi)
-                                         (and
-                                           (= hoitokauden_alkuvuosi edellisen-hoitokauden-alkuvuosi)
-                                           (pvm/jalkeen? (pvm/nyt)
-                                             (kustannusten-seuranta-tiedot/valikatselmuksen-takarajapvm (+ hoitokauden_alkuvuosi 1)))))]
-    [yleiset/wrap-if true
-     [yleiset/tooltip {} :% "Siirry välikatselmukseen"]
-     [:a.klikattava.alleviivaa {:href (str "/#urakat/valikatselmus?&hy=" (:evk_id rivi) "&u=" (:id rivi))
-                                :on-click #(siirtymat/avaa-valikatselmus (:evk_id rivi) (:id rivi) [(pvm/hoitokauden-alkupvm (:hoitokauden_alkuvuosi rivi)) (pvm/hoitokauden-loppupvm (inc (:hoitokauden_alkuvuosi rivi)))])}
-      [:div.tavoitehintapaatos
-       (if (and (nil? tavoitehinnan_muutospaatos) (nil? tavoitehinnan_muutospaatos))
-         (yleiset/tila-indikaattori (if valikatselmuksen-takaraja-ohi? "hylatty" "kesken")
-           {:fmt-fn (constantly "Ei tavoitehinnan\u00ADmuutospäätöstä")})
-         (yleiset/tila-indikaattori "valmis"
-           {:fmt-fn (constantly (kustannusten-seuranta-tiedot/valikatselmuksen-paatostyypin-nimi tavoitehinnan_muutospaatos))}))]
-
-      [:div.tavoitehintapaatos
-       (if (and (nil? tavoitehintaalituspaatos) (nil? tavoitehintaylityspaatos))
-         (yleiset/tila-indikaattori (if valikatselmuksen-takaraja-ohi? "hylatty" "kesken")
-           {:fmt-fn (constantly "Ei tavoitehinta\u00ADpäätöstä")})
-         (yleiset/tila-indikaattori "valmis"
-           {:fmt-fn (constantly (kustannusten-seuranta-tiedot/valikatselmuksen-paatostyypin-nimi (or tavoitehintaalituspaatos tavoitehintaylityspaatos)))}))]
-
-      ; ennen vuotta 2021 alkaneissa urakoissa kattohintapäätös ei ollut kytköksissä tavoitehintapäätökseen, niin näytetään tämä tieto vain silloin
-      ;; 2021 ja jälkeen riittää kertoa onko kattohintapäätös tehty. Jos sitä ei ole aloitettu, niin ei oleteta, että se tehdään
-      [:div.kattohintapaatos
-       (when (and (> urakan_alkuvuosi tiedot/+kattohintapaatos-kynnysvuosi+) (not (nil? kattohintapaatos)))
-         (yleiset/tila-indikaattori "valmis"
-           {:fmt-fn (constantly (kustannusten-seuranta-tiedot/valikatselmuksen-paatostyypin-nimi kattohintapaatos))}))]
-
-      [:div.lupauspaatokset
-       (if (nil? lupauspaatos)
-         (yleiset/tila-indikaattori (if valikatselmuksen-takaraja-ohi? "hylatty" "kesken")
-           {:fmt-fn (constantly "Ei lupaus\u00ADpäätöksiä")})
-         [:span
-          (yleiset/tila-indikaattori "valmis"
-            {:fmt-fn (constantly (kustannusten-seuranta-tiedot/valikatselmuksen-paatostyypin-nimi lupauspaatos))})])]]]))
-
-(defn kustannussuunitelman-tila-sarake
-  [rivi]
-  (let [indeksi-saatavilla? (boolean (:indeksikerroin rivi))
-        {:keys [aloittamattomia vahvistamattomia vahvistettuja suunnitelman_tila]} (:ks_tila rivi)]
-    [yleiset/wrap-if true
-     [yleiset/tooltip {} :% "Siirry kustannussuunnitelmaan"]
-     [:a.klikattava.alleviivaa {:href (str "/#urakat/suunnittelu/kustannussuunnitelma?&hy=" (:evk_id rivi) "&u=" (:id rivi))
-                                :on-click #(siirtymat/siirry-annettuun-valilehteen (:evk_id rivi) (:id rivi) {:taso1 :urakat
-                                                                                                              :taso2 :suunnittelu
-                                                                                                              :taso3 :kustannussuunnitelma})}
-      (cond
-        (= "aloittamatta" suunnitelman_tila)
-        (yleiset/tila-indikaattori "hylatty" {:fmt-fn (constantly "Aloittamatta")})
-
-        (= "aloitettu" suunnitelman_tila)
-        (yleiset/tila-indikaattori (if indeksi-saatavilla?
-                                     "hylatty"
-                                     "kesken")
-          {:fmt-fn #(str
-                      (when indeksi-saatavilla? "Indeksi saatavilla. ")
-                      "Aloittamatta: " aloittamattomia
-                      ", kesken: " vahvistamattomia
-                      ", vahvistettuja: " vahvistettuja)})
-
-        (= "vahvistettu" suunnitelman_tila)
-        (yleiset/tila-indikaattori "valmis" {:fmt-fn (constantly "Valmis")}))]]))
-
-(def urakoiden-maara-per-sivu 20)
-
-(defn virheelliset-tila-sarake
-  [rivi]
-  (for [kohde (:virheelliset_kohteet rivi)]
-    ^{:key (:id kohde)}
-    [yleiset/wrap-if true
-     [yleiset/tooltip {} :%
-      [:div
-       [:p "Siirry päällystys\u00ADilmoitukseen."]
-       (when (:lahetysvirhe kohde)
-         [:p "Virhe: " (:lahetysvirhe kohde)])]]
-     [yleiset/linkki (pot-yhteinen/paallystyskohteen-fmt kohde)
-      #(siirtymat/avaa-paallystysilmoitus! {:paallystyskohde-id (:id kohde)
-                                            :kohteen-urakka-id (:id rivi)})
-      {:block? true}]]))
-
-(defn taulukko-paallystysurakat [e! {:keys [urakat haku-kaynnissa?]}]
-  [grid/grid
-   {:otsikko (str "")
-    :tyhja (if haku-kaynnissa?
-             [ajax-loader "Ladataan tietoja"]
-             "Ei tietoja, tarkistathan valitut suodattimet.")
-    :luokat ["paallystysurakat"]
-    :rivi-jalkeen-fn (fn [urakat]
-                       (let [yhteenveto (tiedot/paallystystietojen-yhteenveto urakat)
-                             valmiit-kohteet (tiedot/valmiit-yhteenveto urakat)
-                             lahetetty (tiedot/lahetetyt-yhteenveto urakat)
-                             valmiit-ei-lahetetty (tiedot/valmiit-ei-lahetetty-yhteenveto urakat)
-                             epaonnistuneet-lahetetty (tiedot/epaonnistuneet-lahetetyt-yhteenveto urakat)
-                             aloittamatta (tiedot/aloittamatta-yhteenveto urakat)]
-                         (when-not (empty? urakat)
-                           [{:teksti "Yhteensä" :luokka "lihavoitu"}
-                            {:teksti (str (count urakat) " urak\u00ADkaa") :luokka "lihavoitu"}
-                            {:teksti yhteenveto :luokka "lihavoitu"}
-                            {:teksti aloittamatta :luokka "lihavoitu"}
-                            {:teksti valmiit-ei-lahetetty :luokka "lihavoitu"}
-                            {:teksti valmiit-kohteet :luokka "lihavoitu"}
-                            {:teksti lahetetty :luokka "lihavoitu"}
-                            {:teksti epaonnistuneet-lahetetty :luokka "lihavoitu"}
-                            {:teksti ""}])))}
-   [{:otsikko "Urakka"
-     :tyyppi :string
-     :nimi :nimi
-     :leveys 7
-     :muokattava? (constantly false)}
-    {:otsikko "Vuosi"
-     :muokattava? (constantly false)
-     :nimi :hoitokauden_alkuvuosi :leveys 3
-     :tyyppi :positiivinen-numero :kokonaisluku? true
-     :tasaa :oikea}
-    {:otsikko "Kohteiden lkm."
-     :muokattava? (constantly false)
-     :nimi :yllapitokohteiden_lkm :leveys 4
-     :tyyppi :positiivinen-numero :kokonaisluku? true
-     :tasaa :oikea}
-    {:otsikko "Aloittamatta"
-     :muokattava? (constantly false)
-     :nimi :aloittamatta :leveys 6
-     :tyyppi :positiivinen-numero :kokonaisluku? true
-     :tasaa :oikea}
-    {:otsikko "Valmiit, ei vielä lähetetty"
-     :muokattava? (constantly false)
-     :nimi :valmiit_ei_lahetetty :leveys 6
-     :tyyppi :positiivinen-numero :kokonaisluku? true
-     :tasaa :oikea}
-    {:otsikko "Valmis/hyväksytty"
-     :muokattava? (constantly false)
-     :nimi :valmis_hyvaksytty :leveys 6
-     :tyyppi :positiivinen-numero :kokonaisluku? true
-     :tasaa :oikea}
-    {:otsikko "Lähetetty onnistuneesti YHA:an"
-     :muokattava? (constantly false)
-     :nimi :lahetetty_onnistuneesti :leveys 6
-     :tyyppi :positiivinen-numero :kokonaisluku? true
-     :tasaa :oikea}
-    {:otsikko "Epäonnistu\u00ADneet YHA-lähetykset"
-     :muokattava? (constantly false)
-     :nimi :epaonnistuneet_lahetetyt :leveys 6
-     :tyyppi :positiivinen-numero :kokonaisluku? true
-     :tasaa :oikea}
-    {:otsikko "Kohteet, joissa lähetys\u00ADvirhe"
-     :muokattava? (constantly false)
-     :nimi :virheelliset_kohteet :leveys 6
-     :tyyppi :komponentti
-     :komponentti (fn [rivi] (virheelliset-tila-sarake rivi))}]
-   urakat])
-
-(defn taulukko-hoitourakat [e! {:keys [urakat haku-kaynnissa?]}]
-  [grid/grid
-   {:otsikko (str "")
-    :sivuta urakoiden-maara-per-sivu
-    :tyhja (if haku-kaynnissa?
-             [ajax-loader "Ladataan tietoja"]
-             "Ei tietoja, tarkistathan valitut suodattimet.")
-    :rivi-jalkeen-fn (fn [urakat]
-                       (let [ks-tilojen-yhteenveto (tiedot/ks-tilojen-yhteenveto urakat)
-                             valikatselmus-tilojen-yhteenveto (tiedot/valikatselmus-tilojen-yhteenveto urakat)
-                             lupaustietojen-yhteenveto (tiedot/lupaustietojen-yhteenveto urakat)
-                             poikkeusten-yhteenveto (tiedot/poikkeusten-yhteenveto urakat)]
-                         (when-not (empty? urakat)
-                           [{:teksti "Yhteensä" :luokka "lihavoitu"}
-                            {:teksti (str (count urakat) " kpl urakoita") :luokka "lihavoitu"}
-                            {:teksti ks-tilojen-yhteenveto :luokka "lihavoitu"}
-                            {:teksti valikatselmus-tilojen-yhteenveto :luokka "lihavoitu"}
-                            {:teksti lupaustietojen-yhteenveto :luokka "lihavoitu"}
-                            {:teksti poikkeusten-yhteenveto :luokka "lihavoitu"}])))}
-   [{:otsikko "Urakka"
-     :tyyppi :string
-     :nimi :nimi
-     :leveys 8
-     :muokattava? (constantly false)}
-    {:otsikko "Hoito\u00ADvuosi"
-     :muokattava? (constantly false)
-     :nimi :hoitokauden_alkuvuosi :leveys 7
-     :tyyppi :string :fmt #(pvm/hoitokausi-str-alkuvuodesta-vuodet %)}
-    {:otsikko "Kustannus\u00ADsuunnitelma"
-     :muokattava? (constantly false)
-     :nimi :ks_tila :leveys 15
-     :tyyppi :komponentti
-     :komponentti (fn [rivi] [kustannussuunitelman-tila-sarake rivi])}
-    {:otsikko "Väli\u00ADkatselmus"
-     :muokattava? (constantly false)
-     :nimi :ks_tila :leveys 15
-     :tyyppi :komponentti
-     :komponentti (fn [rivi] [valikatselmus-sarake rivi])}
-    {:otsikko "Lupausten tavoite\u00ADpiste\u00ADmäärä"
-     :muokattava? (constantly false)
-     :nimi :ks_tila :leveys 15
-     :tyyppi :komponentti
-     :komponentti (fn [rivi] [lupauspisteet-sarake rivi])}
-    {:otsikko "Avoimet poikkeamat"
-     :muokattava? (constantly false)
-     :nimi :ks_tila :leveys 15
-     :tyyppi :komponentti
-     :komponentti (fn [rivi] [avoimet-poikkeamat-sarake rivi])}]
-   urakat])
 
 (defn listaus
-  "Listauskomponentti, joka toimii pohjana eri urakkatyypeille, ja hoitaa urakkatyypeille yhteisen suodattamisen elinvoimakeskuksen, vuoden sekä valitun urakan perusteella."
+  "Listauskomponentti, joka toimii pohjana eri urakkatyypeille, 
+  ja hoitaa urakkatyypeille yhteisen suodattamisen elinvoimakeskuksen, vuoden sekä valitun urakan perusteella."
   [e! {:keys [valinnat urakat haku-kaynnissa?] :as app}]
   (let [valitut-urakat (:urakat valinnat)
         valittu-evk (get-in valinnat [:evk :id])
@@ -351,7 +115,6 @@
                  urakat
                  (filter #((into #{} (map :id valitut-urakat)) (:id %)) urakat))]
     [:div
-     ;; [debug/debug urakat]
      (if (= :paallystys (get-in app [:valinnat :urakkatyyppi :arvo]))
        [taulukko-paallystysurakat e! {:urakat urakat
                                       :haku-kaynnissa? haku-kaynnissa?}]
@@ -359,20 +122,13 @@
                                  :haku-kaynnissa? haku-kaynnissa?}])]))
 
 
-;; Näytetään uuden ominaisuuden vihjetekstiä jonkin aikaa, että käyttäjät oppivat mistä asiassa on kyse
-(def vihjeteksti-uudesta-ominaisuudesta
-  [:p "Tämä on uusi osio, jonka tarkoituksena on parantaa tiedon läpinäkyvyyttä Harjan sisällä.
-       Tässä vaiheessa osio näkyy vain pääkäyttäjille sekä Elinvoimakeskusten pääkäyttäjille ja urakanvalvojille.
-       Myöhemmin laajennamme mahdollisesti tiedon näkyvyyttä myös urakoitsijoille heidän omien urakoidensa osalta. Jos löydät tiedoista virheitä tai sinulla
-       on muita toiveita tämän osion kehittämiseksi, voit "
-   [:a.klikattava.alleviivaa {:href (palaute-tiedot/mailto-kehitystiimi)} "laittaa meille viestiä osoitteeseen harjapalaute@solita.fi"]])
-
-(defn kojelauta* [e! app]
+(defn kojelauta* [e! _app]
   (komp/luo
     (komp/sisaan #(do
-                    (e! (tiedot/->AlustaHallintayksikkoHaku (into []
-                                                              (map (fn [evk] (select-keys evk [:id :nimi :evknumero]))
-                                                                @hal/vaylamuodon-hallintayksikot))))
+                    (e! (tiedot/->AlustaHallintayksikkoHaku
+                          (into []
+                            (map (fn [evk] (select-keys evk [:id :nimi :evknumero]))
+                              @hal/vaylamuodon-hallintayksikot))))
                     (e! (tiedot/->HaeUrakat))))
     (fn [e! app]
       [:div.kojelauta-hallinta
@@ -380,8 +136,8 @@
        (when (pvm/ennen? (pvm/nyt) (pvm/->pvm "7.12.2024"))
          [yleiset/vihje vihjeteksti-uudesta-ominaisuudesta])
        [suodattimet e! app]
-       ;; [debug/debug app]
        [listaus e! app]])))
+
 
 (defn kojelauta []
   [tuck tiedot/tila kojelauta*])

--- a/src/cljs/harja/views/urakkatilanne/sarakkeet/kustannussuunnitelma.cljs
+++ b/src/cljs/harja/views/urakkatilanne/sarakkeet/kustannussuunnitelma.cljs
@@ -1,0 +1,34 @@
+(ns harja.views.urakkatilanne.sarakkeet.kustannussuunnitelma
+  (:require [harja.ui.yleiset :as yleiset]
+            [harja.tiedot.urakka.siirtymat :as siirtymat]))
+
+
+(defn kustannussuunitelman-tila-sarake
+  [rivi]
+  (let [indeksi-saatavilla? (boolean (:indeksikerroin rivi))
+        {:keys [aloittamattomia vahvistamattomia vahvistettuja suunnitelman_tila]} (:ks_tila rivi)]
+    [yleiset/wrap-if true
+     [yleiset/tooltip {} :% "Siirry kustannussuunnitelmaan"]
+     [:a.klikattava.alleviivaa {:href (str "/#urakat/suunnittelu/kustannussuunnitelma?&hy=" (:evk_id rivi) "&u=" (:id rivi))
+                                :on-click #(siirtymat/siirry-annettuun-valilehteen
+                                             (:evk_id rivi)
+                                             (:id rivi)
+                                             {:taso1 :urakat
+                                              :taso2 :suunnittelu
+                                              :taso3 :kustannussuunnitelma})}
+      (cond
+        (= "aloittamatta" suunnitelman_tila)
+        (yleiset/tila-indikaattori "hylatty" {:fmt-fn (constantly "Aloittamatta")})
+
+        (= "aloitettu" suunnitelman_tila)
+        (yleiset/tila-indikaattori (if indeksi-saatavilla?
+                                     "hylatty"
+                                     "kesken")
+          {:fmt-fn #(str
+                      (when indeksi-saatavilla? "Indeksi saatavilla. ")
+                      "Aloittamatta: " aloittamattomia
+                      ", kesken: " vahvistamattomia
+                      ", vahvistettuja: " vahvistettuja)})
+
+        (= "vahvistettu" suunnitelman_tila)
+        (yleiset/tila-indikaattori "valmis" {:fmt-fn (constantly "Valmis")}))]]))

--- a/src/cljs/harja/views/urakkatilanne/sarakkeet/lupaukset.cljs
+++ b/src/cljs/harja/views/urakkatilanne/sarakkeet/lupaukset.cljs
@@ -1,0 +1,16 @@
+(ns harja.views.urakkatilanne.sarakkeet.lupaukset
+  (:require [harja.ui.yleiset :as yleiset]
+            [harja.tiedot.urakka.siirtymat :as siirtymat]))
+
+
+(defn lupauspisteet-sarake
+  [rivi]
+  (let [{:keys [luvatut_pisteet toteutuneet_pisteet hoitokauden_alkuvuosi]} rivi]
+    [yleiset/wrap-if true
+     [yleiset/tooltip {} :% "Siirry lupausnäkymään"]
+     [:a.klikattava.alleviivaa {:href (str "/#urakat/valitavoitteet/lupaukset?&hy=" (:evk_id rivi) "&u=" (:id rivi))
+                                :on-click #(siirtymat/avaa-lupaukset-valitussa-urakassa (:evk_id rivi) (:id rivi) hoitokauden_alkuvuosi)}
+      [:div.lupauspisteet
+       (if (or (nil? luvatut_pisteet) (nil? toteutuneet_pisteet))
+         (yleiset/tila-indikaattori "hylatty" {:fmt-fn (constantly "Ei tavoitepistemäärää")})
+         (yleiset/tila-indikaattori "valmis" {:fmt-fn (constantly "Ok")}))]]]))

--- a/src/cljs/harja/views/urakkatilanne/sarakkeet/poikkeamat.cljs
+++ b/src/cljs/harja/views/urakkatilanne/sarakkeet/poikkeamat.cljs
@@ -1,0 +1,33 @@
+(ns harja.views.urakkatilanne.sarakkeet.poikkeamat
+  (:require [harja.ui.yleiset :as yleiset]
+            [harja.tiedot.urakka.siirtymat :as siirtymat]))
+
+
+(defn avoimet-poikkeamat-sarake
+  [rivi]
+  (let [{:keys [avoimet_laatupoikkeamat avoimet_turvallisuuspoikkeamat]} rivi]
+    [:span.avoimet-poikkeamat
+     [yleiset/wrap-if true
+      [yleiset/tooltip {} :% "Siirry laatupoikkeamiin"]
+      [:a.klikattava.alleviivaa {:href (str "/#urakat/laadunseuranta/laatupoikkeamat?&hy=" (:evk_id rivi) "&u=" (:id rivi))
+                                 :on-click #(siirtymat/siirry-annettuun-valilehteen
+                                              (:evk_id rivi)
+                                              (:id rivi)
+                                              {:taso1 :urakat
+                                               :taso2 :laadunseuranta
+                                               :taso3 :laatupoikkeamat})}
+       (if (> avoimet_laatupoikkeamat 0)
+         (yleiset/tila-indikaattori "hylatty" {:fmt-fn (constantly (str "Avoimia laatupoikkeamia: " avoimet_laatupoikkeamat))})
+         (yleiset/tila-indikaattori "valmis" {:fmt-fn (constantly "Ei avoimia laatupoikkeamia")}))]]
+     [yleiset/wrap-if true
+      [yleiset/tooltip {} :% "Siirry turvallisuuspoikkeamiin"]
+      [:a.klikattava.alleviivaa {:href (str "/#urakat/turvallisuuspoikkeamat?&hy=" (:evk_id rivi) "&u=" (:id rivi))
+                                 :on-click #(siirtymat/siirry-annettuun-valilehteen
+                                              (:evk_id rivi)
+                                              (:id rivi)
+                                              {:taso1 :urakat
+                                               :taso2 :turvallisuuspoikkeamat
+                                               :taso3 nil})}
+       (if (> avoimet_turvallisuuspoikkeamat 0)
+         (yleiset/tila-indikaattori "hylatty" {:fmt-fn (constantly (str "Avoimia turvallisuuspoikkeamia: " avoimet_turvallisuuspoikkeamat))})
+         (yleiset/tila-indikaattori "valmis" {:fmt-fn (constantly "Ei avoimia turvallisuuspoikkeamia")}))]]]))

--- a/src/cljs/harja/views/urakkatilanne/sarakkeet/valikatselmus.cljs
+++ b/src/cljs/harja/views/urakkatilanne/sarakkeet/valikatselmus.cljs
@@ -1,24 +1,17 @@
 (ns harja.views.urakkatilanne.sarakkeet.valikatselmus
   (:require [harja.pvm :as pvm]
             [harja.ui.yleiset :as yleiset]
-            [harja.tiedot.urakka.siirtymat :as siirtymat]
-            [harja.tiedot.urakkatilanne.kojelauta :as tiedot]
-            [harja.domain.kulut.kustannusten-seuranta :as kustannusten-seuranta-tiedot]))
+            [harja.tiedot.urakka.siirtymat :as siirtymat]))
 
 
 (defn valikatselmus-sarake
   [rivi]
   (let [{:keys [tehdyt-paatokset-count mahdolliset-paatokset-count
-                urakan_alkuvuosi tavoitehintaalituspaatos tavoitehintaylityspaatos kattohintapaatos
-                lupauspaatos hoitokauden_alkuvuosi tavoitehinnan_muutospaatos]} rivi
-        edellisen-hoitokauden-alkuvuosi (- (pvm/vuosi (first (pvm/paivamaaran-hoitokausi (pvm/nyt)))) 1)
-        ;; 15.11. on takaraja, edellisen hoitokauden välikatselmus pitää olla tehtynä (edellinen --> kuluva hk -1)
-        valikatselmuksen-takaraja-ohi? (or
-                                         (< hoitokauden_alkuvuosi edellisen-hoitokauden-alkuvuosi)
-                                         (and
-                                           (= hoitokauden_alkuvuosi edellisen-hoitokauden-alkuvuosi)
-                                           (pvm/jalkeen? (pvm/nyt)
-                                             (kustannusten-seuranta-tiedot/valikatselmuksen-takarajapvm (+ hoitokauden_alkuvuosi 1)))))]
+                _urakan_alkuvuosi _hoitokauden_alkuvuosi]} rivi
+        paatokset-kesken? (and
+                            (number? tehdyt-paatokset-count)
+                            (pos? mahdolliset-paatokset-count)
+                            (not= tehdyt-paatokset-count mahdolliset-paatokset-count))]
     [yleiset/wrap-if true
      [yleiset/tooltip {} :% "Siirry välikatselmukseen"]
      [:a.klikattava.alleviivaa {:href (str "/#urakat/valikatselmus?&hy=" (:evk_id rivi) "&u=" (:id rivi))
@@ -28,42 +21,10 @@
                                               (pvm/hoitokauden-loppupvm (inc (:hoitokauden_alkuvuosi rivi)))])}
 
       [:div.tavoitehintapaatos
-       (yleiset/tila-indikaattori "kesken" {:fmt-fn (constantly "Kesken (3/7)")})]
+       (if paatokset-kesken?
+         (yleiset/tila-indikaattori "kesken" {:fmt-fn (constantly
+                                                        (str
+                                                          "Kesken (" tehdyt-paatokset-count
+                                                          "/" mahdolliset-paatokset-count ")"))})
 
-      #_[:div.tavoitehintapaatos
-         (if (and (nil? tavoitehinnan_muutospaatos) (nil? tavoitehinnan_muutospaatos))
-           (yleiset/tila-indikaattori (if valikatselmuksen-takaraja-ohi? "hylatty" "kesken")
-             {:fmt-fn (constantly
-                        "Ei tavoitehinnan\u00ADmuutospäätöstä")})
-           (yleiset/tila-indikaattori "valmis"
-             {:fmt-fn (constantly
-                        (kustannusten-seuranta-tiedot/valikatselmuksen-paatostyypin-nimi tavoitehinnan_muutospaatos))}))]
-
-      #_[:div.tavoitehintapaatos
-         (if (and (nil? tavoitehintaalituspaatos) (nil? tavoitehintaylityspaatos))
-           (yleiset/tila-indikaattori (if valikatselmuksen-takaraja-ohi? "hylatty" "kesken")
-             {:fmt-fn (constantly "Ei tavoitehinta\u00ADpäätöstä")})
-           (yleiset/tila-indikaattori "valmis"
-             {:fmt-fn (constantly
-                        (kustannusten-seuranta-tiedot/valikatselmuksen-paatostyypin-nimi
-                          (or tavoitehintaalituspaatos tavoitehintaylityspaatos)))}))]
-
-      ;; Ennen vuotta 2021 alkaneissa urakoissa kattohintapäätös ei ollut kytköksissä tavoitehintapäätökseen, niin näytetään tämä tieto vain silloin
-      ;; 2021 ja jälkeen riittää kertoa onko kattohintapäätös tehty. Jos sitä ei ole aloitettu, niin ei oleteta, että se tehdään
-      #_[:div.kattohintapaatos
-         (when (and (> urakan_alkuvuosi tiedot/+kattohintapaatos-kynnysvuosi+) (not (nil? kattohintapaatos)))
-           (yleiset/tila-indikaattori "valmis"
-             {:fmt-fn (constantly
-                        (kustannusten-seuranta-tiedot/valikatselmuksen-paatostyypin-nimi kattohintapaatos))}))]
-
-      #_[:div.lupauspaatokset
-         (if (nil? lupauspaatos)
-           (yleiset/tila-indikaattori (if valikatselmuksen-takaraja-ohi? "hylatty" "kesken")
-             {:fmt-fn (constantly
-                        "Ei lupaus\u00ADpäätöksiä")})
-           [:span
-            (yleiset/tila-indikaattori "valmis"
-              {:fmt-fn (constantly
-                         (kustannusten-seuranta-tiedot/valikatselmuksen-paatostyypin-nimi lupauspaatos))})])]
-      ;;
-      ]]))
+         (yleiset/tila-indikaattori "valmis" {:fmt-fn (constantly "Valmis")}))]]]))

--- a/src/cljs/harja/views/urakkatilanne/sarakkeet/valikatselmus.cljs
+++ b/src/cljs/harja/views/urakkatilanne/sarakkeet/valikatselmus.cljs
@@ -8,7 +8,8 @@
 
 (defn valikatselmus-sarake
   [rivi]
-  (let [{:keys [urakan_alkuvuosi tavoitehintaalituspaatos tavoitehintaylityspaatos kattohintapaatos
+  (let [{:keys [tehdyt-paatokset-count mahdolliset-paatokset-count
+                urakan_alkuvuosi tavoitehintaalituspaatos tavoitehintaylityspaatos kattohintapaatos
                 lupauspaatos hoitokauden_alkuvuosi tavoitehinnan_muutospaatos]} rivi
         edellisen-hoitokauden-alkuvuosi (- (pvm/vuosi (first (pvm/paivamaaran-hoitokausi (pvm/nyt)))) 1)
         ;; 15.11. on takaraja, edellisen hoitokauden välikatselmus pitää olla tehtynä (edellinen --> kuluva hk -1)
@@ -25,38 +26,44 @@
                                              (:evk_id rivi) (:id rivi)
                                              [(pvm/hoitokauden-alkupvm (:hoitokauden_alkuvuosi rivi))
                                               (pvm/hoitokauden-loppupvm (inc (:hoitokauden_alkuvuosi rivi)))])}
-      [:div.tavoitehintapaatos
-       (if (and (nil? tavoitehinnan_muutospaatos) (nil? tavoitehinnan_muutospaatos))
-         (yleiset/tila-indikaattori (if valikatselmuksen-takaraja-ohi? "hylatty" "kesken")
-           {:fmt-fn (constantly
-                      "Ei tavoitehinnan\u00ADmuutospäätöstä")})
-         (yleiset/tila-indikaattori "valmis"
-           {:fmt-fn (constantly
-                      (kustannusten-seuranta-tiedot/valikatselmuksen-paatostyypin-nimi tavoitehinnan_muutospaatos))}))]
 
       [:div.tavoitehintapaatos
-       (if (and (nil? tavoitehintaalituspaatos) (nil? tavoitehintaylityspaatos))
-         (yleiset/tila-indikaattori (if valikatselmuksen-takaraja-ohi? "hylatty" "kesken")
-           {:fmt-fn (constantly "Ei tavoitehinta\u00ADpäätöstä")})
-         (yleiset/tila-indikaattori "valmis"
-           {:fmt-fn (constantly
-                      (kustannusten-seuranta-tiedot/valikatselmuksen-paatostyypin-nimi
-                        (or tavoitehintaalituspaatos tavoitehintaylityspaatos)))}))]
+       (yleiset/tila-indikaattori "kesken" {:fmt-fn (constantly "Kesken (3/7)")})]
+
+      #_[:div.tavoitehintapaatos
+         (if (and (nil? tavoitehinnan_muutospaatos) (nil? tavoitehinnan_muutospaatos))
+           (yleiset/tila-indikaattori (if valikatselmuksen-takaraja-ohi? "hylatty" "kesken")
+             {:fmt-fn (constantly
+                        "Ei tavoitehinnan\u00ADmuutospäätöstä")})
+           (yleiset/tila-indikaattori "valmis"
+             {:fmt-fn (constantly
+                        (kustannusten-seuranta-tiedot/valikatselmuksen-paatostyypin-nimi tavoitehinnan_muutospaatos))}))]
+
+      #_[:div.tavoitehintapaatos
+         (if (and (nil? tavoitehintaalituspaatos) (nil? tavoitehintaylityspaatos))
+           (yleiset/tila-indikaattori (if valikatselmuksen-takaraja-ohi? "hylatty" "kesken")
+             {:fmt-fn (constantly "Ei tavoitehinta\u00ADpäätöstä")})
+           (yleiset/tila-indikaattori "valmis"
+             {:fmt-fn (constantly
+                        (kustannusten-seuranta-tiedot/valikatselmuksen-paatostyypin-nimi
+                          (or tavoitehintaalituspaatos tavoitehintaylityspaatos)))}))]
 
       ;; Ennen vuotta 2021 alkaneissa urakoissa kattohintapäätös ei ollut kytköksissä tavoitehintapäätökseen, niin näytetään tämä tieto vain silloin
       ;; 2021 ja jälkeen riittää kertoa onko kattohintapäätös tehty. Jos sitä ei ole aloitettu, niin ei oleteta, että se tehdään
-      [:div.kattohintapaatos
-       (when (and (> urakan_alkuvuosi tiedot/+kattohintapaatos-kynnysvuosi+) (not (nil? kattohintapaatos)))
-         (yleiset/tila-indikaattori "valmis"
-           {:fmt-fn (constantly
-                      (kustannusten-seuranta-tiedot/valikatselmuksen-paatostyypin-nimi kattohintapaatos))}))]
+      #_[:div.kattohintapaatos
+         (when (and (> urakan_alkuvuosi tiedot/+kattohintapaatos-kynnysvuosi+) (not (nil? kattohintapaatos)))
+           (yleiset/tila-indikaattori "valmis"
+             {:fmt-fn (constantly
+                        (kustannusten-seuranta-tiedot/valikatselmuksen-paatostyypin-nimi kattohintapaatos))}))]
 
-      [:div.lupauspaatokset
-       (if (nil? lupauspaatos)
-         (yleiset/tila-indikaattori (if valikatselmuksen-takaraja-ohi? "hylatty" "kesken")
-           {:fmt-fn (constantly
-                      "Ei lupaus\u00ADpäätöksiä")})
-         [:span
-          (yleiset/tila-indikaattori "valmis"
-            {:fmt-fn (constantly
-                       (kustannusten-seuranta-tiedot/valikatselmuksen-paatostyypin-nimi lupauspaatos))})])]]]))
+      #_[:div.lupauspaatokset
+         (if (nil? lupauspaatos)
+           (yleiset/tila-indikaattori (if valikatselmuksen-takaraja-ohi? "hylatty" "kesken")
+             {:fmt-fn (constantly
+                        "Ei lupaus\u00ADpäätöksiä")})
+           [:span
+            (yleiset/tila-indikaattori "valmis"
+              {:fmt-fn (constantly
+                         (kustannusten-seuranta-tiedot/valikatselmuksen-paatostyypin-nimi lupauspaatos))})])]
+      ;;
+      ]]))

--- a/src/cljs/harja/views/urakkatilanne/sarakkeet/valikatselmus.cljs
+++ b/src/cljs/harja/views/urakkatilanne/sarakkeet/valikatselmus.cljs
@@ -1,0 +1,62 @@
+(ns harja.views.urakkatilanne.sarakkeet.valikatselmus
+  (:require [harja.pvm :as pvm]
+            [harja.ui.yleiset :as yleiset]
+            [harja.tiedot.urakka.siirtymat :as siirtymat]
+            [harja.tiedot.urakkatilanne.kojelauta :as tiedot]
+            [harja.domain.kulut.kustannusten-seuranta :as kustannusten-seuranta-tiedot]))
+
+
+(defn valikatselmus-sarake
+  [rivi]
+  (let [{:keys [urakan_alkuvuosi tavoitehintaalituspaatos tavoitehintaylityspaatos kattohintapaatos
+                lupauspaatos hoitokauden_alkuvuosi tavoitehinnan_muutospaatos]} rivi
+        edellisen-hoitokauden-alkuvuosi (- (pvm/vuosi (first (pvm/paivamaaran-hoitokausi (pvm/nyt)))) 1)
+        ;; 15.11. on takaraja, edellisen hoitokauden välikatselmus pitää olla tehtynä (edellinen --> kuluva hk -1)
+        valikatselmuksen-takaraja-ohi? (or
+                                         (< hoitokauden_alkuvuosi edellisen-hoitokauden-alkuvuosi)
+                                         (and
+                                           (= hoitokauden_alkuvuosi edellisen-hoitokauden-alkuvuosi)
+                                           (pvm/jalkeen? (pvm/nyt)
+                                             (kustannusten-seuranta-tiedot/valikatselmuksen-takarajapvm (+ hoitokauden_alkuvuosi 1)))))]
+    [yleiset/wrap-if true
+     [yleiset/tooltip {} :% "Siirry välikatselmukseen"]
+     [:a.klikattava.alleviivaa {:href (str "/#urakat/valikatselmus?&hy=" (:evk_id rivi) "&u=" (:id rivi))
+                                :on-click #(siirtymat/avaa-valikatselmus
+                                             (:evk_id rivi) (:id rivi)
+                                             [(pvm/hoitokauden-alkupvm (:hoitokauden_alkuvuosi rivi))
+                                              (pvm/hoitokauden-loppupvm (inc (:hoitokauden_alkuvuosi rivi)))])}
+      [:div.tavoitehintapaatos
+       (if (and (nil? tavoitehinnan_muutospaatos) (nil? tavoitehinnan_muutospaatos))
+         (yleiset/tila-indikaattori (if valikatselmuksen-takaraja-ohi? "hylatty" "kesken")
+           {:fmt-fn (constantly
+                      "Ei tavoitehinnan\u00ADmuutospäätöstä")})
+         (yleiset/tila-indikaattori "valmis"
+           {:fmt-fn (constantly
+                      (kustannusten-seuranta-tiedot/valikatselmuksen-paatostyypin-nimi tavoitehinnan_muutospaatos))}))]
+
+      [:div.tavoitehintapaatos
+       (if (and (nil? tavoitehintaalituspaatos) (nil? tavoitehintaylityspaatos))
+         (yleiset/tila-indikaattori (if valikatselmuksen-takaraja-ohi? "hylatty" "kesken")
+           {:fmt-fn (constantly "Ei tavoitehinta\u00ADpäätöstä")})
+         (yleiset/tila-indikaattori "valmis"
+           {:fmt-fn (constantly
+                      (kustannusten-seuranta-tiedot/valikatselmuksen-paatostyypin-nimi
+                        (or tavoitehintaalituspaatos tavoitehintaylityspaatos)))}))]
+
+      ;; Ennen vuotta 2021 alkaneissa urakoissa kattohintapäätös ei ollut kytköksissä tavoitehintapäätökseen, niin näytetään tämä tieto vain silloin
+      ;; 2021 ja jälkeen riittää kertoa onko kattohintapäätös tehty. Jos sitä ei ole aloitettu, niin ei oleteta, että se tehdään
+      [:div.kattohintapaatos
+       (when (and (> urakan_alkuvuosi tiedot/+kattohintapaatos-kynnysvuosi+) (not (nil? kattohintapaatos)))
+         (yleiset/tila-indikaattori "valmis"
+           {:fmt-fn (constantly
+                      (kustannusten-seuranta-tiedot/valikatselmuksen-paatostyypin-nimi kattohintapaatos))}))]
+
+      [:div.lupauspaatokset
+       (if (nil? lupauspaatos)
+         (yleiset/tila-indikaattori (if valikatselmuksen-takaraja-ohi? "hylatty" "kesken")
+           {:fmt-fn (constantly
+                      "Ei lupaus\u00ADpäätöksiä")})
+         [:span
+          (yleiset/tila-indikaattori "valmis"
+            {:fmt-fn (constantly
+                       (kustannusten-seuranta-tiedot/valikatselmuksen-paatostyypin-nimi lupauspaatos))})])]]]))

--- a/src/cljs/harja/views/urakkatilanne/sarakkeet/virheelliset.cljs
+++ b/src/cljs/harja/views/urakkatilanne/sarakkeet/virheelliset.cljs
@@ -1,0 +1,20 @@
+(ns harja.views.urakkatilanne.sarakkeet.virheelliset
+  (:require [harja.ui.yleiset :as yleiset]
+            [harja.tiedot.urakka.siirtymat :as siirtymat]
+            [harja.views.urakka.pot-yhteinen :as pot-yhteinen]))
+
+
+(defn virheelliset-tila-sarake
+  [rivi]
+  (for [kohde (:virheelliset_kohteet rivi)]
+    ^{:key (:id kohde)}
+    [yleiset/wrap-if true
+     [yleiset/tooltip {} :%
+      [:div
+       [:p "Siirry päällystys\u00ADilmoitukseen."]
+       (when (:lahetysvirhe kohde)
+         [:p "Virhe: " (:lahetysvirhe kohde)])]]
+     [yleiset/linkki (pot-yhteinen/paallystyskohteen-fmt kohde)
+      #(siirtymat/avaa-paallystysilmoitus! {:paallystyskohde-id (:id kohde)
+                                            :kohteen-urakka-id (:id rivi)})
+      {:block? true}]]))

--- a/src/cljs/harja/views/urakkatilanne/taulukko_hoito.cljs
+++ b/src/cljs/harja/views/urakkatilanne/taulukko_hoito.cljs
@@ -1,0 +1,74 @@
+(ns harja.views.urakkatilanne.taulukko-hoito
+  (:require [harja.pvm :as pvm]
+            [harja.ui.grid :as grid]
+            [harja.ui.yleiset :refer [ajax-loader]]
+            [harja.tiedot.urakkatilanne.kojelauta :as tiedot]
+
+            [harja.views.urakkatilanne.sarakkeet.lupaukset :refer [lupauspisteet-sarake]]
+            [harja.views.urakkatilanne.sarakkeet.valikatselmus :refer [valikatselmus-sarake]]
+            [harja.views.urakkatilanne.sarakkeet.poikkeamat :refer [avoimet-poikkeamat-sarake]]
+            [harja.views.urakkatilanne.sarakkeet.kustannussuunnitelma :refer [kustannussuunitelman-tila-sarake]]))
+
+(defonce +urakoiden-maara-per-sivu+ 20)
+
+
+(defn taulukko-hoitourakat [_e! {:keys [urakat haku-kaynnissa?]}]
+  [grid/grid
+   {:otsikko (str "")
+    :sivuta +urakoiden-maara-per-sivu+
+    :tyhja (if haku-kaynnissa?
+             [ajax-loader "Ladataan tietoja"]
+             "Ei tietoja, tarkistathan valitut suodattimet.")
+    :rivi-jalkeen-fn (fn [urakat]
+                       (let [ks-tilojen-yhteenveto (tiedot/ks-tilojen-yhteenveto urakat)
+                             valikatselmus-tilojen-yhteenveto (tiedot/valikatselmus-tilojen-yhteenveto urakat)
+                             lupaustietojen-yhteenveto (tiedot/lupaustietojen-yhteenveto urakat)
+                             poikkeusten-yhteenveto (tiedot/poikkeusten-yhteenveto urakat)]
+                         (when-not (empty? urakat)
+                           [{:teksti "Yhteensä" :luokka "lihavoitu"}
+                            {:teksti (str (count urakat) " kpl urakoita") :luokka "lihavoitu"}
+                            {:teksti ks-tilojen-yhteenveto :luokka "lihavoitu"}
+                            {:teksti valikatselmus-tilojen-yhteenveto :luokka "lihavoitu"}
+                            {:teksti lupaustietojen-yhteenveto :luokka "lihavoitu"}
+                            {:teksti poikkeusten-yhteenveto :luokka "lihavoitu"}])))}
+   [{:otsikko "Urakka"
+     :tyyppi :string
+     :nimi :nimi
+     :leveys 8
+     :muokattava? (constantly false)}
+
+    {:otsikko "Hoito\u00ADvuosi"
+     :muokattava? (constantly false)
+     :nimi :hoitokauden_alkuvuosi
+     :leveys 7
+     :tyyppi :string
+     :fmt #(pvm/hoitokausi-str-alkuvuodesta-vuodet %)}
+
+    {:otsikko "Kustannus\u00ADsuunnitelma"
+     :muokattava? (constantly false)
+     :nimi :ks_tila
+     :leveys 15
+     :tyyppi :komponentti
+     :komponentti (fn [rivi] [kustannussuunitelman-tila-sarake rivi])}
+
+    {:otsikko "Väli\u00ADkatselmus"
+     :muokattava? (constantly false)
+     :nimi :ks_tila
+     :leveys 15
+     :tyyppi :komponentti
+     :komponentti (fn [rivi] [valikatselmus-sarake rivi])}
+
+    {:otsikko "Lupausten tavoite\u00ADpiste\u00ADmäärä"
+     :muokattava? (constantly false)
+     :nimi :ks_tila
+     :leveys 15
+     :tyyppi :komponentti
+     :komponentti (fn [rivi] [lupauspisteet-sarake rivi])}
+
+    {:otsikko "Avoimet poikkeamat"
+     :muokattava? (constantly false)
+     :nimi :ks_tila
+     :leveys 15
+     :tyyppi :komponentti
+     :komponentti (fn [rivi] [avoimet-poikkeamat-sarake rivi])}]
+   urakat])

--- a/src/cljs/harja/views/urakkatilanne/taulukko_yllapito.cljs
+++ b/src/cljs/harja/views/urakkatilanne/taulukko_yllapito.cljs
@@ -1,0 +1,100 @@
+(ns harja.views.urakkatilanne.taulukko-yllapito
+  (:require [harja.ui.grid :as grid]
+            [harja.ui.yleiset :refer [ajax-loader]]
+            [harja.tiedot.urakkatilanne.kojelauta :as tiedot]
+            [harja.views.urakkatilanne.sarakkeet.virheelliset :refer [virheelliset-tila-sarake]]))
+
+
+(defn taulukko-paallystysurakat [_e! {:keys [urakat haku-kaynnissa?]}]
+  [grid/grid
+   {:otsikko (str "")
+    :tyhja (if haku-kaynnissa?
+             [ajax-loader "Ladataan tietoja"]
+             "Ei tietoja, tarkistathan valitut suodattimet.")
+    :luokat ["paallystysurakat"]
+    :rivi-jalkeen-fn (fn [urakat]
+                       (let [yhteenveto (tiedot/paallystystietojen-yhteenveto urakat)
+                             valmiit-kohteet (tiedot/valmiit-yhteenveto urakat)
+                             lahetetty (tiedot/lahetetyt-yhteenveto urakat)
+                             valmiit-ei-lahetetty (tiedot/valmiit-ei-lahetetty-yhteenveto urakat)
+                             epaonnistuneet-lahetetty (tiedot/epaonnistuneet-lahetetyt-yhteenveto urakat)
+                             aloittamatta (tiedot/aloittamatta-yhteenveto urakat)]
+                         (when-not (empty? urakat)
+                           [{:teksti "Yhteensä" :luokka "lihavoitu"}
+                            {:teksti (str (count urakat) " urak\u00ADkaa") :luokka "lihavoitu"}
+                            {:teksti yhteenveto :luokka "lihavoitu"}
+                            {:teksti aloittamatta :luokka "lihavoitu"}
+                            {:teksti valmiit-ei-lahetetty :luokka "lihavoitu"}
+                            {:teksti valmiit-kohteet :luokka "lihavoitu"}
+                            {:teksti lahetetty :luokka "lihavoitu"}
+                            {:teksti epaonnistuneet-lahetetty :luokka "lihavoitu"}
+                            {:teksti ""}])))}
+   [{:otsikko "Urakka"
+     :tyyppi :string
+     :nimi :nimi
+     :leveys 7
+     :muokattava? (constantly false)}
+
+    {:otsikko "Vuosi"
+     :muokattava? (constantly false)
+     :nimi :hoitokauden_alkuvuosi
+     :leveys 3
+     :tyyppi :positiivinen-numero
+     :kokonaisluku? true
+     :tasaa :oikea}
+
+    {:otsikko "Kohteiden lkm."
+     :muokattava? (constantly false)
+     :nimi :yllapitokohteiden_lkm
+     :leveys 4
+     :tyyppi :positiivinen-numero
+     :kokonaisluku? true
+     :tasaa :oikea}
+
+    {:otsikko "Aloittamatta"
+     :muokattava? (constantly false)
+     :nimi :aloittamatta
+     :leveys 6
+     :tyyppi :positiivinen-numero
+     :kokonaisluku? true
+     :tasaa :oikea}
+
+    {:otsikko "Valmiit, ei vielä lähetetty"
+     :muokattava? (constantly false)
+     :nimi :valmiit_ei_lahetetty
+     :leveys 6
+     :tyyppi :positiivinen-numero
+     :kokonaisluku? true
+     :tasaa :oikea}
+
+    {:otsikko "Valmis/hyväksytty"
+     :muokattava? (constantly false)
+     :nimi :valmis_hyvaksytty
+     :leveys 6
+     :tyyppi :positiivinen-numero
+     :kokonaisluku? true
+     :tasaa :oikea}
+
+    {:otsikko "Lähetetty onnistuneesti YHA:an"
+     :muokattava? (constantly false)
+     :nimi :lahetetty_onnistuneesti
+     :leveys 6
+     :tyyppi :positiivinen-numero
+     :kokonaisluku? true
+     :tasaa :oikea}
+
+    {:otsikko "Epäonnistu\u00ADneet YHA-lähetykset"
+     :muokattava? (constantly false)
+     :nimi :epaonnistuneet_lahetetyt
+     :leveys 6
+     :tyyppi :positiivinen-numero
+     :kokonaisluku? true
+     :tasaa :oikea}
+
+    {:otsikko "Kohteet, joissa lähetys\u00ADvirhe"
+     :muokattava? (constantly false)
+     :nimi :virheelliset_kohteet
+     :leveys 6
+     :tyyppi :komponentti
+     :komponentti (fn [rivi] (virheelliset-tila-sarake rivi))}]
+   urakat])

--- a/test/clj/harja/palvelin/palvelut/urakkatilanne/kojelauta_test.clj
+++ b/test/clj/harja/palvelin/palvelut/urakkatilanne/kojelauta_test.clj
@@ -1,15 +1,15 @@
 (ns harja.palvelin.palvelut.urakkatilanne.kojelauta-test
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
-            [harja.palvelin.palvelut.urakkatilanne.kojelauta :as kojelauta]
             [com.stuartsierra.component :as component]
-            [harja.palvelin.komponentit.tietokanta :as tietokanta]
-            [harja.palvelin.palvelut.valikatselmus.paatos-apurit :as paatos-apurit]
+
+            [harja.pvm :as pvm]
+            [harja [testi :refer :all]]
             [harja.kyselyt.urakat :as urakka-kyselyt]
             [harja.kyselyt.paatos-kyselyt :as paatos-kyselyt]
-            [harja
-             [testi :refer :all]]
-            [harja.pvm :as pvm]))
+            [harja.palvelin.komponentit.tietokanta :as tietokanta]
+            [harja.palvelin.palvelut.urakkatilanne.kojelauta :as kojelauta]
+            [harja.palvelin.palvelut.valikatselmus.paatos-apurit :as paatos-apurit]))
 
 
 (defn jarjestelma-fixture [testit]
@@ -289,10 +289,8 @@
     (is (= 1 (count vastaus)) "Urakoiden lukumäärä")))
 
 
-(deftest valikatselmus-nousee-oikein-kojelautaan-iin-urakassa
+(deftest lupausbonus-nousee-oikein-kojelautaan-iin-urakassa
   (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
-        urakan-parametrit (first (urakka-kyselyt/hae-urakan-parametrit (:db jarjestelma) {:urakkaid urakka-id}))
-        kayttaja-id (:id +kayttaja-jvh+)
         psu-evk-id (hae-pohjois-suomen-evk-id)
         vastaus-ennen-paatoksia (first
                                   (kutsu-palvelua (:http-palvelin jarjestelma)
@@ -300,48 +298,16 @@
                                                                             :hoitokauden-alkuvuosi 2024
                                                                             :urakka-idt [urakka-id]
                                                                             :evk-idt #{}}))
-
-        ;; lisätään kantaan seuraavat päätökset:
-        ;; 1. tavoitehinnan ylitys
-        kayttajaid (:id +kayttaja-jvh+)
-        hoitokauden-alkuvuosi 2024
-        tavoitehinta 5M
-        toteutuneet-kustannukset 5M
-        ylityksen-maara 10M
-        tilaajan-prosentti (:tavoitehinnan_ylityksen_tilaajan_maksuprosentti urakan-parametrit)
-        urakoitsijan-prosentti (- 100 (:tavoitehinnan_ylityksen_tilaajan_maksuprosentti urakan-parametrit))
-        tilaaja-maksaa 150M
-        urakoitsija-maksaa 50M
-        siirto 50M
-        kulu-id 1
-        tavoitehinnan-ylitys-paatos (paatos-apurit/tavoitehinnan-ylityspaatos urakka-id hoitokauden-alkuvuosi tavoitehinta toteutuneet-kustannukset
-                 ylityksen-maara tilaajan-prosentti urakoitsijan-prosentti tilaaja-maksaa
-                 urakoitsija-maksaa siirto kulu-id false kayttajaid)
-        _ (paatos-kyselyt/tee-tavoitehinnan-ylityspaatos (:db jarjestelma) tavoitehinnan-ylitys-paatos)
-        ;; 2. kattohinnan-ylitys
-        hoitokauden-alkuvuosi 2024
-        kattohinta 5M
-        toteutuneet-kustannukset 5M
-        ylityksen-maara 10M
-        urakoitsija-maksaa 50M
-        siirrettava-maara 50M
-        siirtorajoitus-prosentti (:kattohintaylityksen_siirron_prosenttirajoitus urakan-parametrit)
-        maksimi-siirrettava-maara ylityksen-maara           ;; koska rajoitus ei ole käytössä, niin voidaan siirtää koko ylitys
-        viimeinen_hoitokausi false
-        kulu-id 1
-        kattohinnan-ylitys-paatos (paatos-apurit/kattohinnan-ylityspaatos urakka-id hoitokauden-alkuvuosi kattohinta toteutuneet-kustannukset
-                 ylityksen-maara urakoitsija-maksaa siirrettava-maara kulu-id viimeinen_hoitokausi maksimi-siirrettava-maara siirtorajoitus-prosentti kayttaja-id)
-
-        _ (paatos-kyselyt/tee-kattohinnan-ylityspaatos (:db jarjestelma) kattohinnan-ylitys-paatos)
-        ;; 3. lupausbonus
+        tehdyt-paatokset-ennen (:tehdyt-paatokset-count vastaus-ennen-paatoksia)
         _ (tallenna-lupauspaatos urakka-id "bonus" 76 92)
-
         vastaus (first
                   (kutsu-palvelua (:http-palvelin jarjestelma)
                     :hae-urakat-kojelautaan +kayttaja-jvh+ {:urakkatyyppi :hoito
                                                             :hoitokauden-alkuvuosi 2024
                                                             :urakka-idt [urakka-id]
-                                                            :evk-idt #{}}))]
+                                                            :evk-idt #{}}))
+        tehdyt-paatokset-jalkeen (:tehdyt-paatokset-count vastaus)]
+
     (is (= urakka-id (get-in vastaus-ennen-paatoksia [:id])) "Urakka")
     (is (= psu-evk-id (get-in vastaus-ennen-paatoksia [:evk_id])) "PSU EVK")
     (is (nil? (get-in vastaus-ennen-paatoksia [:tavoitehintapaatos])) "Tavoitehinta")
@@ -350,9 +316,8 @@
 
     (is (= urakka-id (get-in vastaus [:id])) "Urakka")
     (is (= psu-evk-id (get-in vastaus [:evk_id])) "PSU EVK")
-    (is (= "kattohinnan-ylitys" (get-in vastaus [:kattohintapaatos])) "Rahapäätökset")
-    (is (= "tavoitehinnan-ylitys" (get-in vastaus [:tavoitehintaylityspaatos])) "Rahapäätökset")
-    (is (= "bonus" (get-in vastaus [:lupauspaatos])) "Lupauspäätökset")))
+    (is (= 1 tehdyt-paatokset-jalkeen))
+    (is (= 0 tehdyt-paatokset-ennen))))
 
 (deftest lupauspisteet-nousee-oikein-kojelautaan-iin-urakassa
   (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
@@ -388,20 +353,24 @@
 (deftest taytetty-nousee-oikein-kojelautaan-iin-urakassa
   (let [urakka-id (hae-urakan-id-nimella "Iin MHU 2021-2026")
         psu-evk-id (hae-pohjois-suomen-evk-id)
+        hae-kojelauta-fn (fn []
+                           (first
+                             (kutsu-palvelua (:http-palvelin jarjestelma)
+                               :hae-urakat-kojelautaan +kayttaja-jvh+ {:urakkatyyppi :hoito
+                                                                       :hoitokauden-alkuvuosi 2024
+                                                                       :urakka-idt [urakka-id]
+                                                                       :evk-idt #{}})))
+        tehdyt-paatokset-ennen (:tehdyt-paatokset-count (hae-kojelauta-fn))
         ;; Tallenna lupauspäätös kantaan
         _ (tallenna-lupauspaatos urakka-id "taytetty" 76 76)
-
-        vastaus (first
-                  (kutsu-palvelua (:http-palvelin jarjestelma)
-                    :hae-urakat-kojelautaan +kayttaja-jvh+ {:urakkatyyppi :hoito
-                                                            :hoitokauden-alkuvuosi 2024
-                                                            :urakka-idt [urakka-id]
-                                                            :evk-idt #{}}))]
+        ;; Hae uusi vastaus
+        vastaus (hae-kojelauta-fn)]
     (is (= urakka-id (get-in vastaus [:id])) "Urakka")
     (is (= psu-evk-id (get-in vastaus [:evk_id])) "PSU EVK")
     (is (= 76 (get-in vastaus [:luvatut_pisteet])) "luvatut_pisteet")
     (is (= 76 (get-in vastaus [:toteutuneet_pisteet])) "luvatut_pisteet")
-    (is (= "taytetty" (get-in vastaus [:lupauspaatos])) "Lupauksen pitäisi olla täytetty")))
+    (is (= 0 tehdyt-paatokset-ennen) "Päätöksiä ei ole ennenkun tehtiin lupauspäätös")
+    (is (= 1 (:tehdyt-paatokset-count vastaus)) "Lupauksen pitäisi nostaa tehtyjen päätösten määrää")))
 
 
 (deftest haku-ei-loyda-kun-evk-ja-urakka-ristiriidassa
@@ -498,18 +467,18 @@
                                                                                 :hoitokauden-alkuvuosi 2022
                                                                                 :urakka-idt [urakka-id]
                                                                                 :evk-idt #{}}))
-        kohteen-odotettu-virhe {:kohdenimi    "Tärkeä kohde mt20 2022"
-                                :kohdenumero  "L42"
+        kohteen-odotettu-virhe {:kohdenimi "Tärkeä kohde mt20 2022"
+                                :kohdenumero "L42"
                                 :lahetysvirhe "paha virhe"
-                                :tunnus       "B"}
+                                :tunnus "B"}
         ;; merkataan vielä lähetys onnistuneeksi ja assertataan niiden määrä
         _ (u (format "UPDATE yllapitokohde SET lahetetty = NOW(), lahetysvirhe = null, lahetys_onnistunut = TRUE WHERE id = %s;" kohde-id))
         vastaus-lahetys-onnistuu (first
-                                      (kutsu-palvelua (:http-palvelin jarjestelma)
-                                        :hae-urakat-kojelautaan +kayttaja-jvh+ {:urakkatyyppi :paallystys
-                                                                                :hoitokauden-alkuvuosi 2022
-                                                                                :urakka-idt [urakka-id]
-                                                                                :evk-idt #{}}))]
+                                   (kutsu-palvelua (:http-palvelin jarjestelma)
+                                     :hae-urakat-kojelautaan +kayttaja-jvh+ {:urakkatyyppi :paallystys
+                                                                             :hoitokauden-alkuvuosi 2022
+                                                                             :urakka-idt [urakka-id]
+                                                                             :evk-idt #{}}))]
     (is (= urakka-id (get-in vastaus-aloitettu [:id])) "Urakka")
     (is (= 1 (get-in vastaus-aloittamatta [:aloittamatta])) "Kohteita aloittamatta")
     (is (= 1 (get-in vastaus-aloitettu [:yllapitokohteiden_lkm])) "ylläpitokohteiden lkm")


### PR DESCRIPTION
## Mitä muutettiin
Kojelautaan yksittäisten päätösten sijaan näytetään numero, tiksulla Figma


## Testaustapa
Naputa välikatselmukseen jotain, ja näiden pitäisi olla synkassa:
<img width="570" height="145" alt="image" src="https://github.com/user-attachments/assets/3cbc1663-84aa-45de-8327-25f5b1fdacd4" />


## Huomioita
Käyttää samaa päätöskonetta, kun välikatselmus. Määrät siis täsmää aina mitä välikatselmuksessa näkyy.
