### PR TITLE
HARJA-2640 toteuma tehtava optimointi

### DIFF
--- a/src/clj/harja/kyselyt/toteumat.sql
+++ b/src/clj/harja/kyselyt/toteumat.sql
@@ -94,6 +94,7 @@ FROM (SELECT
                                                            WHERE id = :toimenpide))
                                              AND (:tehtava :: INTEGER IS NULL OR tk.id = :tehtava))
             AND tt.poistettu IS NOT TRUE
+            AND tt.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
       GROUP BY toimenpidekoodi) x
   JOIN tehtava tk ON x.tpk_id = tk.id
 ORDER BY nimi;
@@ -243,9 +244,7 @@ SELECT
   t.suorittajan_ytunnus,
   t.lisatieto,
   k.jarjestelma                   AS jarjestelmanlisaama,
-  (SELECT nimi
-   FROM tehtava tpk
-   WHERE id = tt.toimenpidekoodi) AS toimenpide,
+  tpk.nimi                        AS toimenpide,
   t.tr_numero,
   t.tr_alkuosa,
   t.tr_alkuetaisyys,
@@ -254,15 +253,17 @@ SELECT
 
 FROM toteuma_tehtava tt
   INNER JOIN toteuma t ON tt.toteuma = t.id
-                          AND urakka = :urakka
-                          AND sopimus = :sopimus
-                          AND alkanut >= :alkupvm
-                          AND paattynyt <= :loppupvm
-                          AND tyyppi = :tyyppi :: toteumatyyppi
-                          AND toimenpidekoodi = :toimenpidekoodi
-                          AND tt.poistettu IS NOT TRUE
+                          AND t.urakka = :urakka
+                          AND t.sopimus = :sopimus
+                          AND (t.alkanut >= :alkupvm AND t.alkanut < (:loppupvm::DATE + interval '1 day')::DATE)
+                          AND t.tyyppi = :tyyppi :: toteumatyyppi
                           AND t.poistettu IS NOT TRUE
   LEFT JOIN kayttaja k ON k.id = t.luoja
+  LEFT JOIN tehtava tpk ON tpk.id = tt.toimenpidekoodi
+WHERE tt.poistettu IS NOT TRUE
+      AND tt.urakka_id = :urakka
+      AND tt.toimenpidekoodi = :toimenpidekoodi
+      AND tt.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
 ORDER BY t.alkanut DESC
 LIMIT 301;
 
@@ -415,50 +416,64 @@ WHERE e.urakka = :urakka
 -- Ryhmittele ja summaa tiedot toimenpidekoodin eli tehtävän perusteella. Suunnitellut toteumat
 -- haetaan erikseen ja ilman suunnittelua olevat toteumat erikseen, käyttäen unionia.
 -- Haetaan tarpeeksi tietoa, jotta tehtävän sisältämät erilliset toteumat voidaan hakea erikseen.
