### PR TITLE
HARJA-2380 - Korjataan urakoiden tilanteen linkki uuteen kustikseen

### DIFF
--- a/src/clj/harja/kyselyt/kojelauta.sql
+++ b/src/clj/harja/kyselyt/kojelauta.sql
@@ -65,7 +65,7 @@ SELECT u.id,
        up.muutosten_hallinta,
        up.hoitovuoden_alun_tavoitehinta_kaytossa
 FROM urakka u
-         JOIN urakka_parametrit up ON u.id = up.urakkaid
+         LEFT JOIN urakka_parametrit up ON u.id = up.urakkaid
          JOIN organisaatio o ON u.elinvoimakeskus_id = o.id
          JOIN yllapitokohde y ON y.urakka = u.id
          LEFT JOIN paallystysilmoitus pot2 ON y.id = pot2.paallystyskohde AND pot2.poistettu IS NOT TRUE
@@ -81,5 +81,5 @@ WHERE
         EXTRACT (YEAR FROM u.loppupvm)) AND
     (:urakat_annettu IS NOT TRUE OR u.id IN (:urakka_idt)) AND
     (:evkt_annettu IS NOT TRUE OR u.elinvoimakeskus_id IN (:evk_idt))
-GROUP BY u.id, u.nimi, u.elinvoimakeskus_id, hoitokauden_alkuvuosi
+GROUP BY u.id, u.nimi, u.elinvoimakeskus_id, hoitokauden_alkuvuosi, up.laskutusraja_kaytossa, up.muutosten_hallinta, up.hoitovuoden_alun_tavoitehinta_kaytossa
 ORDER BY u.nimi;

--- a/src/clj/harja/kyselyt/kojelauta.sql
+++ b/src/clj/harja/kyselyt/kojelauta.sql
@@ -25,8 +25,12 @@ SELECT u.id,
        (SELECT count(*) FROM turvallisuuspoikkeama tp WHERE tp.urakka = u.id AND
            tp.tila IN ('avoin', 'taydennetty') AND
            tp.tapahtunut BETWEEN make_date(:hoitokauden_alkuvuosi::INTEGER, 10, 1) AND
-               make_date(:hoitokauden_alkuvuosi::INTEGER + 1, 9, 30) + interval '23 hours 59 minutes 59 seconds') AS avoimet_turvallisuuspoikkeamat
+               make_date(:hoitokauden_alkuvuosi::INTEGER + 1, 9, 30) + interval '23 hours 59 minutes 59 seconds') AS avoimet_turvallisuuspoikkeamat,
+       up.laskutusraja_kaytossa,
+       up.muutosten_hallinta,
+       up.hoitovuoden_alun_tavoitehinta_kaytossa
   FROM urakka u
+       JOIN urakka_parametrit up ON u.id = up.urakkaid
  WHERE
      u.tyyppi = 'teiden-hoito' AND
      u.urakkanro IS NOT NULL AND -- testiurakat pois
@@ -56,8 +60,12 @@ SELECT u.id,
         WHERE y.lahetetty IS NOT NULL
           AND y.lahetysvirhe IS NOT NULL
           AND y.lahetys_onnistunut IS FALSE
-          AND y.vuodet @> ARRAY[:vuosi]::INTEGER[] AND y.poistettu IS FALSE AND y.urakka = u.id) AS virheelliset_kohteet
+          AND y.vuodet @> ARRAY[:vuosi]::INTEGER[] AND y.poistettu IS FALSE AND y.urakka = u.id) AS virheelliset_kohteet,
+       up.laskutusraja_kaytossa,
+       up.muutosten_hallinta,
+       up.hoitovuoden_alun_tavoitehinta_kaytossa
 FROM urakka u
+         JOIN urakka_parametrit up ON u.id = up.urakkaid
          JOIN organisaatio o ON u.elinvoimakeskus_id = o.id
          JOIN yllapitokohde y ON y.urakka = u.id
          LEFT JOIN paallystysilmoitus pot2 ON y.id = pot2.paallystyskohde AND pot2.poistettu IS NOT TRUE

