### PR TITLE
HARJA-2660 - Korjaa materiaalitoteuman lisäys toteumat/materiaalit sivulta

### DIFF
--- a/src/clj/harja/palvelin/palvelut/toteumat.clj
+++ b/src/clj/harja/palvelin/palvelut/toteumat.clj
@@ -893,7 +893,7 @@
 
                               ;; Hanskataan tässä epämieluisa kulmatapaus: toteuman pvm saattaa muuttua, ja tietokantacachet
                               ;; pitää laittaa jiiriin sekä vanhan että uuden pvm:n osalta joka toteumalle
-                              (when-not (= (:alkanut t) toteuman-alkuperainen-pvm)
+                              (when (and (not (= (:alkanut t) toteuman-alkuperainen-pvm)) (not (nil? toteuman-alkuperainen-pvm)))
                                 (doseq [sopimus-id urakan-sopimus-idt]
                                   (materiaalit-q/paivita-sopimuksen-materiaalin-kaytto c {:sopimus sopimus-id
                                                                                           :alkupvm toteuman-alkuperainen-pvm

--- a/tietokanta/src/main/resources/db/migration/R___Materiaalin_kaytto.sql
+++ b/tietokanta/src/main/resources/db/migration/R___Materiaalin_kaytto.sql
@@ -19,11 +19,11 @@ BEGIN
                 rp.aika::DATE
               FROM toteuma t
                 JOIN toteuman_reittipisteet tr ON tr.toteuma = t.id
-                JOIN LATERAL unnest(tr.reittipisteet) rp ON true
+                JOIN LATERAL unnest(tr.reittipisteet) rp ON true AND (rp.aika::DATE >= alkupvm::DATE AND rp.aika::DATE < (loppupvm::DATE + interval '1 day')::DATE)
                 JOIN LATERAL unnest(rp.materiaalit) mat ON true
-              WHERE rp.aika::DATE BETWEEN alkupvm::DATE AND (loppupvm + interval '1 day')::DATE
-                    AND (u IS NULL OR t.urakka = u) 
+              WHERE (u IS NULL OR t.urakka = u)
                     AND t.poistettu IS FALSE
+                AND (t.alkanut >= alkupvm::TIMESTAMP AND t.alkanut < (loppupvm::TIMESTAMP + interval '1 day')::DATE)
               GROUP BY t.urakka, rp.talvihoitoluokka, rp.soratiehoitoluokka, mat.materiaalikoodi, rp.aika::DATE
   -- Tässä otetaan talteen erikoiskäsittelyllä kaikki käsin syötetyt toteumat, ja annetaan niille
   -- hoitoluokaksi 99 eli 'Käsin kirjattu'
@@ -44,9 +44,10 @@ BEGIN
     FROM toteuma t
              JOIN toteuma_materiaali tm ON tm.toteuma = t.id and tm.poistettu IS FALSE
              JOIN materiaalikoodi m on tm.materiaalikoodi = m.id
-   WHERE t.lahde = 'harja-ui' and
-         t.alkanut BETWEEN alkupvm::DATE AND (loppupvm + interval '1 day')::DATE
-         AND (u IS NULL OR t.urakka = u) AND t.poistettu IS FALSE
+   WHERE t.lahde = 'harja-ui'
+         AND (u IS NULL OR t.urakka = u)
+         AND t.poistettu IS FALSE
+         AND t.alkanut >= alkupvm::TIMESTAMP AND t.alkanut < (loppupvm::TIMESTAMP + interval '1 day')::DATE
    GROUP BY t.urakka, talvihoitoluokka, soratiehoitoluokka, tm.materiaalikoodi, t.alkanut::DATE
   LOOP
     INSERT INTO urakan_materiaalin_kaytto_hoitoluokittain


### PR DESCRIPTION


## Mitä muutettiin
Toteumat palvelussa kutsuttiin vahingossa materiaalicachen päivitystä ilman päivämäärää, jos ei oltu muokkaamassa vanhaa vaan lisäämässä uutta.
Tämä toi useamman minuutin suoritusaikaan lisää uutta lisättäessä (kloonilla)

Materiaalicachen päivittävään proseduuriin lisättiin päivämäärähaku toteumien osalta, jotta ei haettaisi urakan kaikkia toteumia vaan pelkästään ne, joita päivitys koskee.

## Miksi
Tuotannossa ei voi lisätä toteuma/materiaali sivulta mitään, kun tämä haku on niin hidas.

## Testaustapa
Ota klooni ja Raahen urakka. Käy tekemässä muutama toteuma materiaali ja katso kauanko siinä menee.
Ota sitten nämä koodit käyttöön ja vertaa aikoja.
On muuten nopeampi.

## Huomioita
Haut voi olla pielessä. Varmista, että en muokannut proseduuria mitenkään väärin.
