### PR TITLE
HARJA-2640 - Optimoi materiaalitoteuman tallennusta

### DIFF
--- a/src/clj/harja/palvelin/palvelut/toteumat.clj
+++ b/src/clj/harja/palvelin/palvelut/toteumat.clj
@@ -893,23 +893,17 @@
 
                               ;; Hanskataan tässä epämieluisa kulmatapaus: toteuman pvm saattaa muuttua, ja tietokantacachet
                               ;; pitää laittaa jiiriin sekä vanhan että uuden pvm:n osalta joka toteumalle
-                              (when-not (= (:alkanut t) toteuman-alkuperainen-pvm)
+                              (when (and (not (= (:alkanut t) toteuman-alkuperainen-pvm)) (not (nil? toteuman-alkuperainen-pvm)))
                                 (doseq [sopimus-id urakan-sopimus-idt]
                                   (materiaalit-q/paivita-sopimuksen-materiaalin-kaytto c {:sopimus sopimus-id
                                                                                           :alkupvm toteuman-alkuperainen-pvm
-                                                                                          :urakkaid urakka-id}))
-                                (materiaalit-q/paivita-urakan-materiaalin-kaytto-hoitoluokittain c {:urakka urakka-id
-                                                                                                    :alkupvm toteuman-alkuperainen-pvm
-                                                                                                    :loppupvm toteuman-alkuperainen-pvm}))
+                                                                                          :urakkaid urakka-id})))
 
                               ;; Tässä cachejen päivitys uuden pvm:n osalta
                               (doseq [sopimus-id urakan-sopimus-idt]
                                 (materiaalit-q/paivita-sopimuksen-materiaalin-kaytto c {:sopimus sopimus-id
                                                                                         :alkupvm (:alkanut t)
                                                                                         :urakkaid urakka-id}))
-                              (materiaalit-q/paivita-urakan-materiaalin-kaytto-hoitoluokittain c {:urakka urakka-id
-                                                                                                  :alkupvm (:alkanut t)
-                                                                                                  :loppupvm (:alkanut t)})
 
                               ;; Jos saatiin parametrina hoitokausi, voidaan palauttaa urakassa käytetyt materiaalit
                               ;; Tämä ei ole ehkä paras mahdollinen tapa hoitaa tätä, mutta toteuma/materiaalit näkymässä

--- a/test/clj/harja/palvelin/palvelut/toteumat_test.clj
+++ b/test/clj/harja/palvelin/palvelut/toteumat_test.clj
@@ -540,7 +540,53 @@
       (u "DELETE FROM toteuma_materiaali WHERE id in (" (clojure.string/join "," tmidt) ")")
       (u "DELETE FROM toteuma WHERE id=" tid))))
 