--- a/src/cljs/harja/views/urakkatilanne/sarakkeet/kustannussuunnitelma.cljs
+++ b/src/cljs/harja/views/urakkatilanne/sarakkeet/kustannussuunnitelma.cljs
@@ -8,14 +8,18 @@
   (let [indeksi-saatavilla? (boolean (:indeksikerroin rivi))
         {:keys [aloittamattomia vahvistamattomia vahvistettuja suunnitelman_tila]} (:ks_tila rivi)]
     [yleiset/wrap-if true
-     [yleiset/tooltip {} :% "Siirry kustannussuunnitelmaan"]
+     [yleiset/tooltip {} :% (if (:hoitovuoden_alun_tavoitehinta_kaytossa rivi)
+                              "Siirry hoitovuoden alun tavoitehinta -sivulle"
+                              "Siirry kustannussuunnitelmaan")]
      [:a.klikattava.alleviivaa {:href (str "/#urakat/suunnittelu/kustannussuunnitelma?&hy=" (:evk_id rivi) "&u=" (:id rivi))
                                 :on-click #(siirtymat/siirry-annettuun-valilehteen
                                              (:evk_id rivi)
                                              (:id rivi)
                                              {:taso1 :urakat
                                               :taso2 :suunnittelu
-                                              :taso3 :kustannussuunnitelma})}
+                                              :taso3 (if (:hoitovuoden_alun_tavoitehinta_kaytossa rivi)
+                                                       :uusi-kustannussuunnitelma
+                                                       :kustannussuunnitelma)})}
       (cond
         (= "aloittamatta" suunnitelman_tila)
         (yleiset/tila-indikaattori "hylatty" {:fmt-fn (constantly "Aloittamatta")})

--- a/tietokanta/src/main/resources/db/migration/V1_1285__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1285__.sql
@@ -4,6 +4,8 @@ ALTER TABLE urakka_parametrit
 
 -- Oletuksena asetus on epätosi; otetaan se käyttöön vuonna 2025 ja myöhemmin alkaville urakoille.
 UPDATE urakka_parametrit up
-SET hoitovuoden_alun_tavoitehinta_kaytossa = true
-FROM urakka u
-WHERE u.id = up.urakkaid AND EXTRACT(YEAR FROM u.alkupvm) >= 2025;
+   SET hoitovuoden_alun_tavoitehinta_kaytossa = true
+  FROM urakka u
+ WHERE u.id = up.urakkaid
+   AND EXTRACT(YEAR FROM u.alkupvm) >= 2025
+   AND u.tyyppi = 'teiden-hoito';

--- a/tietokanta/src/main/resources/db/migration/V1_1285__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1285__.sql
@@ -1,0 +1,9 @@
+-- Uusi parametri katsomaan, onko uusi kustannussuunnitelma eli hoitovuoden alun tavoitehinta sivu käytössä
+ALTER TABLE urakka_parametrit
+    ADD COLUMN hoitovuoden_alun_tavoitehinta_kaytossa boolean DEFAULT false NOT NULL;
+
+-- Oletuksena asetus on epätosi; otetaan se käyttöön vuonna 2025 ja myöhemmin alkaville urakoille.
+UPDATE urakka_parametrit up
+SET hoitovuoden_alun_tavoitehinta_kaytossa = true
+FROM urakka u
+WHERE u.id = up.urakkaid AND EXTRACT(YEAR FROM u.alkupvm) >= 2025;

--- a/tietokanta/testidata/urakat2.sql
+++ b/tietokanta/testidata/urakat2.sql
@@ -44,6 +44,12 @@ UPDATE urakka_parametrit
 SET laskutusraja_kaytossa = true
 WHERE urakkaid = (SELECT id FROM urakka WHERE nimi = 'POP MHU Kajaani 2025-2030');
 
+-- Asetetaan hoitovuoden alun tavoitehinta käyttöön kaikille urakoille, jotka alkavat vuonna 2025 tai sen jälkeen
+UPDATE urakka_parametrit up
+SET hoitovuoden_alun_tavoitehinta_kaytossa = true
+FROM urakka u
+WHERE u.id = up.urakkaid AND EXTRACT(YEAR FROM u.alkupvm) >= 2025;
+
 -- Kalustoresurssit-alasivun testaamista varten tarvittava testidata.
 -- Luodaan MHU26-urakka (alkuvuosi 2026) Suunnittelu/Kalustoresurssit-alasivun testaamista varten.
 -- Kopioidaan hallintayksikkö, elinvoimakeskus ja urakoitsija Kittilän MHU 2025-2030 -urakalta.

--- a/tietokanta/testidata/urakat2.sql
+++ b/tietokanta/testidata/urakat2.sql
@@ -46,9 +46,11 @@ WHERE urakkaid = (SELECT id FROM urakka WHERE nimi = 'POP MHU Kajaani 2025-2030'
 
 -- Asetetaan hoitovuoden alun tavoitehinta käyttöön kaikille urakoille, jotka alkavat vuonna 2025 tai sen jälkeen
 UPDATE urakka_parametrit up
-SET hoitovuoden_alun_tavoitehinta_kaytossa = true
-FROM urakka u
-WHERE u.id = up.urakkaid AND EXTRACT(YEAR FROM u.alkupvm) >= 2025;
+   SET hoitovuoden_alun_tavoitehinta_kaytossa = true
+  FROM urakka u
+ WHERE u.id = up.urakkaid
+   AND EXTRACT(YEAR FROM u.alkupvm) >= 2025
+   AND u.tyyppi = 'teiden-hoito';
 
 -- Kalustoresurssit-alasivun testaamista varten tarvittava testidata.
 -- Luodaan MHU26-urakka (alkuvuosi 2026) Suunnittelu/Kalustoresurssit-alasivun testaamista varten.


### PR DESCRIPTION
## Mitä muutettiin
Lisättiin uusi urakka_parametri, josta tiedetään, että onko uusi kustis käytössä.
Otettiin parametri käyttöön urakoiden tilanne -sivulla

## Miksi
bugi

## Testaustapa
Mene urakoiden tilanne sivulle ja avaa -25 urakka ja katso, että linkki toimii

## Huomioita
Hoitovuoden alun tavoitehinta -sivu ei käytä vielä tätä parametria. Olisi hyvä, että käyttäisi, mutta en tehnyt sitä muutosta tässä.