### PR TITLE
HARJA-1821 Korjaa pot2 alustalomakkeen syötteen validointi

### DIFF
--- a/src/cljc/harja/domain/pot2.cljc
+++ b/src/cljc/harja/domain/pot2.cljc
@@ -25,10 +25,11 @@
                      :validoi [[:rajattu-numero-tai-tyhja 1 500 "Arvon tulee olla välillä 1-500cm"]]
                      :tyyppi :positiivinen-numero :kokonaisluku? true
                      :validoi-kentta-fn (fn [numero] (v/validoi-numero numero 1 500 0))}
-  ;; Alustatoimenpiteet näkyvät päällystysilmoituksessa koosteena Toimenpiteen tiedot-sarakkeessa.
-  ;; :lisatty-paksuus on poistettu koosteesta lokakuussa 2025
+   ;; Alustatoimenpiteet näkyvät päällystysilmoituksessa koosteena Toimenpiteen tiedot-sarakkeessa.
+   ;; :lisatty-paksuus on poistettu koosteesta lokakuussa 2025
    :massamenekki {:nimi :massamenekki :otsikko "Massamenekki" :yksikko "kg/m²"
                   :tyyppi :positiivinen-numero :desimaalien-maara 1
+                  :validoi [[:rajattu-numero-tai-tyhja 0 1000000 "Arvon tulee olla välillä 0-1000000"]]
                   :validoi-kentta-fn (fn [numero] (v/validoi-numero numero 0 1000000 1))}
    :murske {:nimi :murske :otsikko "Murske"
             :tyyppi :valinta
@@ -39,9 +40,11 @@
                      :validoi-kentta-fn (fn [numero] (v/validoi-numero numero 1 500 0))}
    :leveys {:nimi :leveys :otsikko "Leveys" :yksikko "m"
             :tyyppi :positiivinen-numero :desimaalien-maara 2
+            :validoi [[:rajattu-numero-tai-tyhja 0 20 "Arvon tulee olla välillä 0-20"]]
             :validoi-kentta-fn (fn [numero] (v/validoi-numero numero 0 20 2))}
    :pinta-ala {:nimi :pinta_ala :tyyppi :positiivinen-numero :otsikko "Pinta-ala" :yksikko "m²"
                :pakollinen? (constantly false)
+               :validoi [[:rajattu-numero-tai-tyhja 0 1000000 "Arvon tulee olla välillä 0-1000000"]]
                :validoi-kentta-fn (fn [numero] (v/validoi-numero numero 0 1000000 1))
                :muokattava? (fn [rivi]
                               ;; 2 = AB
@@ -51,10 +54,10 @@
                                 (= (:toimenpide rivi) 2)
                                 (= (:toimenpide rivi) 21)
                                 (= (:toimenpide rivi) 22)))
