### PR TITLE
Korjaa bugi Tehtävä-taulussa

### DIFF
--- a/src/cljs/harja/views/urakka/toteumat/maarien_toteuma_lomake.cljs
+++ b/src/cljs/harja/views/urakka/toteumat/maarien_toteuma_lomake.cljs
@@ -187,8 +187,7 @@
                      :muokattu?             true
                      :virhe?                (kentassa-virhe? [::t/toteumat indeksi ::t/sijainti] validius)
                      :vaadi-vali? false
-                     :vayla-tyyli?          true
-                     :sijainti              sijainti}
+                     :vayla-tyyli?          true}
                     (r/wrap sijainti
                             (r/partial paivita! :tierekisteriosoite indeksi))]]
                   [:div.row
@@ -413,7 +412,6 @@
              :tyyppi :tierekisteriosoite
              :vaadi-vali? false
              :vayla-tyyli? true
-             :sijainti sijainti
              :lataa-piirrettaessa-koordinaatit? true}
             {:nimi [::t/toteumat 0 ::t/ei-sijaintia]
              :disabled? pakota-sijainti?


### PR DESCRIPTION
## Mitä muutettiin
Poistamalla :sijainti parametri, kentat.cljs nyt käyttää ainoastaan data-parametria, joka on aina wrap-atomi ja toimii oikein.

## Miksi
Korjataan räsähdys kun klikataan toteumat/tehtävät näkymän tehtävätaulua ja klikataan sieltä yksittäistä toteumaa.

## Testaustapa
<!-- Miten muutos on hyvä testata -->

## Huomioita
<!-- Riskejä, sivuvaikutuksia tai muita huomioita (valinnainen) -->
