### PR TITLE
HARJA-2686 - Poista väliaikaisratkaisu Dockerfilen depsujen päivitykseen liittyen

### DIFF
--- a/aws/fargate/Dockerfile
+++ b/aws/fargate/Dockerfile
@@ -27,14 +27,6 @@ RUN apt-get update \
     && ln -snf /usr/share/zoneinfo/Europe/Helsinki /etc/localtime \
     && echo "Europe/Helsinki" > /etc/timezone
 
-# Päivitä libc ja muut paketit
-RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get -y install --only-upgrade \
-        libc6 \
-        libc-bin \
-        locales \
-    && rm -rf /var/lib/apt/lists/*
-
 # Asenna apurit
 RUN apt-get update && apt-get install -y \
     bash \


### PR DESCRIPTION
* eclipse-temurin:17.0.19_10-jre-noble pohjakuva on päivitetty taustalla uuteen n. viikko sitten, jonka takia sieltä on hävinnyt merkittävä määrä haavoittuvuuksia
  * Tietoa: [Linkki](https://hub.docker.com/layers/library/eclipse-temurin/17.0.19_10-jre-noble/images/sha256-4ee555761eee713b651b8ea460810d2b8ebc2adb7d3ff7f6ae7c90abc7a6d1b0)
* Käytetään mieluummin uudempaa pohjakuvaa, ja vältetään pohjakuvan tuomien pakettien päivittämistä meidän omassa imagessa

## Mitä muutettiin
* Poistettu haavoittuvuuden korjaava kirjastojen päivitys, joka on väliaikainen ratkaisu. Testataan onko haavoittuvuus vielä läsnä uudessa pohjakuvassa, ja onko se relevantti.

## Miksi
* Pyritään pitämään meidän oma image selkeänä ja hallittavana, spesifit pohjakuvan kirjastojen päivitykset ylemmän tason imagessa ovat väliaikaisratkaisuja.

## Testaustapa
* Katsotaan Trivy-raportti ja dev-tilin ECR-skannauksen tulokset.