-WITH osa_toteumat AS
-         (SELECT tt.toimenpidekoodi  AS toimenpidekoodi,
-                 SUM(tt.maara)       AS maara,
-                 SUM(tm.maara)       AS materiaalimaara,
-                 :urakka             AS urakka,     -- Hakuehtojen perusteella tiedetään urakka, joten käytetään sitä
-                 MAX(t.id)           AS toteuma_id, -- Kaikilla on sama toimenpidekoodi, joten on sama mitä toteumaa tietojen yhdistämisessä käytetään
-                 MAX(tt.id)          AS toteuma_tehtava_id,
-                 MAX(t.tyyppi::TEXT) AS tyyppi      -- Kaikilla on sama tyyppi, joten otetaan vain niistä joku
-          FROM toteuma t
-                   JOIN toteuma_tehtava tt ON t.id = tt.toteuma AND tt.urakka_id = :urakka AND tt.poistettu = FALSE AND tt.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
-                   LEFT JOIN toteuma_materiaali tm
-                             ON t.id = tm.toteuma AND tm.urakka_id = :urakka AND tm.poistettu = FALSE AND tm.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
-          WHERE t.urakka = :urakka
-            AND (t.alkanut BETWEEN :alkupvm::DATE AND :loppupvm::DATE)
-            AND t.poistettu = FALSE
+WITH rajatut_toteumat AS MATERIALIZED (
+    SELECT t.id,
+           t.urakka,
+           t.alkanut,
+           t.tyyppi
+      FROM toteuma t
+     WHERE t.urakka = :urakka
+       AND t.alkanut >= :alkupvm::DATE
+       AND t.alkanut < (:loppupvm::DATE + INTERVAL '1 day')
+       AND t.poistettu IS NOT TRUE),
+     rajatut_tehtavat AS MATERIALIZED (
+         SELECT tt.toteuma,
+                tt.toimenpidekoodi,
+                tt.maara
+           FROM toteuma_tehtava tt
+          WHERE tt.urakka_id = :urakka
+            AND tt.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
+            AND tt.poistettu = FALSE),
+     materiaalit AS (
+         SELECT tm.toteuma,
+                SUM(tm.maara) AS materiaalimaara
+           FROM rajatut_toteumat t
+                  JOIN toteuma_materiaali tm ON tm.toteuma = t.id
+          WHERE tm.urakka_id = :urakka
+            AND tm.poistettu = FALSE
+            AND tm.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
+          GROUP BY tm.toteuma),
+     tehtavasummat AS (
+         SELECT tt.toimenpidekoodi,
+                SUM(tt.maara) AS maara,
+                SUM(m.materiaalimaara) AS materiaalimaara,
+                MAX(t.tyyppi::TEXT) AS tyyppi
+           FROM rajatut_toteumat t
+                  JOIN rajatut_tehtavat tt ON tt.toteuma = t.id
+                  LEFT JOIN materiaalit m ON m.toteuma = t.id
           GROUP BY tt.toimenpidekoodi)
-SELECT tk.id                                     AS toimenpidekoodi_id,
-       o.otsikko                                 AS toimenpide,
-       tk.nimi                                   AS tehtava,
-       SUM(ot.maara)                             AS maara,
-       SUM(ot.materiaalimaara)                   AS materiaalimaara,
-       SUM(ut.laskettu_maara)                    AS suunniteltu_maara,
-       tk.kasin_lisattava_maara                  AS kasin_lisattava_maara,
-       tk.suunnitteluyksikko                     AS yk,
+SELECT tk.id AS toimenpidekoodi_id,
+       o.otsikko AS toimenpide,
+       tk.nimi AS tehtava,
+       ts.maara,
+       ts.materiaalimaara,
+       ut.laskettu_maara AS suunniteltu_maara,
+       tk.kasin_lisattava_maara,
+       tk.suunnitteluyksikko AS yk,
        CASE
            WHEN o.otsikko = '9 LISÄTYÖT'
                THEN 'lisatyo'
-           ELSE 'kokonaishintainen' END          AS tyyppi
-
+           ELSE 'kokonaishintainen' END AS tyyppi
 FROM tehtava tk
-     -- Alataso on linkitetty toimenpidekoodiin
-     JOIN tehtavaryhma tr_alataso ON tr_alataso.id = tk.tehtavaryhma
-     JOIN tehtavaryhmaotsikko o ON tr_alataso.tehtavaryhmaotsikko_id = o.id AND (:tehtavaryhma::TEXT IS NULL OR o.otsikko = :tehtavaryhma)
-     LEFT JOIN urakka_tehtavamaara_yhteenveto ut ON ut.urakka = :urakka AND ut.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi
-                    AND tk.id = ut.tehtava
-     LEFT JOIN osa_toteumat ot ON tk.id = ot.toimenpidekoodi
-     JOIN urakka u on u.id = :urakka
-WHERE -- Rajataan pois hoitoluokka- eli aluetiedot paitsi, jos niihin saa kirjata toteumia käsin
-      (tk.aluetieto = false OR (tk.aluetieto = TRUE AND tk.kasin_lisattava_maara = TRUE))
-  AND tk."mhu-tehtava?" = true -- Rajataan pois ne, jotka eivät ole mhu tehtäviä.
+         JOIN tehtavaryhma tr_alataso ON tr_alataso.id = tk.tehtavaryhma
+         JOIN tehtavaryhmaotsikko o ON tr_alataso.tehtavaryhmaotsikko_id = o.id AND (:tehtavaryhma::TEXT IS NULL OR o.otsikko = :tehtavaryhma)
+         LEFT JOIN urakka_tehtavamaara_yhteenveto ut ON ut.urakka = :urakka AND ut.hoitokauden_alkuvuosi = :hoitokauden_alkuvuosi AND tk.id = ut.tehtava
+         LEFT JOIN tehtavasummat ts ON ts.toimenpidekoodi = tk.id
+         JOIN urakka u ON u.id = :urakka
+WHERE (tk.aluetieto = FALSE OR ( tk.aluetieto = TRUE AND tk.kasin_lisattava_maara = TRUE))
+  AND tk."mhu-tehtava?" = TRUE
   AND (tk.voimassaolo_alkuvuosi IS NULL OR tk.voimassaolo_alkuvuosi <= date_part('year', u.alkupvm)::INTEGER)
-  AND (tk.voimassaolo_loppuvuosi IS NULL OR tk.voimassaolo_loppuvuosi >= date_part('year', u.alkupvm)::INTEGER)
-  -- Rajataan pois tehtävät joilla ei ole suunnitteluyksikköä ja tehtävät joiden yksikkö on euro
-  -- mutta otetaan mukaan Kolmansien osapuolten aiheuttamien vahinkojen korjaaminen ja lisätyöt
+  AND (tk.voimassaolo_loppuvuosi IS NULL OR tk.voimassaolo_loppuvuosi >= date_part('year', u.alkupvm)::INTEGER )
   AND ((tk.suunnitteluyksikko IS not null AND tk.suunnitteluyksikko != 'euroa') OR
        tk.yksiloiva_tunniste IN ('49b7388b-419c-47fa-9b1b-3797f1fab21d',
                                  '63a2585b-5597-43ea-945c-1b25b16a06e2',
@@ -466,8 +481,8 @@ WHERE -- Rajataan pois hoitoluokka- eli aluetiedot paitsi, jos niihin saa kirjat
                                  'e32341fc-775a-490a-8eab-c98b8849f968',
                                  '0c466f20-620d-407d-87b0-3cbb41e8342e',
                                  'c058933e-58d3-414d-99d1-352929aa8cf9'))
-GROUP BY tk.id, tk.nimi, o.otsikko, tk.kasin_lisattava_maara, tk.suunnitteluyksikko, ot.tyyppi
-ORDER BY o.otsikko asc, tk.nimi asc;
+GROUP BY tk.id, tk.nimi, o.otsikko, ts.maara, ts.materiaalimaara, ut.laskettu_maara, tk.kasin_lisattava_maara, tk.suunnitteluyksikko, u.alkupvm
+ORDER BY o.otsikko ASC, tk.nimi ASC;
 
 -- name: listaa-tehtavan-toteumat
 -- Haetaan yksittäiselle tehtavalle kaikki toteumat.

--- a/src/clj/harja/palvelin/palvelut/toteumat.clj
+++ b/src/clj/harja/palvelin/palvelut/toteumat.clj
@@ -120,7 +120,8 @@
            :paattynyt  (konv/sql-date loppupvm)
            :tyyppi     (name tyyppi)
            :toimenpide toimenpide-id
-           :tehtava    tehtava-id})))
+           :tehtava    tehtava-id
+           :hoitokauden_alkuvuosi (pvm/hoitokauden-alkuvuosi (pvm/joda-timeksi alkupvm))})))
 
 (defn hae-urakan-toteutuneet-tehtavat-toimenpidekoodilla [db user {:keys [urakka-id sopimus-id alkupvm loppupvm tyyppi toimenpidekoodi]}]
   (log/debug "Haetaan urakan toteutuneet tehtävät tyypillä ja toimenpidekoodilla: " urakka-id sopimus-id alkupvm loppupvm tyyppi toimenpidekoodi)
@@ -137,12 +138,13 @@
               muunna-desimaaliluvut-xf)
         (toteumat-q/hae-urakan-toteutuneet-tehtavat-toimenpidekoodilla
           db
-          urakka-id
-          sopimus-id
-          (konv/sql-timestamp alkupvm)
-          (konv/sql-timestamp loppupvm)
-          (name tyyppi)
-          toimenpidekoodi)))
+          {:urakka urakka-id
+           :sopimus sopimus-id
+           :alkupvm (konv/sql-timestamp alkupvm)
+           :loppupvm (konv/sql-timestamp loppupvm)
+           :tyyppi (name tyyppi)
+           :toimenpidekoodi toimenpidekoodi
+           :hoitokauden_alkuvuosi (pvm/hoitokauden-alkuvuosi (pvm/joda-timeksi alkupvm))})))
 
 (defn- kasittele-toteumatehtava [c user toteuma tehtava]
   (if (and (:tehtava-id tehtava) (pos? (:tehtava-id tehtava)))
@@ -328,7 +330,8 @@
                                                                                  :alkupvm         alkupvm
                                                                                  :loppupvm        loppupvm
                                                                                  :tyyppi          tyyppi
-                                                                                 :toimenpidekoodi (:toimenpidekoodi (first tehtavat))})
+                                                                                 :toimenpidekoodi (:toimenpidekoodi (first tehtavat))
+                                                                                 :hoitokauden_alkuvuosi (pvm/hoitokauden-alkuvuosi (pvm/joda-timeksi alkupvm))})
         paivitetyt-summat (hae-urakan-toteumien-tehtavien-summat db user
                                                                  {:urakka-id     urakka-id
                                                                   :sopimus-id    sopimus-id

--- a/tietokanta/src/main/resources/db/migration/V1_1287__.sql
+++ b/tietokanta/src/main/resources/db/migration/V1_1287__.sql
@@ -1,0 +1,659 @@
+-- Tehdään Hoitokausittain partitiot tauluille toteuma_tehtava ja toteuma_materiaali.
+--
+--
+-- Toteutustapa:
+--   * Deklaratiivinen partitiointi (PARTITION BY RANGE), ei INHERITS. Partition pruning,
+--     rivien automaattinen ohjaus partitioihin ja partitioidut indeksit tulevat valmiina.
+--   * Partitiointiavain on lähdetauluissa jo oleva hoitokauden_alkuvuosi-sarake.
+--   * NULL-arvot ja orvot rivit (toteuma-viite ei osu mihinkään toteumaan; FK poistettiin
+--     migraatiossa V1_832) saavat arvon -1 ja päätyvät partitioon *_ennen_2014.
+--
+-- Kopiointi voidaan keskeyttää milloin tahansa (Ctrl-C / yhteyden katkeaminen). Uusi
+-- CALL kopioi_toteuma_hk_data() jatkaa siitä ID:stä, mihin edellinen ajo ehti.
+-- Etenemistä seurataan taulusta toteuma_hk_siirto_tila.
+
+-- Aiempien yritysten jäänteet pois. DROP ROUTINE poistaa sekä funktion että proseduurin.
+DROP ROUTINE IF EXISTS partitioi_toteumataulu(TEXT, TEXT, DATE, DATE, INTEGER);
+DROP ROUTINE IF EXISTS partitioi_toteumat(INTEGER);
+
+-- Pudotetaan myös tämän tiedoston omat rutiinit, jotta parametrien uudelleennimeäminen
+-- ei kaadu CREATE OR REPLACE -rajoitteeseen skriptiä uudelleen ajettaessa.
+DROP ROUTINE IF EXISTS partitioi_toteumat_hoitokausittain(INTEGER);
+DROP ROUTINE IF EXISTS viimeistele_toteuma_hk_taulut();
+DROP ROUTINE IF EXISTS kopioi_toteuma_hk_data(INTEGER);
+DROP ROUTINE IF EXISTS kopioi_toteuma_hk_taulu(TEXT, INTEGER);
+DROP ROUTINE IF EXISTS luo_toteuma_hk_taulut(INTEGER, INTEGER);
+DROP ROUTINE IF EXISTS luo_toteuma_hk_taulu(TEXT, INTEGER, INTEGER);
+DROP ROUTINE IF EXISTS vaihda_toteuma_hk_taulut();
+
+
+-- Partitiointiavaimena käytetään lähdetauluissa jo olevaa
+-- hoitokauden_alkuvuosi-saraketta. NULL-arvot ohjataan kopioinnissa arvolla -1
+-- vanhimpaan partitioon.
+
+
+-- Siirron tila. Yksi rivi per lähdetaulu. Päivitetään samassa transaktiossa erän kanssa,
+-- joten tila vastaa aina kohdetaulun sisältöä myös keskeytyksen jälkeen.
+CREATE TABLE IF NOT EXISTS toteuma_hk_siirto_tila
+(
+    lahde_taulu  TEXT PRIMARY KEY,
+    kohde_taulu  TEXT      NOT NULL,
+    viimeinen_id BIGINT    NOT NULL DEFAULT -1,
+    siirretty    BIGINT    NOT NULL DEFAULT 0,
+    valmis       BOOLEAN   NOT NULL DEFAULT FALSE,
+    luotu        TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    muokattu     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE OR REPLACE FUNCTION estä_kirjoitukset()
+    RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION 'Kirjoitukset tilapäisesti estetty ylläpidon ajan';
+END;
+$$ LANGUAGE plpgsql;
+
+-- Luo yhden hoitokausipartitioidun taulun ja sen partitiot.
+-- Taulun nimi on lähdetaulun nimi + _hk. Partitiointiavain on hoitokauden_alkuvuosi.
+-- Partitiointi alkaa *_hk_ennen_2014 ja päättyy *_hk_tulevat. Partitioiden nimet ovat muotoa *_YYYY_YYYY.
+-- Eli perustaulun nimi on *_hk_2014_2015, seuraava *_hk_2015_2016 jne. Viimeinen partitiot on *_tulevat.
+-- Tässä tiedostossa partitioidaan toteuma_tehtavat ja toteuma_materiaalit, joten
+-- partitioitujen taulujen nimet on tyyliin toteuma_tehtava_hk_2014_2015, toteuma_materiaali_hk_2014_2015 jne.
+-- Tätä voi tosin kohtuu helposti laajentaa myös muistin tauluihin. Siksi tässä käytetään lähdetaulua parametrina.
+CREATE OR REPLACE PROCEDURE luo_toteuma_hk_taulu(lahdetaulu TEXT,
+                                                 ensimmainen_hoitokausi INTEGER,
+                                                 viimeinen_hoitokausi INTEGER)
+    LANGUAGE plpgsql AS
+$$
+DECLARE
+    kohdetaulu TEXT := lahdetaulu || '_hk';
+    hk         INTEGER;
+    partitio   TEXT;
+BEGIN
+    IF to_regclass(format('public.%I', kohdetaulu)) IS NULL THEN
+        EXECUTE format(
+            'CREATE TABLE public.%I (LIKE public.%I INCLUDING DEFAULTS)
+            PARTITION BY RANGE (hoitokauden_alkuvuosi)',
+            kohdetaulu, lahdetaulu);
+        RAISE NOTICE 'Luotiin partitioitu taulu public.%', kohdetaulu;
+    ELSE
+        RAISE NOTICE 'Taulu public.% on jo olemassa, ohitetaan luonti', kohdetaulu;
+    END IF;
+
+    partitio := kohdetaulu || '_ennen_' || ensimmainen_hoitokausi;
+    IF to_regclass(format('public.%I', partitio)) IS NULL THEN
+        EXECUTE format(
+            'CREATE TABLE public.%I PARTITION OF public.%I
+             FOR VALUES FROM (MINVALUE) TO (%s)',
+            partitio, kohdetaulu, ensimmainen_hoitokausi);
+    END IF;
+
+    FOR hk IN ensimmainen_hoitokausi..viimeinen_hoitokausi
+        LOOP
+            partitio := format('%s_%s_%s', kohdetaulu, hk, hk + 1);
+            IF to_regclass(format('public.%I', partitio)) IS NULL THEN
+                EXECUTE format(
+                    'CREATE TABLE public.%I PARTITION OF public.%I
+                     FOR VALUES FROM (%s) TO (%s)',
+                    partitio, kohdetaulu, hk, hk + 1);
+            END IF;
+        END LOOP;
+
+    partitio := kohdetaulu || '_tulevat';
+    IF to_regclass(format('public.%I', partitio)) IS NULL THEN
+        EXECUTE format(
+            'CREATE TABLE public.%I PARTITION OF public.%I
+             FOR VALUES FROM (%s) TO (MAXVALUE)',
+            partitio, kohdetaulu, viimeinen_hoitokausi + 1);
+    END IF;
+
+    INSERT INTO toteuma_hk_siirto_tila (lahde_taulu, kohde_taulu)
+    VALUES (lahdetaulu, kohdetaulu)
+    ON CONFLICT (lahde_taulu) DO NOTHING;
+
+    RAISE NOTICE 'Taulun % partitiot valmiina (hoitokaudet % - %)',
+        kohdetaulu, ensimmainen_hoitokausi, viimeinen_hoitokausi;
+END;
+$$;
+
+
+-- Luodaan uudet partitioitavat taulut. Viimeinen hoitokausi päätellään toteuma-taulun
+-- suurimmasta järkevästä alkanut-arvosta, ellei sitä anneta.
+CREATE OR REPLACE PROCEDURE luo_toteuma_hk_taulut(ensimmainen_hoitokausi INTEGER DEFAULT 2014,
+                                                  viimeinen_hoitokausi INTEGER DEFAULT NULL)
+    LANGUAGE plpgsql AS
+$$
+DECLARE
+    viimeinen INTEGER := viimeinen_hoitokausi;
+BEGIN
+    IF viimeinen IS NULL THEN
+        SELECT GREATEST(hoitokauden_alkuvuosi(max(alkanut)),
+                        hoitokauden_alkuvuosi(CURRENT_TIMESTAMP::TIMESTAMP))
+        INTO viimeinen
+        FROM toteuma
+        WHERE alkanut < CURRENT_TIMESTAMP + INTERVAL '2 years';
+        viimeinen := GREATEST(COALESCE(viimeinen, ensimmainen_hoitokausi),
+                              ensimmainen_hoitokausi);
+    END IF;
+
+    CALL luo_toteuma_hk_taulu('toteuma_tehtava', ensimmainen_hoitokausi, viimeinen);
+    CALL luo_toteuma_hk_taulu('toteuma_materiaali', ensimmainen_hoitokausi, viimeinen);
+    -- Hox. Tämä on laajennettavissa periatteessa mille tahansa taululle, jolla on hotokauden_alkuvuosi-sarake.
+    -- Esim jos toteuman_reittipisteet taululle lisäisi hoitokauden_alkuvuosi-sarakkeen, voisi senkin partitioida samalla tavalla.
+END;
+$$;
+
+
+-- Kopioi yhden lähdetaulun datan partitioituun tauluun erissä.
+-- Jatkaa aina taulusta toteuma_hk_siirto_tila luetusta ID:stä, joten keskeytys on turvallinen.
+CREATE OR REPLACE PROCEDURE kopioi_toteuma_hk_taulu(lahdetaulu TEXT,
+                                                    eran_koko INTEGER DEFAULT 500000)
+    LANGUAGE plpgsql AS
+$$
+DECLARE
+    kohdetaulu      TEXT;
+    edellinen_id    BIGINT;
+    rivit_yhteensa  BIGINT;
+    onko_valmis     BOOLEAN;
+    sarakkeet       TEXT;
+    sarakkeet_alias TEXT;
+    eran_ylaraja    BIGINT;
+    erassa          BIGINT;
+    arvio_yhteensa  BIGINT;
+    aloitus_aika    TIMESTAMP := clock_timestamp();
+    alku_siirretty  BIGINT;
+    kulunut_s       NUMERIC;
+    jaljella_s      NUMERIC;
+    prosentti       NUMERIC;
+BEGIN
+    IF eran_koko <= 0 THEN
+        RAISE EXCEPTION 'Erän koon on oltava positiivinen, annettu: %', eran_koko;
+    END IF;
+
+    SELECT t.kohde_taulu, t.viimeinen_id, t.siirretty, t.valmis
+    INTO kohdetaulu, edellinen_id, rivit_yhteensa, onko_valmis
+    FROM toteuma_hk_siirto_tila t
+    WHERE t.lahde_taulu = lahdetaulu;
+
+    IF kohdetaulu IS NULL THEN
+        RAISE EXCEPTION 'Taululle % ei löydy siirron tilaa. Aja ensin CALL luo_toteuma_hk_taulut()',
+            lahdetaulu;
+    END IF;
+
+    IF onko_valmis THEN
+        RAISE NOTICE 'Taulu % on jo kopioitu (% riviä), ohitetaan', lahdetaulu, rivit_yhteensa;
+        RETURN;
+    END IF;
+
+    alku_siirretty := rivit_yhteensa;
+
+    SELECT string_agg(format('%I', column_name), ', ' ORDER BY ordinal_position),
+           string_agg(
+               CASE
+                   WHEN column_name = 'hoitokauden_alkuvuosi'
+                       THEN format('COALESCE(s.%I, -1) AS %I', column_name, column_name)
+                   ELSE format('s.%I', column_name)
+                   END,
+               ', ' ORDER BY ordinal_position)
+    INTO sarakkeet, sarakkeet_alias
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = lahdetaulu;
+
+    -- Karkea kokonaismäärä arviota varten. Tilastoarvio riittää eikä vaadi täyttä laskentaa. (rentouttaa sielua, kun näkee etenemisen)
+    SELECT GREATEST(reltuples, 0)::BIGINT
+    INTO arvio_yhteensa
+    FROM pg_class
+    WHERE oid = format('public.%I', lahdetaulu)::REGCLASS;
+
+    RAISE NOTICE 'Kopiointi % -> % alkaa. Arvio lähteessä % riviä, valmiina % riviä, jatketaan ID:stä %',
+        lahdetaulu, kohdetaulu, arvio_yhteensa, rivit_yhteensa, edellinen_id + 1;
+
+    LOOP
+        -- Erän yläraja päätellään etukäteen, jotta INSERT on deterministinen.
+        EXECUTE format(
+            'SELECT max(id) FROM (SELECT id FROM public.%I WHERE id > %s ORDER BY id LIMIT %s) e',
+            lahdetaulu, edellinen_id, eran_koko)
+            INTO eran_ylaraja;
+
+        EXIT WHEN eran_ylaraja IS NULL;
+
+        EXECUTE format(
+            'INSERT INTO public.%I (%s)
+             SELECT %s
+               FROM public.%I s
+              WHERE s.id > %s
+                AND s.id <= %s',
+            kohdetaulu, sarakkeet, sarakkeet_alias, lahdetaulu,
+            edellinen_id, eran_ylaraja);
+        GET DIAGNOSTICS erassa = ROW_COUNT;
+
+        edellinen_id := eran_ylaraja;
+        rivit_yhteensa := rivit_yhteensa + erassa;
+
+        UPDATE toteuma_hk_siirto_tila t
+        SET viimeinen_id = edellinen_id,
+            siirretty    = rivit_yhteensa,
+            muokattu     = CURRENT_TIMESTAMP
+        WHERE t.lahde_taulu = lahdetaulu;
+
+        COMMIT;
+
+        kulunut_s := EXTRACT(EPOCH FROM clock_timestamp() - aloitus_aika);
+        prosentti := CASE
+                         WHEN arvio_yhteensa > 0
+                             THEN LEAST(100, 100.0 * rivit_yhteensa / arvio_yhteensa)
+                         ELSE NULL END;
+        jaljella_s := CASE
+                          WHEN rivit_yhteensa > alku_siirretty AND arvio_yhteensa > rivit_yhteensa
+                              THEN kulunut_s * (arvio_yhteensa - rivit_yhteensa)
+                              / (rivit_yhteensa - alku_siirretty)
+                          ELSE NULL END;
+
+        RAISE NOTICE '% -> %: erä % riviä, yhteensä % / % (% %%), ID <= %, kulunut % s, arvio jäljellä % s',
+            lahdetaulu, kohdetaulu, erassa, rivit_yhteensa, arvio_yhteensa,
+            round(COALESCE(prosentti, 0), 2), edellinen_id,
+            round(kulunut_s), round(COALESCE(jaljella_s, 0));
+    END LOOP;
+
+    UPDATE toteuma_hk_siirto_tila t
+    SET valmis   = TRUE,
+        muokattu = CURRENT_TIMESTAMP
+    WHERE t.lahde_taulu = lahdetaulu;
+    COMMIT;
+
+    RAISE NOTICE 'Kopiointi % -> % valmis, yhteensä % riviä, kesto % s',
+        lahdetaulu, kohdetaulu, rivit_yhteensa,
+        round(EXTRACT(EPOCH FROM clock_timestamp() - aloitus_aika));
+END;
+$$;
+
+
+CREATE OR REPLACE PROCEDURE kopioi_toteuma_hk_data(eran_koko INTEGER DEFAULT 500000)
+    LANGUAGE plpgsql AS
+$$
+BEGIN
+    CALL kopioi_toteuma_hk_taulu('toteuma_tehtava', eran_koko);
+    CALL kopioi_toteuma_hk_taulu('toteuma_materiaali', eran_koko);
+    -- Jos tätä laajennetaan uusille tauluille, niin tänne myös se uusi taulu muistaa lisätä
+END;
+$$;
+
+
+-- Indeksit, foreignkeyt ja tilastot luodaan vasta kopioinnin jälkeen: se on selvästi
+-- nopeampaa kuin ylläpitää niitä jokaisen erän ajan.
+CREATE OR REPLACE PROCEDURE viimeistele_toteuma_hk_taulut()
+    LANGUAGE plpgsql AS
+$$
+DECLARE
+    kesken TEXT;
+BEGIN
+    SELECT string_agg(lahde_taulu, ', ')
+    INTO kesken
+    FROM toteuma_hk_siirto_tila
+    WHERE NOT valmis;
+
+    IF kesken IS NOT NULL THEN
+        RAISE EXCEPTION 'Kopiointi on kesken tauluille: %. Aja ensin CALL kopioi_toteuma_hk_data()',
+            kesken;
+    END IF;
+
+    -- Partitiointiavaimen on oltava mukana perusavaimessa.
+    IF NOT EXISTS (SELECT 1
+                   FROM pg_constraint
+                   WHERE conrelid = 'public.toteuma_tehtava_hk'::REGCLASS
+                     AND contype = 'p') THEN
+        ALTER TABLE public.toteuma_tehtava_hk
+            ADD CONSTRAINT toteuma_tehtava_hk_pkey PRIMARY KEY (id, hoitokauden_alkuvuosi);
+    END IF;
+    IF NOT EXISTS (SELECT 1
+                   FROM pg_constraint
+                   WHERE conrelid = 'public.toteuma_materiaali_hk'::REGCLASS
+                     AND contype = 'p') THEN
+        ALTER TABLE public.toteuma_materiaali_hk
+            ADD CONSTRAINT toteuma_materiaali_hk_pkey PRIMARY KEY (id, hoitokauden_alkuvuosi);
+    END IF;
+    RAISE NOTICE 'Perusavaimet luotu';
+
+    -- Vastaavat indeksit kuin alkuperäisissä tauluissa
+    CREATE INDEX IF NOT EXISTS idx_toteuma_tehtava_hk_toteuma_tpk_poistettu
+        ON public.toteuma_tehtava_hk (toteuma, toimenpidekoodi, poistettu);
+    CREATE INDEX IF NOT EXISTS idx_toteuma_tehtava_hk_urakka_hk
+        ON public.toteuma_tehtava_hk (urakka_id, hoitokauden_alkuvuosi, toimenpidekoodi)
+        INCLUDE (maara, toteuma)
+        WHERE poistettu = FALSE;
+    CREATE INDEX IF NOT EXISTS idx_toteuma_tehtava_hk_toimenpidekoodi
+        ON public.toteuma_tehtava_hk (toimenpidekoodi);
+    CREATE INDEX IF NOT EXISTS idx_toteuma_tehtava_hk_toteuma
+        ON public.toteuma_tehtava_hk (toteuma);
+    CREATE INDEX IF NOT EXISTS idx_toteuma_tehtava_hk_urakka_poistettu
+        ON public.toteuma_tehtava_hk (urakka_id, poistettu);
+
+    CREATE INDEX IF NOT EXISTS idx_toteuma_materiaali_hk_toteuma_urakka_hk
+        ON public.toteuma_materiaali_hk (toteuma, urakka_id, hoitokauden_alkuvuosi)
+        INCLUDE (maara)
+        WHERE poistettu = FALSE;
+    CREATE INDEX IF NOT EXISTS idx_toteuma_materiaali_hk_urakka_hk
+        ON public.toteuma_materiaali_hk (materiaalikoodi, urakka_id, hoitokauden_alkuvuosi)
+        INCLUDE (maara, toteuma)
+        WHERE poistettu = FALSE;
+    CREATE INDEX IF NOT EXISTS idx_toteuma_materiaali_hk_toteuma
+        ON public.toteuma_materiaali_hk (toteuma);
+    CREATE INDEX IF NOT EXISTS idx_toteuma_materiaali_hk_urakka_poistettu
+        ON public.toteuma_materiaali_hk (urakka_id, poistettu);
+    -- Listään yksi testattu indeksi, joka parantaa vielä materiaalien hakua
+    CREATE INDEX IF NOT EXISTS idx_toteuma_materiaali_hk_urakka_hoitokausi
+        ON public.toteuma_materiaali_hk
+            (urakka_id, hoitokauden_alkuvuosi)
+        INCLUDE (toteuma, maara)
+        WHERE poistettu = FALSE;
+    ANALYZE public.toteuma_materiaali_hk;
+    RAISE NOTICE 'Indeksit luotu';
+
+    -- Viiteavaimet vain tauluihin, joihin alkuperäisissäkin tauluissa viitataan.
+    -- toteuma-sarakkeelle ei voi tehdä viiteavainta, koska toteuma on INHERITS-partitioitu.
+    IF NOT EXISTS (SELECT 1
+                   FROM pg_constraint
+                   WHERE conname = 'toteuma_tehtava_hk_luoja_fkey') THEN
+        ALTER TABLE public.toteuma_tehtava_hk
+            ADD CONSTRAINT toteuma_tehtava_hk_luoja_fkey
+                FOREIGN KEY (luoja) REFERENCES public.kayttaja (id);
+    END IF;
+    IF NOT EXISTS (SELECT 1
+                   FROM pg_constraint
+                   WHERE conname = 'toteuma_tehtava_hk_toimenpidekoodi_fkey') THEN
+        ALTER TABLE public.toteuma_tehtava_hk
+            ADD CONSTRAINT toteuma_tehtava_hk_toimenpidekoodi_fkey
+                FOREIGN KEY (toimenpidekoodi) REFERENCES public.tehtava (id);
+    END IF;
+    IF NOT EXISTS (SELECT 1
+                   FROM pg_constraint
+                   WHERE conname = 'toteuma_materiaali_hk_materiaalikoodi_fkey') THEN
+        ALTER TABLE public.toteuma_materiaali_hk
+            ADD CONSTRAINT toteuma_materiaali_hk_materiaalikoodi_fkey
+                FOREIGN KEY (materiaalikoodi) REFERENCES public.materiaalikoodi (id);
+    END IF;
+    RAISE NOTICE 'Viiteavaimet luotu';
+
+    ANALYZE public.toteuma_tehtava_hk;
+    ANALYZE public.toteuma_materiaali_hk;
+    RAISE NOTICE 'Tilastot päivitetty, vertailutaulut ovat käyttövalmiit';
+
+    -- Luodaan triggerit
+    -- Jos toteuma_tehtava muuttuu, poista laskutusyhteenvedot cachesta. koska
+    -- esim määrän muutoksella on vaikutus yksikköhintaisten töiden kustannuksiin
+    CREATE TRIGGER tg_poista_muistetut_laskutusyht_toteuma_tehtava_hk
+        AFTER INSERT OR UPDATE
+        ON toteuma_tehtava_hk
+        FOR EACH ROW
+    EXECUTE PROCEDURE poista_muistetut_laskutusyht_toteuma_tehtava();
+
+END;
+$$;
+
+
+-- Vaihdetaan hoitokausittain partitioidut toteumataulut alkuperäisille nimille.
+-- Vaihtaa nimet vasta kun kopiointi ja viimeistely ovat onnistuneet.
+-- Tämä CALL suoritetaan erillisenä, koska kopiointiproseduuri tekee COMMITit.
+CREATE OR REPLACE PROCEDURE vaihda_toteuma_hk_taulut()
+    LANGUAGE plpgsql AS
+$$
+BEGIN
+
+    -- Varmistellaan, että taulut todellakin ovat olemassa
+    IF to_regclass('public.toteuma_tehtava_hk') IS NULL
+        OR to_regclass('public.toteuma_materiaali_hk') IS NULL THEN
+        RAISE EXCEPTION 'Partitioitu kohdetaulu puuttuu ennen nimeämistä';
+    END IF;
+
+    -- Varmuuskopioidaan vanhat taulut!
+    -- Nimeämiset ovat nopeita. ACCESS EXCLUSIVE -lukot syntyvät ALTER TABLE
+    -- -lauseiden ajaksi ja estävät samanaikaiset SELECTit ja muutokset.
+    ALTER TABLE public.toteuma_tehtava
+        RENAME TO toteuma_tehtava_vanha;
+    ALTER TABLE public.toteuma_materiaali
+        RENAME TO toteuma_materiaali_vanha;
+
+    -- Otetaan uudet partitioidut taulut käyttöön.
+    ALTER TABLE public.toteuma_tehtava_hk
+        RENAME TO toteuma_tehtava;
+    ALTER TABLE public.toteuma_materiaali_hk
+        RENAME TO toteuma_materiaali;
+
+    -- Siirron tila kuvaa nimeämisen jälkeen käytössä olevia kohdetauluja.
+    UPDATE toteuma_hk_siirto_tila
+    SET kohde_taulu = CASE lahde_taulu
+                          WHEN 'toteuma_tehtava' THEN 'toteuma_tehtava'
+                          WHEN 'toteuma_materiaali' THEN 'toteuma_materiaali'
+                          ELSE kohde_taulu
+        END,
+        muokattu = CURRENT_TIMESTAMP
+    WHERE lahde_taulu IN ('toteuma_tehtava', 'toteuma_materiaali');
+
+    UPDATE toteuma_hk_siirto_tila
+    SET muokattu = CURRENT_TIMESTAMP
+    WHERE lahde_taulu IN ('toteuma_tehtava', 'toteuma_materiaali');
+
+    RAISE NOTICE 'Toteumataulut vaihdettu partitioituihin tauluihin; vanhat taulut ovat *_vanha-nimillä';
+END;
+$$;
+
+-- Koko putki kerralla.
+-- Jos ajo keskeytyy, niin riittää, että kutsuu nuo kaksi alinta uusiksi.
+-- Tuo 500 000 on hyvä oletusarvo, mutta voi olla tarpeen suurentaa, jos koneessa on vääntöä. Isompi koko voi olla nopeampi
+CREATE OR REPLACE PROCEDURE partitioi_toteumat_hoitokausittain(eran_koko INTEGER DEFAULT 500000)
+    LANGUAGE plpgsql AS
+$$
+BEGIN
+    -- Lukitaan toteuma_tehtava ja toteuma_materiaali, jotta kukaan ei voi kirjoittaa niihin kopioinnin aikana.
+    IF NOT EXISTS (SELECT 1
+                   FROM pg_trigger
+                   WHERE tgrelid = 'public.toteuma_tehtava'::REGCLASS
+                     AND tgname = 'tg_estaa_toteuma_hk_kirjoitus'
+                     AND NOT tgisinternal) THEN
+        CREATE TRIGGER tg_estaa_toteuma_hk_kirjoitus
+            BEFORE INSERT OR UPDATE OR DELETE
+            ON public.toteuma_tehtava
+            FOR EACH ROW
+        EXECUTE FUNCTION estä_kirjoitukset();
+    END IF;
+
+    IF NOT EXISTS (SELECT 1
+                   FROM pg_trigger
+                   WHERE tgrelid = 'public.toteuma_materiaali'::REGCLASS
+                     AND tgname = 'tg_estaa_toteuma_hk_kirjoitus'
+                     AND NOT tgisinternal) THEN
+        CREATE TRIGGER tg_estaa_toteuma_hk_kirjoitus
+            BEFORE INSERT OR UPDATE OR DELETE
+            ON public.toteuma_materiaali
+            FOR EACH ROW
+        EXECUTE FUNCTION estä_kirjoitukset();
+    END IF;
+
+
+    CALL luo_toteuma_hk_taulut();
+    CALL kopioi_toteuma_hk_data(eran_koko);
+    CALL viimeistele_toteuma_hk_taulut();
+    CALL vaihda_toteuma_hk_taulut();
+
+END;
+$$;
+
+-- Tätä tarvitaan vain jos prosessi keskeytyy ja ei päästä suoraan vaihtamaan uusiin partitioituihin tauluihin.
+-- Jos tätä käytetään sen jälkeen, kun lukotukset on poistettu ja dataa on jo tallennettu uusiin toteuma_tehtava ja toteuma_materiaalitauluihin,
+-- niin se data menetetään. MEille jää siis toteuma -tauluun dataa, joista ei ole toteuma_tehtava ja toteuma_materiaali -tauluissa vastaavia rivejä.
+-- Eli tätä toivottavasti ei koskaan tarvita. Eikä tarvitakaan, jos kaikki menee kuten on harjoiteltu
+CREATE OR REPLACE PROCEDURE poista_toteuma_hk_kirjoitusestot()
+    LANGUAGE plpgsql AS
+$$
+BEGIN
+    DROP TRIGGER IF EXISTS tg_estaa_toteuma_hk_kirjoitus
+        ON public.toteuma_tehtava;
+
+    DROP TRIGGER IF EXISTS tg_estaa_toteuma_hk_kirjoitus
+        ON public.toteuma_materiaali;
+
+    RAISE NOTICE 'Toteumataulujen kirjoitusestot poistettu';
+END;
+$$;
+
+
+-- Palauttaa testikannan onnistuneen tauluvaihdon jälkeisestä tilasta takaisin
+-- migraatiota edeltävään tilaan. Tämä on tarkoitettu vain tilanteeseen, jossa
+-- toteuma_tehtava_vanha ja toteuma_materiaali_vanha ovat olemassa ja nykyiset
+-- toteuma_tehtava- ja toteuma_materiaali-taulut ovat tämän migraation luomia
+-- partitioituja tauluja.
+--
+-- *_hk-nimet ovat onnistuneen vaihdon jälkeen näkymiä, joten niitä ei voi poistaa
+-- DROP TABLE -komennolla. Alkuperäisissä tauluissa olevat kirjoituseston triggerit
+-- poistetaan ennen kuin taulut nimetään takaisin alkuperäisille nimilleen.
+CREATE OR REPLACE FUNCTION palauta_toteuma_hk_taulut()
+    RETURNS VOID
+    LANGUAGE plpgsql AS
+$$
+DECLARE
+    vanha_tehtava_tyyppi      "char";
+    vanha_materiaali_tyyppi   "char";
+    nykyinen_tehtava_tyyppi  "char";
+    nykyinen_materiaali_tyyppi "char";
+    hk_tehtava_tyyppi        "char";
+    hk_materiaali_tyyppi     "char";
+BEGIN
+    IF to_regclass('public.toteuma_tehtava_vanha') IS NULL
+        OR to_regclass('public.toteuma_materiaali_vanha') IS NULL THEN
+        RAISE EXCEPTION 'Alkuperäisiä *_vanha-tauluja ei löydy; palautusta ei suoriteta';
+    END IF;
+
+    SELECT c.relkind
+    INTO vanha_tehtava_tyyppi
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'toteuma_tehtava_vanha';
+
+    SELECT c.relkind
+    INTO vanha_materiaali_tyyppi
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'toteuma_materiaali_vanha';
+
+    IF vanha_tehtava_tyyppi IS DISTINCT FROM 'r'
+        OR vanha_materiaali_tyyppi IS DISTINCT FROM 'r' THEN
+        RAISE EXCEPTION 'Alkuperäiset *_vanha-objektit eivät ole tavallisia tauluja';
+    END IF;
+
+    SELECT c.relkind
+    INTO nykyinen_tehtava_tyyppi
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'toteuma_tehtava';
+
+    SELECT c.relkind
+    INTO nykyinen_materiaali_tyyppi
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'toteuma_materiaali';
+
+    IF nykyinen_tehtava_tyyppi IS DISTINCT FROM 'p'
+        OR nykyinen_materiaali_tyyppi IS DISTINCT FROM 'p' THEN
+        RAISE EXCEPTION 'Nykyiset toteumataulut eivät ole tämän migraation luomia partitioituja tauluja';
+    END IF;
+
+    SELECT c.relkind
+    INTO hk_tehtava_tyyppi
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'toteuma_tehtava_hk';
+
+    SELECT c.relkind
+    INTO hk_materiaali_tyyppi
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'toteuma_materiaali_hk';
+
+    IF hk_tehtava_tyyppi IS NOT NULL AND hk_tehtava_tyyppi <> 'v' THEN
+        RAISE EXCEPTION 'toteuma_tehtava_hk ei ole näkymä; palautusta ei suoriteta';
+    END IF;
+    IF hk_materiaali_tyyppi IS NOT NULL AND hk_materiaali_tyyppi <> 'v' THEN
+        RAISE EXCEPTION 'toteuma_materiaali_hk ei ole näkymä; palautusta ei suoriteta';
+    END IF;
+
+    DROP TRIGGER IF EXISTS tg_estaa_toteuma_hk_kirjoitus
+        ON public.toteuma_tehtava_vanha;
+    DROP TRIGGER IF EXISTS tg_estaa_toteuma_hk_kirjoitus
+        ON public.toteuma_materiaali_vanha;
+
+    DROP VIEW IF EXISTS public.toteuma_tehtava_hk CASCADE;
+    DROP VIEW IF EXISTS public.toteuma_materiaali_hk CASCADE;
+
+    -- Partitioitu päätaulu ja siihen kuuluvat partitiot, indeksit sekä
+    -- migraatiossa lisätyt avaimet poistetaan yhtenä kokonaisuutena.
+    DROP TABLE public.toteuma_tehtava CASCADE;
+    DROP TABLE public.toteuma_materiaali CASCADE;
+
+    -- Palautetaan *_vanha taulut, joita käytettiin varmuuskopiona, alkuperäisiksi, ja taas homma pelaa.
+    ALTER TABLE public.toteuma_tehtava_vanha
+        RENAME TO toteuma_tehtava;
+    ALTER TABLE public.toteuma_materiaali_vanha
+        RENAME TO toteuma_materiaali;
+
+    DROP TABLE IF EXISTS public.toteuma_hk_siirto_tila CASCADE;
+
+    RAISE NOTICE 'Toteumataulut palautettu migraatiota edeltävään tilaan';
+END;
+$$;
+
+
+-- Tilanteen tarkastelu:
+--   SELECT * FROM toteuma_hk_siirto_tila;
+--   SELECT relname, n_live_tup
+--     FROM pg_stat_user_tables
+--    WHERE relname LIKE 'toteuma%\_hk\_%'
+--    ORDER BY relname;
+--
+-- Ajo (jokainen omana lauseenaan, ei transaktiolohkon sisällä):
+--   CALL partitioi_toteumat_hoitokausittain();
+-- Jos ajo keskeytyy ja on tarpeen aloittaa se kokonan alusta, niin poista kirjoitusestot.
+-- Tätä ei tarvita, jos kaikki menee hienosti. Ne taulut, jotka on lukittu on nimetty uudelleen ja niitä ei enää käytetä.
+-- Mutta jos homma menee pieleen ja partitioituja tauluja ei saadakaan käyttöön, niin on tärkeää avata lukot ja päästää liikenne taas läpi.
+--   CALL poista_toteuma_hk_kirjoitusestot();
+
+
+-- Testikannan palautus onnistuneen vaihdon jälkeen:
+--
+--   SELECT palauta_toteuma_hk_taulut();
+--
+-- Funktio tekee seuraavat toimet:
+--   1. Poistaa *_hk-näkymät.
+--   2. Poistaa uudet partitioidut toteuma_tehtava- ja toteuma_materiaali-taulut
+--      sekä niiden partitiot, indeksit ja avaimet CASCADE-optiolla.
+--   3. Poistaa vanhoista tauluista migraation kirjoituseston triggerit.
+--   4. Nimeää toteuma_tehtava_vanha- ja toteuma_materiaali_vanha-taulut takaisin
+--      nimille toteuma_tehtava ja toteuma_materiaali.
+--   5. Poistaa migraation siirron tilataulun.
+--
+-- Funktio keskeyttää palautuksen, jos *_vanha-tauluja ei löydy, nykyiset
+-- toteumataulut eivät ole partitioituja tauluja tai *_hk-objektit eivät ole
+-- näkymiä. Älä aja tätä tuotantokannassa.
+--
+-- Palautuksen jälkeen tilan voi tarkistaa esimerkiksi näin: (palauttaa tyhjää, jos palautus onnistui)
+--   SELECT to_regclass('public.toteuma_tehtava_vanha'),
+--          to_regclass('public.toteuma_materiaali_vanha'),
+--          to_regclass('public.toteuma_tehtava_hk'),
+--          to_regclass('public.toteuma_materiaali_hk'),
+--          to_regclass('public.toteuma_hk_siirto_tila');
+--
+-- Jos *_hk-tauluja pitää poistaa erikseen ennen onnistunutta tauluvaihtoa,
+-- tarkista sen tyyppi ensin. DROP TABLE ei poista näkymää eikä DROP VIEW poista
+-- taulua, vaikka komennossa käytettäisiin IF EXISTS -optiota.
+--   SELECT c.relname, c.relkind
+--     FROM pg_class c
+--     JOIN pg_namespace n ON n.oid = c.relnamespace
+--    WHERE n.nspname = 'public'
+--      AND c.relname IN ('toteuma_tehtava_hk', 'toteuma_materiaali_hk');
+
+


### PR DESCRIPTION
## Mitä muutettiin
toteuma_tehtava ja toteuma_materiaali taulut partitioidaan tämän avulla.
Mitään ei toki ajeta itsestään. Partitiointi pitää käynnistää käsin.

Toteumahakuihin tehtiin muutoksia, jotta hoitokauden_alkuvuosi partitiointia hyödynnettäisiin tehokkaammin.

## Miksi
Käyttäjät ovat olleet ongelmissa liian hitaiden toteumahakujen kanssa.

## Testaustapa
Ota käyttöön klooni, johon ajat nämä muutokset. Vertaile hakuja tuotantoa vastaan.
Testaa, että kaikki toteumiin liittyvät asiat toimii edelleen: APIt, käyttöliittymät yms.

## Huomioita
Tämän ajaminen tuotannossa vie tod näk n. 15min. Sen aikaa toteuma_tehtava ja toteuma_materiaali taulut ovat lukossa.
Tilanteen voi palauttaa takaisin, jos prosessissa syntyy ongelmia. Siihenkin on funkkarit valmiina.