-               :fmt #(fmt/desimaaliluku-opt % 1)
-               }
+               :fmt #(fmt/desimaaliluku-opt % 1)}
    :kokonaismassamaara {:nimi :kokonaismassamaara :otsikko "Kokonais\u00ADmassa\u00ADmäärä" :yksikko "t"
                         :tyyppi :positiivinen-numero :desimaalien-maara 1
+                        :validoi [[:rajattu-numero-tai-tyhja 0 1000000 "Arvon tulee olla välillä 0-1000000"]]
                         :validoi-kentta-fn (fn [numero] (v/validoi-numero numero 0 1000000 1))}
    :massa {:nimi :massa :otsikko "Massa"
            :tyyppi :valinta
@@ -65,6 +68,7 @@
    :sideainepitoisuus {:nimi :sideainepitoisuus :otsikko "Sideaine\u00ADpitoisuus"
                        :tyyppi :positiivinen-numero :desimaalien-maara 1
                        :yksikko "%"
+                       :validoi [[:rajattu-numero-tai-tyhja 0 100 "Arvon tulee olla välillä 0-100"]]
                        :validoi-kentta-fn (fn [numero] (v/validoi-numero numero 0 100 1))}
    :sideaine2 {:nimi :sideaine2 :otsikko "Sideaine"
                :tyyppi :valinta :valinnat-koodisto :sidotun-kantavan-kerroksen-sideaine

--- a/src/cljc/harja/domain/pot2.cljc
+++ b/src/cljc/harja/domain/pot2.cljc
@@ -4,7 +4,6 @@
             [specql.data-types]
             [harja.domain.muokkaustiedot :as m]
             [harja.fmt :as fmt]
-            [harja.validointi :as v]
             [clojure.set :as set]
             [clojure.spec.alpha :as s]
             [harja.domain.tierekisteri :as tr]
@@ -24,28 +23,27 @@
   {:lisatty-paksuus {:nimi :lisatty-paksuus :otsikko "Lisätty paksuus" :yksikko "cm"
                      :validoi [[:rajattu-numero-tai-tyhja 1 500 "Arvon tulee olla välillä 1-500cm"]]
                      :tyyppi :positiivinen-numero :kokonaisluku? true
-                     :validoi-kentta-fn (fn [numero] (v/validoi-numero numero 1 500 0))}
+                     }
    ;; Alustatoimenpiteet näkyvät päällystysilmoituksessa koosteena Toimenpiteen tiedot-sarakkeessa.
    ;; :lisatty-paksuus on poistettu koosteesta lokakuussa 2025
    :massamenekki {:nimi :massamenekki :otsikko "Massamenekki" :yksikko "kg/m²"
                   :tyyppi :positiivinen-numero :desimaalien-maara 1
                   :validoi [[:rajattu-numero-tai-tyhja 0 1000000 "Arvon tulee olla välillä 0-1000000"]]
-                  :validoi-kentta-fn (fn [numero] (v/validoi-numero numero 0 1000000 1))}
+                  }
    :murske {:nimi :murske :otsikko "Murske"
             :tyyppi :valinta
             :valinta-arvo ::murske-id}
    :kasittelysyvyys {:nimi :kasittelysyvyys :otsikko "Käsittely\u00ADsyvyys" :yksikko "cm"
                      :validoi [[:rajattu-numero-tai-tyhja 1 500 "Arvon tulee olla välillä 1-500cm"]]
                      :tyyppi :positiivinen-numero :kokonaisluku? true
-                     :validoi-kentta-fn (fn [numero] (v/validoi-numero numero 1 500 0))}
+                     }
    :leveys {:nimi :leveys :otsikko "Leveys" :yksikko "m"
             :tyyppi :positiivinen-numero :desimaalien-maara 2
             :validoi [[:rajattu-numero-tai-tyhja 0 20 "Arvon tulee olla välillä 0-20"]]
-            :validoi-kentta-fn (fn [numero] (v/validoi-numero numero 0 20 2))}
+            }
    :pinta-ala {:nimi :pinta_ala :tyyppi :positiivinen-numero :otsikko "Pinta-ala" :yksikko "m²"
                :pakollinen? (constantly false)
                :validoi [[:rajattu-numero-tai-tyhja 0 1000000 "Arvon tulee olla välillä 0-1000000"]]
-               :validoi-kentta-fn (fn [numero] (v/validoi-numero numero 0 1000000 1))
                :muokattava? (fn [rivi]
                               ;; 2 = AB
                               ;; 21 = ABK
@@ -58,7 +56,7 @@
    :kokonaismassamaara {:nimi :kokonaismassamaara :otsikko "Kokonais\u00ADmassa\u00ADmäärä" :yksikko "t"
                         :tyyppi :positiivinen-numero :desimaalien-maara 1
                         :validoi [[:rajattu-numero-tai-tyhja 0 1000000 "Arvon tulee olla välillä 0-1000000"]]
-                        :validoi-kentta-fn (fn [numero] (v/validoi-numero numero 0 1000000 1))}
+                        }
    :massa {:nimi :massa :otsikko "Massa"
            :tyyppi :valinta
            :valinta-arvo ::massa-id}
@@ -69,7 +67,7 @@
                        :tyyppi :positiivinen-numero :desimaalien-maara 1
                        :yksikko "%"
                        :validoi [[:rajattu-numero-tai-tyhja 0 100 "Arvon tulee olla välillä 0-100"]]
-                       :validoi-kentta-fn (fn [numero] (v/validoi-numero numero 0 100 1))}
+                       }
    :sideaine2 {:nimi :sideaine2 :otsikko "Sideaine"
                :tyyppi :valinta :valinnat-koodisto :sidotun-kantavan-kerroksen-sideaine
                :valinta-arvo ::koodi :valinta-nayta ::nimi}