-(deftest materiaalin-pvm-muuttuu-cachet-pysyy-jiirissa
+(deftest materiaalin-pvm-muuttuu-reitilliset-cachet-pysyy-jiirissa
+  (let [urakka-id (hae-oulun-alueurakan-2014-2019-id)
+        sopimus-id (hae-oulun-alueurakan-2014-2019-paasopimuksen-id)
+
+        hoitoluokittaiset-ennen-odotettu (set [[#inst "2015-02-17T22:00:00.000-00:00" 1 99 4 1800M]
+                                               [#inst "2015-02-18T22:00:00.000-00:00" 7 99 4 200M]
+                                               [#inst "2015-02-18T22:00:00.000-00:00" 16 99 4 2000M]])
+        hoitoluokittaiset-jalkeen-odotettu (set [[#inst "2015-02-17T22:00:00.000-00:00" 1 99 4 1800M]
+                                                 [#inst "2015-02-18T22:00:00.000-00:00" 7 99 4 200M]
+                                                 [#inst "2015-02-13T22:00:00.000-00:00" 16 99 4 2100M]])
+        hoitoluokittaiset-ennen (set (q (str "SELECT pvm, materiaalikoodi, talvihoitoluokka, urakka, maara FROM urakan_materiaalin_kaytto_hoitoluokittain WHERE urakka = " urakka-id
+                                          (pvm-vali-sql-tekstina "pvm" "'2015-02-01' AND '2015-02-28'") ";")))
+        toteuman-id (ffirst (q (str "SELECT id FROM toteuma WHERE lisatieto = 'LYV-toteuma Natriumformiaatti';")))
+        tm-id (ffirst (q (str "SELECT id FROM toteuma_materiaali WHERE toteuma = " toteuman-id ";")))
+        toteuma {:id toteuman-id, :urakka urakka-id :sopimus sopimus-id
+                 :alkanut (pvm/->pvm "14.02.2015") :paattynyt (pvm/->pvm "14.02.2015")
+                 :tyyppi "materiaali" :suorittajan-nimi "Ahkera hommailija" :suorittajan-ytunnus 1234 :lisatieto "Pvm muutos ja cachet toimii"}
+        tmt [{:id tm-id :materiaalikoodi 16 :maara 2100 :toteuma toteuman-id}]]
+    ;; tarkistetaan että kaikki cachesta palautetut tulokset löytyvät expected-setistä
+    (is (= hoitoluokittaiset-ennen-odotettu hoitoluokittaiset-ennen) "hoitoluokittaisten cache ennen muutosta")
+
+    ;; kyseessä päivitys, löytyvät kannasta jo ennen palvelukutsua
+    (is (= 1 (ffirst (q (str "SELECT count(*) FROM toteuma_materiaali WHERE toteuma = " toteuman-id " AND poistettu IS NOT TRUE;")))))
+    (is (= 1 (ffirst (q (str "SELECT count(*) FROM toteuma WHERE id=" toteuman-id " AND poistettu IS NOT TRUE;")))))
+
+    (kutsu-palvelua (:http-palvelin jarjestelma) :tallenna-toteuma-ja-toteumamateriaalit +kayttaja-jvh+
+      {:toteuma toteuma
+       :toteumamateriaalit tmt
+       :hoitokausi [#inst "2014-09-30T21:00:00.000-00:00" #inst "2015-09-30T20:59:59.000-00:00"]
+       :sopimus sopimus-id})
+    ;; Reitillistä cachea ei enää kutsuta samasa prosessissa. Se päivitetään öisin, koska se vaikuttaa vain raportteihin, eikä sitä tarvitse
+    ;; dynaamisesti päivittää ui:ta varten.
+    ;; Joten päivitetään se käsin.
+    (q (str "SELECT paivita_urakan_materiaalin_kaytto_hoitoluokittain(" urakka-id "::INTEGER,'2014-10-01'::DATE,'2015-09-30'::DATE);"))
+
+
+    ;; lisäyksen jälkeenkin jutut löytyvät kannasta yhden kerran...
+    (is (= 1 (ffirst (q (str "SELECT count(*) FROM toteuma_materiaali WHERE toteuma = " toteuman-id ";")))))
+    (is (= 1 (ffirst (q (str "SELECT count(*) FROM toteuma WHERE id=" toteuman-id " AND poistettu IS NOT TRUE;")))))
+
+    (let [hoitoluokittaiset-jalkeen (set (q (str "SELECT pvm, materiaalikoodi, talvihoitoluokka, urakka, maara FROM urakan_materiaalin_kaytto_hoitoluokittain WHERE urakka = " urakka-id
+                                              (pvm-vali-sql-tekstina "pvm" "'2015-02-01' AND '2015-02-28'") ";")))]
+
+      ;; lisäyksen jälkeen cachet päivittyvät oikein, vanhalla pvm:llä ollut määrä poistuu, ja uusi määrä uudelle päivällä
+      (is (= hoitoluokittaiset-jalkeen-odotettu hoitoluokittaiset-jalkeen) "hoitoluokittaisten cache jalkeen muutoksen"))))
+
+(deftest materiaalin-pvm-muuttuu-reitittomat-cachet-pysyy-jiirissa
   (let [urakka-id (hae-oulun-alueurakan-2014-2019-id)
         sopimus-id (hae-oulun-alueurakan-2014-2019-paasopimuksen-id)
         sopimuksen-kaytetty-mat-ennen-odotettu (set [[sopimus-id #inst "2015-02-17T22:00:00.000-00:00" 1 1800M]
@@ -549,16 +595,8 @@
         sopimuksen-kaytetty-mat-jalkeen-odotettu (set [[sopimus-id #inst "2015-02-17T22:00:00.000-00:00" 1 1800M]
                                                        [sopimus-id #inst "2015-02-18T22:00:00.000-00:00" 7 200M]
                                                        [sopimus-id #inst "2015-02-13T22:00:00.000-00:00" 16 2100M]])
-        hoitoluokittaiset-ennen-odotettu (set [[#inst "2015-02-17T22:00:00.000-00:00" 1 99 4 1800M]
-                                               [#inst "2015-02-18T22:00:00.000-00:00" 7 99 4 200M]
-                                               [#inst "2015-02-18T22:00:00.000-00:00" 16 99 4 2000M]])
-        hoitoluokittaiset-jalkeen-odotettu (set [[#inst "2015-02-17T22:00:00.000-00:00" 1 99 4 1800M]
-                                                 [#inst "2015-02-18T22:00:00.000-00:00" 7 99 4 200M]
-                                                 [#inst "2015-02-13T22:00:00.000-00:00" 16 99 4 2100M]])
         sopimuksen-mat-kaytto-ennen (set (q (str "SELECT sopimus, alkupvm, materiaalikoodi, maara FROM sopimuksen_kaytetty_materiaali WHERE sopimus = " sopimus-id
                                               (pvm-vali-sql-tekstina "alkupvm" "'2015-02-01' AND '2015-02-28'") ";")))
-        hoitoluokittaiset-ennen (set (q (str "SELECT pvm, materiaalikoodi, talvihoitoluokka, urakka, maara FROM urakan_materiaalin_kaytto_hoitoluokittain WHERE urakka = " urakka-id
-                                          (pvm-vali-sql-tekstina "pvm" "'2015-02-01' AND '2015-02-28'") ";")))
         toteuman-id (ffirst (q (str "SELECT id FROM toteuma WHERE lisatieto = 'LYV-toteuma Natriumformiaatti';")))
         tm-id (ffirst (q (str "SELECT id FROM toteuma_materiaali WHERE toteuma = " toteuman-id ";")))
 
@@ -569,7 +607,6 @@
         tmt [{:id tm-id :materiaalikoodi 16 :maara 2100 :toteuma toteuman-id}]]
     ;; tarkistetaan että kaikki cachesta palautetut tulokset löytyvät expected-setistä
     (is (= sopimuksen-kaytetty-mat-ennen-odotettu sopimuksen-mat-kaytto-ennen) "sopimuksen materiaalin käyttö cache ennen muutosta")
-    (is (= hoitoluokittaiset-ennen-odotettu hoitoluokittaiset-ennen) "hoitoluokittaisten cache ennen muutosta")
 
     ;; kyseessä päivitys, löytyvät kannasta jo ennen palvelukutsua
     (is (= 1 (ffirst (q (str "SELECT count(*) FROM toteuma_materiaali WHERE toteuma = " toteuman-id " AND poistettu IS NOT TRUE;")))))
@@ -585,13 +622,10 @@
     (is (= 1 (ffirst (q (str "SELECT count(*) FROM toteuma WHERE id=" toteuman-id " AND poistettu IS NOT TRUE;")))))
 
     (let [sopimuksen-mat-kaytto-jalkeen (set (q (str "SELECT sopimus, alkupvm, materiaalikoodi, maara FROM sopimuksen_kaytetty_materiaali WHERE sopimus = " sopimus-id
-                                                  (pvm-vali-sql-tekstina "alkupvm" "'2015-02-01' AND '2015-02-28'") ";")))
-          hoitoluokittaiset-jalkeen (set (q (str "SELECT pvm, materiaalikoodi, talvihoitoluokka, urakka, maara FROM urakan_materiaalin_kaytto_hoitoluokittain WHERE urakka = " urakka-id
-                                              (pvm-vali-sql-tekstina "pvm" "'2015-02-01' AND '2015-02-28'") ";")))]
+                                                  (pvm-vali-sql-tekstina "alkupvm" "'2015-02-01' AND '2015-02-28'") ";")))]
 
       ;; lisäyksen jälkeen cachet päivittyvät oikein, vanhalla pvm:llä ollut määrä poistuu, ja uusi määrä uudelle päivällä
-      (is (= sopimuksen-kaytetty-mat-jalkeen-odotettu sopimuksen-mat-kaytto-jalkeen) "sopimuksen materiaalin käyttö cache jalkeen muutoksen")
-      (is (= hoitoluokittaiset-jalkeen-odotettu hoitoluokittaiset-jalkeen) "hoitoluokittaisten cache jalkeen muutoksen"))))
+      (is (= sopimuksen-kaytetty-mat-jalkeen-odotettu sopimuksen-mat-kaytto-jalkeen) "sopimuksen materiaalin käyttö cache jalkeen muutoksen"))))
 
 
 (deftest uusi-materiaali-cachet-pysyy-jiirissa
@@ -620,6 +654,9 @@
        :toteumamateriaalit tmt
        :hoitokausi [#inst "2010-09-30T21:00:00.000-00:00" #inst "2011-09-30T20:59:59.000-00:00"]
        :sopimus sopimus-id})
+
+    ;; Pakotetaan reitteihin liittyvän cachen päivitys käin
+    (q (str "SELECT paivita_urakan_materiaalin_kaytto_hoitoluokittain(" urakka-id "::INTEGER,'2010-10-01'::DATE,'2011-09-30'::DATE);"))
 
     (let [toteuman-id-jalkeen (ffirst (q (str "SELECT id FROM toteuma WHERE lisatieto='Täysin uusi jiirijutska';")))]
       (is (= 1 (ffirst (q (str "SELECT count(*) FROM toteuma_materiaali WHERE toteuma = " toteuman-id-jalkeen ";")))))


### PR DESCRIPTION
## Mitä muutettiin
Estettiin materiaalitoteumien luonnissa turha cachepäivitys ja poistettiin toinenkin turha cachepäivitys samassa rytäkässä

## Miksi
Nopeuttaa toteuman tallennusta noin 100x

## Testaustapa
Testaa vanhalla koodilla ja huomaaa hitaus (Tarttet kloonia) ja testaa uudella ja huomaa, miten ihanaa on, kun kaikki on nopeaa.
