### PR TITLE
HARJA-2659 Korjaa UI-bugi toteuman lisäämisen yhteydessä

### DIFF
--- a/src/cljs/harja/tiedot/urakka/toteumat/maarien_toteumat.cljs
+++ b/src/cljs/harja/tiedot/urakka/toteumat/maarien_toteumat.cljs
@@ -428,11 +428,7 @@
           uusi-app (if (or
                          (= ::t/toimenpide polku)
                          (= ::t/tyyppi polku))
-                     (-> uusi-app
-                         (assoc :tehtavat [])
-                         (update-in [:lomake ::t/toteumat]
-                                    (fn [tehtavat]
-                                      (mapv #(assoc % ::t/tehtava nil) tehtavat))))
+                     (assoc uusi-app :tehtavat [])
                      uusi-app)]
       uusi-app))
 

--- a/src/cljs/harja/views/urakka/toteumat/maarien_toteuma_lomake.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/maarien_toteuma_lomake.cljs
@@ -188,7 +188,7 @@
                      :virhe?                (kentassa-virhe? [::t/toteumat indeksi ::t/sijainti] validius)
                      :vaadi-vali? false
                      :vayla-tyyli?          true
-                     :sijainti              (r/wrap sijainti (constantly true))}
+                     :sijainti              sijainti}
                     (r/wrap sijainti
                             (r/partial paivita! :tierekisteriosoite indeksi))]]
                   [:div.row
@@ -413,7 +413,7 @@
              :tyyppi :tierekisteriosoite
              :vaadi-vali? false
              :vayla-tyyli? true
-             :sijainti (r/wrap sijainti (constantly true))
+             :sijainti sijainti
              :lataa-piirrettaessa-koordinaatit? true}
             {:nimi [::t/toteumat 0 ::t/ei-sijaintia]
              :disabled? pakota-sijainti?


### PR DESCRIPTION
## Mitä muutettiin
maarien_toteuma_lomake.cljs — Poistettiin turhaksi muodostuneet wrappaukset: :sijainti sijainti 
maarien_toteumat.cljs — Muutettiin tehtävien nolla-logiikkaa: nollataan vain :tehtavat [], tehtävät-kentät nollautuvat implisiittisesti kun lista on tyhjä

## Miksi
Joka renderöinnillä luotiin uusi (r/wrap sijainti (constantly true)) -objekti maarien_toteuma_lomake.cljs:ssa. Tämä uusi wrapper-identiteetti rikkoi kentat.cljs:n sisäisen go-loop:in asynkronisia operaatioita, jotka olivat kesken, jolloin syntyi keskinäisesti viittaavia reaktiivisia olioita.