--- a/src/cljs/harja/views/urakka/pot2/alusta.cljs
+++ b/src/cljs/harja/views/urakka/pot2/alusta.cljs
@@ -1,6 +1,7 @@
 (ns harja.views.urakka.pot2.alusta
   "POT2-lomakkeen alustarivien näkymä"
   (:require
+    [clojure.string]
     [reagent.core :refer [atom] :as r]
     [harja.loki :refer [log]]
     [harja.pvm :as pvm]
@@ -54,7 +55,7 @@
     (yllapitokohteet-domain/validoi-alustatoimenpide-teksti validoitu)))
 
 (defn- alustalomakkeen-lisakentat
-  [{:keys [alustalomake massat murskeet koodistot] :as alusta}]
+  [{:keys [alustalomake massat murskeet koodistot]}]
   (let [{massatyypit :massatyypit
          mursketyypit :mursketyypit} koodistot
         mukautetut-lisakentat {:murske {:nimi :murske
@@ -74,17 +75,19 @@
                                                           "-"))
                                        :valinnat massat}}
         toimenpidespesifit-lisakentat (pot2-domain/alusta-toimenpidespesifit-metadata alustalomake)
-        lisakentta-generaattori (fn [{:keys [nimi pakollinen? valinnat-koodisto jos] :as kentta-metadata}]
+        lisakentta-generaattori (fn [{:keys [nimi pakollinen? valinnat-koodisto] :as kentta-metadata}]
                                   (let [kentta (get mukautetut-lisakentat nimi)
                                         valinnat (or (:valinnat kentta)
                                                      (get koodistot valinnat-koodisto))
                                         valinnat-ja-nil (if pakollinen?
                                                           valinnat
                                                           (conj valinnat nil))]
-                                    (lomake/rivi (merge kentta-metadata
-                                                        kentta
-                                                        {:palstoja 3
-                                                         :valinnat valinnat-ja-nil}))))]
+                                    (lomake/rivi (dissoc
+                                                   (merge kentta-metadata
+                                                          kentta
+                                                          {:palstoja 3
+                                                           :valinnat valinnat-ja-nil})
+                                                   :validoi-kentta-fn))))]
     (map lisakentta-generaattori toimenpidespesifit-lisakentat)))
 
 (defn- alustalomakkeen-kentat [{:keys [alusta-toimenpiteet alustalomake] :as tiedot}]


### PR DESCRIPTION
## Mitä muutettiin
pot2.cljc: lisätty näkyvät :validoi-säännöt Alustan numeerisille lisäkentille.
alusta.cljs: overlay-lomakkeen dynaamisilta kentiltä poistetaan hiljainen :validoi-kentta-fn-syötteenesto, jotta virheellinen arvo voidaan näyttää lomakkeen validointipalautteena.

## Miksi
Syötteen validointi ei näytä virheilmoitusta alustalomakkeessa.

## Testaustapa
<!-- Miten muutos on hyvä testata -->

## Huomioita
<!-- Riskejä, sivuvaikutuksia tai muita huomioita (valinnainen) -->
