### PR TITLE
HARJA-2524 Välikatselmus päätöksen peruminen ketjutetusti

### DIFF
--- a/src/clj/harja/palvelin/integraatiot/api/analytiikka.clj
+++ b/src/clj/harja/palvelin/integraatiot/api/analytiikka.clj
@@ -1,48 +1,51 @@
 (ns harja.palvelin.integraatiot.api.analytiikka
   "Analytiikkaportaalille endpointit"
-  (:require [harja.fmt :as fmt]
-            [taoensso.timbre :as log]
-            [clojure.set :as set]
+  (:require [clojure.set :as set]
             [clojure.string :as str]
+            [taoensso.timbre :as log]
             [clojure.spec.alpha :as s]
             [compojure.core :refer :all]
             [compojure.route :refer :all]
-            [compojure.core :refer [GET]]
             [com.stuartsierra.component :as component]
 
+            [harja.fmt :as fmt]
             [harja.pvm :as pvm]
             [harja.domain.kulut :as kulut-domain]
-            [harja.kyselyt.konversio :as konversio]
-            [harja.kyselyt.konversio-optimoitu :as konv-opt]
-            [harja.kyselyt.toteumat :as toteuma-kyselyt]
-            [harja.kyselyt.materiaalit :as materiaalit-kyselyt]
             [harja.domain.tierekisteri :as tr-domain]
             [harja.domain.paallystysilmoitus :as paallystysilmoitus]
             [harja.domain.paallystys-ja-paikkaus :as paallystys-ja-paikkaus]
-            [harja.palvelin.palvelut.yllapitokohteet.yleiset :as yllapitokohteet-yleiset]
-            [harja.kyselyt.urakat :as urakat-kyselyt]
+
             [harja.kyselyt.kulut :as kulu-kyselyt]
+            [harja.kyselyt.konversio :as konversio]
+            [harja.kyselyt.urakat :as urakat-kyselyt]
             [harja.kyselyt.sanktiot :as sanktio-kyselyt]
+            [harja.kyselyt.toteumat :as toteuma-kyselyt]
             [harja.kyselyt.paikkaus :as paikkaus-kyselyt]
+            [harja.kyselyt.konversio-optimoitu :as konv-opt]
+            [harja.kyselyt.materiaalit :as materiaalit-kyselyt]
             [harja.kyselyt.valikatselmus :as valitavoite-kyselyt]
             [harja.kyselyt.rahavaraukset :as rahavaravaus-kyselyt]
             [harja.kyselyt.organisaatiot :as organisaatiot-kyselyt]
             [harja.kyselyt.tehtavamaarat :as tehtavamaarat-kyselyt]
-            [harja.kyselyt.erilliskustannus-kyselyt :as bonus-kyselyt]
             [harja.kyselyt.paallystys-kyselyt :as paallystys-kyselyt]
+            [harja.kyselyt.erilliskustannus-kyselyt :as bonus-kyselyt]
             [harja.kyselyt.toimenpidekoodit :as toimenpidekoodi-kyselyt]
             [harja.kyselyt.suolarajoitus-kyselyt :as suolarajoitus-kyselyt]
             [harja.kyselyt.turvallisuuspoikkeamat :as turvallisuuspoikkeamat]
             [harja.kyselyt.budjettisuunnittelu :as budjettisuunnittelu-kyselyt]
+
+            [harja.palvelin.palvelut.valikatselmus.apurit :as v-apurit]
             [harja.palvelin.integraatiot.api.tyokalut.virheet :as virheet]
-            [harja.palvelin.integraatiot.api.validointi.parametrit :as parametrivalidointi]
             [harja.palvelin.integraatiot.api.tyokalut.parametrit :as parametrit]
             [harja.palvelin.integraatiot.api.tyokalut.json-skeemat :as json-skeemat]
             [harja.palvelin.palvelut.valikatselmus.paatosnakyvyyskone :as paatoskone]
+            [harja.palvelin.palvelut.yllapitokohteet.yleiset :as yllapitokohteet-yleiset]
+            [harja.palvelin.integraatiot.api.validointi.parametrit :as parametrivalidointi]
             [harja.palvelin.palvelut.valikatselmus.valikatselmukset :as valikatselmus-palvelu]
             [harja.palvelin.komponentit.http-palvelin :refer [julkaise-reitti poista-palvelut]]
             [harja.palvelin.integraatiot.api.sanomat.analytiikka-sanomat :as analytiikka-sanomat]
             [harja.palvelin.integraatiot.api.tyokalut.kutsukasittely :refer [kasittele-kevyesti-get-kutsu kasittele-get-kutsu]])
+
   (:import (java.text SimpleDateFormat))
   (:use [slingshot.slingshot :only [throw+]]))
 
@@ -982,7 +985,7 @@
         urakan-alkuvuosi (-> urakan-tiedot :alkupvm pvm/vuosi)
         urakan-loppuvuosi (dec (-> urakan-tiedot :loppupvm pvm/vuosi)) ;; Viimeisen hoitovuoden alkuvuosi käytännössä
         mhu+urakka? (= "mhu+" (:sopimustyyppi urakan-tiedot))
-        mhu-tyyppi (paatoskone/urakan-hoitotyyppi mhu+urakka?)
+        mhu-tyyppi (v-apurit/urakan-hoitotyyppi mhu+urakka?)
         kulut (kulu-kyselyt/hae-toteutuneet-kustannukset-analytiikalle db {:urakka-id urakka-id})
         sanktiot (sanktio-kyselyt/hae-urakan-sanktiot-analytiikalle db urakka-id)
         bonukset (bonus-kyselyt/hae-urakan-bonukset-analytiikalle db urakka-id)

--- a/src/clj/harja/palvelin/palvelut/urakkatilanne/kojelauta.clj
+++ b/src/clj/harja/palvelin/palvelut/urakkatilanne/kojelauta.clj
@@ -63,7 +63,7 @@
                  (mapv
                    (fn [urakka]
                      (let [paatokset
-                           (v/palauta-kaikki-mahdolliset-ja-tehdyt-paatokset-kojelautaan
+                           (v/palauta-kaikki-mahdolliset-ja-tehdyt-paatokset
                              db kayttaja
                              {:urakkaid (:id urakka)
                               :kuluva-hoitovuosi hoitokauden-alkuvuosi})]

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/apurit.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/apurit.clj
@@ -1,0 +1,103 @@
+(ns harja.palvelin.palvelut.valikatselmus.apurit
+  (:require [clojure.string :as str]
+
+            [harja.pvm :as pvm]
+            [harja.kokoelmat :refer [distinct-by]]
+            [harja.tyokalut.yleiset :refer [round2]]
+            [harja.kyselyt.urakat :as urakka-kyselyt]
+            [harja.domain.lupaus-domain :as lupaus-domain]
+            [harja.kyselyt.lupaus-kyselyt :as lupaus-kyselyt]
+            [harja.palvelin.palvelut.valikatselmus.paatostyypit :refer [paatostyypit]]))
+
+
+(defn urakan-hoitotyyppi
+  "Erittäin vaativat hoitourakat merkitään päätöstauluun hoitotyyppinä MHU+"
+  [erittain_vaativa_hoitourakka]
+  (if erittain_vaativa_hoitourakka "MHU+" "MHU"))
+
+
+(defn mahdolliset-paatokset-tyypilla [mhu-tyyppi paatokset]
+  (filter #(contains? (:hoitotyyppi %) mhu-tyyppi) paatokset))
+
+
+(defn mahdolliset-paatokset-urakan-alkuvuodella [urakan-alkuvuosi paatokset]
+  (filter (fn [paatos]
+            (<= (:urakan_alkuvuosi paatos) urakan-alkuvuosi))
+    paatokset))
+
+
+(defn mahdolliset-paatokset-nakyvyys-asti [urakan-alkuvuosi paatokset]
+  (filter #(or (nil? (:nakyvyys_asti %))
+             (and (:nakyvyys_asti %) (>= (:nakyvyys_asti %) urakan-alkuvuosi))) paatokset))
+
+
+(defn mahdolliset-paatokset-nakyvyys-vuodella [kuluva-vuosi paatokset]
+  (filter #(<= (:nakyvyys_alkaen %) kuluva-vuosi) paatokset))
+
+
+(defn vain-yksi-paatos-per-tyyppi [paatokset]
+  (let [uniikit-tyypit (map (fn [paatos]
+                              (assoc paatos :uniikki-tyyppi (str (:tyyppi paatos) (:nimi paatos)))) paatokset)
+        uniikit (distinct-by :uniikki-tyyppi uniikit-tyypit)
+        paatokset (map (fn [paatos]
+                         (dissoc paatos :uniikki-tyyppi)) uniikit)]
+    paatokset))
+
+
+(defn kaikki-mahdolliset-paatokset [mhu-tyyppi urakan-alkuvuosi _urakan-loppuvuosi kuluva-hoitovuosi]
+  (let [mahdollset-tyypilla (mahdolliset-paatokset-tyypilla mhu-tyyppi paatostyypit)
+        mahdolliset-aloitusvuodella (mahdolliset-paatokset-urakan-alkuvuodella urakan-alkuvuosi mahdollset-tyypilla)
+        mahdolliset-nakyvyys-asti (mahdolliset-paatokset-nakyvyys-asti urakan-alkuvuosi mahdolliset-aloitusvuodella)
+        mahdolliset-kuluvalle-vuodelle (mahdolliset-paatokset-nakyvyys-vuodella kuluva-hoitovuosi mahdolliset-nakyvyys-asti)
+        paatokset (vain-yksi-paatos-per-tyyppi mahdolliset-kuluvalle-vuodelle)]
+    paatokset))
+
+
+(defn lisaa-paatos-virheellisena
+  "Jos päätös on mukana päätöslistassa, mutta sille ei ole antaa tarkentavia tietoja, niin lisätään siihen virhe.
+  Mikäli päätöstä ei löydy listasta, niin älä lisää mitään."
+  [paatokset nimi virhe lisataan? jarjestys & args]
+  (let [virhepaatos (merge (first args) ;; Ensimmäinen parametri on päätös
+                      {:nimi nimi :virhe virhe :jarjestys jarjestys})]
+    (keep identity
+      (sort-by :jarjestys
+        (if (some #(= (:nimi %) nimi) paatokset)
+          (conj
+            (filter #(not= (:nimi %) nimi) paatokset)
+            ;; Jos ehdot eivät täyttyneet, niin päätöstä ei voida lisätä edes virheellisenä
+            (when lisataan?
+              virhepaatos))
+          paatokset)))))
+
+
+(defn laske-indeksikorotus-lupaukselle [db urakkaid paatos-pvm indeksi summa sanktio?]
+  (let [indeksikorotus-parametrit {:pvm paatos-pvm
+                                   :indeksi indeksi
+                                   :maara summa
+                                   :urakka-id urakkaid
+                                   :sanktiolaji (if sanktio? "lupaussanktio" nil)}
+        ;; Taustalla ajetaan tämmönen: SELECT korotus FROM sanktion_indeksikorotus(:pvm::DATE, :indeksi,:maara::NUMERIC, :urakka-id::INTEGER, :sanktiolaji::sanktiolaji);
+        indeksikorotus (:korotus (first (lupaus-kyselyt/hae-indeksikorotus-summalle db indeksikorotus-parametrit)))]
+    indeksikorotus))
+
+
+(defn hoitovuosi-paattynyt?
+  "Tarkista, onko saatu aika myöhemmin kuin 30.9."
+  [valittu-hoitovuosi]
+  (let [nyt (pvm/nyt)
+        nykyvuosi (pvm/vuosi nyt)
+        kuukausi (pvm/kuukausi nyt)
+        ;; valittu-hoitovuosi on aina hoitokauden alkuvuosi, mutta hoitokausi päättyy vasta seuraavan vuoden syyskuussa, joten korotetaan yhdellä
+        valittu-hoitovuosi (inc valittu-hoitovuosi)]
+    (cond
+      (> nykyvuosi valittu-hoitovuosi) true
+      (and (= nykyvuosi valittu-hoitovuosi) (>= kuukausi 10)) true
+      :else false)))
+
+
+(defn paatos-tallennettu-tietokantaan? [tietokanta-paatokset nimi]
+  (:id (first (filter #(when (= (:nimi %) nimi) %) tietokanta-paatokset))))
+
+
+(defn paatos-mahdollinen? [mahdolliset-paatokset nimi]
+  (boolean (seq (filter #(when (= (:nimi %) nimi) %) mahdolliset-paatokset))))

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/apurit.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/apurit.clj
@@ -1,11 +1,6 @@
 (ns harja.palvelin.palvelut.valikatselmus.apurit
-  (:require [clojure.string :as str]
-
-            [harja.pvm :as pvm]
+  (:require [harja.pvm :as pvm]
             [harja.kokoelmat :refer [distinct-by]]
-            [harja.tyokalut.yleiset :refer [round2]]
-            [harja.kyselyt.urakat :as urakka-kyselyt]
-            [harja.domain.lupaus-domain :as lupaus-domain]
             [harja.kyselyt.lupaus-kyselyt :as lupaus-kyselyt]
             [harja.palvelin.palvelut.valikatselmus.paatostyypit :refer [paatostyypit]]))
 

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/apurit.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/apurit.clj
@@ -101,3 +101,26 @@
 
 (defn paatos-mahdollinen? [mahdolliset-paatokset nimi]
   (boolean (seq (filter #(when (= (:nimi %) nimi) %) mahdolliset-paatokset))))
+
+
+(defn hae-ketjutetusti-kumoutuvat-paatokset
+  [paatokset peruttu-avain]
+  (loop [kasiteltavat [peruttu-avain]
+         loydetyt #{}
+         tulos []]
+    (if-let [avain (first kasiteltavat)]
+      (let [riippuvaiset (->> paatokset
+                           (filter
+                             (fn [paatos]
+                               (some #(= avain (:avain %))
+                                 (:riippuu paatos))))
+                           (remove #(contains? loydetyt (:avain %))))
+
+            riippuvaiset-avaimet (mapv :avain riippuvaiset)]
+
+        (recur
+          (into (vec (rest kasiteltavat)) riippuvaiset-avaimet)
+          (into loydetyt riippuvaiset-avaimet)
+          (into tulos riippuvaiset)))
+
+      tulos)))

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/paatosnakyvyyskone.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/paatosnakyvyyskone.clj
@@ -100,6 +100,7 @@
         paatokset (sort-by :jarjestys (conj paatokset lupauspaatos))]
     paatokset))
 
+
 (defn valmistele-tavoitehinnan-muutospaatos [validoinnit-kaytossa? paatokset oikaistu-tavoitehinta kattohinta
                                              muokkaa-kattohinta? kuluva-hoitovuosi]
   ;; Edeltävät vaatimukset päätöksen tallentamiselle:
@@ -165,6 +166,7 @@
           paatokset (remove (fn [paatos] (= (:nimi paatos) "Tavoitehinnan pysyvät muutokset")) paatokset)
           paatokset (sort-by :jarjestys (conj paatokset tavoitehinnan-pysyva-muutospaatos))]
       paatokset)))
+
 
 (defn valmistele-indeksikorjauspaatos [validoinnit-kaytossa? paatokset oikaistu-tavoitehinta tavoitehinnan-muutokset
                                        taman-vuoden-muutokset-summa hoitokauden-indeksikuukaudet alkuperainen-pisteluku hoitokauden-alkuvuosi
@@ -245,6 +247,7 @@
       :else
       (apurit/lisaa-paatos-virheellisena paatokset "Hoitovuoden lopun indeksikorjaus" "Tavoitehintaa, tavoitehinnan muutoksia tai hoitokauden indeksikuukausia ei ole määritelty." true 3))))
 
+
 (defn valmistele-tavoitehinnan-alituspaatos [db validoinnit-kaytossa? urakkaid paatokset urakan-alkuvuosi urakan-loppuvuosi kuluva-hoitovuosi
                                              hoitokauden-alun-tavoitehinta hoitokauden-lopun-indeksikorjattu-tavoitehinta kustannukset
                                              tietokanta-paatokset tavoitehinta-vahvistettu?]
@@ -308,6 +311,7 @@
           paatokset (sort-by :jarjestys (conj paatokset tavoitehinnan-alituspaatos))]
       paatokset)))
 
+
 (defn valmistele-tavoitehinnan-ylityspaatos [_db validoinnit-kaytossa? urakkaid paatokset urakan-alkuvuosi
                                              urakan-loppuvuosi kuluva-hoitovuosi hoitovuoden-lopun-tavoitehinta
                                              hoitovuoden-lopun-kattohinta kustannukset tietokanta-paatokset
@@ -360,6 +364,7 @@
                     (sort-by :jarjestys (conj paatokset tavoitehinnan-ylityspaatos))
                     paatokset)]
     paatokset))
+
 
 (defn valmistele-kattohinnan-paatokset [db validoinnit-kaytossa? urakkaid paatokset hoitovuoden-lopun-kattohinta kustannukset
                                         kuluva-hoitovuosi urakan-alkuvuosi urakan-loppuvuosi tietokanta-paatokset tavoitehinta-vahvistettu?]
@@ -428,6 +433,7 @@
       :else
       (apurit/lisaa-paatos-virheellisena paatokset "Kattohinnan ylitys" "Kattohintaa tai toteutuneita kustannuksia ei ole määritelty." false 7))))
 
+
 ;; Hoitovuoden lopun tavoite- ja kattohinta
 (defn valmistele-hv-lopun-tavoite-ja-kattohinta [validoinnit-kaytossa? urakan-alkuvuosi valittu-hoitovuosi paatokset tavoitehinta-indeksikorjattu
                                                  tavoitehinnan-muutokset taman-vuoden-muutokset-summa hoitokauden-lopun-indeksikorjaus
@@ -482,6 +488,7 @@
           paatokset (remove (fn [paatos] (= (:nimi paatos) "Hoitovuoden lopun tavoite- ja kattohinta")) paatokset)
           paatokset (sort-by :jarjestys (conj paatokset hintapaatos))]
       paatokset)))
+
 
 (defn valmistele-hoidonjohtopalkkionmuutospaatos [validoinnit-kaytossa? valittu-hoitovuosi paatokset hv-lopun-tavoitehinta-ilman-indeksia
                                                   tarjouksen-tavoitehinta hoidonjohtopalkkio tietokanta-paatokset urakan-alkuvuosi]
@@ -544,6 +551,7 @@
           paatokset (sort-by :jarjestys (conj paatokset paatos))]
       paatokset)))
 
+
 (defn valmistele-raporttipaatos [validoinnit-kaytossa? valittu-hoitovuosi paatokset]
   (if (first (filter #(= (:nimi %) "Välikatselmuspöytäkirjaan liitettävät raportit") paatokset))
     ;; Mikäli raporttipäätös on olemassa
@@ -562,6 +570,7 @@
                              (str/replace #"ä" "a")
                              (str/replace #" " "-")
                              (str/replace #"--" "-")))))
+
 
 (defn filtteroi-mahdolliset-paatokset
   "Poistetaan mahdollisista päätöksistä kaikki päätökset, jotka kuuluvat jo olemassa olevaan luokkaan.

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/paatosnakyvyyskone.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/paatosnakyvyyskone.clj
@@ -1,137 +1,12 @@
 (ns harja.palvelin.palvelut.valikatselmus.paatosnakyvyyskone
   (:require [clojure.string :as str]
+
             [harja.pvm :as pvm]
             [harja.tyokalut.yleiset :refer [round2]]
             [harja.kyselyt.urakat :as urakka-kyselyt]
-            [harja.kyselyt.lupaus-kyselyt :as lupaus-kyselyt]
-            [harja.domain.lupaus-domain :as lupaus-domain]))
+            [harja.domain.lupaus-domain :as lupaus-domain]
+            [harja.palvelin.palvelut.valikatselmus.apurit :as apurit]))
 
-(def paatostyypit
-  [{:nimi "Tavoitehinnan muutokset" :urakan_alkuvuosi 2019 :nakyvyys_alkaen 2019 :nakyvyys_asti 2024 :hoitotyyppi #{"MHU"} :jarjestys 2 :paatostyyppi "tavoitehinnan-muutokset"}
-   {:nimi "Tavoitehinnan muutokset" :urakan_alkuvuosi 2021 :nakyvyys_alkaen 2021 :nakyvyys_asti 2028 :hoitotyyppi #{"MHU"} :jarjestys 2 :paatostyyppi "tavoitehinnan-muutokset"}
-   {:nimi "Tavoitehinnan muutokset" :urakan_alkuvuosi 2024 :nakyvyys_alkaen 2024 :nakyvyys_asti 2024 :hoitotyyppi #{"MHU+"} :jarjestys 2 :paatostyyppi "tavoitehinnan-muutokset"}
-   {:nimi "Tavoitehinnan pysyvät muutokset" :urakan_alkuvuosi 2025 :nakyvyys_alkaen 2025 :hoitotyyppi #{"MHU" "MHU+"} :jarjestys 2 :paatostyyppi "tavoitehinnan-pysyvat-muutokset"}
-   {:nimi "Hoitovuoden lopun indeksikorjaus" :tyyppi nil :urakan_alkuvuosi 2024 :nakyvyys_alkaen 2024 :hoitotyyppi #{"MHU" "MHU+"} :jarjestys 3 :paatostyyppi "indeksikorjaus"}
-   {:nimi "Hoitovuoden lopun tavoite- ja kattohinta" :tyyppi "A" :urakan_alkuvuosi 2021 :nakyvyys_alkaen 2024 :nakyvyys_asti 2024 :hoitotyyppi #{"MHU"} :jarjestys 4 :paatostyyppi "hoitovuoden-lopun-hinta"}
-   {:nimi "Hoitovuoden lopun tavoite- ja kattohinta" :tyyppi "B" :urakan_alkuvuosi 2024 :nakyvyys_alkaen 2024 :nakyvyys_asti 2024 :hoitotyyppi #{"MHU"} :jarjestys 4 :paatostyyppi "hoitovuoden-lopun-hinta"}
-   {:nimi "Hoitovuoden lopun tavoite- ja kattohinta" :tyyppi "B" :urakan_alkuvuosi 2024 :nakyvyys_alkaen 2024 :hoitotyyppi #{"MHU+"} :jarjestys 4 :paatostyyppi "hoitovuoden-lopun-hinta-v2"}
-   {:nimi "Hoitovuoden lopun tavoite- ja kattohinta" :tyyppi "C" :urakan_alkuvuosi 2025 :nakyvyys_alkaen 2025 :hoitotyyppi #{"MHU"} :jarjestys 4 :paatostyyppi "hoitovuoden-lopun-hinta-v2"}
-   {:nimi "Tavoitehinnan alitus" :urakan_alkuvuosi 2019 :nakyvyys_alkaen 2019 :hoitotyyppi #{"MHU"} :jarjestys 5 :paatostyyppi "tavoitehinta"}
-   {:nimi "Tavoitehinnan alitus" :urakan_alkuvuosi 2024 :nakyvyys_alkaen 2024 :hoitotyyppi #{"MHU+"} :jarjestys 5 :paatostyyppi "tavoitehinta"}
-   {:nimi "Tavoitehinnan ylitys" :tyyppi "A" :urakan_alkuvuosi 2019 :nakyvyys_alkaen 2019 :hoitotyyppi #{"MHU"} :jarjestys 6 :paatostyyppi "tavoitehinta"}
-   {:nimi "Tavoitehinnan ylitys" :tyyppi "B" :urakan_alkuvuosi 2024 :nakyvyys_alkaen 2019 :hoitotyyppi #{"MHU" "MHU+"} :jarjestys 6 :paatostyyppi "tavoitehinta"}
-   {:nimi "Kattohinnan ylitys" :urakan_alkuvuosi 2019 :nakyvyys_alkaen 2019 :hoitotyyppi #{"MHU"} :jarjestys 7 :paatostyyppi "kattohinta"}
-   {:nimi "Kattohinnan ylitys" :urakan_alkuvuosi 2024 :nakyvyys_alkaen 2024 :hoitotyyppi #{"MHU+"} :jarjestys 7 :paatostyyppi "kattohinta"}
-   {:nimi "Lupaukset" :tyyppi "bonus" :urakan_alkuvuosi 2019 :nakyvyys_alkaen 2019 :hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :paatostyyppi "lupaus"}
-   {:nimi "Lupaukset" :tyyppi "sanktio" :urakan_alkuvuosi 2019 :nakyvyys_alkaen 2019 :hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :paatostyyppi "lupaus"}
-   {:nimi "Lupaukset" :tyyppi "taytetty" :urakan_alkuvuosi 2019 :nakyvyys_alkaen 2019 :hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :paatostyyppi "lupaus"}
-   {:nimi "Hoidonjohtopalkkion muutos" :urakan_alkuvuosi 2021 :nakyvyys_alkaen 2024 :hoitotyyppi #{"MHU"} :jarjestys 9 :paatostyyppi "hoidonjohtopalkkio"}
-   {:nimi "Hoidonjohtopalkkion muutos" :urakan_alkuvuosi 2024 :nakyvyys_alkaen 2024 :hoitotyyppi #{"MHU" "MHU+"} :jarjestys 9 :paatostyyppi "hoidonjohtopalkkio"}
-   {:nimi "Välikatselmuspöytäkirjaan liitettävät raportit" :urakan_alkuvuosi 2020 :nakyvyys_alkaen 2024 :hoitotyyppi #{"MHU"} :jarjestys 10 :paatostyyppi "raportti"}
-   {:nimi "Välikatselmuspöytäkirjaan liitettävät raportit" :urakan_alkuvuosi 2024 :nakyvyys_alkaen 2024 :hoitotyyppi #{"MHU" "MHU+"} :jarjestys 10 :paatostyyppi "raportti"}])
-
-(defn distinct-by [vektori avain]
-  (:result (reduce
-             (fn [{:keys [seen result]} m]
-               (let [arvo (get-in m [avain])]
-                 (if (contains? seen arvo)
-                   {:seen seen :result result}
-                   {:seen (conj seen arvo) :result (conj result m)})))
-             {:seen #{}, :result []}
-             vektori)))
-
-(defn urakan-hoitotyyppi
-  "Erittäin vaativat hoitourakat merkitään päätöstauluun hoitotyyppinä MHU+"
-  [erittain_vaativa_hoitourakka]
-  (if erittain_vaativa_hoitourakka "MHU+" "MHU"))
-
-(defn mahdolliset-paatokset-tyypilla [mhu-tyyppi paatokset]
-  (filter #(contains? (:hoitotyyppi %) mhu-tyyppi) paatokset))
-
-(defn mahdolliset-paatokset-urakan-alkuvuodella [urakan-alkuvuosi paatokset]
-  (filter (fn [paatos]
-            (<= (:urakan_alkuvuosi paatos) urakan-alkuvuosi))
-    paatokset))
-
-(defn mahdolliset-paatokset-nakyvyys-asti [urakan-alkuvuosi paatokset]
-  (filter #(or (nil? (:nakyvyys_asti %))
-             (and (:nakyvyys_asti %) (>= (:nakyvyys_asti %) urakan-alkuvuosi))) paatokset))
-
-(defn mahdolliset-paatokset-nakyvyys-vuodella [kuluva-vuosi paatokset]
-  (filter #(<= (:nakyvyys_alkaen %) kuluva-vuosi) paatokset))
-
-(defn vain-yksi-paatos-per-tyyppi [paatokset]
-  (let [uniikit-tyypit (map (fn [paatos]
-                              (assoc paatos :uniikki-tyyppi (str (:tyyppi paatos) (:nimi paatos)))) paatokset)
-        uniikit (distinct-by uniikit-tyypit :uniikki-tyyppi)
-        paatokset (map (fn [paatos]
-                         (dissoc paatos :uniikki-tyyppi)) uniikit)]
-    paatokset))
-
-(defn kaikki-mahdolliset-paatokset [mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi kuluva-hoitovuosi]
-  (let [mahdollset-tyypilla (mahdolliset-paatokset-tyypilla mhu-tyyppi paatostyypit)
-        mahdolliset-aloitusvuodella (mahdolliset-paatokset-urakan-alkuvuodella urakan-alkuvuosi mahdollset-tyypilla)
-        mahdolliset-nakyvyys-asti (mahdolliset-paatokset-nakyvyys-asti urakan-alkuvuosi mahdolliset-aloitusvuodella)
-        mahdolliset-kuluvalle-vuodelle (mahdolliset-paatokset-nakyvyys-vuodella kuluva-hoitovuosi mahdolliset-nakyvyys-asti)
-        paatokset (vain-yksi-paatos-per-tyyppi mahdolliset-kuluvalle-vuodelle)]
-    paatokset))
-
-(defn yhdista-mapit
-  "Yhdistetään tietokannasta tulevat ja päätöskoneelta tulevat päätökset niin, että
-   käytetään päätöskoneen päätöksiä, jos niitä ei ole vielä tietokannassa ja muuten tietokannan päätöksiä.
-   Vertailussa käytetään :nimi avainta. Se täytyy löytyä molemmista mapeistä."
-  [pk-paatokset db-paatokset]
-  (let [index-map (into {} (map (fn [m] [(:nimi m) m]) db-paatokset))]
-    (map (fn [m1]
-           (if-let [m2 (index-map (:nimi m1))]
-             m2
-             m1))
-      pk-paatokset)))
-
-(defn lisaa-paatos-virheellisena
-  "Jos päätös on mukana päätöslistassa, mutta sille ei ole antaa tarkentavia tietoja, niin lisätään siihen virhe.
-  Mikäli päätöstä ei löydy listasta, niin älä lisää mitään."
-  [paatokset nimi virhe lisataan? jarjestys & args]
-  (let [virhepaatos (merge (first args) ;; Ensimmäinen parametri on päätös
-                      {:nimi nimi :virhe virhe :jarjestys jarjestys})]
-    (keep identity
-      (sort-by :jarjestys
-        (if (some #(= (:nimi %) nimi) paatokset)
-          (conj
-            (filter #(not= (:nimi %) nimi) paatokset)
-            ;; Jos ehdot eivät täyttyneet, niin päätöstä ei voida lisätä edes virheellisenä
-            (when lisataan?
-              virhepaatos))
-          paatokset)))))
-
-(defn laske-indeksikorotus-lupaukselle [db urakkaid paatos-pvm indeksi summa sanktio?]
-  (let [indeksikorotus-parametrit {:pvm paatos-pvm
-                                   :indeksi indeksi
-                                   :maara summa
-                                   :urakka-id urakkaid
-                                   :sanktiolaji (if sanktio? "lupaussanktio" nil)}
-        ;; Taustalla ajetaan tämmönen: SELECT korotus FROM sanktion_indeksikorotus(:pvm::DATE, :indeksi,:maara::NUMERIC, :urakka-id::INTEGER, :sanktiolaji::sanktiolaji);
-        indeksikorotus (:korotus (first (lupaus-kyselyt/hae-indeksikorotus-summalle db indeksikorotus-parametrit)))]
-    indeksikorotus))
-
-(defn hoitovuosi-paattynyt?
-  "Tarkista, onko saatu aika myöhemmin kuin 30.9."
-  [valittu-hoitovuosi]
-  (let [nyt (pvm/nyt)
-        nykyvuosi (pvm/vuosi nyt)
-        kuukausi (pvm/kuukausi nyt)
-        ;; valittu-hoitovuosi on aina hoitokauden alkuvuosi, mutta hoitokausi päättyy vasta seuraavan vuoden syyskuussa, joten korotetaan yhdellä
-        valittu-hoitovuosi (inc valittu-hoitovuosi)]
-    (cond
-      (> nykyvuosi valittu-hoitovuosi) true
-      (and (= nykyvuosi valittu-hoitovuosi) (>= kuukausi 10)) true
-      :else false)))
-
-(defn paatos-tallennettu-tietokantaan? [tietokanta-paatokset nimi]
-  (:id (first (filter #(when (= (:nimi %) nimi) %) tietokanta-paatokset))))
-
-(defn paatos-mahdollinen? [mahdolliset-paatokset nimi]
-  (boolean (seq (filter #(when (= (:nimi %) nimi) %) mahdolliset-paatokset))))
 
 (defn valmistele-lupauspaatokset [db validoinnit-kaytossa? valittu-hoitovuosi urakkaid paatokset toteutuneet-pisteet
                                   luvatut-pisteet tavoitehinta-indeksikorjattu tarjouksen-tavoitehinta indeksi tietokanta-paatokset
@@ -141,9 +16,8 @@
   ;; Hoitovuodelle on syötetty tarjouksen tavoitehinta
   ;; Hoitovuodelle on syötetty kaikkien lupausten toteumat
   ;; 2024 vuodesta alkaen Hoitovuoden lopun tavoite- ja kattohinta -päätös pitää olla tehtynä ensin
-  (let [
-        virheet (cond-> []
-                  (and validoinnit-kaytossa? (not (hoitovuosi-paattynyt? valittu-hoitovuosi)))
+  (let [virheet (cond-> []
+                  (and validoinnit-kaytossa? (not (apurit/hoitovuosi-paattynyt? valittu-hoitovuosi)))
                   (conj "Hoitovuosi on kesken.")
 
                   (nil? luvatut-pisteet)
@@ -158,7 +32,7 @@
                   ;; Vaaditaan hoitovuoden lopun tavoite-ja kattohinta vain jos kuluva hoitovuosi on 2024 tai myöemmin
                   ;; Ja, jos urakka on alkanut 2021 tai myöhemmin
                   (and validoinnit-kaytossa? (>= urakan-alkuvuosi 2021) (<= 2024 valittu-hoitovuosi)
-                    (not (paatos-tallennettu-tietokantaan? tietokanta-paatokset "Hoitovuoden lopun tavoite- ja kattohinta")))
+                    (not (apurit/paatos-tallennettu-tietokantaan? tietokanta-paatokset "Hoitovuoden lopun tavoite- ja kattohinta")))
                   (conj "Hoitovuoden lopun tavoite- ja kattohinta -päätöstä ei ole vahvistettu."))
 
         ;; Urakan parametreista lupaussanktion ja bonuksen prosentit
@@ -198,10 +72,10 @@
                               paatokset))
         indeksikorotus (cond
                          (and (= tyyppi "bonus") (:indeksi_kaytossa_bonuksella urakan-parametrit))
-                         (laske-indeksikorotus-lupaukselle db urakkaid paatospaiva indeksi lupausbonus false)
+                         (apurit/laske-indeksikorotus-lupaukselle db urakkaid paatospaiva indeksi lupausbonus false)
 
                          (and (= tyyppi "sanktio") (:indeksi_kaytossa_sanktiolla urakan-parametrit))
-                         (laske-indeksikorotus-lupaukselle db urakkaid paatospaiva indeksi lupaussanktio true)
+                         (apurit/laske-indeksikorotus-lupaukselle db urakkaid paatospaiva indeksi lupaussanktio true)
 
                          :else nil)
 
@@ -218,7 +92,7 @@
                        (assoc :bonusprosentti bonusprosentti)
                        (assoc :indeksi indeksi)
                        (assoc :indeksikorotus indeksikorotus)
-                       (assoc :hoitovuosi-kesken? (and validoinnit-kaytossa? (not (hoitovuosi-paattynyt? valittu-hoitovuosi))))
+                       (assoc :hoitovuosi-kesken? (and validoinnit-kaytossa? (not (apurit/hoitovuosi-paattynyt? valittu-hoitovuosi))))
                        (assoc :virheet (when-not (empty? virheet) virheet)))
         ;; Poista kaikki lupauspäätökset listasta
         paatokset (remove (fn [paatos] (= (:nimi paatos) "Lupaukset")) paatokset)
@@ -234,7 +108,7 @@
   (if-not (first (filter #(when (= (:nimi %) "Tavoitehinnan muutokset") %) paatokset))
     paatokset
     (let [virheet (cond-> []
-                    (and validoinnit-kaytossa? (not (hoitovuosi-paattynyt? kuluva-hoitovuosi)))
+                    (and validoinnit-kaytossa? (not (apurit/hoitovuosi-paattynyt? kuluva-hoitovuosi)))
                     (conj "Hoitovuosi on kesken.")
 
                     (not oikaistu-tavoitehinta)
@@ -249,7 +123,7 @@
                                        (assoc :tavoitehinta oikaistu-tavoitehinta)
                                        (assoc :kattohinta kattohinta)
                                        (assoc :muokkaa_kattohinta muokkaa-kattohinta?)
-                                       (assoc :hoitovuosi-kesken? (not (hoitovuosi-paattynyt? kuluva-hoitovuosi)))
+                                       (assoc :hoitovuosi-kesken? (not (apurit/hoitovuosi-paattynyt? kuluva-hoitovuosi)))
                                        (assoc :virheet (when-not (empty? virheet) virheet)))
           paatokset (remove (fn [paatos] (= (:nimi paatos) "Tavoitehinnan muutokset")) paatokset)
           paatokset (sort-by :jarjestys (conj paatokset tavoitehinnan-muutospaatos))]
@@ -268,7 +142,7 @@
 
     ;; Kokeillaan tähän erilaista lähestymistapaa. Kirjoitetaan validoinnit päätösmäppiin sisälle
     (let [virheet (cond-> []
-                    (and validoinnit-kaytossa? (not (hoitovuosi-paattynyt? kuluva-hoitovuosi)))
+                    (and validoinnit-kaytossa? (not (apurit/hoitovuosi-paattynyt? kuluva-hoitovuosi)))
                     (conj "Hoitovuosi on kesken."))
 
           tavoitehinna-muutokset-yhteensa (+ (or kirjallisesti-sovitut-muutokset 0) (or pysyvat-muutokset 0) (or muutostyo-muutokset 0)
@@ -286,7 +160,7 @@
                                               (assoc :rahavarausten_muutokset (or rahavarausmuutos-summa 0))
                                               (assoc :arvonvahennysten_muutokset (or arvonvahennykset-yht 0))
                                               (assoc :tavoitehinnan_muutokset_yhteensa (or tavoitehinna-muutokset-yhteensa 0))
-                                              (assoc :hoitovuosi-kesken? (and validoinnit-kaytossa? (not (hoitovuosi-paattynyt? kuluva-hoitovuosi))))
+                                              (assoc :hoitovuosi-kesken? (and validoinnit-kaytossa? (not (apurit/hoitovuosi-paattynyt? kuluva-hoitovuosi))))
                                               (assoc :virheet (when-not (empty? virheet) virheet)))
           paatokset (remove (fn [paatos] (= (:nimi paatos) "Tavoitehinnan pysyvät muutokset")) paatokset)
           paatokset (sort-by :jarjestys (conj paatokset tavoitehinnan-pysyva-muutospaatos))]
@@ -305,16 +179,16 @@
     (cond
       ;; Jos validoinnit on asetuksista laitettu päälle, tavoitehinta pitää olla vahvistettu
       (and validoinnit-kaytossa? (not tavoitehinta-vahvistettu?))
-      (lisaa-paatos-virheellisena paatokset "Hoitovuoden lopun indeksikorjaus" "Hoitovuoden alun indeksikorjattu tavoitehinta on vahvistamatta.
+      (apurit/lisaa-paatos-virheellisena paatokset "Hoitovuoden lopun indeksikorjaus" "Hoitovuoden alun indeksikorjattu tavoitehinta on vahvistamatta.
       Voit vahvistaa tiedon hoitovuoden alun tavoitehinta -välilehdeltä." true 3)
 
       ;; Jos validoinnit on asetuksista laitettu päälle, niin hoitovuoden pitää olla päättynyt
-      (and validoinnit-kaytossa? (not (hoitovuosi-paattynyt? hoitokauden-alkuvuosi)))
-      (lisaa-paatos-virheellisena paatokset "Hoitovuoden lopun indeksikorjaus" "Hoitovuosi on vielä kesken." true 3)
+      (and validoinnit-kaytossa? (not (apurit/hoitovuosi-paattynyt? hoitokauden-alkuvuosi)))
+      (apurit/lisaa-paatos-virheellisena paatokset "Hoitovuoden lopun indeksikorjaus" "Hoitovuosi on vielä kesken." true 3)
 
       ;; Jos validoinnit on asetuksista laitettu päälle, niin Tavoitehinnan muutokset -päätös pitää olla tallennettu
-      (and validoinnit-kaytossa? (not (paatos-tallennettu-tietokantaan? tietokanta-paatokset "Tavoitehinnan muutokset")))
-      (lisaa-paatos-virheellisena paatokset "Hoitovuoden lopun indeksikorjaus" "Hoitovuoden lopun indeksikorjaus
+      (and validoinnit-kaytossa? (not (apurit/paatos-tallennettu-tietokantaan? tietokanta-paatokset "Tavoitehinnan muutokset")))
+      (apurit/lisaa-paatos-virheellisena paatokset "Hoitovuoden lopun indeksikorjaus" "Hoitovuoden lopun indeksikorjaus
       laskentaan automaattisesti, kun tavoitehintamuutokset on vahvistettu." true 3)
 
       (and oikaistu-tavoitehinta hoitokauden-indeksikuukaudet)
@@ -369,7 +243,7 @@
 
       ;; Ehdot eivät täyttyneet, otetaan indeksipäätökset pois listasta ja lisätään virheilmoitus päätökselle
       :else
-      (lisaa-paatos-virheellisena paatokset "Hoitovuoden lopun indeksikorjaus" "Tavoitehintaa, tavoitehinnan muutoksia tai hoitokauden indeksikuukausia ei ole määritelty." true 3))))
+      (apurit/lisaa-paatos-virheellisena paatokset "Hoitovuoden lopun indeksikorjaus" "Tavoitehintaa, tavoitehinnan muutoksia tai hoitokauden indeksikuukausia ei ole määritelty." true 3))))
 
 (defn valmistele-tavoitehinnan-alituspaatos [db validoinnit-kaytossa? urakkaid paatokset urakan-alkuvuosi urakan-loppuvuosi kuluva-hoitovuosi
                                              hoitokauden-alun-tavoitehinta hoitokauden-lopun-indeksikorjattu-tavoitehinta kustannukset
@@ -386,15 +260,15 @@
     paatokset
     (let [virheet (cond-> []
                     (and validoinnit-kaytossa? (<= 2024 kuluva-hoitovuosi)
-                      (not (paatos-tallennettu-tietokantaan? tietokanta-paatokset "Tavoitehinnan muutokset")))
+                      (not (apurit/paatos-tallennettu-tietokantaan? tietokanta-paatokset "Tavoitehinnan muutokset")))
                     (conj "Tavoitehinnan muutokset -päätös on vielä tekemättä.")
                     (and validoinnit-kaytossa? (<= 2024 kuluva-hoitovuosi) (not tavoitehinta-vahvistettu?))
                     (conj "Kustannussuunnitelma on vahvistamatta.")
                     (and validoinnit-kaytossa? (>= urakan-alkuvuosi 2021) (<= 2024 kuluva-hoitovuosi)
-                      (not (paatos-tallennettu-tietokantaan? tietokanta-paatokset "Hoitovuoden lopun tavoite- ja kattohinta")))
+                      (not (apurit/paatos-tallennettu-tietokantaan? tietokanta-paatokset "Hoitovuoden lopun tavoite- ja kattohinta")))
                     (conj "Hoitovuoden lopun tavoite- ja kattohinta -päätös on vielä tekemättä.")
 
-                    (and validoinnit-kaytossa? (not (hoitovuosi-paattynyt? kuluva-hoitovuosi)))
+                    (and validoinnit-kaytossa? (not (apurit/hoitovuosi-paattynyt? kuluva-hoitovuosi)))
                     (conj "Hoitovuosi on kesken."))
           urakan-parametrit (first (urakka-kyselyt/hae-urakan-parametrit db {:urakkaid urakkaid}))
           tavoitehinnan-alitus (if (and hoitokauden-lopun-indeksikorjattu-tavoitehinta kustannukset)
@@ -434,7 +308,7 @@
           paatokset (sort-by :jarjestys (conj paatokset tavoitehinnan-alituspaatos))]
       paatokset)))
 
-(defn valmistele-tavoitehinnan-ylityspaatos [db validoinnit-kaytossa? urakkaid paatokset urakan-alkuvuosi
+(defn valmistele-tavoitehinnan-ylityspaatos [_db validoinnit-kaytossa? urakkaid paatokset urakan-alkuvuosi
                                              urakan-loppuvuosi kuluva-hoitovuosi hoitovuoden-lopun-tavoitehinta
                                              hoitovuoden-lopun-kattohinta kustannukset tietokanta-paatokset
                                              tavoitehinta-vahvistettu? urakan-parametrit]
@@ -447,14 +321,14 @@
                   (and validoinnit-kaytossa? (<= 2024 kuluva-hoitovuosi) (not tavoitehinta-vahvistettu?))
                   (conj "Kustannussuunnitelma on vahvistamatta.")
                   (and validoinnit-kaytossa? (<= 2024 kuluva-hoitovuosi)
-                    (not (paatos-tallennettu-tietokantaan? tietokanta-paatokset "Tavoitehinnan muutokset")))
+                    (not (apurit/paatos-tallennettu-tietokantaan? tietokanta-paatokset "Tavoitehinnan muutokset")))
                   (conj "Tavoitehinnan muutokset -päätös on vielä tekemättä.")
 
                   (and validoinnit-kaytossa? (>= urakan-alkuvuosi 2021) (<= 2024 kuluva-hoitovuosi)
-                    (not (paatos-tallennettu-tietokantaan? tietokanta-paatokset "Hoitovuoden lopun tavoite- ja kattohinta")))
+                    (not (apurit/paatos-tallennettu-tietokantaan? tietokanta-paatokset "Hoitovuoden lopun tavoite- ja kattohinta")))
                   (conj "Hoitovuoden lopun tavoite- ja kattohinta -päätös on vielä tekemättä.")
 
-                  (and validoinnit-kaytossa? (not (hoitovuosi-paattynyt? kuluva-hoitovuosi)))
+                  (and validoinnit-kaytossa? (not (apurit/hoitovuosi-paattynyt? kuluva-hoitovuosi)))
                   (conj "Hoitovuosi on kesken."))
 
         ;; Ylitys + tavoitehinta ei voi ylittää kattohintaa. Eli maksettavat rahat on aina tavoitehinnan ja
@@ -496,27 +370,27 @@
   ;; Hoitovuoden lopun tavoitehintapäätös tallennettu
   ;; Ja vielä lisäksi: Tavoitehinnan ylityspäätös tallennettu
   (if-not (and hoitovuoden-lopun-kattohinta kustannukset (> kustannukset hoitovuoden-lopun-kattohinta))
-    (lisaa-paatos-virheellisena paatokset "Kattohinnan ylitys" "Poistetaan vain koko päätös." false 7)
+    (apurit/lisaa-paatos-virheellisena paatokset "Kattohinnan ylitys" "Poistetaan vain koko päätös." false 7)
 
     (cond
       (and validoinnit-kaytossa? (<= 2024 kuluva-hoitovuosi) (not tavoitehinta-vahvistettu?))
-      (lisaa-paatos-virheellisena paatokset "Kattohinnan ylitys" "Kustannussuunnitelma on vahvistamatta." true 7)
+      (apurit/lisaa-paatos-virheellisena paatokset "Kattohinnan ylitys" "Kustannussuunnitelma on vahvistamatta." true 7)
 
       (and validoinnit-kaytossa? (<= 2024 kuluva-hoitovuosi)
-        (not (paatos-tallennettu-tietokantaan? tietokanta-paatokset "Tavoitehinnan muutokset")))
-      (lisaa-paatos-virheellisena paatokset "Kattohinnan ylitys" "Tavoitehinnan muutokset -päätös on vielä tekemättä." true 7)
+        (not (apurit/paatos-tallennettu-tietokantaan? tietokanta-paatokset "Tavoitehinnan muutokset")))
+      (apurit/lisaa-paatos-virheellisena paatokset "Kattohinnan ylitys" "Tavoitehinnan muutokset -päätös on vielä tekemättä." true 7)
 
       ;; Vaaditaan hoitovuoden lopun tavoite-ja kattohinta vain jos kuluva hoitovuosi on 2024 tai myöemmin
       ;; Ja, jos urakka on alkanut 2021 tai myöhemmin
       (and validoinnit-kaytossa? (>= urakan-alkuvuosi 2021) (<= 2024 kuluva-hoitovuosi)
-        (not (paatos-tallennettu-tietokantaan? tietokanta-paatokset "Hoitovuoden lopun tavoite- ja kattohinta")))
-      (lisaa-paatos-virheellisena paatokset "Kattohinnan ylitys" "Hoitovuoden lopun tavoite- ja kattohinta -päätös on vielä tekemättä." true 7)
+        (not (apurit/paatos-tallennettu-tietokantaan? tietokanta-paatokset "Hoitovuoden lopun tavoite- ja kattohinta")))
+      (apurit/lisaa-paatos-virheellisena paatokset "Kattohinnan ylitys" "Hoitovuoden lopun tavoite- ja kattohinta -päätös on vielä tekemättä." true 7)
 
       ;; Vaaditaan Tavoitehinnan ylitys päätös, pitää olla tallennettuna
       ;; Ja, jos urakka on alkanut 2021 tai myöhemmin
       (and validoinnit-kaytossa? (>= urakan-alkuvuosi 2021)
-        (not (paatos-tallennettu-tietokantaan? tietokanta-paatokset "Tavoitehinnan ylitys")))
-      (lisaa-paatos-virheellisena paatokset "Kattohinnan ylitys" "Tavoitehinnan ylitys -päätös on vielä tekemättä." true 7)
+        (not (apurit/paatos-tallennettu-tietokantaan? tietokanta-paatokset "Tavoitehinnan ylitys")))
+      (apurit/lisaa-paatos-virheellisena paatokset "Kattohinnan ylitys" "Tavoitehinnan ylitys -päätös on vielä tekemättä." true 7)
 
       (and hoitovuoden-lopun-kattohinta kustannukset (> kustannukset hoitovuoden-lopun-kattohinta))
       (let [urakan-parametrit (first (urakka-kyselyt/hae-urakan-parametrit db {:urakkaid urakkaid}))
@@ -552,7 +426,7 @@
 
       ;; Jos tarvittavia tietoja ei ole, niin poistetaan kattohinnan ylitys
       :else
-      (lisaa-paatos-virheellisena paatokset "Kattohinnan ylitys" "Kattohintaa tai toteutuneita kustannuksia ei ole määritelty." false 7))))
+      (apurit/lisaa-paatos-virheellisena paatokset "Kattohinnan ylitys" "Kattohintaa tai toteutuneita kustannuksia ei ole määritelty." false 7))))
 
 ;; Hoitovuoden lopun tavoite- ja kattohinta
 (defn valmistele-hv-lopun-tavoite-ja-kattohinta [validoinnit-kaytossa? urakan-alkuvuosi valittu-hoitovuosi paatokset tavoitehinta-indeksikorjattu
@@ -568,12 +442,12 @@
   (if-not (first (filter #(when (= (:nimi %) "Hoitovuoden lopun tavoite- ja kattohinta") %) paatokset))
     paatokset
     (let [virheet (cond-> [] (and validoinnit-kaytossa? (<= 2024 valittu-hoitovuosi)
-                               (not (paatos-tallennettu-tietokantaan? tietokanta-paatokset "Tavoitehinnan muutokset")))
+                               (not (apurit/paatos-tallennettu-tietokantaan? tietokanta-paatokset "Tavoitehinnan muutokset")))
                     (conj "Tavoitehinnan muutokset -päätös on vielä tekemättä.")
                     (and validoinnit-kaytossa?
                       (and
-                        (paatos-mahdollinen? mahdolliset-paatokset "Hoitovuoden lopun indeksikorjaus")
-                        (not (paatos-tallennettu-tietokantaan? tietokanta-paatokset "Hoitovuoden lopun indeksikorjaus"))))
+                        (apurit/paatos-mahdollinen? mahdolliset-paatokset "Hoitovuoden lopun indeksikorjaus")
+                        (not (apurit/paatos-tallennettu-tietokantaan? tietokanta-paatokset "Hoitovuoden lopun indeksikorjaus"))))
                     (conj "Hoitovuoden lopun indeksikorjaus -päätös on vielä tekemättä.")
 
                     (not tavoitehinta-indeksikorjattu)
@@ -585,7 +459,7 @@
                     (and validoinnit-kaytossa? (<= 2024 valittu-hoitovuosi) (not tavoitehinta-vahvistettu?))
                     (conj "Kustannussuunnitelma on vahvistamatta.")
 
-                    (and validoinnit-kaytossa? (not (hoitovuosi-paattynyt? valittu-hoitovuosi)))
+                    (and validoinnit-kaytossa? (not (apurit/hoitovuosi-paattynyt? valittu-hoitovuosi)))
                     (conj "Hoitovuosi on kesken."))
 
           hintapaatos (first (filter #(= (:nimi %) "Hoitovuoden lopun tavoite- ja kattohinta") paatokset))
@@ -621,11 +495,11 @@
   (if-not (first (filter #(= (:nimi %) "Hoidonjohtopalkkion muutos") paatokset))
     paatokset
     (let [virheet (cond-> []
-                    (and validoinnit-kaytossa? (not (hoitovuosi-paattynyt? valittu-hoitovuosi)))
+                    (and validoinnit-kaytossa? (not (apurit/hoitovuosi-paattynyt? valittu-hoitovuosi)))
                     (conj "Hoitovuosi on kesken.")
 
                     (and validoinnit-kaytossa? (>= urakan-alkuvuosi 2021)
-                      (not (paatos-tallennettu-tietokantaan? tietokanta-paatokset "Hoitovuoden lopun tavoite- ja kattohinta")))
+                      (not (apurit/paatos-tallennettu-tietokantaan? tietokanta-paatokset "Hoitovuoden lopun tavoite- ja kattohinta")))
                     (conj "Hoitovuoden lopun tavoite- ja kattohinta -päätös on vielä tekemättä.")
 
                     (not hv-lopun-tavoitehinta-ilman-indeksia)
@@ -660,7 +534,7 @@
                    (assoc :hoidonjohtopalkkio hoidonjohtopalkkio)
                    (assoc :muutosprosentti muutosprosentti)
                    (assoc :hoidonjohtopalkkio_muutos hoidonjohtopalkkio-muutos)
-                   (assoc :hoitovuosi-kesken? (and validoinnit-kaytossa? (not (hoitovuosi-paattynyt? valittu-hoitovuosi))))
+                   (assoc :hoitovuosi-kesken? (and validoinnit-kaytossa? (not (apurit/hoitovuosi-paattynyt? valittu-hoitovuosi))))
                    (assoc :virheet (when-not (empty? virheet) virheet)))
 
           paatokset (remove
@@ -674,7 +548,7 @@
   (if (first (filter #(= (:nimi %) "Välikatselmuspöytäkirjaan liitettävät raportit") paatokset))
     ;; Mikäli raporttipäätös on olemassa
     (let [paatos (first (filter #(= (:nimi %) "Välikatselmuspöytäkirjaan liitettävät raportit") paatokset))
-          paatos (if (and validoinnit-kaytossa? (not (hoitovuosi-paattynyt? valittu-hoitovuosi)))
+          paatos (if (and validoinnit-kaytossa? (not (apurit/hoitovuosi-paattynyt? valittu-hoitovuosi)))
                    (assoc paatos :virhe "Hoitovuosi on kesken.")
                    paatos)
           paatokset (remove #(= (:nimi %) "Välikatselmuspöytäkirjaan liitettävät raportit") paatokset)]

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/paatostyypit.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/paatostyypit.clj
@@ -1,0 +1,229 @@
+(ns harja.palvelin.palvelut.valikatselmus.paatostyypit
+  (:require [clojure.string :as str]
+
+            [harja.pvm :as pvm]
+            [harja.tyokalut.yleiset :refer [round2]]
+            [harja.kyselyt.urakat :as urakka-kyselyt]
+            [harja.domain.lupaus-domain :as lupaus-domain]
+            [harja.kyselyt.lupaus-kyselyt :as lupaus-kyselyt]))
+
+
+(def paatostyypit
+  [{:nimi "Tavoitehinnan muutokset"
+    :urakan_alkuvuosi 2019
+    :nakyvyys_alkaen 2019
+    :nakyvyys_asti 2024
+    :hoitotyyppi #{"MHU"}
+    :jarjestys 2
+    :paatostyyppi "tavoitehinnan-muutokset"
+    :avain :tavoitehinnan-muutokset
+    :riippuu []}
+
+   {:nimi "Tavoitehinnan muutokset"
+    :urakan_alkuvuosi 2021
+    :nakyvyys_alkaen 2021
+    :nakyvyys_asti 2028
+    :hoitotyyppi #{"MHU"}
+    :jarjestys 2
+    :paatostyyppi "tavoitehinnan-muutokset"
+    :avain :tavoitehinnan-muutokset
+    :riippuu []}
+
+   {:nimi "Tavoitehinnan muutokset"
+    :urakan_alkuvuosi 2024
+    :nakyvyys_alkaen 2024
+    :nakyvyys_asti 2024
+    :hoitotyyppi #{"MHU+"}
+    :jarjestys 2
+    :paatostyyppi "tavoitehinnan-muutokset"
+    :avain :tavoitehinnan-muutokset
+    :riippuu []}
+
+   {:nimi "Tavoitehinnan pysyvät muutokset"
+    :urakan_alkuvuosi 2025
+    :nakyvyys_alkaen 2025
+    :hoitotyyppi #{"MHU" "MHU+"}
+    :jarjestys 2
+    :paatostyyppi "tavoitehinnan-pysyvat-muutokset"
+    :avain :tavoitehinnan-muutokset
+    :riippuu []}
+
+   {:nimi "Hoitovuoden lopun indeksikorjaus"
+    :tyyppi nil
+    :urakan_alkuvuosi 2024
+    :nakyvyys_alkaen 2024
+    :hoitotyyppi #{"MHU" "MHU+"}
+    :jarjestys 3
+    :paatostyyppi "indeksikorjaus"
+    :avain :indeksikorjaus
+    :riippuu [{:avain :tavoitehinnan-muutokset}]}
+
+   {:nimi "Hoitovuoden lopun tavoite- ja kattohinta"
+    :tyyppi "A"
+    :urakan_alkuvuosi 2021
+    :nakyvyys_alkaen 2024
+    :nakyvyys_asti 2024
+    :hoitotyyppi #{"MHU"}
+    :jarjestys 4
+    :paatostyyppi "hoitovuoden-lopun-hinta"
+    :avain :hoitovuoden-lopun-hinta
+    :riippuu [{:avain :tavoitehinnan-muutokset}]}
+
+   {:nimi "Hoitovuoden lopun tavoite- ja kattohinta"
+    :tyyppi "B"
+    :urakan_alkuvuosi 2024
+    :nakyvyys_alkaen 2024
+    :nakyvyys_asti 2024
+    :hoitotyyppi #{"MHU"}
+    :jarjestys 4
+    :paatostyyppi "hoitovuoden-lopun-hinta"
+    :avain :hoitovuoden-lopun-hinta
+    :riippuu [{:avain :tavoitehinnan-muutokset}
+              {:avain :indeksikorjaus}]}
+
+   {:nimi "Hoitovuoden lopun tavoite- ja kattohinta"
+    :tyyppi "B"
+    :urakan_alkuvuosi 2024
+    :nakyvyys_alkaen 2024
+    :hoitotyyppi #{"MHU+"}
+    :jarjestys 4
+    :paatostyyppi "hoitovuoden-lopun-hinta-v2"
+    :avain :hoitovuoden-lopun-hinta
+    :riippuu [{:avain :tavoitehinnan-muutokset}
+              {:avain :indeksikorjaus}]}
+
+   {:nimi "Hoitovuoden lopun tavoite- ja kattohinta"
+    :tyyppi "C"
+    :urakan_alkuvuosi 2025
+    :nakyvyys_alkaen 2025
+    :hoitotyyppi #{"MHU"}
+    :jarjestys 4
+    :paatostyyppi "hoitovuoden-lopun-hinta-v2"
+    :avain :hoitovuoden-lopun-hinta
+    :riippuu [{:avain :tavoitehinnan-muutokset}
+              {:avain :indeksikorjaus}]}
+
+   {:nimi "Tavoitehinnan alitus"
+    :urakan_alkuvuosi 2019
+    :nakyvyys_alkaen 2019
+    :hoitotyyppi #{"MHU"}
+    :jarjestys 5
+    :paatostyyppi "tavoitehinta"
+    :avain :tavoitehinnan-alitus
+    :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+
+   {:nimi "Tavoitehinnan alitus"
+    :urakan_alkuvuosi 2024
+    :nakyvyys_alkaen 2024
+    :hoitotyyppi #{"MHU+"}
+    :jarjestys 5
+    :paatostyyppi "tavoitehinta"
+    :avain :tavoitehinnan-alitus
+    :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+
+   {:nimi "Tavoitehinnan ylitys"
+    :tyyppi "A"
+    :urakan_alkuvuosi 2019
+    :nakyvyys_alkaen 2019
+    :hoitotyyppi #{"MHU"}
+    :jarjestys 6
+    :paatostyyppi "tavoitehinta"
+    :avain :tavoitehinnan-ylitys
+    :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+
+   {:nimi "Tavoitehinnan ylitys"
+    :tyyppi "B"
+    :urakan_alkuvuosi 2024
+    :nakyvyys_alkaen 2019
+    :hoitotyyppi #{"MHU" "MHU+"}
+    :jarjestys 6
+    :paatostyyppi "tavoitehinta"
+    :avain :tavoitehinnan-ylitys
+    :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+
+   {:nimi "Kattohinnan ylitys"
+    :urakan_alkuvuosi 2019
+    :nakyvyys_alkaen 2019
+    :hoitotyyppi #{"MHU"}
+    :jarjestys 7
+    :paatostyyppi "kattohinta"
+    :avain :kattohinnan-ylitys
+    :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+
+   {:nimi "Kattohinnan ylitys"
+    :urakan_alkuvuosi 2024
+    :nakyvyys_alkaen 2024
+    :hoitotyyppi #{"MHU+"}
+    :jarjestys 7
+    :paatostyyppi "kattohinta"
+    :avain :kattohinnan-ylitys
+    :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+
+   {:nimi "Lupaukset"
+    :tyyppi "bonus"
+    :urakan_alkuvuosi 2019
+    :nakyvyys_alkaen 2019
+    :hoitotyyppi #{"MHU" "MHU+"}
+    :jarjestys 8
+    :paatostyyppi "lupaus"
+    :avain :lupaus
+    :riippuu [{:avain :hoitovuoden-lopun-hinta
+               :urakan_alkuvuosi_alkaen 2025}]}
+
+   {:nimi "Lupaukset"
+    :tyyppi "sanktio"
+    :urakan_alkuvuosi 2019
+    :nakyvyys_alkaen 2019
+    :hoitotyyppi #{"MHU" "MHU+"}
+    :jarjestys 8
+    :paatostyyppi "lupaus"
+    :avain :lupaus
+    :riippuu [{:avain :hoitovuoden-lopun-hinta
+               :urakan_alkuvuosi_alkaen 2025}]}
+
+   {:nimi "Lupaukset"
+    :tyyppi "taytetty"
+    :urakan_alkuvuosi 2019
+    :nakyvyys_alkaen 2019
+    :hoitotyyppi #{"MHU" "MHU+"}
+    :jarjestys 8
+    :paatostyyppi "lupaus"
+    :avain :lupaus
+    :riippuu [{:avain :hoitovuoden-lopun-hinta
+               :urakan_alkuvuosi_alkaen 2025}]}
+
+   {:nimi "Hoidonjohtopalkkion muutos"
+    :urakan_alkuvuosi 2021
+    :nakyvyys_alkaen 2024
+    :hoitotyyppi #{"MHU"}
+    :jarjestys 9
+    :paatostyyppi "hoidonjohtopalkkio"
+    :avain :hoidonjohtopalkkio
+    :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+
+   {:nimi "Hoidonjohtopalkkion muutos"
+    :urakan_alkuvuosi 2024
+    :nakyvyys_alkaen 2024
+    :hoitotyyppi #{"MHU" "MHU+"}
+    :jarjestys 9
+    :paatostyyppi "hoidonjohtopalkkio"
+    :avain :hoidonjohtopalkkio
+    :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+
+   {:nimi "Välikatselmuspöytäkirjaan liitettävät raportit"
+    :urakan_alkuvuosi 2020
+    :nakyvyys_alkaen 2024
+    :hoitotyyppi #{"MHU"}
+    :jarjestys 10
+    :paatostyyppi "raportti"
+    :avain :raportti
+    :riippuu []}
+
+   {:nimi "Välikatselmuspöytäkirjaan liitettävät raportit"
+    :urakan_alkuvuosi 2024
+    :nakyvyys_alkaen 2024
+    :hoitotyyppi #{"MHU" "MHU+"}
+    :jarjestys 10
+    :paatostyyppi "raportti"
+    :avain :raportti
+    :riippuu []}])

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/paatostyypit.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/paatostyypit.clj
@@ -1,11 +1,4 @@
-(ns harja.palvelin.palvelut.valikatselmus.paatostyypit
-  (:require [clojure.string :as str]
-
-            [harja.pvm :as pvm]
-            [harja.tyokalut.yleiset :refer [round2]]
-            [harja.kyselyt.urakat :as urakka-kyselyt]
-            [harja.domain.lupaus-domain :as lupaus-domain]
-            [harja.kyselyt.lupaus-kyselyt :as lupaus-kyselyt]))
+(ns harja.palvelin.palvelut.valikatselmus.paatostyypit)
 
 
 (def paatostyypit

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
@@ -30,6 +30,7 @@
             [harja.palvelin.palvelut.indeksit :as indeksipalvelu]
             [harja.palvelin.palvelut.toteumat :as toteumat-palvelu]
             [harja.palvelin.palvelut.kulut.kulut :as kulut-palvelu]
+            [harja.palvelin.palvelut.valikatselmus.apurit :as v-apurit]
             [harja.palvelin.palvelut.kulut.paatos-apurit :as paatos-apurit]
             [harja.palvelin.palvelut.muutos.muutos-palvelu :as muutos-palvelu]
             [harja.palvelin.palvelut.lupaus.lupaus-palvelu :as lupaus-palvelu]
@@ -159,7 +160,7 @@
         hoitokauden-loppupvm (pvm/hoitokauden-loppupvm (inc valittu-hoitovuosi))
         valittu-hoitokausi [hoitokauden-alkupvm hoitokauden-loppupvm]
         mhu+urakka? (= "mhu+" (:sopimustyyppi urakan-tiedot))
-        mhu-tyyppi (paatoskone/urakan-hoitotyyppi mhu+urakka?)
+        mhu-tyyppi (v-apurit/urakan-hoitotyyppi mhu+urakka?)
         tavoitehinta-vahvistettu? (:exists (first (budjettisuunnittelu-q/onko-kustannussuunnitelma-vahvistettu db
                                                     {:urakkaid urakkaid
                                                      :hoitovuosinro hoitovuosinro})))
@@ -187,7 +188,7 @@
         taman-vuoden-muutokset-summa (if (:muutosten_hallinta urakan-parametrit)
                                        (+ (or kirjallisesti-sovitut-muutokset 0) (or tehtava-ja-maaramuutos-summa 0) (or rahavarausmuutos-summa 0))
                                        0)
-        mahdolliset-paatokset (paatoskone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi valittu-hoitovuosi)
+        mahdolliset-paatokset (v-apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi valittu-hoitovuosi)
         hv-lopun-tavoitehinta-ilman-indeksia (maarita-hv-lopun-indeksikorjaamaton-tavoitehinta db kayttaja valittu-hoitovuosi valittu-hoitokausi urakkaid urakan-alkuvuosi budjettitavoite-vuodelle)
         arvonvahennykset (valikatselmus-q/hae-arvonvahennykset db {:urakka-id urakkaid
                                                                    :alkupvm (first valittu-hoitokausi)
@@ -1041,7 +1042,7 @@
                                                          kuluva-hoitovuosi toteutuneet-kustannukset
                                                          hoitovuoden-lopun-kattohinta hoitovuoden-lopun-tavoitehinta]
   (let [; Haetaan ensin kaikki mahdolliset päätökset
-        mahdolliset-paatokset (paatoskone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi kuluva-hoitovuosi)
+        mahdolliset-paatokset (v-apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi kuluva-hoitovuosi)
         mahdolliset-paatokset (paatoskone/filtteroi-mahdolliset-paatokset mahdolliset-paatokset toteutuneet-kustannukset hoitovuoden-lopun-kattohinta hoitovuoden-lopun-tavoitehinta)
         ;; Poistetaan mahdollinen raporttipäätös
         mahdolliset-paatokset (remove (fn [rivi] (= (:nimi rivi) "Välikatselmuspöytäkirjaan liitettävät raportit")) mahdolliset-paatokset)
@@ -1061,7 +1062,7 @@
         hoitokauden-loppupvm (pvm/hoitokauden-loppupvm (inc kuluva-hoitovuosi))
         valittu-hoitokausi [hoitokauden-alkupvm hoitokauden-loppupvm]
         mhu+urakka? (= "mhu+" (:sopimustyyppi urakan-tiedot))
-        mhu-tyyppi (paatoskone/urakan-hoitotyyppi mhu+urakka?)
+        mhu-tyyppi (v-apurit/urakan-hoitotyyppi mhu+urakka?)
         ;; Haetaan urakan taloustiedot, jotta tiedetään kuuluuko tavoitehinnan alitus, ylitys ja kattohinta pakettiin
         kustannukset (hae-kustannukset-jarjestettyna db urakkaid kuluva-hoitovuosi
                        (pvm/hoitokauden-alkupvm kuluva-hoitovuosi) (pvm/hoitokauden-loppupvm (inc kuluva-hoitovuosi)))
@@ -1079,7 +1080,7 @@
                                          budjettitavoite-vuodelle)
 
         ; Haetaan ensin kaikki mahdolliset päätökset
-        mahdolliset-paatokset (paatoskone/kaikki-mahdolliset-paatokset
+        mahdolliset-paatokset (v-apurit/kaikki-mahdolliset-paatokset
                                 mhu-tyyppi
                                 urakan-alkuvuosi
                                 urakan-loppuvuosi

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
@@ -1186,8 +1186,10 @@
         _ (poista-yksittainen-paatos db kayttaja paatos urakka-id)]
 
     ;; Poista kaikki siihen ketjutetut päätökset
-    (doseq [paatos tehdyt-kumoutuvat-paatokset]
-      (poista-yksittainen-paatos db kayttaja paatos urakka-id))
+    ;; Tehdään transaktiossa, jotta yksi faili peruu muutkin
+    (jdbc/with-db-transaction [conn db]
+      (doseq [paatos tehdyt-kumoutuvat-paatokset]
+        (poista-yksittainen-paatos conn kayttaja paatos urakka-id)))
 
     (hae-valikatselmuksen-tiedot-hoitovuodelle db kayttaja {:urakkaid urakka-id :hoitovuosi hoitokauden_alkuvuosi})))
 

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
@@ -1,40 +1,42 @@
 (ns harja.palvelin.palvelut.valikatselmus.valikatselmukset
-  (:require
-    [com.stuartsierra.component :as component]
-    [clojure.string :as string]
-    [harja.domain.kulut.kustannusten-seuranta :as kustannusten-seuranta]
-    [harja.kyselyt.rahavaraukset :as rahavaraus-kyselyt]
-    [harja.palvelin.integraatiot.api.tyokalut.virheet :as virheet]
-    [harja.palvelin.palvelut.indeksit :as indeksipalvelu]
-    [harja.palvelin.palvelut.lupaus.lupaus-palvelu :as lupaus-palvelu]
-    [slingshot.slingshot :refer [throw+]]
-    [taoensso.timbre :as log]
-    [specql.core :refer [columns]]
-    [harja.tyokalut.functor :refer [fmap]]
-    [harja.tyokalut.yleiset :refer [round2]]
-    [harja.domain.kulut.valikatselmus :as valikatselmus]
-    [harja.domain.muokkaustiedot :as muokkaustiedot]
-    [harja.domain.oikeudet :as oikeudet]
-    [harja.domain.urakka :as urakka]
-    [harja.domain.valikatselmus :as valikatselmus-domain]
-    [harja.kyselyt.konversio :as konversio]
-    [harja.kyselyt.urakat :as q-urakat]
-    [harja.kyselyt.valikatselmus :as valikatselmus-q]
-    [harja.kyselyt.paatos-kyselyt :as paatos-kyselyt]
-    [harja.kyselyt.budjettisuunnittelu :as budjettisuunnittelu-q]
-    [harja.kyselyt.indeksit :as indeksi-kyselyt]
-    [harja.kyselyt.jarjestelman-tila :as jarjestelma-kyselyt]
-    [harja.palvelin.palvelut.laadunseuranta :as laadunseuranta-palvelu]
-    [harja.palvelin.palvelut.toteumat :as toteumat-palvelu]
-    [harja.palvelin.palvelut.kulut.kulut :as kulut-palvelu]
-    [harja.palvelin.palvelut.kulut.kustannusten-seuranta :as kustannusten-seuranta-palvelu]
-    [harja.palvelin.palvelut.kulut.paatos-apurit :as paatos-apurit]
-    [harja.palvelin.palvelut.muutos.muutos-palvelu :as muutos-palvelu]
-    [harja.palvelin.komponentit.http-palvelin :refer [julkaise-palvelu poista-palvelut transit-vastaus]]
-    [harja.pvm :as pvm]
-    [harja.domain.lupaus-domain :as lupaus-domain]
-    [clojure.java.jdbc :as jdbc]
-    [harja.palvelin.palvelut.valikatselmus.paatosnakyvyyskone :as paatoskone]))
+  (:require [taoensso.timbre :as log]
+            [clojure.string :as string]
+            [clojure.java.jdbc :as jdbc]
+            [specql.core :refer [columns]]
+            [slingshot.slingshot :refer [throw+]]
+            [com.stuartsierra.component :as component]
+
+            [harja.pvm :as pvm]
+            [harja.tyokalut.functor :refer [fmap]]
+            [harja.tyokalut.yleiset :refer [round2] :as yleiset]
+
+            [harja.domain.urakka :as urakka]
+            [harja.domain.oikeudet :as oikeudet]
+            [harja.domain.lupaus-domain :as lupaus-domain]
+            [harja.domain.muokkaustiedot :as muokkaustiedot]
+            [harja.domain.kulut.valikatselmus :as valikatselmus]
+            [harja.domain.valikatselmus :as valikatselmus-domain]
+            [harja.domain.kulut.kustannusten-seuranta :as kustannusten-seuranta]
+
+            [harja.kyselyt.urakat :as q-urakat]
+            [harja.kyselyt.konversio :as konversio]
+            [harja.kyselyt.indeksit :as indeksi-kyselyt]
+            [harja.kyselyt.paatos-kyselyt :as paatos-kyselyt]
+            [harja.kyselyt.valikatselmus :as valikatselmus-q]
+            [harja.kyselyt.rahavaraukset :as rahavaraus-kyselyt]
+            [harja.kyselyt.jarjestelman-tila :as jarjestelma-kyselyt]
+            [harja.kyselyt.budjettisuunnittelu :as budjettisuunnittelu-q]
+
+            [harja.palvelin.palvelut.indeksit :as indeksipalvelu]
+            [harja.palvelin.palvelut.toteumat :as toteumat-palvelu]
+            [harja.palvelin.palvelut.kulut.kulut :as kulut-palvelu]
+            [harja.palvelin.palvelut.kulut.paatos-apurit :as paatos-apurit]
+            [harja.palvelin.palvelut.muutos.muutos-palvelu :as muutos-palvelu]
+            [harja.palvelin.palvelut.lupaus.lupaus-palvelu :as lupaus-palvelu]
+            [harja.palvelin.palvelut.laadunseuranta :as laadunseuranta-palvelu]
+            [harja.palvelin.palvelut.valikatselmus.paatosnakyvyyskone :as paatoskone]
+            [harja.palvelin.komponentit.http-palvelin :refer [julkaise-palvelu poista-palvelut]]
+            [harja.palvelin.palvelut.kulut.kustannusten-seuranta :as kustannusten-seuranta-palvelu]))
 
 (defn hoitokaudet-vektorimuotoon
   "Muuntaa hoitokaudet {:alkupvm .. :loppupvm ..} -muodosta vektoreiksi [alkupvm loppupvm],
@@ -247,7 +249,7 @@
                                 mahdolliset-paatokset)
 
         ;; Yhdistä päätökset listaksi. Tietokannasta haetut päätökset ovat tärkeydeltään tärkeämpiä, kuin päätöskoneelta saadut
-        paatokset (paatoskone/yhdista-mapit mahdolliset-paatokset tietokanta-paatokset)]
+        paatokset (yleiset/yhdista-mapit mahdolliset-paatokset tietokanta-paatokset)]
     paatokset))
 
 (defn hae-kustannukset-jarjestettyna [db urakkaid hoitovuosi hoitokauden-alkupvm hoitokauden-loppupvm]

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
@@ -250,7 +250,7 @@
                                 mahdolliset-paatokset)
 
         ;; Yhdistä päätökset listaksi. Tietokannasta haetut päätökset ovat tärkeydeltään tärkeämpiä, kuin päätöskoneelta saadut
-        paatokset (yleiset/yhdista-mapit mahdolliset-paatokset tietokanta-paatokset)]
+        paatokset (yleiset/yhdista-mapit :nimi mahdolliset-paatokset tietokanta-paatokset)]
     paatokset))
 
 (defn hae-kustannukset-jarjestettyna [db urakkaid hoitovuosi hoitokauden-alkupvm hoitokauden-loppupvm]

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
@@ -225,18 +225,6 @@
         mahdolliset-paatokset (paatoskone/valmistele-hoidonjohtopalkkionmuutospaatos validoinnit-kaytossa? valittu-hoitovuosi mahdolliset-paatokset hv-lopun-tavoitehinta-ilman-indeksia tarjouksen-tavoitehinta hoidonjohtopalkkio tietokanta-paatokset urakan-alkuvuosi)
         mahdolliset-paatokset (paatoskone/valmistele-raporttipaatos validoinnit-kaytossa? valittu-hoitovuosi mahdolliset-paatokset)
 
-        ;; Keskeneräiselle tai tulevaisuuden hoitovuodelle näytetään vain yksi päätös - Tavoitehinnan muutospäätös.
-        mahdolliset-paatokset (if (and validoinnit-kaytossa? (or (>= valittu-hoitovuosi nyt-vuosi) hoitovuosi-kesken?))
-                                ;; Poistetaan kaikki muut päätökset, kuin tavoitehinnan muutospäätös
-                                (filter (fn [paatos]
-                                          (when (contains? #{"Hoidonjohtopalkkion muutos" "Lupaukset" "Tavoitehinnan muutokset" "Tavoitehinnan alitus"
-                                                             "Tavoitehinnan ylitys" "Hoitovuoden lopun tavoite- ja kattohinta"
-                                                             "Kattohinnan ylitys" "Välikatselmuspöytäkirjaan liitettävät raportit"} (:nimi paatos))
-                                            paatos))
-                                  mahdolliset-paatokset)
-                                ;; Palautetaan kaikki päätökset, jos ei ole hoitovuosi menossa tai jos validoinnit on poissa päältä
-                                mahdolliset-paatokset)
-
         ;; Keskeneräiselle tai tulevaisuuden hoitovuodelle näytetään vain tietyt päätökset.
         mahdolliset-paatokset (if (and validoinnit-kaytossa? (or (>= valittu-hoitovuosi nyt-vuosi) hoitovuosi-kesken?))
                                 ;; Poistetaan kaikki muut päätökset, kuin tässä määritellyt päätökset
@@ -1221,6 +1209,7 @@
           (tallenna-tavoitehinnan-oikaisu db user tiedot)))
 
       ;; FIXME Poistuu: http palvelua ei tarvita, funktio jää 
+      ;;  Testit hajoaa tästä
       (julkaise-palvelu http
         :poista-tavoitehinnan-oikaisu
         (fn [user tiedot]
@@ -1254,6 +1243,7 @@
         {:kysely-spec ::valikatselmus-domain/lupauspaatos})
 
       ;; FIXME Poistuu 
+      ;;  Testit hajoaa tästä
       (julkaise-palvelu (:http-palvelin this)
         :poista-lupauspaatos
         (fn [user tiedot]
@@ -1267,6 +1257,7 @@
         {:kysely-spec ::valikatselmus-domain/tavoitehinnan-muutospaatos})
 
       ;; FIXME Poistuu: http palvelua ei tarvita, funktio jää 
+      ;;  Testit hajoaa tästä
       (julkaise-palvelu (:http-palvelin this)
         :poista-tavoitehinnan-muutospaatos
         (fn [user tiedot]
@@ -1293,6 +1284,7 @@
         {:kysely-spec ::valikatselmus-domain/tavoitehinnan-alituspaatos})
 
       ;; FIXME Poistuu: http palvelua ei tarvita, funktio jää 
+      ;;  Testit hajoaa tästä
       (julkaise-palvelu (:http-palvelin this)
         :poista-tavoitehinnan-alituspaatos
         (fn [user tiedot]
@@ -1306,6 +1298,7 @@
         {:kysely-spec ::valikatselmus-domain/tavoitehinnan-ylityspaatos})
 
       ;; FIXME Poistuu: http palvelua ei tarvita, funktio jää 
+      ;;  Testit hajoaa tästä
       (julkaise-palvelu (:http-palvelin this)
         :poista-tavoitehinnan-ylityspaatos
         (fn [user tiedot]
@@ -1319,6 +1312,7 @@
         {:kysely-spec ::valikatselmus-domain/kattohinnan-ylityspaatos})
 
       ;; FIXME Poistuu: http palvelua ei tarvita, funktio jää 
+      ;;  Testit hajoaa tästä
       (julkaise-palvelu (:http-palvelin this)
         :poista-kattohinnan-ylityspaatos
         (fn [user tiedot]
@@ -1332,6 +1326,7 @@
         {:kysely-spec ::valikatselmus-domain/indeksikorjauspaatos})
 
       ;; FIXME Poistuu: http palvelua ei tarvita, funktio jää 
+      ;;  Testit hajoaa tästä
       (julkaise-palvelu (:http-palvelin this)
         :poista-indeksikorjauspaatos
         (fn [user tiedot]
@@ -1345,6 +1340,7 @@
         {:kysely-spec ::valikatselmus-domain/hoitokauden-lopun-hintapaatos})
 
       ;; FIXME Poistuu: http palvelua ei tarvita, funktio jää 
+      ;;  Testit hajoaa tästä
       (julkaise-palvelu (:http-palvelin this)
         :poista-hoitovuoden-lopun-hintapaatos
         (fn [user tiedot]
@@ -1358,6 +1354,7 @@
         {:kysely-spec ::valikatselmus-domain/hoidonjohtopalkkiomuutospaatos})
 
       ;; FIXME Poistuu: http palvelua ei tarvita, funktio jää 
+      ;;  Testit hajoaa tästä
       (julkaise-palvelu (:http-palvelin this)
         :poista-hoidonjohtopalkkion-muutospaatos
         (fn [user tiedot]
@@ -1371,6 +1368,7 @@
         {:kysely-spec ::valikatselmus-domain/raporttipaatos})
 
       ;; FIXME Poistuu: http palvelua ei tarvita, funktio jää 
+      ;;  Testit hajoaa tästä
       (julkaise-palvelu (:http-palvelin this)
         :poista-poytakirjan-raporttipaatos
         (fn [user tiedot]

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
@@ -1136,8 +1136,13 @@
 
 
 (defn poista-yksittainen-paatos
-  [db kayttaja {:keys [avain paatostyyppi] :as paatos}]
-  (log/debug "poista-yksittainen-paatos :: avain" (pr-str avain))
+  [db kayttaja {:keys [avain paatostyyppi urakkaid] :as paatos} valittu-urakka-id]
+  (when-not (= urakkaid valittu-urakka-id)
+    ;; Lopettaa funktion ajon, mikäli jostain syystä päätös mappi sisältää toisen urakan päätöksen 
+    (throw+ {:type "Error"
+             :virheet {:koodi "ERROR"
+                       :viesti (str "Yritettiin perua urakan " urakkaid " päätös, valittu urakka: " valittu-urakka-id ".")}}))
+
   (case avain
     :hoitovuoden-lopun-hinta
     (poista-hoitovuoden-lopun-hintapaatos db kayttaja paatos)
@@ -1173,18 +1178,18 @@
 
 
 (defn poista-paatokset-ketjutetusti
-  [db kayttaja {:keys [paatos tehdyt-kumoutuvat-paatokset] :as _tiedot}]
+  [db kayttaja {:keys [paatos tehdyt-kumoutuvat-paatokset urakka-id] :as _tiedot}]
 
-  (let [{:keys [urakkaid hoitokauden_alkuvuosi]} paatos
-        _ (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-lupaukset kayttaja urakkaid)
+  (let [{:keys [hoitokauden_alkuvuosi]} paatos
+        _ (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-lupaukset kayttaja urakka-id)
         ;; Poista itse valittu päätös
-        _ (poista-yksittainen-paatos db kayttaja paatos)]
+        _ (poista-yksittainen-paatos db kayttaja paatos urakka-id)]
 
     ;; Poista kaikki siihen ketjutetut päätökset
     (doseq [paatos tehdyt-kumoutuvat-paatokset]
-      (poista-yksittainen-paatos db kayttaja paatos))
+      (poista-yksittainen-paatos db kayttaja paatos urakka-id))
 
-    (hae-valikatselmuksen-tiedot-hoitovuodelle db kayttaja {:urakkaid urakkaid :hoitovuosi hoitokauden_alkuvuosi})))
+    (hae-valikatselmuksen-tiedot-hoitovuodelle db kayttaja {:urakkaid urakka-id :hoitovuosi hoitokauden_alkuvuosi})))
 
 
 (defrecord Valikatselmukset []

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
@@ -1123,6 +1123,7 @@
         vastaus (not (or (= (count mahdolliset-paatokset) (count tietokanta-paatokset)) false))]
     vastaus))
 
+
 (defn hae-ketjutetusti-kumoutuvat-paatokset
   "Syötetään päätös, joka halutaan kumota. 
   Palauttaa kaikki riippuvaiset päätökset, jotka kumoutuvat sen mukana."
@@ -1138,12 +1139,64 @@
                             (hae-urakan-mahdolliset-paatokset db kayttaja payload)
                             (:avain paatos))
 
-        ;; Palauita pelkästään tehdyt päätökset, jotka kumoutuvat
-        tehdyt-nimet (set (map :nimi tehdyt-paatokset))
-        tehdyt-kumoutuvat-paatokset (filterv
-                                      #(contains? tehdyt-nimet (:nimi %))
-                                      kaikki-kumoutuvat)]
+        ;; Palauta pelkästään tehdyt päätökset, jotka kumoutuvat
+        tehdyt-kumoutuvat-paatokset (->>
+                                      (yleiset/yhdista-mapit :nimi kaikki-kumoutuvat tehdyt-paatokset)
+                                      (filter :id)
+                                      vec)]
     tehdyt-kumoutuvat-paatokset))
+
+
+(defn poista-yksittainen-paatos
+  [db kayttaja {:keys [avain paatostyyppi] :as paatos}]
+  (log/debug "poista-yksittainen-paatos :: avain" (pr-str avain))
+  (case avain
+    :hoitovuoden-lopun-hinta
+    (poista-hoitovuoden-lopun-hintapaatos db kayttaja paatos)
+
+    :tavoitehinnan-ylitys
+    (poista-tavoitehinnan-ylityspaatos db kayttaja paatos)
+
+    :tavoitehinnan-alitus
+    (poista-tavoitehinnan-alituspaatos db kayttaja paatos)
+
+    :kattohinnan-ylitys
+    (poista-kattohinnan-ylityspaatos db kayttaja paatos)
+
+    :hoidonjohtopalkkio
+    (poista-hoidonjohtopalkkion-muutospaatos db kayttaja paatos)
+
+    :indeksikorjaus
+    (poista-indeksikorjauspaatos db kayttaja paatos)
+
+    :lupaus
+    (poista-lupauspaatos db kayttaja paatos)
+
+    :raportti
+    (poista-poytakirjan-raporttipaatos db kayttaja paatos)
+
+    :tavoitehinnan-muutokset
+    (case paatostyyppi
+      "tavoitehinnan-pysyvat-muutokset"
+      (poista-tavoitehinnan-pysyva-muutospaatos db kayttaja paatos)
+
+      "tavoitehinnan-muutokset"
+      (poista-tavoitehinnan-muutospaatos db kayttaja paatos))))
+
+
+(defn poista-paatokset-ketjutetusti
+  [db kayttaja {:keys [paatos tehdyt-kumoutuvat-paatokset] :as _tiedot}]
+
+  (let [{:keys [urakkaid hoitokauden_alkuvuosi]} paatos
+        _ (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-lupaukset kayttaja urakkaid)
+        ;; Poista itse valittu päätös
+        _ (poista-yksittainen-paatos db kayttaja paatos)]
+
+    ;; Poista kaikki siihen ketjutetut päätökset
+    (doseq [paatos tehdyt-kumoutuvat-paatokset]
+      (poista-yksittainen-paatos db kayttaja paatos))
+
+    (hae-valikatselmuksen-tiedot-hoitovuodelle db kayttaja {:urakkaid urakkaid :hoitovuosi hoitokauden_alkuvuosi})))
 
 (defrecord Valikatselmukset []
   component/Lifecycle
@@ -1154,6 +1207,10 @@
       (julkaise-palvelu http :hae-ketjutetusti-kumoutuvat-paatokset
         (fn [user tiedot]
           (hae-ketjutetusti-kumoutuvat-paatokset db user tiedot)))
+
+      (julkaise-palvelu http :poista-paatokset-ketjutetusti
+        (fn [user tiedot]
+          (poista-paatokset-ketjutetusti db user tiedot)))
 
       (julkaise-palvelu http :tallenna-tavoitehinnan-oikaisu
         (fn [user tiedot]
@@ -1304,6 +1361,7 @@
 
   (stop [this]
     (poista-palvelut (:http-palvelin this)
+      :poista-paatokset-ketjutetusti
       :hae-ketjutetusti-kumoutuvat-paatokset
       :tallenna-tavoitehinnan-oikaisu
       :poista-tavoitehinnan-oikaisu

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
@@ -1092,7 +1092,7 @@
                                 hoitovuoden-lopun-tavoitehinta)]
     mahdolliset-paatokset))
 
-(defn palauta-kaikki-mahdolliset-ja-tehdyt-paatokset-kojelautaan
+(defn palauta-kaikki-mahdolliset-ja-tehdyt-paatokset
   "Palauttaa urakalle mahdolliset, sekä kaikki tehdyt päätökset. Ei poissulje mitään."
   [db kayttaja {:keys [urakkaid kuluva-hoitovuosi] :as tiedot}]
   ;; Huomaa, että tämä on oikeutettu urakkatilanne näkymään
@@ -1123,134 +1123,188 @@
         vastaus (not (or (= (count mahdolliset-paatokset) (count tietokanta-paatokset)) false))]
     vastaus))
 
+(defn hae-ketjutetusti-kumoutuvat-paatokset
+  "Syötetään päätös, joka halutaan kumota. 
+  Palauttaa kaikki riippuvaiset päätökset, jotka kumoutuvat sen mukana."
+  [db kayttaja {:keys [urakkaid hoitokauden_alkuvuosi] :as paatos}]
+  (oikeudet/vaadi-lukuoikeus oikeudet/urakat-lupaukset kayttaja urakkaid)
+
+  (let [payload {:urakkaid urakkaid :kuluva-hoitovuosi hoitokauden_alkuvuosi}
+        kaikki-paatokset (palauta-kaikki-mahdolliset-ja-tehdyt-paatokset db kayttaja payload)
+        tehdyt-paatokset (:tietokanta-paatokset kaikki-paatokset)
+
+        ;; Kaikki urakan mahdolliset kumoutuvat päätökset
+        kaikki-kumoutuvat (v-apurit/hae-ketjutetusti-kumoutuvat-paatokset
+                            (hae-urakan-mahdolliset-paatokset db kayttaja payload)
+                            (:avain paatos))
+
+        ;; Palauita pelkästään tehdyt päätökset, jotka kumoutuvat
+        tehdyt-nimet (set (map :nimi tehdyt-paatokset))
+        tehdyt-kumoutuvat-paatokset (filterv
+                                      #(contains? tehdyt-nimet (:nimi %))
+                                      kaikki-kumoutuvat)]
+    tehdyt-kumoutuvat-paatokset))
+
 (defrecord Valikatselmukset []
   component/Lifecycle
   (start [this]
     (let [http (:http-palvelin this)
           db (:db this)]
+
+      (julkaise-palvelu http :hae-ketjutetusti-kumoutuvat-paatokset
+        (fn [user tiedot]
+          (hae-ketjutetusti-kumoutuvat-paatokset db user tiedot)))
+
       (julkaise-palvelu http :tallenna-tavoitehinnan-oikaisu
         (fn [user tiedot]
           (tallenna-tavoitehinnan-oikaisu db user tiedot)))
+
       (julkaise-palvelu http :poista-tavoitehinnan-oikaisu
         (fn [user tiedot]
           (poista-tavoitehinnan-oikaisu db user tiedot)))
+
       (julkaise-palvelu http :tallenna-kattohinnan-oikaisu
         (fn [user tiedot]
           (tallenna-kattohinnan-oikaisu db user tiedot)))
+
       (julkaise-palvelu http :poista-kattohinnan-oikaisu
         (fn [user tiedot]
           (poista-kattohinnan-oikaisu db user tiedot)))
+
       (julkaise-palvelu (:http-palvelin this)
         :hae-valikatselmuksen-tiedot-hoitovuodelle
         (fn [user tiedot]
           (hae-valikatselmuksen-tiedot-hoitovuodelle (:db this) user tiedot)))
+
       (julkaise-palvelu (:http-palvelin this)
         :onko-paatoksia-tekematta
         (fn [user tiedot]
           (onko-paatoksia-tekematta (:db this) user tiedot)))
+
       (julkaise-palvelu (:http-palvelin this)
         :tee-lupauspaatos
         (fn [user tiedot]
           (tee-lupauspaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/lupauspaatos})
+
       (julkaise-palvelu (:http-palvelin this)
         :poista-lupauspaatos
         (fn [user tiedot]
           (poista-lupauspaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/lupauspaatos})
+
       (julkaise-palvelu (:http-palvelin this)
         :tee-tavoitehinnan-muutospaatos
         (fn [user tiedot]
           (tee-tavoitehinnan-muutospaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/tavoitehinnan-muutospaatos})
+
       (julkaise-palvelu (:http-palvelin this)
         :poista-tavoitehinnan-muutospaatos
         (fn [user tiedot]
           (poista-tavoitehinnan-muutospaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/tavoitehinnan-muutospaatos})
+
       (julkaise-palvelu (:http-palvelin this)
         :tee-tavoitehinnan-pysyvamuutospaatos
         (fn [user tiedot]
           (tee-tavoitehinnan-pysyva-muutospaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/tavoitehinnan-pysyva-muutospaatos})
+
       (julkaise-palvelu (:http-palvelin this)
         :poista-tavoitehinnan-pysyvamuutospaatos
         (fn [user tiedot]
           (poista-tavoitehinnan-pysyva-muutospaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/tavoitehinnan-pysyva-muutospaatos})
+
       (julkaise-palvelu (:http-palvelin this)
         :tee-tavoitehinnan-alituspaatos
         (fn [user tiedot]
           (tee-tavoitehinnan-alituspaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/tavoitehinnan-alituspaatos})
+
       (julkaise-palvelu (:http-palvelin this)
         :poista-tavoitehinnan-alituspaatos
         (fn [user tiedot]
           (poista-tavoitehinnan-alituspaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/tavoitehinnan-alituspaatos})
+
       (julkaise-palvelu (:http-palvelin this)
         :tee-tavoitehinnan-ylityspaatos
         (fn [user tiedot]
           (tee-tavoitehinnan-ylityspaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/tavoitehinnan-ylityspaatos})
+
       (julkaise-palvelu (:http-palvelin this)
         :poista-tavoitehinnan-ylityspaatos
         (fn [user tiedot]
           (poista-tavoitehinnan-ylityspaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/tavoitehinnan-ylityspaatos})
+
       (julkaise-palvelu (:http-palvelin this)
         :tee-kattohinnan-ylityspaatos
         (fn [user tiedot]
           (tee-kattohinnan-ylityspaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/kattohinnan-ylityspaatos})
+
       (julkaise-palvelu (:http-palvelin this)
         :poista-kattohinnan-ylityspaatos
         (fn [user tiedot]
           (poista-kattohinnan-ylityspaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/kattohinnan-ylityspaatos})
+
       (julkaise-palvelu (:http-palvelin this)
         :tee-indeksikorjauspaatos
         (fn [user tiedot]
           (tee-indeksikorjauspaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/indeksikorjauspaatos})
+
       (julkaise-palvelu (:http-palvelin this)
         :poista-indeksikorjauspaatos
         (fn [user tiedot]
           (poista-indeksikorjauspaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/indeksikorjauspaatos})
+
       (julkaise-palvelu (:http-palvelin this)
         :tee-hv-lopun-tavoite-ja-kattohintapaatos
         (fn [user tiedot]
           (tee-hv-lopun-tavoite-ja-kattohintapaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/hoitokauden-lopun-hintapaatos})
+
       (julkaise-palvelu (:http-palvelin this)
         :poista-hoitovuoden-lopun-hintapaatos
         (fn [user tiedot]
           (poista-hoitovuoden-lopun-hintapaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/hoitokauden-lopun-hintapaatos})
+
       (julkaise-palvelu (:http-palvelin this)
         :tee-hoidonjohtopalkkion-muutospaatos
         (fn [user tiedot]
           (tee-hoidonjohtopalkkion-muutospaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/hoidonjohtopalkkiomuutospaatos})
+
       (julkaise-palvelu (:http-palvelin this)
         :poista-hoidonjohtopalkkion-muutospaatos
         (fn [user tiedot]
           (poista-hoidonjohtopalkkion-muutospaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/hoidonjohtopalkkiomuutospaatos})
+
       (julkaise-palvelu (:http-palvelin this)
         :tee-poytakirjan-raporttipaatos
         (fn [user tiedot]
           (tee-poytakirjan-raporttipaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/raporttipaatos})
+
       (julkaise-palvelu (:http-palvelin this)
         :poista-poytakirjan-raporttipaatos
         (fn [user tiedot]
           (poista-poytakirjan-raporttipaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/raporttipaatos})
       this))
+
   (stop [this]
     (poista-palvelut (:http-palvelin this)
+      :hae-ketjutetusti-kumoutuvat-paatokset
       :tallenna-tavoitehinnan-oikaisu
       :poista-tavoitehinnan-oikaisu
       :tallenna-kattohinnan-oikaisu

--- a/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
+++ b/src/clj/harja/palvelin/palvelut/valikatselmus/valikatselmukset.clj
@@ -1198,33 +1198,42 @@
 
     (hae-valikatselmuksen-tiedot-hoitovuodelle db kayttaja {:urakkaid urakkaid :hoitovuosi hoitokauden_alkuvuosi})))
 
+
 (defrecord Valikatselmukset []
   component/Lifecycle
   (start [this]
     (let [http (:http-palvelin this)
           db (:db this)]
 
-      (julkaise-palvelu http :hae-ketjutetusti-kumoutuvat-paatokset
+      (julkaise-palvelu http
+        :hae-ketjutetusti-kumoutuvat-paatokset
         (fn [user tiedot]
           (hae-ketjutetusti-kumoutuvat-paatokset db user tiedot)))
 
-      (julkaise-palvelu http :poista-paatokset-ketjutetusti
+      (julkaise-palvelu http
+        :poista-paatokset-ketjutetusti
         (fn [user tiedot]
           (poista-paatokset-ketjutetusti db user tiedot)))
 
-      (julkaise-palvelu http :tallenna-tavoitehinnan-oikaisu
+      (julkaise-palvelu http
+        :tallenna-tavoitehinnan-oikaisu
         (fn [user tiedot]
           (tallenna-tavoitehinnan-oikaisu db user tiedot)))
 
-      (julkaise-palvelu http :poista-tavoitehinnan-oikaisu
+      ;; FIXME Poistuu: http palvelua ei tarvita, funktio jää 
+      (julkaise-palvelu http
+        :poista-tavoitehinnan-oikaisu
         (fn [user tiedot]
           (poista-tavoitehinnan-oikaisu db user tiedot)))
 
-      (julkaise-palvelu http :tallenna-kattohinnan-oikaisu
+      (julkaise-palvelu http
+        :tallenna-kattohinnan-oikaisu
         (fn [user tiedot]
           (tallenna-kattohinnan-oikaisu db user tiedot)))
 
-      (julkaise-palvelu http :poista-kattohinnan-oikaisu
+      ;; FIXME Poistuu?
+      (julkaise-palvelu http
+        :poista-kattohinnan-oikaisu
         (fn [user tiedot]
           (poista-kattohinnan-oikaisu db user tiedot)))
 
@@ -1244,6 +1253,7 @@
           (tee-lupauspaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/lupauspaatos})
 
+      ;; FIXME Poistuu 
       (julkaise-palvelu (:http-palvelin this)
         :poista-lupauspaatos
         (fn [user tiedot]
@@ -1256,6 +1266,7 @@
           (tee-tavoitehinnan-muutospaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/tavoitehinnan-muutospaatos})
 
+      ;; FIXME Poistuu: http palvelua ei tarvita, funktio jää 
       (julkaise-palvelu (:http-palvelin this)
         :poista-tavoitehinnan-muutospaatos
         (fn [user tiedot]
@@ -1268,6 +1279,7 @@
           (tee-tavoitehinnan-pysyva-muutospaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/tavoitehinnan-pysyva-muutospaatos})
 
+      ;; FIXME Poistuu: http palvelua ei tarvita, funktio jää 
       (julkaise-palvelu (:http-palvelin this)
         :poista-tavoitehinnan-pysyvamuutospaatos
         (fn [user tiedot]
@@ -1280,6 +1292,7 @@
           (tee-tavoitehinnan-alituspaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/tavoitehinnan-alituspaatos})
 
+      ;; FIXME Poistuu: http palvelua ei tarvita, funktio jää 
       (julkaise-palvelu (:http-palvelin this)
         :poista-tavoitehinnan-alituspaatos
         (fn [user tiedot]
@@ -1292,6 +1305,7 @@
           (tee-tavoitehinnan-ylityspaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/tavoitehinnan-ylityspaatos})
 
+      ;; FIXME Poistuu: http palvelua ei tarvita, funktio jää 
       (julkaise-palvelu (:http-palvelin this)
         :poista-tavoitehinnan-ylityspaatos
         (fn [user tiedot]
@@ -1304,6 +1318,7 @@
           (tee-kattohinnan-ylityspaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/kattohinnan-ylityspaatos})
 
+      ;; FIXME Poistuu: http palvelua ei tarvita, funktio jää 
       (julkaise-palvelu (:http-palvelin this)
         :poista-kattohinnan-ylityspaatos
         (fn [user tiedot]
@@ -1316,6 +1331,7 @@
           (tee-indeksikorjauspaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/indeksikorjauspaatos})
 
+      ;; FIXME Poistuu: http palvelua ei tarvita, funktio jää 
       (julkaise-palvelu (:http-palvelin this)
         :poista-indeksikorjauspaatos
         (fn [user tiedot]
@@ -1328,6 +1344,7 @@
           (tee-hv-lopun-tavoite-ja-kattohintapaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/hoitokauden-lopun-hintapaatos})
 
+      ;; FIXME Poistuu: http palvelua ei tarvita, funktio jää 
       (julkaise-palvelu (:http-palvelin this)
         :poista-hoitovuoden-lopun-hintapaatos
         (fn [user tiedot]
@@ -1340,6 +1357,7 @@
           (tee-hoidonjohtopalkkion-muutospaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/hoidonjohtopalkkiomuutospaatos})
 
+      ;; FIXME Poistuu: http palvelua ei tarvita, funktio jää 
       (julkaise-palvelu (:http-palvelin this)
         :poista-hoidonjohtopalkkion-muutospaatos
         (fn [user tiedot]
@@ -1352,6 +1370,7 @@
           (tee-poytakirjan-raporttipaatos (:db this) user tiedot))
         {:kysely-spec ::valikatselmus-domain/raporttipaatos})
 
+      ;; FIXME Poistuu: http palvelua ei tarvita, funktio jää 
       (julkaise-palvelu (:http-palvelin this)
         :poista-poytakirjan-raporttipaatos
         (fn [user tiedot]

--- a/src/cljc/harja/tyokalut/yleiset.cljc
+++ b/src/cljc/harja/tyokalut/yleiset.cljc
@@ -100,16 +100,15 @@
 
 
 (defn yhdista-mapit
-  "Yhdistetään tietokannasta tulevat ja päätöskoneelta tulevat päätökset niin, että
-   käytetään päätöskoneen päätöksiä, jos niitä ei ole vielä tietokannassa ja muuten tietokannan päätöksiä.
-   Vertailussa käytetään :nimi avainta. Se täytyy löytyä molemmista mapeistä."
-  [pk-paatokset db-paatokset]
-  (let [index-map (into {} (map (fn [m] [(:nimi m) m]) db-paatokset))]
-    (map (fn [m1]
-           (if-let [m2 (index-map (:nimi m1))]
-             m2
-             m1))
-      pk-paatokset)))
+  "Yhdistää mapit annetun avaimen perusteella.
+  Jos sama avain löytyy molemmista, jälkimmäisen arvot ylikirjoittavat ensimmäisen vastaavat arvot."
+  [avain pohjat paivitykset]
+  (let [index (into {} (map (juxt avain identity) paivitykset))]
+    (map (fn [pohja]
+           (if-let [paivitys (get index (avain pohja))]
+             (merge pohja paivitys)
+             pohja))
+      pohjat)))
 
 
 (defn random-luku-valilta

--- a/src/cljc/harja/tyokalut/yleiset.cljc
+++ b/src/cljc/harja/tyokalut/yleiset.cljc
@@ -70,7 +70,7 @@
       (> hoitokauden-numero 1)) (+ hoitokauden-numero urakan-aloitusvuosi)))
 
 
-(defn liita-yhteen-mapit-ja-korvaa-avain 
+(defn liita-yhteen-mapit-ja-korvaa-avain
   "Tekee join-liitoksen kahden kokoelman välillä jotka sisältävät mappeja.
    Parametrit:
   * kokoelma1: Kokoelma mappeja johon liitos tehdään
@@ -97,6 +97,19 @@
     (map (fn [a]
            (merge (get m2 a {}) (get m1 a {})))
       kaikki-avaimet)))
+
+
+(defn yhdista-mapit
+  "Yhdistetään tietokannasta tulevat ja päätöskoneelta tulevat päätökset niin, että
+   käytetään päätöskoneen päätöksiä, jos niitä ei ole vielä tietokannassa ja muuten tietokannan päätöksiä.
+   Vertailussa käytetään :nimi avainta. Se täytyy löytyä molemmista mapeistä."
+  [pk-paatokset db-paatokset]
+  (let [index-map (into {} (map (fn [m] [(:nimi m) m]) db-paatokset))]
+    (map (fn [m1]
+           (if-let [m2 (index-map (:nimi m1))]
+             m2
+             m1))
+      pk-paatokset)))
 
 
 (defn random-luku-valilta

--- a/src/cljs/harja/tiedot/urakka/valikatselmus/valikatselmus_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/valikatselmus/valikatselmus_tiedot.cljs
@@ -64,23 +64,16 @@
 
 ;; Päätökset
 (defrecord TallennaLupausPaatos [paatos])
-(defrecord PoistaLupausPaatos [paatos])
-(defrecord PoistaLupausPaatosOnnistui [vastaus])
-(defrecord PoistaLupausPaatosEpaonnistui [vastaus])
 (defrecord TallennaTavoitehinnanMuutosPaatos [paatos])
 (defrecord TallennaTavoitehinnanPysyvaMuutosPaatos [paatos])
 (defrecord TallennaTavoitehinnanAlitusPaatos [paatos])
 (defrecord TallennaTavoitehinnanYlitysPaatos [paatos])
-(defrecord PoistaTavoitehinnanYlitysPaatos [paatos])
 (defrecord TallennaKattohinnanYlitysPaatos [paatos])
 (defrecord TallennaKattohinnanYlitysPaatosEpaonnistui [vastaus])
-(defrecord PoistaKattohinnanYlitysPaatos [paatos])
 (defrecord TallennaPoytakirjanRaporttiPaatos [paatos])
-(defrecord PoistaPoytakirjanRaporttiPaatos [paatos])
 (defrecord TallennaHoidonjohtopalkkionMuutospaatos [paatos])
 (defrecord TallennaHoitokaudenlopunHintapaatos [paatos])
 (defrecord TallennaHoitovuodenlopunIndeksikorjauspaatos [paatos])
-(defrecord PoistaHoitovuodenlopunIndeksikorjauspaatos [paatos])
 
 (defrecord HaeKetjutetustiKumoutuvatPaatokset [paatos peru-fn])
 (defrecord HaeKumoutuvatOnnistui [vastaus])
@@ -315,26 +308,6 @@
        :paasta-virhe-lapi? true})
     (assoc app :tallennus-kesken? true))
 
-  PoistaLupausPaatos
-  (process-event [{paatos :paatos} app]
-    (tuck-apurit/post! :poista-lupauspaatos
-      paatos
-      {:onnistui ->PoistaLupausPaatosOnnistui
-       :epaonnistui ->PoistaLupausPaatosEpaonnistui
-       :paasta-virhe-lapi? true})
-    (assoc app :tallennus-kesken? true))
-
-  PoistaLupausPaatosOnnistui
-  (process-event [{vastaus :vastaus} app]
-    (kasittele-valikatselmuksen-vastaus app vastaus))
-
-  PoistaLupausPaatosEpaonnistui
-  (process-event [{vastaus :vastaus} app]
-    (viesti/nayta-toast! "Päätöksen poistossa tapahtui virhe" :varoitus)
-    (-> app
-      (assoc :haku-kaynnissa? false)
-      (assoc :tallennus-kesken? false)))
-
   ValitseHoitokausi
   (process-event [{urakkaid :urakkaid vuosi :vuosi} app]
     (let [app (-> app
@@ -422,14 +395,6 @@
        :paasta-virhe-lapi? true})
     (assoc app :tallennus-kesken? true))
 
-  PoistaTavoitehinnanYlitysPaatos
-  (process-event [{paatos :paatos} app]
-    (tuck-apurit/post! :poista-tavoitehinnan-ylityspaatos
-      (assoc paatos :luoja (:id @istunto/kayttaja))
-      {:onnistui ->HaeValikatselmuksenTiedotOnnistui
-       :epaonnistui ->HaeValikatselmuksenTiedotEpaonnistui})
-    (assoc app :tallennus-kesken? true))
-
   TallennaKattohinnanYlitysPaatos
   (process-event [{paatos :paatos} app]
     (tuck-apurit/post! :tee-kattohinnan-ylityspaatos
@@ -454,14 +419,6 @@
         (assoc :tallennus-kesken? false)
         (assoc :haku-kaynnissa? false))))
 
-  PoistaKattohinnanYlitysPaatos
-  (process-event [{paatos :paatos} app]
-    (tuck-apurit/post! :poista-kattohinnan-ylityspaatos
-      (assoc paatos :luoja (:id @istunto/kayttaja))
-      {:onnistui ->HaeValikatselmuksenTiedotOnnistui
-       :epaonnistui ->HaeValikatselmuksenTiedotEpaonnistui})
-    (assoc app :tallennus-kesken? true))
-
   TallennaPoytakirjanRaporttiPaatos
   (process-event [{paatos :paatos} app]
     (tuck-apurit/post! :tee-poytakirjan-raporttipaatos
@@ -469,14 +426,6 @@
       {:onnistui ->HaeValikatselmuksenTiedotOnnistui
        :epaonnistui ->HaeValikatselmuksenTiedotEpaonnistui
        :paasta-virhe-lapi? true})
-    (assoc app :tallennus-kesken? true))
-
-  PoistaPoytakirjanRaporttiPaatos
-  (process-event [{paatos :paatos} app]
-    (tuck-apurit/post! :poista-poytakirjan-raporttipaatos
-      (assoc paatos :luoja (:id @istunto/kayttaja))
-      {:onnistui ->HaeValikatselmuksenTiedotOnnistui
-       :epaonnistui ->HaeValikatselmuksenTiedotEpaonnistui})
     (assoc app :tallennus-kesken? true))
 
   TallennaHoidonjohtopalkkionMuutospaatos
@@ -504,14 +453,6 @@
       {:onnistui ->HaeValikatselmuksenTiedotOnnistui
        :epaonnistui ->HaeValikatselmuksenTiedotEpaonnistui
        :paasta-virhe-lapi? true})
-    (assoc app :tallennus-kesken? true))
-
-  PoistaHoitovuodenlopunIndeksikorjauspaatos
-  (process-event [{paatos :paatos} app]
-    (tuck-apurit/post! :poista-indeksikorjauspaatos
-      (assoc paatos :luoja (:id @istunto/kayttaja))
-      {:onnistui ->HaeValikatselmuksenTiedotOnnistui
-       :epaonnistui ->HaeValikatselmuksenTiedotEpaonnistui})
     (assoc app :tallennus-kesken? true))
 
   HaeKetjutetustiKumoutuvatPaatokset

--- a/src/cljs/harja/tiedot/urakka/valikatselmus/valikatselmus_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/valikatselmus/valikatselmus_tiedot.cljs
@@ -1,15 +1,17 @@
 (ns harja.tiedot.urakka.valikatselmus.valikatselmus-tiedot
-  (:require [clojure.string :as str]
-            [tuck.core :as tuck]
+  (:require [tuck.core :as tuck]
+            [clojure.string :as str]
+
+            [harja.pvm :as pvm]
             [harja.ui.dom :as dom]
-            [harja.tyokalut.tuck :as tuck-apurit]
+            [harja.ui.viesti :as viesti]
+            [harja.domain.urakka :as urakka]
+            [harja.tiedot.navigaatio :as nav]
             [harja.tiedot.istunto :as istunto]
             [harja.ui.nakymasiirrin :as siirrin]
-            [harja.domain.urakka :as urakka]
-            [harja.domain.kulut.valikatselmus :as valikatselmus]
-            [harja.ui.viesti :as viesti]
             [harja.tiedot.urakka.urakka :as tila]
-            [harja.pvm :as pvm]))
+            [harja.tyokalut.tuck :as tuck-apurit]
+            [harja.domain.kulut.valikatselmus :as valikatselmus]))
 
 (def valikatselmus-nakymassa? (atom false))
 (def tavoitehinnan-muutostallennus-max (atom 9999))
@@ -33,6 +35,7 @@
         muutokset))))
 
 (defn kasittele-throw-virhe [vastaus]
+
   (let [raaka-virhe (get-in vastaus [:parse-error :original-text])
         raaka-virhe (if (nil? raaka-virhe) "Virhe! Palvelin palautti virheen!" raaka-virhe)
         raaka-virhe (str/replace raaka-virhe #"\\" "")
@@ -76,6 +79,7 @@
 (defrecord HaeKumoutuvatOnnistui [vastaus])
 (defrecord SuljePaatosModal [])
 (defrecord PeruValikatselmusPaatos [paatos])
+(defrecord PeruValikatselmusPaatosEpaonnistui [vastaus])
 
 
 (defrecord PaivitaKattohinnanSiirtoCheckbox [uusi-arvo])
@@ -448,15 +452,25 @@
   (process-event [{:keys [paatos]} app]
     (tuck-apurit/post!
       :poista-paatokset-ketjutetusti
-      {:paatos (assoc paatos :luoja (:id @istunto/kayttaja))
+      {:urakka-id @nav/valittu-urakka-id
+       :paatos (assoc paatos :luoja (:id @istunto/kayttaja))
        :tehdyt-kumoutuvat-paatokset (:tehdyt-kumoutuvat-paatokset app)}
-      {:onnistui ->HaeValikatselmuksenTiedotOnnistui
-       :epaonnistui ->HaeValikatselmuksenTiedotEpaonnistui})
+      {:paasta-virhe-lapi? true
+       :onnistui ->HaeValikatselmuksenTiedotOnnistui
+       :epaonnistui ->PeruValikatselmusPaatosEpaonnistui})
     (assoc app
       :tallennus-kesken? true
       :nayta-kumoa-modal? false
       :tehdyt-kumoutuvat-paatokset nil
       :kumottava-paatos-nimi (:nimi paatos)))
+
+  PeruValikatselmusPaatosEpaonnistui
+  (process-event [{vastaus :vastaus} app]
+    (viesti/nayta-toast! (str "Tapahtui virhe! "
+                           (some->> (get-in vastaus [:response :virheet :viesti]))) :varoitus)
+    (-> app
+      (assoc :haku-kaynnissa? false)
+      (assoc :tallennus-kesken? false)))
 
   SuljePaatosModal
   (process-event [_ app]

--- a/src/cljs/harja/tiedot/urakka/valikatselmus/valikatselmus_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/valikatselmus/valikatselmus_tiedot.cljs
@@ -85,9 +85,7 @@
 (defrecord TallennaPoytakirjanRaporttiPaatos [paatos])
 (defrecord PoistaPoytakirjanRaporttiPaatos [paatos])
 (defrecord TallennaHoidonjohtopalkkionMuutospaatos [paatos])
-(defrecord PoistaHoidonjohtopalkkionMuutospaatos [paatos])
 (defrecord TallennaHoitokaudenlopunHintapaatos [paatos])
-(defrecord PoistaHoitokaudenlopunHintapaatos [paatos])
 (defrecord TallennaHoitovuodenlopunIndeksikorjauspaatos [paatos])
 (defrecord PoistaHoitovuodenlopunIndeksikorjauspaatos [paatos])
 
@@ -542,14 +540,6 @@
        :paasta-virhe-lapi? true})
     (assoc app :tallennus-kesken? true))
 
-  PoistaHoidonjohtopalkkionMuutospaatos
-  (process-event [{paatos :paatos} app]
-    (tuck-apurit/post! :poista-hoidonjohtopalkkion-muutospaatos
-      (assoc paatos :luoja (:id @istunto/kayttaja))
-      {:onnistui ->HaeValikatselmuksenTiedotOnnistui
-       :epaonnistui ->HaeValikatselmuksenTiedotEpaonnistui})
-    (assoc app :tallennus-kesken? true))
-
   TallennaHoitokaudenlopunHintapaatos
   (process-event [{paatos :paatos} app]
     (tuck-apurit/post! :tee-hv-lopun-tavoite-ja-kattohintapaatos
@@ -557,14 +547,6 @@
       {:onnistui ->HaeValikatselmuksenTiedotOnnistui
        :epaonnistui ->HaeValikatselmuksenTiedotEpaonnistui
        :paasta-virhe-lapi? true})
-    (assoc app :tallennus-kesken? true))
-
-  PoistaHoitokaudenlopunHintapaatos
-  (process-event [{paatos :paatos} app]
-    (tuck-apurit/post! :poista-hoitovuoden-lopun-hintapaatos
-      (assoc paatos :luoja (:id @istunto/kayttaja))
-      {:onnistui ->HaeValikatselmuksenTiedotOnnistui
-       :epaonnistui ->HaeValikatselmuksenTiedotEpaonnistui})
     (assoc app :tallennus-kesken? true))
 
   TallennaHoitovuodenlopunIndeksikorjauspaatos

--- a/src/cljs/harja/tiedot/urakka/valikatselmus/valikatselmus_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/valikatselmus/valikatselmus_tiedot.cljs
@@ -68,13 +68,7 @@
 (defrecord PoistaLupausPaatosOnnistui [vastaus])
 (defrecord PoistaLupausPaatosEpaonnistui [vastaus])
 (defrecord TallennaTavoitehinnanMuutosPaatos [paatos])
-(defrecord PoistaTavoitehinnanMuutosPaatos [paatos])
-(defrecord PoistaTavoitehinnanMuutosPaatosOnnistui [vastaus])
-(defrecord PoistaTavoitehinnanMuutosPaatosEpaonnistui [vastaus])
 (defrecord TallennaTavoitehinnanPysyvaMuutosPaatos [paatos])
-(defrecord PoistaTavoitehinnanPysyvaMuutosPaatos [paatos])
-(defrecord PoistaTavoitehinnanPysyvaMuutosPaatosOnnistui [vastaus])
-(defrecord PoistaTavoitehinnanPysyvaMuutosPaatosEpaonnistui [vastaus])
 (defrecord TallennaTavoitehinnanAlitusPaatos [paatos])
 (defrecord TallennaTavoitehinnanYlitysPaatos [paatos])
 (defrecord PoistaTavoitehinnanYlitysPaatos [paatos])
@@ -401,24 +395,6 @@
        :paasta-virhe-lapi? true})
     (assoc app :tallennus-kesken? true))
 
-  PoistaTavoitehinnanMuutosPaatos
-  (process-event [{paatos :paatos} app]
-    (tuck-apurit/post! :poista-tavoitehinnan-muutospaatos
-      (assoc paatos :luoja (:id @istunto/kayttaja))
-      {:onnistui ->PoistaTavoitehinnanMuutosPaatosOnnistui
-       :epaonnistui ->PoistaTavoitehinnanMuutosPaatosEpaonnistui})
-    (assoc app :tallennus-kesken? true))
-
-  PoistaTavoitehinnanMuutosPaatosOnnistui
-  (process-event [{vastaus :vastaus} app]
-    (viesti/nayta-toast! "Päätöksen poisto onnistui!")
-    (kasittele-valikatselmuksen-vastaus app vastaus))
-
-  PoistaTavoitehinnanMuutosPaatosEpaonnistui
-  (process-event [{vastaus :vastaus} app]
-    (viesti/nayta-toast! "Päätöksen poistossa tapahtui virhe" :varoitus)
-    (kasittele-valikatselmuksen-vastaus app vastaus))
-
   TallennaTavoitehinnanPysyvaMuutosPaatos
   (process-event [{paatos :paatos} app]
     (tuck-apurit/post! :tee-tavoitehinnan-pysyvamuutospaatos
@@ -427,25 +403,6 @@
        :epaonnistui ->HaeValikatselmuksenTiedotEpaonnistui
        :paasta-virhe-lapi? true})
     (assoc app :tallennus-kesken? true))
-
-  PoistaTavoitehinnanPysyvaMuutosPaatos
-  (process-event [{paatos :paatos} app]
-    (tuck-apurit/post! :poista-tavoitehinnan-pysyvamuutospaatos
-      (assoc paatos :luoja (:id @istunto/kayttaja))
-      {:onnistui ->PoistaTavoitehinnanPysyvaMuutosPaatosOnnistui
-       :epaonnistui ->PoistaTavoitehinnanPysyvaMuutosPaatosEpaonnistui})
-    (assoc app :tallennus-kesken? true))
-
-
-  PoistaTavoitehinnanPysyvaMuutosPaatosOnnistui
-  (process-event [{vastaus :vastaus} app]
-    (viesti/nayta-toast! "Päätöksen poisto onnistui!")
-    (kasittele-valikatselmuksen-vastaus app vastaus))
-
-  PoistaTavoitehinnanPysyvaMuutosPaatosEpaonnistui
-  (process-event [{vastaus :vastaus} app]
-    (viesti/nayta-toast! "Päätöksen poistossa tapahtui virhe" :varoitus)
-    (kasittele-valikatselmuksen-vastaus app vastaus))
 
   TallennaTavoitehinnanAlitusPaatos
   (process-event [{paatos :paatos} app]

--- a/src/cljs/harja/tiedot/urakka/valikatselmus/valikatselmus_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/valikatselmus/valikatselmus_tiedot.cljs
@@ -76,7 +76,6 @@
 (defrecord PoistaTavoitehinnanPysyvaMuutosPaatosOnnistui [vastaus])
 (defrecord PoistaTavoitehinnanPysyvaMuutosPaatosEpaonnistui [vastaus])
 (defrecord TallennaTavoitehinnanAlitusPaatos [paatos])
-(defrecord PoistaTavoitehinnanAlitusPaatos [paatos])
 (defrecord TallennaTavoitehinnanYlitysPaatos [paatos])
 (defrecord PoistaTavoitehinnanYlitysPaatos [paatos])
 (defrecord TallennaKattohinnanYlitysPaatos [paatos])
@@ -455,14 +454,6 @@
       {:onnistui ->HaeValikatselmuksenTiedotOnnistui
        :epaonnistui ->HaeValikatselmuksenTiedotEpaonnistui
        :paasta-virhe-lapi? true})
-    (assoc app :tallennus-kesken? true))
-
-  PoistaTavoitehinnanAlitusPaatos
-  (process-event [{paatos :paatos} app]
-    (tuck-apurit/post! :poista-tavoitehinnan-alituspaatos
-      (assoc paatos :luoja (:id @istunto/kayttaja))
-      {:onnistui ->HaeValikatselmuksenTiedotOnnistui
-       :epaonnistui ->HaeValikatselmuksenTiedotEpaonnistui})
     (assoc app :tallennus-kesken? true))
 
   TallennaTavoitehinnanYlitysPaatos

--- a/src/cljs/harja/tiedot/urakka/valikatselmus/valikatselmus_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/valikatselmus/valikatselmus_tiedot.cljs
@@ -57,9 +57,6 @@
 (defrecord TallennaKattohinnanOikaisu [uusi-kattohinta hoitokauden-alkuvuosi])
 (defrecord TallennaKattohinnanOikaisuOnnistui [vastaus id])
 (defrecord TallennaKattohinnanOikaisuEpaonnistui [vastaus])
-(defrecord PoistaKattohinnanOikaisu [])
-(defrecord PoistaKattohinnanOikaisuOnnistui [vastaus id])
-(defrecord PoistaKattohinnanOikaisuEpaonnistui [vastaus])
 (defrecord KattohinnanMuokkaaPainettu [kattohinta])
 
 ;; Päätökset
@@ -93,14 +90,6 @@
 (defrecord HaeValikatselmuksenTiedot [urakkaid hoitovuosi])
 
 (defrecord AvaaPaatos [avain])
-
-(defn poista-kattohinnan-oikaisu [app]
-  (tuck-apurit/post! app :poista-kattohinnan-oikaisu
-    {::urakka/id (-> @tila/yleiset :urakka :id)
-     ::valikatselmus/hoitokauden-alkuvuosi (:hoitokauden-alkuvuosi app)}
-    {:onnistui ->PoistaKattohinnanOikaisuOnnistui
-     :epaonnistui ->PoistaKattohinnanOikaisuEpaonnistui
-     :paasta-virhe-lapi? true}))
 
 (defn hae-valikatselmuksen-tiedot [urakkaid hoitovuosi]
   (tuck-apurit/post! :hae-valikatselmuksen-tiedot-hoitovuodelle
@@ -271,27 +260,6 @@
         "Kattohinnan oikaisun tallennuksessa tapahtui virhe.")
       :varoitus)
     (kasittele-valikatselmuksen-vastaus app vastaus))
-
-  PoistaKattohinnanOikaisu
-  (process-event [_ app]
-    (poista-kattohinnan-oikaisu app)
-    app)
-
-  PoistaKattohinnanOikaisuOnnistui
-  (process-event [{vastaus :vastaus} app]
-    (do
-      (viesti/nayta-toast! "Kattohinnan oikaisu poistettu")
-      (hae-valikatselmuksen-tiedot (-> @tila/yleiset :urakka :id) (:hoitokauden-alkuvuosi app))
-      (->
-        app
-        (update-in [:kattohintojen-oikaisut] dissoc (:hoitokauden-alkuvuosi app))
-        (dissoc app :kattohinnan-oikaisu))))
-
-  PoistaKattohinnanOikaisuEpaonnistui
-  (process-event [{vastaus :vastaus} app]
-    (js/console.warn "PoistaKattohinnanOikaisuEpaonnistui" vastaus)
-    (viesti/nayta-toast! "Kattohinnan oikaisun poistamisessa tapahtui virhe" :varoitus)
-    app)
 
   KattohinnanMuokkaaPainettu
   (process-event [{kattohinta :kattohinta} app]

--- a/src/cljs/harja/tiedot/urakka/valikatselmus/valikatselmus_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/valikatselmus/valikatselmus_tiedot.cljs
@@ -94,6 +94,8 @@
 (defrecord HaeKetjutetustiKumoutuvatPaatokset [paatos peru-fn])
 (defrecord HaeKumoutuvatOnnistui [vastaus])
 (defrecord SuljePaatosModal [])
+(defrecord PeruValikatselmusPaatos [paatos])
+
 
 (defrecord PaivitaKattohinnanSiirtoCheckbox [uusi-arvo])
 (defrecord PaivitaKattohinnanSiirtoMaara [uusi-arvo])
@@ -602,6 +604,20 @@
       :tallennus-kesken? false
       :nayta-kumoa-modal? true
       :tehdyt-kumoutuvat-paatokset vastaus))
+
+  PeruValikatselmusPaatos
+  (process-event [{:keys [paatos]} app]
+    (tuck-apurit/post!
+      :poista-paatokset-ketjutetusti
+      {:paatos (assoc paatos :luoja (:id @istunto/kayttaja))
+       :tehdyt-kumoutuvat-paatokset (:tehdyt-kumoutuvat-paatokset app)}
+      {:onnistui ->HaeValikatselmuksenTiedotOnnistui
+       :epaonnistui ->HaeValikatselmuksenTiedotEpaonnistui})
+    (assoc app
+      :tallennus-kesken? true
+      :nayta-kumoa-modal? false
+      :tehdyt-kumoutuvat-paatokset nil
+      :kumottava-paatos-nimi (:nimi paatos)))
 
   SuljePaatosModal
   (process-event [_ app]

--- a/src/cljs/harja/tiedot/urakka/valikatselmus/valikatselmus_tiedot.cljs
+++ b/src/cljs/harja/tiedot/urakka/valikatselmus/valikatselmus_tiedot.cljs
@@ -91,6 +91,10 @@
 (defrecord TallennaHoitovuodenlopunIndeksikorjauspaatos [paatos])
 (defrecord PoistaHoitovuodenlopunIndeksikorjauspaatos [paatos])
 
+(defrecord HaeKetjutetustiKumoutuvatPaatokset [paatos peru-fn])
+(defrecord HaeKumoutuvatOnnistui [vastaus])
+(defrecord SuljePaatosModal [])
+
 (defrecord PaivitaKattohinnanSiirtoCheckbox [uusi-arvo])
 (defrecord PaivitaKattohinnanSiirtoMaara [uusi-arvo])
 
@@ -132,7 +136,9 @@
       (assoc :yhteenveto (:yhteenveto vastaus))
       (assoc :urakan-parametrit (:urakan-parametrit vastaus))
       (assoc :haku-kaynnissa? false)
-      (assoc :tallennus-kesken? false))))
+      (assoc :tallennus-kesken? false)
+      (assoc :nayta-kumoa-modal? false)
+      (assoc :tehdyt-kumoutuvat-paatokset nil))))
 
 (extend-protocol tuck/Event
 
@@ -574,7 +580,37 @@
       (assoc paatos :luoja (:id @istunto/kayttaja))
       {:onnistui ->HaeValikatselmuksenTiedotOnnistui
        :epaonnistui ->HaeValikatselmuksenTiedotEpaonnistui})
-    (assoc app :tallennus-kesken? true)))
+    (assoc app :tallennus-kesken? true))
+
+  HaeKetjutetustiKumoutuvatPaatokset
+  (process-event [{paatos :paatos peru-fn :peru-fn} app]
+    (tuck-apurit/post!
+      :hae-ketjutetusti-kumoutuvat-paatokset
+      paatos
+      {:onnistui ->HaeKumoutuvatOnnistui
+       :epaonnistui ->HaeValikatselmuksenTiedotEpaonnistui})
+    (assoc app
+      :peru-fn peru-fn
+      :tallennus-kesken? true
+      :nayta-kumoa-modal? false
+      :tehdyt-kumoutuvat-paatokset nil
+      :kumottava-paatos-nimi (:nimi paatos)))
+
+  HaeKumoutuvatOnnistui
+  (process-event [{vastaus :vastaus} app]
+    (assoc app
+      :tallennus-kesken? false
+      :nayta-kumoa-modal? true
+      :tehdyt-kumoutuvat-paatokset vastaus))
+
+  SuljePaatosModal
+  (process-event [_ app]
+    (assoc app
+      :peru-fn nil
+      :tallennus-kesken? false
+      :nayta-kumoa-modal? false
+      :kumottava-paatos-nimi nil
+      :tehdyt-kumoutuvat-paatokset nil)))
 
 (defn avaa-tai-sulje-haitari [event avain]
   (when (dom/enter-nappain? event)

--- a/src/cljs/harja/views/urakka/valikatselmus/hintapaatokset.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/hintapaatokset.cljs
@@ -117,7 +117,7 @@
           ;; Peru päätös 
           #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
                  paatos
-                 (fn [] (e! (valikatselmus-tiedot/->PoistaTavoitehinnanAlitusPaatos paatos)))))]]])]))
+                 (fn [] (e! (valikatselmus-tiedot/->PoistaTavoitehinnanYlitysPaatos paatos)))))]]])]))
 
 (defn kattohinnan-ylitys [e! paatos voi-muokata? tallennus-kesken? avatut-paatokset]
   (let [paatos-avain :kattohinta-ylitys

--- a/src/cljs/harja/views/urakka/valikatselmus/hintapaatokset.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/hintapaatokset.cljs
@@ -48,9 +48,12 @@
            [yleiset/info-laatikko :vahva-ilmoitus "Et voi vahvistaa päätöstä, sillä osa pohjatiedoista puuttuu" (:virheet paatos) nil {:ikoni-fn #(ikonit/harja-icon-status-alert)}])
          [valikatselmus-yhteiset/paatosnapit paatos-tehty? on-oikeudet? paatos tallennus-kesken?
           (and voi-muokata? (not (:virheet paatos)))
+          ;; Vahvista
           #(e! (valikatselmus-tiedot/->TallennaTavoitehinnanYlitysPaatos paatos))
-          (valikatselmus-yhteiset/paatoksen-poistovarmistus-modaali {:peru-paatos-fn #(e! (valikatselmus-tiedot/->PoistaTavoitehinnanYlitysPaatos paatos))
-                                                                     :teksti "Automaattisesti kirjattu tavoitehinnan ylitys -kulu poistetaan."})]]])]))
+          ;; Peru päätös
+          #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
+                 paatos
+                 (fn [] (e! (valikatselmus-tiedot/->PoistaTavoitehinnanYlitysPaatos paatos)))))]]])]))
 
 (defn- tavoitehinnan-laskentamodaali [paatos]
   (let []
@@ -120,7 +123,7 @@
         on-oikeudet? (valikatselmus-yhteiset/onko-oikeudet-tehda-paatos? (-> @tila/yleiset :urakka :id))
         siirrettava (atom (if (:siirrettava_maara paatos) (:siirrettava_maara paatos) 0))
         siirtorajoitus? (when (:siirtorajoitus_prosentti paatos) true)
-        maksimi-siirrettava-maara (fmt/desimaaliluku (or (:maksimi_siirrettava_maara paatos) 0)  2 2 false)
+        maksimi-siirrettava-maara (fmt/desimaaliluku (or (:maksimi_siirrettava_maara paatos) 0) 2 2 false)
         muokattu-maksimi-siirrettava-maara (str/replace maksimi-siirrettava-maara "," ".")]
     ^{:key (str "kattohinnan-ylitys-" (gensym))}
     [:div.paatos-komponentti-reunuksella

--- a/src/cljs/harja/views/urakka/valikatselmus/hintapaatokset.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/hintapaatokset.cljs
@@ -53,7 +53,7 @@
           ;; Peru päätös
           #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
                  paatos
-                 (fn [] (e! (valikatselmus-tiedot/->PoistaTavoitehinnanYlitysPaatos paatos)))))]]])]))
+                 (fn [] (e! (valikatselmus-tiedot/->PeruValikatselmusPaatos paatos)))))]]])]))
 
 (defn- tavoitehinnan-laskentamodaali [paatos]
   (let []
@@ -117,7 +117,7 @@
           ;; Peru päätös 
           #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
                  paatos
-                 (fn [] (e! (valikatselmus-tiedot/->PoistaTavoitehinnanYlitysPaatos paatos)))))]]])]))
+                 (fn [] (e! (valikatselmus-tiedot/->PeruValikatselmusPaatos paatos)))))]]])]))
 
 (defn kattohinnan-ylitys [e! paatos voi-muokata? tallennus-kesken? avatut-paatokset]
   (let [paatos-avain :kattohinta-ylitys
@@ -199,4 +199,4 @@
          ;; Peru päätös 
          #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
                 paatos
-                (fn [] (e! (valikatselmus-tiedot/->PoistaKattohinnanYlitysPaatos paatos)))))]])]))
+                (fn [] (e! (valikatselmus-tiedot/->PeruValikatselmusPaatos paatos)))))]])]))

--- a/src/cljs/harja/views/urakka/valikatselmus/hintapaatokset.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/hintapaatokset.cljs
@@ -112,9 +112,12 @@
          (when (:virheet paatos)
            [yleiset/info-laatikko :vahva-ilmoitus "Et voi vahvistaa päätöstä, sillä osa pohjatiedoista puuttuu" (:virheet paatos) nil {:ikoni-fn #(ikonit/harja-icon-status-alert)}])
          [valikatselmus-yhteiset/paatosnapit paatos-tehty? on-oikeudet? paatos tallennus-kesken? (not (:virheet paatos))
+          ;; Vahvista 
           #(e! (valikatselmus-tiedot/->TallennaTavoitehinnanAlitusPaatos paatos))
-          (valikatselmus-yhteiset/paatoksen-poistovarmistus-modaali {:peru-paatos-fn #(e! (valikatselmus-tiedot/->PoistaTavoitehinnanAlitusPaatos paatos))
-                                                                     :teksti "Automaattisesti kirjattu tavoitepalkkio ja siirtosumma poistetaan."})]]])]))
+          ;; Peru päätös 
+          #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
+                 paatos
+                 (fn [] (e! (valikatselmus-tiedot/->PoistaTavoitehinnanAlitusPaatos paatos)))))]]])]))
 
 (defn kattohinnan-ylitys [e! paatos voi-muokata? tallennus-kesken? avatut-paatokset]
   (let [paatos-avain :kattohinta-ylitys
@@ -122,9 +125,7 @@
         siirra? (:siirra? paatos)
         on-oikeudet? (valikatselmus-yhteiset/onko-oikeudet-tehda-paatos? (-> @tila/yleiset :urakka :id))
         siirrettava (atom (if (:siirrettava_maara paatos) (:siirrettava_maara paatos) 0))
-        siirtorajoitus? (when (:siirtorajoitus_prosentti paatos) true)
-        maksimi-siirrettava-maara (fmt/desimaaliluku (or (:maksimi_siirrettava_maara paatos) 0) 2 2 false)
-        muokattu-maksimi-siirrettava-maara (str/replace maksimi-siirrettava-maara "," ".")]
+        siirtorajoitus? (when (:siirtorajoitus_prosentti paatos) true)]
     ^{:key (str "kattohinnan-ylitys-" (gensym))}
     [:div.paatos-komponentti-reunuksella
 
@@ -193,6 +194,9 @@
 
         ;; Päätöksenteko napit
         [valikatselmus-yhteiset/paatosnapit paatos-tehty? on-oikeudet? paatos tallennus-kesken? voi-muokata?
+         ;; Vahvista
          #(e! (valikatselmus-tiedot/->TallennaKattohinnanYlitysPaatos paatos))
-         (valikatselmus-yhteiset/paatoksen-poistovarmistus-modaali {:peru-paatos-fn #(e! (valikatselmus-tiedot/->PoistaKattohinnanYlitysPaatos paatos))
-                                                                    :teksti "Automaattisesti kirjattu kattohinnan ylitys ja siirtosumma poistetaan."})]])]))
+         ;; Peru päätös 
+         #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
+                paatos
+                (fn [] (e! (valikatselmus-tiedot/->PoistaKattohinnanYlitysPaatos paatos)))))]])]))

--- a/src/cljs/harja/views/urakka/valikatselmus/hoidonjohtopalkkio.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/hoidonjohtopalkkio.cljs
@@ -88,9 +88,12 @@
                                                       "Päätöksen tallentaminen luo kulun Harjaan. Kulua ei lasketa tavoitehintaan.")) nil nil]]
 
           [valikatselmus-yhteiset/paatosnapit paatos-tehty? on-oikeudet? paatos tallennus-kesken? (and (not (:virheet paatos)) voi-muokata?)
+           ;; Vahvista
            #(e! (valikatselmus-tiedot/->TallennaHoidonjohtopalkkionMuutospaatos paatos))
-           (valikatselmus-yhteiset/paatoksen-poistovarmistus-modaali {:peru-paatos-fn #(e! (valikatselmus-tiedot/->PoistaHoidonjohtopalkkionMuutospaatos paatos))
-                                                                      :teksti "Automaattisesti kirjattu kulu poistetaan."})]
+           ;; Peru päätös 
+           #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
+                  paatos
+                  (fn [] (e! (valikatselmus-tiedot/->PoistaHoidonjohtopalkkionMuutospaatos paatos)))))]
           (when (:virheet paatos)
             [:div.muokkaustoiminnot
              [yleiset/info-laatikko :vahva-ilmoitus "Et voi vahvistaa päätöstä, sillä osa pohjatiedoista puuttuu"

--- a/src/cljs/harja/views/urakka/valikatselmus/hoidonjohtopalkkio.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/hoidonjohtopalkkio.cljs
@@ -93,8 +93,8 @@
            ;; Peru päätös 
            #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
                   paatos
-                  (fn [] (e! (valikatselmus-tiedot/->PoistaHoidonjohtopalkkionMuutospaatos paatos)))))]
-          
+                  (fn [] (e! (valikatselmus-tiedot/->PeruValikatselmusPaatos paatos)))))]
+
           (when (:virheet paatos)
             [:div.muokkaustoiminnot
              [yleiset/info-laatikko :vahva-ilmoitus "Et voi vahvistaa päätöstä, sillä osa pohjatiedoista puuttuu"

--- a/src/cljs/harja/views/urakka/valikatselmus/hoidonjohtopalkkio.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/hoidonjohtopalkkio.cljs
@@ -94,6 +94,7 @@
            #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
                   paatos
                   (fn [] (e! (valikatselmus-tiedot/->PoistaHoidonjohtopalkkionMuutospaatos paatos)))))]
+          
           (when (:virheet paatos)
             [:div.muokkaustoiminnot
              [yleiset/info-laatikko :vahva-ilmoitus "Et voi vahvistaa päätöstä, sillä osa pohjatiedoista puuttuu"

--- a/src/cljs/harja/views/urakka/valikatselmus/hoitovuoden_lopun_hinnat.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/hoitovuoden_lopun_hinnat.cljs
@@ -55,4 +55,4 @@
            ;; Peru päätös 
            #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
                   paatos
-                  (fn [] (e! (valikatselmus-tiedot/->PoistaHoitokaudenlopunHintapaatos paatos)))))]]]])]))
+                  (fn [] (e! (valikatselmus-tiedot/->PeruValikatselmusPaatos paatos)))))]]]])]))

--- a/src/cljs/harja/views/urakka/valikatselmus/hoitovuoden_lopun_hinnat.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/hoitovuoden_lopun_hinnat.cljs
@@ -10,13 +10,14 @@
   (let [paatos-avain :hoitovuoden-lopun-tavoite-ja-kattohinta
         paatos-tehty? (some? (:id paatos))
         on-oikeudet? (valikatselmus-yhteiset/onko-oikeudet-tehda-paatos? (-> @tila/yleiset :urakka :id))]
+
     ^{:key (str "kattohinnan-ylitys-" (gensym))}
     [:div.paatos-komponentti-reunuksella
      [valikatselmus-yhteiset/paatosotsikko-ja-avaus e! "Hoitovuoden lopun tavoite- ja kattohinta" paatos-tehty? paatos-avain avatut-paatokset
       (partial valikatselmus-tiedot/avaa-tai-sulje-haitari) (valikatselmus-tiedot/->AvaaPaatos paatos-avain)]
+
      (when (not (contains? avatut-paatokset paatos-avain))
        [:div
-
         [:div
          [:div
           [:div.flex-row.lista-rivi-korkea
@@ -29,25 +30,29 @@
           (when (:lisaa_tavoitehintaan_lopunindeksikorjaus paatos)
             [:div.flex-row.lista-rivi-korkea
              [:div "Hoitovuoden lopun indeksikorjaus"]
-              [:div [:strong (fmt/euro-opt false (:hoitokauden_lopun_indeksikorjaus paatos))]]])
+             [:div [:strong (fmt/euro-opt false (:hoitokauden_lopun_indeksikorjaus paatos))]]])
 
-           [:div.flex-row
-            [:div.big-text "Hoitovuoden lopun tavoitehinta"]
-            [:div.big-text.lihavoitu (fmt/euro-opt false (:tavoitehinta_jalkeen paatos))]]
-           [:div.flex-row
-            [:div
-             [:div.big-text "Hoitovuoden lopun kattohinta"]
-             [:div.small-text (str (fmt/piste->pilkku (:kattohintakerroin paatos)) " x hoitovuoden lopun tavoitehinta")]]
-            [:div.big-text.lihavoitu (fmt/euro-opt false (:kattohinta paatos))]]]
-          [:hr.paatos-hr]
+          [:div.flex-row
+           [:div.big-text "Hoitovuoden lopun tavoitehinta"]
+           [:div.big-text.lihavoitu (fmt/euro-opt false (:tavoitehinta_jalkeen paatos))]]
+          [:div.flex-row
+           [:div
+            [:div.big-text "Hoitovuoden lopun kattohinta"]
+            [:div.small-text (str (fmt/piste->pilkku (:kattohintakerroin paatos)) " x hoitovuoden lopun tavoitehinta")]]
+           [:div.big-text.lihavoitu (fmt/euro-opt false (:kattohinta paatos))]]]
+         [:hr.paatos-hr]
 
          (when (:virheet paatos)
            [:div
             [yleiset/info-laatikko :vahva-ilmoitus "Et voi vahvistaa päätöstä, sillä osa pohjatiedoista puuttuu"
              (:virheet paatos) nil {:ikoni-fn #(ikonit/harja-icon-status-alert)}]])
 
-          [:div
-           [valikatselmus-yhteiset/paatosnapit paatos-tehty? on-oikeudet? paatos tallennus-kesken?
-            (or (not on-oikeudet?) (not (:virheet paatos)))
-            #(e! (valikatselmus-tiedot/->TallennaHoitokaudenlopunHintapaatos paatos))
-            #(e! (valikatselmus-tiedot/->PoistaHoitokaudenlopunHintapaatos paatos))]]]])]))
+         [:div
+          [valikatselmus-yhteiset/paatosnapit paatos-tehty? on-oikeudet? paatos tallennus-kesken?
+           (or (not on-oikeudet?) (not (:virheet paatos)))
+           ;; Vahvista
+           #(e! (valikatselmus-tiedot/->TallennaHoitokaudenlopunHintapaatos paatos))
+           ;; Peru päätös 
+           #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
+                  paatos
+                  (fn [] (e! (valikatselmus-tiedot/->PoistaHoitokaudenlopunHintapaatos paatos)))))]]]])]))

--- a/src/cljs/harja/views/urakka/valikatselmus/indeksikorjaus.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/indeksikorjaus.cljs
@@ -41,7 +41,7 @@
 
      (when (not= 12 (count (:hoitokauden_kuukaudet paatos)))
        [yleiset/info-laatikko :vahva-ilmoitus
-       "Kaikkien kuukausien indeksin pistelukua ei ole vielä saatavilla."
+        "Kaikkien kuukausien indeksin pistelukua ei ole vielä saatavilla."
         nil nil {:ikoni-fn #(ikonit/harja-icon-status-alert)}])
 
      [:hr.hr-tiivis]
@@ -65,12 +65,14 @@
 (defn paatos [e! paatos voi-muokata? tallennus-kesken? avatut-paatokset]
   (let [paatos-avain :indeksikorjaus
         paatos-tehty? (some? (:id paatos))
-
         on-oikeudet? (valikatselmus-yhteiset/onko-oikeudet-tehda-paatos? (-> @tila/yleiset :urakka :id))]
+
     ^{:key (str "kattohinnan-ylitys-" (gensym))}
     [:div.paatos-komponentti-reunuksella
+
      [valikatselmus-yhteiset/paatosotsikko-ja-avaus e! "Hoitovuoden lopun indeksikorjaus" paatos-tehty? paatos-avain avatut-paatokset
       (partial valikatselmus-tiedot/avaa-tai-sulje-haitari) (valikatselmus-tiedot/->AvaaPaatos paatos-avain)]
+
      (when (not (contains? avatut-paatokset paatos-avain))
        [:div
         (if-not (:virhe paatos)
@@ -115,7 +117,12 @@
            [:hr.paatos-hr]
 
            [valikatselmus-yhteiset/paatosnapit paatos-tehty? on-oikeudet? paatos tallennus-kesken? voi-muokata?
+            ;; Vahvista
             #(e! (valikatselmus-tiedot/->TallennaHoitovuodenlopunIndeksikorjauspaatos paatos))
-            #(e! (valikatselmus-tiedot/->PoistaHoitovuodenlopunIndeksikorjauspaatos paatos))]]
+            ;; Peru päätös
+            #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
+                   paatos
+                   (fn [] (e! (valikatselmus-tiedot/->PoistaHoitovuodenlopunIndeksikorjauspaatos paatos)))))]]
+
           [:div.muokkaustoiminnot
            [yleiset/info-laatikko :neutraali (:virhe paatos) nil nil {:ikoni-fn #(ikonit/harja-icon-status-alert)}]])])]))

--- a/src/cljs/harja/views/urakka/valikatselmus/indeksikorjaus.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/indeksikorjaus.cljs
@@ -122,7 +122,7 @@
             ;; Peru päätös
             #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
                    paatos
-                   (fn [] (e! (valikatselmus-tiedot/->PoistaHoitovuodenlopunIndeksikorjauspaatos paatos)))))]]
+                   (fn [] (e! (valikatselmus-tiedot/->PeruValikatselmusPaatos paatos)))))]]
 
           [:div.muokkaustoiminnot
            [yleiset/info-laatikko :neutraali (:virhe paatos) nil nil {:ikoni-fn #(ikonit/harja-icon-status-alert)}]])])]))

--- a/src/cljs/harja/views/urakka/valikatselmus/lupaukset.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/lupaukset.cljs
@@ -18,10 +18,10 @@
     [:div.paatos-komponentti-reunuksella
      [valikatselmus-yhteiset/paatosotsikko-ja-avaus e! "Lupaukset" paatos-tehty? paatos-avain avatut-paatokset
       (partial valikatselmus-tiedot/avaa-tai-sulje-haitari) (valikatselmus-tiedot/->AvaaPaatos paatos-avain)]
-     
+
      (when tallennus-kesken?
        [yleiset/ajax-loader-pieni "Tallennetaan tietoja..."])
-     
+
      (when (and (not (:hoitovuosi-kesken? paatos)) (not (contains? avatut-paatokset paatos-avain)))
        [:div
         ;; Tuloksia ei näytetä mikäli tarjouksen tavoitehinta puuttuu
@@ -60,18 +60,18 @@
                [:p (str "Luvatun yhteispistemäärän alittaminen johtaa kutakin alittuvaa pistettä kohden " (:sanktioprosentti paatos) " %
            sanktioon kyseisen hoitovuoden tarjouksen mukaisesta tavoitehinnasta.")]
                [:p.paatos-laskelma (str "Lupaussanktio = " alitetut-pisteet
-               " * " (/ (:sanktioprosentti paatos) 100)
-               " * " (:tarjous_tavoitehinta paatos)
-               " = " ) [:span.laskenta-rivi-lukema (fmt/euro-opt (:lupaussanktio paatos))]]]
+                                     " * " (/ (:sanktioprosentti paatos) 100)
+                                     " * " (:tarjous_tavoitehinta paatos)
+                                     " = ") [:span.laskenta-rivi-lukema (fmt/euro-opt (:lupaussanktio paatos))]]]
               (= "bonus" tyyppi)
               ^{:key (str "lupaus-" (gensym))}
               [:div
                [:p (str "Luvatun yhteispistemäärän ylittäminen kutakin ylittävää pistettä kohden tuottaa " (:bonusprosentti paatos) " %
            bonuksen kyseisen hoitovuoden tarjouksen mukaisesta tavoitehinnasta.")]
                [:p.paatos-laskelma (str "Lupausbonus = " ylitetyt-pisteet
-               " * " (/ (:bonusprosentti paatos) 100)
-               " * " (:tarjous_tavoitehinta paatos)
-               " = " ) [:span.laskenta-rivi-lukema (fmt/euro-opt (:lupausbonus paatos))]]])]
+                                     " * " (/ (:bonusprosentti paatos) 100)
+                                     " * " (:tarjous_tavoitehinta paatos)
+                                     " = ") [:span.laskenta-rivi-lukema (fmt/euro-opt (:lupausbonus paatos))]]])]
 
            [:div
             (cond
@@ -102,9 +102,12 @@
 
         ;; Muokkaa, eli poista päätös, tai jos sitä ei ole tehty, niin tee päätös
         [valikatselmus-yhteiset/paatosnapit paatos-tehty? on-oikeudet? paatos tallennus-kesken? (and (not (:virheet paatos)) voi-muokata?)
+         ;; Vahvista
          #(e! (valikatselmus-tiedot/->TallennaLupausPaatos paatos))
-         (valikatselmus-yhteiset/paatoksen-poistovarmistus-modaali {:peru-paatos-fn #(e! (valikatselmus-tiedot/->PoistaLupausPaatos paatos))
-                                                                    :teksti "Automaattisesti kirjattu bonus/sanktio poistetaan."})
+         ;; Peru päätös 
+         #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
+                paatos
+                (fn [] (e! (valikatselmus-tiedot/->PoistaLupausPaatos paatos)))))
          #(if (:lupaussanktio paatos)
             [:p "Aluevastaava tekee päätöksen sanktion maksamisesta."]
             [:p "Aluevastaava tekee päätöksen bonuksen maksamisesta."])]])

--- a/src/cljs/harja/views/urakka/valikatselmus/lupaukset.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/lupaukset.cljs
@@ -107,7 +107,7 @@
          ;; Peru päätös 
          #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
                 paatos
-                (fn [] (e! (valikatselmus-tiedot/->PoistaLupausPaatos paatos)))))
+                (fn [] (e! (valikatselmus-tiedot/->PeruValikatselmusPaatos paatos)))))
          #(if (:lupaussanktio paatos)
             [:p "Aluevastaava tekee päätöksen sanktion maksamisesta."]
             [:p "Aluevastaava tekee päätöksen bonuksen maksamisesta."])]])

--- a/src/cljs/harja/views/urakka/valikatselmus/raportit.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/raportit.cljs
@@ -52,4 +52,4 @@
           ;; Peru päätös 
           #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
                  paatos
-                 (fn [] (e! (valikatselmus-tiedot/->PoistaPoytakirjanRaporttiPaatos paatos)))))]]])]))
+                 (fn [] (e! (valikatselmus-tiedot/->PeruValikatselmusPaatos paatos)))))]]])]))

--- a/src/cljs/harja/views/urakka/valikatselmus/raportit.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/raportit.cljs
@@ -47,5 +47,9 @@
 
         [:div.muokkaustoiminnot
          [valikatselmus-yhteiset/paatosnapit paatos-tehty? on-oikeudet? paatos tallennus-kesken? (and voi-muokata? (not virhe))
+          ;; Vahvista
           #(e! (valikatselmus-tiedot/->TallennaPoytakirjanRaporttiPaatos paatos))
-          #(e! (valikatselmus-tiedot/->PoistaPoytakirjanRaporttiPaatos paatos))]]])]))
+          ;; Peru päätös 
+          #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
+                 paatos
+                 (fn [] (e! (valikatselmus-tiedot/->PoistaPoytakirjanRaporttiPaatos paatos)))))]]])]))

--- a/src/cljs/harja/views/urakka/valikatselmus/tavoitehinnan_muutokset.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/tavoitehinnan_muutokset.cljs
@@ -17,10 +17,10 @@
 (defonce virheet-atom (atom {}))
 (defonce tallenna-painettu (atom false))
 
-(defn- rivi-painikkeet [e! uusi-id  muuttui?
+(defn- rivi-painikkeet [e! uusi-id muuttui?
                         uudet-simplified
-                        tallennus-kesken? 
-                        hoitokauden-alkuvuosi 
+                        tallennus-kesken?
+                        hoitokauden-alkuvuosi
                         hoitokauden-oikaisut-atom
                         voi-muokata? rivilla-tyhja-elementti]
   [:div.painikkeet
@@ -145,10 +145,10 @@
           :elementin-id (str "summa-" uusi-id)
           :aria-label "Vaikutus euroina"}]
         hoitokauden-oikaisut-atom]]
-      
+
       ;; Tallenna / Lisää rivi 
       ;; Siirretty alas, koska "Vahvista päätös" voidaan sotkea tallenna- napiksi.
-      (rivi-painikkeet e! uusi-id  muuttui?
+      (rivi-painikkeet e! uusi-id muuttui?
         uudet-simplified
         tallennus-kesken?
         hoitokauden-alkuvuosi
@@ -203,15 +203,15 @@
                                            poikkeusvuosi?)]
     ^{:key (str "tavoitehinnan-muutokset-" (gensym))}
     [:div#tavhinnan-muutokset.paatos-komponentti-reunuksella
-     
+
      (if hoitovuosi-kesken?
        [valikatselmus-yhteiset/paatosotsikko "Tavoitehinnan muutokset" paatos-tehty?]
        [valikatselmus-yhteiset/paatosotsikko-ja-avaus e! "Tavoitehinnan muutokset" paatos-tehty? paatos-avain avatut-paatokset
-        (partial valikatselmus-tiedot/avaa-tai-sulje-haitari)  (valikatselmus-tiedot/->AvaaPaatos paatos-avain)])
-     
+        (partial valikatselmus-tiedot/avaa-tai-sulje-haitari) (valikatselmus-tiedot/->AvaaPaatos paatos-avain)])
+
      (when tallennus-kesken?
        [yleiset/ajax-loader-pieni "Tallennetaan tietoja..."])
-     
+
      (when (not (contains? avatut-paatokset paatos-avain))
        [:div
         [tavoitehinnan-oikaisut-taulukko e! hoitokauden-oikaisut-atom
@@ -238,8 +238,12 @@
              (:virheet paatos) nil {:ikoni-fn #(ikonit/harja-icon-status-alert)}])
           [valikatselmus-yhteiset/paatosnapit paatos-tehty? on-oikeudet? paatoksen-tiedot tallennus-kesken?
            (and (not hoitovuosi-kesken?) (not (:virheet paatos)))
+           ;; Vahvista
            #(e! (valikatselmus-tiedot/->TallennaTavoitehinnanMuutosPaatos paatoksen-tiedot))
-           #(e! (valikatselmus-tiedot/->PoistaTavoitehinnanMuutosPaatos paatoksen-tiedot))]]]])]))
+           ;; Peru päätös 
+           #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
+                  paatos
+                  (fn [] (e! (valikatselmus-tiedot/->PoistaTavoitehinnanMuutosPaatos paatoksen-tiedot)))))]]]])]))
 
 (defn tavoitehinnan-muutokset-2025
   "-25 ja myöhemmin alkaville urakoille näytetään täysin erilainen tavoitehinnan muutokset komponentti. Erotetaan se sen vuoksi
@@ -259,7 +263,7 @@
      (if hoitovuosi-kesken?
        [valikatselmus-yhteiset/paatosotsikko "Tavoitehinnan muutokset" paatos-tehty?]
        [valikatselmus-yhteiset/paatosotsikko-ja-avaus e! "Tavoitehinnan muutokset" paatos-tehty? paatos-avain avatut-paatokset
-        (partial valikatselmus-tiedot/avaa-tai-sulje-haitari)  (valikatselmus-tiedot/->AvaaPaatos paatos-avain)])
+        (partial valikatselmus-tiedot/avaa-tai-sulje-haitari) (valikatselmus-tiedot/->AvaaPaatos paatos-avain)])
 
      (when tallennus-kesken?
        [yleiset/ajax-loader-pieni "Tallennetaan tietoja..."])
@@ -277,7 +281,7 @@
 
          [:div.flex-row.summa-rivi
           [:span.sisennys "• Johto- ja hallintokorvauksen muutokset"]
-          [:span (positiivinen-arvo-fn :johto_ja_hallintakorvaus_muutokset )]]
+          [:span (positiivinen-arvo-fn :johto_ja_hallintakorvaus_muutokset)]]
 
          [:div.flex-row.summa-rivi
           [:span.sisennys "• Muutostyöt (erillisrahoitetut)"]
@@ -324,7 +328,11 @@
             [yleiset/info-laatikko :vahva-ilmoitus "Et voi vahvistaa päätöstä, sillä osa pohjatiedoista puuttuu"
              (:virheet paatos) nil {:ikoni-fn #(ikonit/harja-icon-status-alert)}])
 
-            [valikatselmus-yhteiset/paatosnapit paatos-tehty? on-oikeudet? paatoksen-tiedot tallennus-kesken?
-             (and (not (:virheet paatos)) voi-muokata?)
-             #(e! (valikatselmus-tiedot/->TallennaTavoitehinnanPysyvaMuutosPaatos paatoksen-tiedot))
-             #(e! (valikatselmus-tiedot/->PoistaTavoitehinnanPysyvaMuutosPaatos paatoksen-tiedot))]]]])]))
+          [valikatselmus-yhteiset/paatosnapit paatos-tehty? on-oikeudet? paatoksen-tiedot tallennus-kesken?
+           (and (not (:virheet paatos)) voi-muokata?)
+           ;; Vahvista
+           #(e! (valikatselmus-tiedot/->TallennaTavoitehinnanPysyvaMuutosPaatos paatoksen-tiedot))
+           ;; Peru päätös 
+           #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
+                  paatos
+                  (fn [] (e! (valikatselmus-tiedot/->PoistaTavoitehinnanPysyvaMuutosPaatos paatoksen-tiedot)))))]]]])]))

--- a/src/cljs/harja/views/urakka/valikatselmus/tavoitehinnan_muutokset.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/tavoitehinnan_muutokset.cljs
@@ -243,7 +243,7 @@
            ;; Peru päätös 
            #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
                   paatos
-                  (fn [] (e! (valikatselmus-tiedot/->PoistaTavoitehinnanMuutosPaatos paatoksen-tiedot)))))]]]])]))
+                  (fn [] (e! (valikatselmus-tiedot/->PeruValikatselmusPaatos paatos)))))]]]])]))
 
 (defn tavoitehinnan-muutokset-2025
   "-25 ja myöhemmin alkaville urakoille näytetään täysin erilainen tavoitehinnan muutokset komponentti. Erotetaan se sen vuoksi
@@ -335,4 +335,4 @@
            ;; Peru päätös 
            #(e! (valikatselmus-tiedot/->HaeKetjutetustiKumoutuvatPaatokset
                   paatos
-                  (fn [] (e! (valikatselmus-tiedot/->PoistaTavoitehinnanPysyvaMuutosPaatos paatoksen-tiedot)))))]]]])]))
+                  (fn [] (e! (valikatselmus-tiedot/->PeruValikatselmusPaatos paatos)))))]]]])]))

--- a/src/cljs/harja/views/urakka/valikatselmus/valikatselmus_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/valikatselmus_nakyma.cljs
@@ -1,27 +1,32 @@
 (ns harja.views.urakka.valikatselmus.valikatselmus-nakyma
   (:require [tuck.core :as tuck]
-            [harja.domain.roolit :as roolit]
-            [harja.domain.lupaus-domain :as lupaus-domain]
+
             [harja.fmt :as fmt]
             [harja.pvm :as pvm]
-            [harja.tiedot.istunto :as istunto]
-            [harja.tiedot.navigaatio :as nav]
-            [harja.tiedot.urakka.valikatselmus.valikatselmus-tiedot :as valikatselmus-tiedot]
-            [harja.tiedot.urakka.kulut.yhteiset :as t-yhteiset]
-            [harja.tiedot.urakka.urakka :as tila]
+            [harja.ui.modal :as modal]
+            [harja.ui.napit :as napit]
+            [harja.ui.lomake :as lomake]
             [harja.ui.ikonit :as ikonit]
-            [harja.ui.komponentti :as komp]
-            [harja.ui.debug :as debug]
             [harja.ui.yleiset :as yleiset]
-            [harja.views.urakka.valikatselmus.yhteiset :as valikatselmus-yhteiset]
-            [harja.views.urakka.valikatselmus.yhteenvetolaatikko :as yhteevetolaatikko]
-            [harja.views.urakka.valikatselmus.tavoitehinnan-muutokset :as tavoitehinnan-muutokset]
+
+            [harja.tiedot.navigaatio :as nav]
+            [harja.tiedot.istunto :as istunto]
+            [harja.tiedot.urakka.urakka :as tila]
+            [harja.tiedot.urakka.kulut.yhteiset :as t-yhteiset]
+            [harja.tiedot.urakka.valikatselmus.valikatselmus-tiedot :as valikatselmus-tiedot]
+
+            [harja.ui.komponentti :as komp]
+            [harja.domain.roolit :as roolit]
+            [harja.domain.lupaus-domain :as lupaus-domain]
+            [harja.views.urakka.valikatselmus.raportit :as raportit]
             [harja.views.urakka.valikatselmus.lupaukset :as lupaukset]
             [harja.views.urakka.valikatselmus.hintapaatokset :as hintapaatokset]
-            [harja.views.urakka.valikatselmus.raportit :as raportit]
+            [harja.views.urakka.valikatselmus.indeksikorjaus :as indeksikorjaus]
+            [harja.views.urakka.valikatselmus.yhteiset :as valikatselmus-yhteiset]
+            [harja.views.urakka.valikatselmus.yhteenvetolaatikko :as yhteevetolaatikko]
             [harja.views.urakka.valikatselmus.hoidonjohtopalkkio :as hoidonjohtopalkkio]
-            [harja.views.urakka.valikatselmus.hoitovuoden-lopun-hinnat :as hoitovuoden-lopun-hinnat]
-            [harja.views.urakka.valikatselmus.indeksikorjaus :as indeksikorjaus])
+            [harja.views.urakka.valikatselmus.tavoitehinnan-muutokset :as tavoitehinnan-muutokset]
+            [harja.views.urakka.valikatselmus.hoitovuoden-lopun-hinnat :as hoitovuoden-lopun-hinnat])
   (:require-macros [harja.tyokalut.ui :refer [for*]]))
 
 (defn- onko-hoitokausi-tulevaisuudessa? [hoitokausi nykyhetki]
@@ -95,7 +100,8 @@
         [ikonit/harja-icon-status-alert]
         [:span "Hoitovuosi on lukittu vuoden vaihteessa ja välikatselmusta ei voi enää muokata."]])]))
 
-(defn paatoskomponentit [e! {:keys [valittu-hoitokausi tallennus-kesken? paatokset] :as app}]
+(defn paatoskomponentit [e! {:keys [valittu-hoitokausi tallennus-kesken? paatokset
+                                    kumottava-paatos-nimi tehdyt-kumoutuvat-paatokset nayta-kumoa-modal? peru-fn] :as app}]
   (let [urakan-alkuvuosi (pvm/vuosi (-> @tila/yleiset :urakka :alkupvm))
         nykyhetki (pvm/nyt)
         poikkeusvuosi? (lupaus-domain/vuosi-19-20? urakan-alkuvuosi)
@@ -110,16 +116,49 @@
                                 (not (valikatselmus-yhteiset/onko-hoitokausi-menneisyydessa? valittu-hoitokausi nykyhetki urakan-alkuvuosi)))))
         hoitovuosi-kesken? (pvm/valissa? nykyhetki (first valittu-hoitokausi) (second valittu-hoitokausi))
         hoitokausi-tulevaisuudessa? (onko-hoitokausi-tulevaisuudessa? valittu-hoitokausi (pvm/nyt))]
+    
     [:<>
      (when (or hoitovuosi-kesken? hoitokausi-tulevaisuudessa?)
        [:div.hoitovuosi-info
         (when hoitovuosi-kesken?
           [yleiset/info-laatikko :neutraali "Hoitovuosi ei ole vielä päättynyt."
-           (str "Välikatselmuksen päätökset voi tallentaa 1.10. " (pvm/vuosi (second valittu-hoitokausi))" alkaen. "
+           (str "Välikatselmuksen päätökset voi tallentaa 1.10. " (pvm/vuosi (second valittu-hoitokausi)) " alkaen. "
              (when (<= urakan-alkuvuosi 2024) " Voit lisätä tavoitehinnan muutoksia myös kesken hoitovuoden.")) nil {:luokka "koko-levea"}])
         (when hoitokausi-tulevaisuudessa?
           [yleiset/info-laatikko :neutraali "Hoitovuosi ei ole vielä alkanut." nil nil])])
+
      [:div
+      [modal/modal
+       {:nakyvissa? nayta-kumoa-modal?
+        :sulje-fn #(e! (valikatselmus-tiedot/->SuljePaatosModal))
+        :leveys "567px"
+        :content-tyyli {:margin "0" :padding "16px"}
+        :body-tyyli {:margin "0"}}
+
+       [lomake/lomake
+        {:ei-borderia? true
+         :voi-muokata? true
+         :tarkkaile-ulkopuolisia-muutoksia? true
+         :header [:div.col-md-12
+                  [:h2.header-yhteiset "Haluatko perua päätöksen?"]
+                  [:div.body
+
+                   [:<>
+                    "“"
+                    [:span.lihavoitu kumottava-paatos-nimi]
+                    "“"
+                    "-päätöksen peruminen peruuttaa  myös automaattiset kulut, 
+                    bonus- tai sanktiomaksut sekä tietojen lukitukset, jotka mahdollisesti syntyivät päätöksestä."]
+
+                   [:div.padding-top-24 "Päätöksen peruminen peruuttaa myös seuraavat päätökset:"]
+                   (for* [x tehdyt-kumoutuvat-paatokset]
+                     [:div.sisennys "• " (:nimi x)])]]
+
+         :footer [:<>
+                  [:div.muokkaus-modal-napit.padding-top-16
+                   [napit/tallenna "Kyllä, peru päätös" #(peru-fn)]
+                   [napit/yleinen-toissijainen "Peruuta" #(e! (valikatselmus-tiedot/->SuljePaatosModal))]]]}]]
+
       (doall
         (for* [paatos paatokset]
           (cond
@@ -130,7 +169,8 @@
             (= (ffirst paatos) :tavoitehinnan-alitus) [hintapaatokset/tavoitehinnan-alitus e! (second (first paatos)) tallennus-kesken? avatut-paatokset]
             (= (ffirst paatos) :kattohinnan-ylitys) [hintapaatokset/kattohinnan-ylitys e! (second (first paatos)) oikeudet-muokata? tallennus-kesken? avatut-paatokset]
             (= (ffirst paatos) :valikatselmuspoytakirjaan-liitettavat-raportit) [raportit/raportit e! (second (first paatos)) tallennus-kesken? hoitokauden-alkuvuosi avatut-paatokset]
-            (= (ffirst paatos) :hoitovuoden-lopun-indeksikorjaus) [indeksikorjaus/paatos e! (second (first paatos)) oikeudet-muokata? tallennus-kesken? avatut-paatokset]
+            ;; TODO .. viritä avain tänne jotenkin paremmin
+            (= (ffirst paatos) :hoitovuoden-lopun-indeksikorjaus) [indeksikorjaus/paatos e! (assoc (second (first paatos)) :avain :indeksikorjaus) oikeudet-muokata? tallennus-kesken? avatut-paatokset]
             (= (ffirst paatos) :hoidonjohtopalkkion-muutos) [hoidonjohtopalkkio/paatos e! (second (first paatos)) oikeudet-muokata? tallennus-kesken? avatut-paatokset]
             (= (ffirst paatos) :hoitovuoden-lopun-tavoite-ja-kattohinta) [hoitovuoden-lopun-hinnat/paatos e! (second (first paatos)) oikeudet-muokata? tallennus-kesken? avatut-paatokset]
             :else nil)))]]))
@@ -179,7 +219,6 @@
            [:div.valikatselmus-haku
             [yleiset/ajax-loader-pieni "Haetaan välikatselmuksen tietoja..."]]
            [:div.valikatselmus-container
-            #_ [debug/debug app]
             [:div.col-xs-12.col-md-7
 
              [valikatselmus-otsikko-ja-tiedot e! app]

--- a/src/cljs/harja/views/urakka/valikatselmus/valikatselmus_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/valikatselmus_nakyma.cljs
@@ -116,7 +116,7 @@
                                 (not (valikatselmus-yhteiset/onko-hoitokausi-menneisyydessa? valittu-hoitokausi nykyhetki urakan-alkuvuosi)))))
         hoitovuosi-kesken? (pvm/valissa? nykyhetki (first valittu-hoitokausi) (second valittu-hoitokausi))
         hoitokausi-tulevaisuudessa? (onko-hoitokausi-tulevaisuudessa? valittu-hoitokausi (pvm/nyt))]
-    
+
     [:<>
      (when (or hoitovuosi-kesken? hoitokausi-tulevaisuudessa?)
        [:div.hoitovuosi-info
@@ -141,23 +141,24 @@
          :tarkkaile-ulkopuolisia-muutoksia? true
          :header [:div.col-md-12
                   [:h2.header-yhteiset "Haluatko perua päätöksen?"]
-                  [:div.body
+                  (if tallennus-kesken?
+                    [yleiset/ajax-loader-pieni "Haetaan tietoja..."]
+                    [:div.body
+                     [:<>
+                      "“"
+                      [:span.lihavoitu kumottava-paatos-nimi]
+                      "“"
+                      "-päätöksen peruminen peruuttaa  myös automaattiset kulut, 
+                      bonus- tai sanktiomaksut sekä tietojen lukitukset, jotka mahdollisesti syntyivät päätöksestä."]
 
-                   [:<>
-                    "“"
-                    [:span.lihavoitu kumottava-paatos-nimi]
-                    "“"
-                    "-päätöksen peruminen peruuttaa  myös automaattiset kulut, 
-                    bonus- tai sanktiomaksut sekä tietojen lukitukset, jotka mahdollisesti syntyivät päätöksestä."]
-
-                   [:div.padding-top-24 "Päätöksen peruminen peruuttaa myös seuraavat päätökset:"]
-                   (for* [x tehdyt-kumoutuvat-paatokset]
-                     [:div.sisennys "• " (:nimi x)])]]
+                     [:div.padding-top-24 "Päätöksen peruminen peruuttaa myös seuraavat päätökset:"]
+                     (for* [x tehdyt-kumoutuvat-paatokset]
+                       [:div.sisennys "• " (:nimi x)])])]
 
          :footer [:<>
                   [:div.muokkaus-modal-napit.padding-top-16
-                   [napit/tallenna "Kyllä, peru päätös" #(peru-fn)]
-                   [napit/yleinen-toissijainen "Peruuta" #(e! (valikatselmus-tiedot/->SuljePaatosModal))]]]}]]
+                   [napit/tallenna "Kyllä, peru päätös" #(peru-fn) {:disabled tallennus-kesken?}]
+                   [napit/yleinen-toissijainen "Peruuta" #(e! (valikatselmus-tiedot/->SuljePaatosModal)) {:disabled tallennus-kesken?}]]]}]]
 
       (doall
         (for* [paatos paatokset]
@@ -169,8 +170,7 @@
             (= (ffirst paatos) :tavoitehinnan-alitus) [hintapaatokset/tavoitehinnan-alitus e! (second (first paatos)) tallennus-kesken? avatut-paatokset]
             (= (ffirst paatos) :kattohinnan-ylitys) [hintapaatokset/kattohinnan-ylitys e! (second (first paatos)) oikeudet-muokata? tallennus-kesken? avatut-paatokset]
             (= (ffirst paatos) :valikatselmuspoytakirjaan-liitettavat-raportit) [raportit/raportit e! (second (first paatos)) tallennus-kesken? hoitokauden-alkuvuosi avatut-paatokset]
-            ;; TODO .. viritä avain tänne jotenkin paremmin
-            (= (ffirst paatos) :hoitovuoden-lopun-indeksikorjaus) [indeksikorjaus/paatos e! (assoc (second (first paatos)) :avain :indeksikorjaus) oikeudet-muokata? tallennus-kesken? avatut-paatokset]
+            (= (ffirst paatos) :hoitovuoden-lopun-indeksikorjaus) [indeksikorjaus/paatos e! (second (first paatos)) oikeudet-muokata? tallennus-kesken? avatut-paatokset]
             (= (ffirst paatos) :hoidonjohtopalkkion-muutos) [hoidonjohtopalkkio/paatos e! (second (first paatos)) oikeudet-muokata? tallennus-kesken? avatut-paatokset]
             (= (ffirst paatos) :hoitovuoden-lopun-tavoite-ja-kattohinta) [hoitovuoden-lopun-hinnat/paatos e! (second (first paatos)) oikeudet-muokata? tallennus-kesken? avatut-paatokset]
             :else nil)))]]))

--- a/src/cljs/harja/views/urakka/valikatselmus/valikatselmus_nakyma.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/valikatselmus_nakyma.cljs
@@ -151,9 +151,11 @@
                       "-päätöksen peruminen peruuttaa  myös automaattiset kulut, 
                       bonus- tai sanktiomaksut sekä tietojen lukitukset, jotka mahdollisesti syntyivät päätöksestä."]
 
-                     [:div.padding-top-24 "Päätöksen peruminen peruuttaa myös seuraavat päätökset:"]
-                     (for* [x tehdyt-kumoutuvat-paatokset]
-                       [:div.sisennys "• " (:nimi x)])])]
+                     (when (> (count tehdyt-kumoutuvat-paatokset) 0)
+                       [:<>
+                        [:div.padding-top-24 "Päätöksen peruminen peruuttaa myös seuraavat päätökset:"]
+                        (for* [x tehdyt-kumoutuvat-paatokset]
+                          [:div.sisennys "• " (:nimi x)])])])]
 
          :footer [:<>
                   [:div.muokkaus-modal-napit.padding-top-16

--- a/src/cljs/harja/views/urakka/valikatselmus/yhteiset.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/yhteiset.cljs
@@ -1,10 +1,12 @@
 (ns harja.views.urakka.valikatselmus.yhteiset
-  (:require [harja.domain.oikeudet :as oikeudet]
-            [harja.tiedot.istunto :as istunto]
-            [harja.ui.modal :as modal]
+  (:require [harja.ui.modal :as modal]
             [harja.ui.napit :as napit]
-            [harja.ui.ikonit :as ikonit]))
+            [harja.ui.ikonit :as ikonit]
+            [harja.tiedot.istunto :as istunto]
+            [harja.domain.oikeudet :as oikeudet]))
 
+
+;; TODO poistuu ehkä
 (defn paatoksen-poistovarmistus-modaali
   [{:keys [peru-paatos-fn teksti]}]
   (let [varmistus-modaalin-kutsu-fn #(modal/nayta! {:otsikko "Perutaanko päätös?"
@@ -47,6 +49,7 @@
         :else
         false)))
 
+
 (defn paatosotsikko-ja-avaus [e! otsikko paatos-tehty? paatos-avain avatut-paatokset avaa-tai-sulje-haitari-fn avaa-paatos-fn]
   [:div.paatos-komponentti-otsikko-row.klikattava {:on-click #(e! avaa-paatos-fn)}
    [:div.navigation-ikoni {:on-click #(avaa-tai-sulje-haitari-fn % paatos-avain)}
@@ -60,6 +63,7 @@
       [:div.badge.paatetty.paatos-badge "Päätetty"]
       [:div.badge.avoin.paatos-badge "Avoin"])]])
 
+
 (defn paatosotsikko [otsikko paatos-tehty?]
   [:div.paatos-komponentti-otsikko-row
    [:h2.paatos-komponentti-otsikko otsikko]
@@ -68,13 +72,14 @@
       [:div.badge.paatetty.paatos-badge "Päätetty"]
       [:div.badge.avoin.paatos-badge "Avoin"])]])
 
+
 (defn paatosnapit [paatos-tehty? on-oikeudet? paatoksen-tiedot tallennus-kesken? voi-muokata? tallenna-paatos-fn poista-paatos-fn ei-oikeuksia-teksti-fn]
   (if (not paatos-tehty?)
     [:div.paatos-toiminto
      (if on-oikeudet?
        [napit/yleinen-ensisijainen "Vahvista päätös" tallenna-paatos-fn
         {:ikoni [ikonit/harja-icon-status-selected]
-         :disabled (or tallennus-kesken? (not voi-muokata?)(:virhe paatoksen-tiedot))}]
+         :disabled (or tallennus-kesken? (not voi-muokata?) (:virhe paatoksen-tiedot))}]
        (when ei-oikeuksia-teksti-fn (ei-oikeuksia-teksti-fn)))]
     [:div.paatos-toiminto
      (if on-oikeudet?

--- a/src/cljs/harja/views/urakka/valikatselmus/yhteiset.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/yhteiset.cljs
@@ -1,6 +1,5 @@
 (ns harja.views.urakka.valikatselmus.yhteiset
-  (:require [harja.ui.modal :as modal]
-            [harja.ui.napit :as napit]
+  (:require [harja.ui.napit :as napit]
             [harja.ui.ikonit :as ikonit]
             [harja.tiedot.istunto :as istunto]
             [harja.domain.oikeudet :as oikeudet]))

--- a/src/cljs/harja/views/urakka/valikatselmus/yhteiset.cljs
+++ b/src/cljs/harja/views/urakka/valikatselmus/yhteiset.cljs
@@ -6,24 +6,6 @@
             [harja.domain.oikeudet :as oikeudet]))
 
 
-;; TODO poistuu ehkä
-(defn paatoksen-poistovarmistus-modaali
-  [{:keys [peru-paatos-fn teksti]}]
-  (let [varmistus-modaalin-kutsu-fn #(modal/nayta! {:otsikko "Perutaanko päätös?"
-                                                    :otsikko-muotoilut {:font-size "28px" :margin-bottom "24px"}
-                                                    :leveys "560px"
-                                                    :content-tyyli {:line-height "24px" :padding-top "24px" :padding-bottom "24px"}
-                                                    :body-tyyli {:margin-bottom "24px"}
-                                                    :footer [:div
-                                                             [napit/yleinen-ensisijainen "Peru päätös" (fn []
-                                                                                                         (modal/piilota!)
-                                                                                                         (peru-paatos-fn)) {:luokka "valikatselmus-nappi nappi-ensisijainen"}]
-                                                             [napit/yleinen-toissijainen "Peruuta" (fn [] (modal/piilota!)) {:luokka "valikatselmus-nappi nappi-toissijainen"}]]
-                                                    :footer-tyyli {:text-align "left"}
-                                                    :ruksi-tyyli {:color "#004D99" :font-size "24px"}}
-                                       [:div teksti])]
-    varmistus-modaalin-kutsu-fn))
-
 ;; Varmistetaan, että on kirjoitusoikeudet. Välikatselmusta voi katsoa lukuoikeuksilla, mutta päätöksiä ei voi tehdä
 ;; lukuoikeuksilla
 (defn onko-oikeudet-tehda-paatos? [urakka-id]

--- a/test/clj/harja/palvelin/palvelut/valikatselmus/paatokset_ketjutus_test.clj
+++ b/test/clj/harja/palvelin/palvelut/valikatselmus/paatokset_ketjutus_test.clj
@@ -118,7 +118,7 @@
         odotettu-vastaus {:paatokset :haettu}]
 
     (with-redefs [valikatselmukset/poista-yksittainen-paatos
-                  (fn [_db _kayttaja poistettava]
+                  (fn [_db _kayttaja poistettava _urakkaid]
                     (swap! poistot conj (:id poistettava)))
 
                   valikatselmukset/hae-valikatselmuksen-tiedot-hoitovuodelle
@@ -133,6 +133,7 @@
               (:db jarjestelma)
               +kayttaja-jvh+
               {:paatos paatos
+               :urakka-id urakkaid
                :tehdyt-kumoutuvat-paatokset kumoutuvat}))))
 
     (is (= [1 2 3 4] @poistot))))

--- a/test/clj/harja/palvelin/palvelut/valikatselmus/paatokset_ketjutus_test.clj
+++ b/test/clj/harja/palvelin/palvelut/valikatselmus/paatokset_ketjutus_test.clj
@@ -1,0 +1,151 @@
+(ns harja.palvelin.palvelut.valikatselmus.paatokset-ketjutus-test
+  (:require [clojure.test :refer :all]
+            [com.stuartsierra.component :as component]
+
+            [harja.testi :refer :all]
+            [harja.palvelin.komponentit.tietokanta :as tietokanta]
+            [harja.palvelin.palvelut.valikatselmus.apurit :as v-apurit]
+            [harja.palvelin.palvelut.valikatselmus.paatostyypit :as paatostyypit]
+            [harja.palvelin.palvelut.valikatselmus.valikatselmukset :as valikatselmukset]))
+
+
+(defn jarjestelma-fixture [testit]
+  (alter-var-root #'jarjestelma
+    (fn [_]
+      (component/start
+        (component/system-map
+          :db (tietokanta/luo-tietokanta testitietokanta)))))
+  (testit)
+  (alter-var-root #'jarjestelma component/stop))
+
+
+(use-fixtures :each
+  (compose-fixtures tietokanta-fixture jarjestelma-fixture))
+
+
+(defn- paatosavaimet [paatokset]
+  (set (map :avain paatokset)))
+
+
+(deftest hae-ketjutetusti-kumoutuvat-paatokset-koko-ketju-toimii
+  (let [vastaus (v-apurit/hae-ketjutetusti-kumoutuvat-paatokset
+                  paatostyypit/paatostyypit
+                  :tavoitehinnan-muutokset)]
+
+    (is (= #{:indeksikorjaus
+             :hoitovuoden-lopun-hinta
+             :tavoitehinnan-alitus
+             :tavoitehinnan-ylitys
+             :kattohinnan-ylitys
+             :lupaus
+             :hoidonjohtopalkkio}
+          (paatosavaimet vastaus)))
+
+    (is (not (contains? (paatosavaimet vastaus) :raportti)))))
+
+
+(deftest hae-ketjutetusti-kumoutuvat-paatokset-raportti-toimii
+  (is (empty?
+        (v-apurit/hae-ketjutetusti-kumoutuvat-paatokset
+          paatostyypit/paatostyypit
+          :raportti))))
+
+
+(deftest hae-ketjutetusti-kumoutuvat-paatokset-palvelu-palauttaa-vain-tehdyt
+  (let [hoitokauden-alkuvuosi 2024
+        urakkaid (hae-urakan-id-nimella "POP MHU Suomussalmi 2024-2029")
+
+        tehdyt [{:id 10
+                 :nimi "Hoitovuoden lopun indeksikorjaus"}
+                {:id 20
+                 :nimi "Tavoitehinnan ylitys"}]
+
+        peruttava {:urakkaid urakkaid
+                   :hoitokauden_alkuvuosi hoitokauden-alkuvuosi
+                   :nimi "Tavoitehinnan muutokset"
+                   :avain :tavoitehinnan-muutokset}
+
+        vastaus (with-redefs [valikatselmukset/hae-urakan-mahdolliset-paatokset
+                              (fn [_db _kayttaja _payload]
+                                paatostyypit/paatostyypit)
+                              valikatselmukset/palauta-kaikki-mahdolliset-ja-tehdyt-paatokset
+                              (fn [_db _kayttaja _payload]
+                                {:tietokanta-paatokset tehdyt})]
+                  (valikatselmukset/hae-ketjutetusti-kumoutuvat-paatokset
+                    (:db jarjestelma)
+                    +kayttaja-jvh+
+                    peruttava))]
+
+    (is (= #{10 20}
+          (set (map :id vastaus))) "Vastaus täsmää tehtyjä päätöksiä")
+
+    (is (= #{:indeksikorjaus
+             :tavoitehinnan-ylitys}
+          (paatosavaimet vastaus)) "Avaimet ovat oikein")))
+
+
+(deftest poista-yksittainen-paatos-reititys-toimii
+  (let [kutsuttu (atom nil)
+        pysyva-muutospaatos (first
+                              (filter #(= "tavoitehinnan-pysyvat-muutokset"
+                                         (:paatostyyppi %))
+                                paatostyypit/paatostyypit))
+        tavoitehinnan-muutospaatos (first
+                                     (filter #(= "tavoitehinnan-muutokset"
+                                                (:paatostyyppi %))
+                                       paatostyypit/paatostyypit))]
+
+    (with-redefs [valikatselmukset/poista-tavoitehinnan-pysyva-muutospaatos
+                  (fn [_db _kayttaja _paatos]
+                    (reset! kutsuttu :tavoitehinnan-pysyva-muutospaatos))
+
+                  valikatselmukset/poista-tavoitehinnan-muutospaatos
+                  (fn [_db _kayttaja _paatos]
+                    (reset! kutsuttu :tavoitehinnan-muutospaatos))]
+
+      ;; Testaa että haluttuja poistoja kutsutaan, ei ole kovin tärkeä testi 
+      (valikatselmukset/poista-yksittainen-paatos :db :kayttaja pysyva-muutospaatos)
+      (is (= :tavoitehinnan-pysyva-muutospaatos @kutsuttu))
+
+      (valikatselmukset/poista-yksittainen-paatos :db :kayttaja tavoitehinnan-muutospaatos)
+      (is (= :tavoitehinnan-muutospaatos @kutsuttu)))))
+
+
+(deftest poista-paatokset-ketjutetusti-toimii
+  (let [urakkaid (hae-urakan-id-nimella "POP MHU Suomussalmi 2024-2029")
+        hoitokauden-alkuvuosi 2024
+
+        paatos {:id 1
+                :urakkaid urakkaid
+                :hoitokauden_alkuvuosi hoitokauden-alkuvuosi
+                :avain :tavoitehinnan-muutokset}
+
+        kumoutuvat [{:id 2
+                     :avain :indeksikorjaus}
+                    {:id 3
+                     :avain :hoitovuoden-lopun-hinta}
+                    {:id 4
+                     :avain :tavoitehinnan-ylitys}]
+
+        poistot (atom [])
+        odotettu-vastaus {:paatokset :haettu}]
+
+    (with-redefs [valikatselmukset/poista-yksittainen-paatos
+                  (fn [_db _kayttaja poistettava]
+                    (swap! poistot conj (:id poistettava)))
+
+                  valikatselmukset/hae-valikatselmuksen-tiedot-hoitovuodelle
+                  (fn [_db _kayttaja payload]
+                    (is (= {:urakkaid urakkaid
+                            :hoitovuosi hoitokauden-alkuvuosi}
+                          payload))
+                    odotettu-vastaus)]
+
+      (is (= odotettu-vastaus
+            (valikatselmukset/poista-paatokset-ketjutetusti
+              (:db jarjestelma)
+              +kayttaja-jvh+
+              {:paatos paatos
+               :tehdyt-kumoutuvat-paatokset kumoutuvat}))))
+
+    (is (= [1 2 3 4] @poistot))))

--- a/test/clj/harja/palvelin/palvelut/valikatselmus/paatokset_ketjutus_test.clj
+++ b/test/clj/harja/palvelin/palvelut/valikatselmus/paatokset_ketjutus_test.clj
@@ -3,9 +3,12 @@
             [com.stuartsierra.component :as component]
 
             [harja.testi :refer :all]
+            [harja.kyselyt.urakat :as urakka-kyselyt]
+            [harja.kyselyt.paatos-kyselyt :as paatos-kyselyt]
             [harja.palvelin.komponentit.tietokanta :as tietokanta]
             [harja.palvelin.palvelut.valikatselmus.apurit :as v-apurit]
             [harja.palvelin.palvelut.valikatselmus.paatostyypit :as paatostyypit]
+            [harja.palvelin.palvelut.valikatselmus.paatos-apurit :as paatos-apurit]
             [harja.palvelin.palvelut.valikatselmus.valikatselmukset :as valikatselmukset]))
 
 
@@ -14,7 +17,12 @@
     (fn [_]
       (component/start
         (component/system-map
-          :db (tietokanta/luo-tietokanta testitietokanta)))))
+          :db (tietokanta/luo-tietokanta testitietokanta)
+          :db-replica (tietokanta/luo-tietokanta testitietokanta)
+          :http-palvelin (testi-http-palvelin)
+          :valikatselmus (component/using
+                           (valikatselmukset/->Valikatselmukset)
+                           [:http-palvelin :db :db-replica])))))
   (testit)
   (alter-var-root #'jarjestelma component/stop))
 
@@ -25,6 +33,11 @@
 
 (defn- paatosavaimet [paatokset]
   (set (map :avain paatokset)))
+
+
+(defn valitse-paatos
+  [paatokset avain]
+  (get (first (filter #(= (ffirst %) avain) paatokset)) avain))
 
 
 (deftest hae-ketjutetusti-kumoutuvat-paatokset-koko-ketju-toimii
@@ -81,37 +94,10 @@
 
     (is (= #{:indeksikorjaus
              :tavoitehinnan-ylitys}
-          (paatosavaimet vastaus)) "Avaimet ovat oikein")))
+          (paatosavaimet vastaus)))))
 
 
-(deftest poista-yksittainen-paatos-reititys-toimii
-  (let [kutsuttu (atom nil)
-        pysyva-muutospaatos (first
-                              (filter #(= "tavoitehinnan-pysyvat-muutokset"
-                                         (:paatostyyppi %))
-                                paatostyypit/paatostyypit))
-        tavoitehinnan-muutospaatos (first
-                                     (filter #(= "tavoitehinnan-muutokset"
-                                                (:paatostyyppi %))
-                                       paatostyypit/paatostyypit))]
-
-    (with-redefs [valikatselmukset/poista-tavoitehinnan-pysyva-muutospaatos
-                  (fn [_db _kayttaja _paatos]
-                    (reset! kutsuttu :tavoitehinnan-pysyva-muutospaatos))
-
-                  valikatselmukset/poista-tavoitehinnan-muutospaatos
-                  (fn [_db _kayttaja _paatos]
-                    (reset! kutsuttu :tavoitehinnan-muutospaatos))]
-
-      ;; Testaa että haluttuja poistoja kutsutaan, ei ole kovin tärkeä testi 
-      (valikatselmukset/poista-yksittainen-paatos :db :kayttaja pysyva-muutospaatos)
-      (is (= :tavoitehinnan-pysyva-muutospaatos @kutsuttu))
-
-      (valikatselmukset/poista-yksittainen-paatos :db :kayttaja tavoitehinnan-muutospaatos)
-      (is (= :tavoitehinnan-muutospaatos @kutsuttu)))))
-
-
-(deftest poista-paatokset-ketjutetusti-toimii
+(deftest poista-paatokset-ketjutetusti-funktiohierarkia-toimii
   (let [urakkaid (hae-urakan-id-nimella "POP MHU Suomussalmi 2024-2029")
         hoitokauden-alkuvuosi 2024
 
@@ -149,3 +135,125 @@
                :tehdyt-kumoutuvat-paatokset kumoutuvat}))))
 
     (is (= [1 2 3 4] @poistot))))
+
+
+(deftest paatosten-poisto-ketjutetusti-toimii
+
+  (let [urakkaid (hae-urakan-id-nimella "POP MHU Kajaani 2025-2030")
+        urakan-parametrit (first (urakka-kyselyt/hae-urakan-parametrit (:db jarjestelma) {:urakkaid urakkaid}))
+        muokkaa-kattohinta (:muokkaa_kattohinta_kasin urakan-parametrit)
+
+        ;; -----------------------------
+        ;; Tavoitehinnan muutospäätös
+        kattohinta 5M
+        tavoitehinta 5M
+        hoitokauden-alkuvuosi 2025
+        kayttajaid (:id +kayttaja-jvh+)
+
+        paatos (paatos-apurit/tavoitehinnan-muutospaatos
+                 urakkaid
+                 hoitokauden-alkuvuosi
+                 muokkaa-kattohinta
+                 tavoitehinta
+                 kattohinta
+                 kayttajaid)
+
+        vastaus-tavoitahinnan-muutos (paatos-kyselyt/tee-tavoitehinnan-muutospaatos (:db jarjestelma) paatos kayttajaid)
+        ;; Katso että päätös tallentui
+        ;; Kaikkia arvoja ei tässä testissä tarvitse tarkistella
+        _ (is (= urakkaid (:urakkaid vastaus-tavoitahinnan-muutos)))
+        _ (is (= hoitokauden-alkuvuosi (:hoitokauden_alkuvuosi vastaus-tavoitahinnan-muutos)))
+        _ (is (= muokkaa-kattohinta (:muokkaa_kattohinta vastaus-tavoitahinnan-muutos)))
+
+
+        ;; -----------------------------
+        ;; Lopun päätös 
+        hoitokauden-alkuvuosi 2024
+        tavoitehinta_ennen 2000000M
+        tavoitehinnan_muutokset 40000M
+        hoitokauden-lopun-indeksikorjaus 40000M
+
+        tavoitehinta_jalkeen (+ tavoitehinta_ennen hoitokauden-lopun-indeksikorjaus tavoitehinnan_muutokset)
+        kattohintakerroin (:hoitokauden_lopun_kattohinta_kerroin urakan-parametrit)
+        kattohinta (* kattohintakerroin tavoitehinta_jalkeen)
+
+        lisaa-tavoitehintaan-lopunindeksikorjaus (:lisaa_tavoitehintaan_hoitovuodenlopunindeksikorjaus urakan-parametrit)
+
+        paatos (paatos-apurit/lopun-hintapaatos urakkaid hoitokauden-alkuvuosi tavoitehinta_ennen hoitokauden-lopun-indeksikorjaus
+                 tavoitehinnan_muutokset tavoitehinta_jalkeen kattohinta kattohintakerroin lisaa-tavoitehintaan-lopunindeksikorjaus kayttajaid)
+
+        vastaus-hintapaatos (paatos-kyselyt/tee-hoitokauden-lopun-hintapaatos (:db jarjestelma) paatos)
+        ;; Katso että päätös tallentui
+        ;; Kaikkia arvoja ei tässä testissä tarvitse tarkistella
+        _ (is (= urakkaid (:urakkaid vastaus-hintapaatos)))
+        _ (is (= hoitokauden-alkuvuosi (:hoitokauden_alkuvuosi vastaus-hintapaatos)))
+        _ (is (= tavoitehinta_ennen (:tavoitehinta_ennen vastaus-hintapaatos)))
+
+
+        ;; -----------------------------
+        ;; Hoidonjohtopalkkion päätös 
+        kulu_id 1
+        hoidonjohtopalkkio 40000M
+        tarjouksen_tavoitehinta 2000000M
+        hv_lopun_indkorjaamaton_tavoitehinta 2100000M
+
+        muutosprosentti (* (- (/ hv_lopun_indkorjaamaton_tavoitehinta tarjouksen_tavoitehinta) 1) 100)
+        hoidonjohtopalkkio_muutos (* hoidonjohtopalkkio muutosprosentti)
+
+        paatos (paatos-apurit/hoidojohtopalkkiomuutospaatos
+                 urakkaid
+                 hoitokauden-alkuvuosi
+                 hv_lopun_indkorjaamaton_tavoitehinta
+                 tarjouksen_tavoitehinta
+                 muutosprosentti
+                 hoidonjohtopalkkio
+                 hoidonjohtopalkkio_muutos
+                 kulu_id
+                 kayttajaid)
+
+        vastaus-hoidonjohtopalkkio-muutos (paatos-kyselyt/tee-hoidonjohtopalkkiomuutospaatos (:db jarjestelma) paatos)
+        ;; Katso että päätös tallentui
+        ;; Kaikkia arvoja ei tässä testissä tarvitse tarkistella
+        _ (is (= urakkaid (:urakkaid vastaus-hoidonjohtopalkkio-muutos)))
+        _ (is (= hoitokauden-alkuvuosi (:hoitokauden_alkuvuosi vastaus-hoidonjohtopalkkio-muutos)))
+        _ (is (= hv_lopun_indkorjaamaton_tavoitehinta (:hv_lopun_indkorjaamaton_tavoitehinta vastaus-hoidonjohtopalkkio-muutos)))]
+
+
+    (testing "Ketjutus haku, sekä kumoaminen toimii"
+      (let [valikatselmus-vastaus (valikatselmukset/hae-valikatselmuksen-tiedot-hoitovuodelle
+                                    (:db jarjestelma) +kayttaja-jvh+
+                                    {:urakkaid urakkaid :hoitovuosi hoitokauden-alkuvuosi})
+
+            _ (is (some? (:id (valitse-paatos (:paatokset valikatselmus-vastaus) :hoitovuoden-lopun-tavoite-ja-kattohinta)))
+                "Hoitovuoden lopun tavoite- ja kattohintapäätös on olemassa")
+            _ (is (some? (:id (valitse-paatos (:paatokset valikatselmus-vastaus) :hoidonjohtopalkkion-muutos)))
+                "Hoidonjohtopalkkion muutospäätös on olemassa")
+
+            peruttava-paatos (valitse-paatos (:paatokset valikatselmus-vastaus) :hoitovuoden-lopun-tavoite-ja-kattohinta)
+            _ (is (not (nil? (:urakkaid peruttava-paatos))))
+
+
+            ;; -----------------------------
+            ;; Hae kaikki kumoutuvat
+            tehdyt-kumoutuvat-paatokset (kutsu-palvelua
+                                          (:http-palvelin jarjestelma)
+                                          :hae-ketjutetusti-kumoutuvat-paatokset +kayttaja-jvh+
+                                          peruttava-paatos)
+
+            peruuntuva-paatostyyppi (some->> tehdyt-kumoutuvat-paatokset first :paatostyyppi)
+
+            _ (is (= peruuntuva-paatostyyppi "hoidonjohtopalkkio")
+                "Hoidonjohtopalkkio peruuntuu lopun tavoite-ja-kattohinta päätöksen mukana")
+
+
+            poista-paatokset-vastaus (kutsu-palvelua
+                                       (:http-palvelin jarjestelma)
+                                       :poista-paatokset-ketjutetusti +kayttaja-jvh+
+                                       {:urakka-id urakkaid
+                                        :paatos (assoc peruttava-paatos :luoja kayttajaid)
+                                        :tehdyt-kumoutuvat-paatokset tehdyt-kumoutuvat-paatokset})
+
+            _ (is (nil? (:id (valitse-paatos (:paatokset poista-paatokset-vastaus) :hoitovuoden-lopun-tavoite-ja-kattohinta)))
+                "Hoitovuoden lopun tavoite- ja kattohintapäätös poistettiin")
+            _ (is (nil? (:id (valitse-paatos (:paatokset poista-paatokset-vastaus) :hoidonjohtopalkkion-muutos)))
+                "Hoidonjohtopalkkion muutospäätös poistettiin")]))))

--- a/test/clj/harja/palvelin/palvelut/valikatselmus/paatokset_ketjutus_test.clj
+++ b/test/clj/harja/palvelin/palvelut/valikatselmus/paatokset_ketjutus_test.clj
@@ -1,5 +1,6 @@
 (ns harja.palvelin.palvelut.valikatselmus.paatokset-ketjutus-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
             [com.stuartsierra.component :as component]
 
             [harja.testi :refer :all]
@@ -257,3 +258,73 @@
                 "Hoitovuoden lopun tavoite- ja kattohintapäätös poistettiin")
             _ (is (nil? (:id (valitse-paatos (:paatokset poista-paatokset-vastaus) :hoidonjohtopalkkion-muutos)))
                 "Hoidonjohtopalkkion muutospäätös poistettiin")]))))
+
+
+(deftest paatosten-poisto-ketjutetusti-palauttaa-virheen
+  (let [urakkaid (hae-urakan-id-nimella "POP MHU Kajaani 2025-2030")
+        urakan-parametrit (first (urakka-kyselyt/hae-urakan-parametrit (:db jarjestelma) {:urakkaid urakkaid}))
+        kayttajaid (:id +kayttaja-jvh+)
+
+        ;; -----------------------------
+        ;; Lopun päätös 
+        hoitokauden-alkuvuosi 2024
+        tavoitehinta_ennen 2000000M
+        tavoitehinnan_muutokset 40000M
+        hoitokauden-lopun-indeksikorjaus 40000M
+
+        tavoitehinta_jalkeen (+ tavoitehinta_ennen hoitokauden-lopun-indeksikorjaus tavoitehinnan_muutokset)
+        kattohintakerroin (:hoitokauden_lopun_kattohinta_kerroin urakan-parametrit)
+        kattohinta (* kattohintakerroin tavoitehinta_jalkeen)
+
+        lisaa-tavoitehintaan-lopunindeksikorjaus (:lisaa_tavoitehintaan_hoitovuodenlopunindeksikorjaus urakan-parametrit)
+
+        paatos (paatos-apurit/lopun-hintapaatos urakkaid hoitokauden-alkuvuosi tavoitehinta_ennen hoitokauden-lopun-indeksikorjaus
+                 tavoitehinnan_muutokset tavoitehinta_jalkeen kattohinta kattohintakerroin lisaa-tavoitehintaan-lopunindeksikorjaus kayttajaid)
+
+        vastaus-hintapaatos (paatos-kyselyt/tee-hoitokauden-lopun-hintapaatos (:db jarjestelma) paatos)
+        _ (is (= urakkaid (:urakkaid vastaus-hintapaatos)))
+        _ (is (= hoitokauden-alkuvuosi (:hoitokauden_alkuvuosi vastaus-hintapaatos)))
+        _ (is (= tavoitehinta_ennen (:tavoitehinta_ennen vastaus-hintapaatos)))]
+
+
+    (testing "Päätöksen ketjutus kumoaminen palauttaa virheen, väärä urakka"
+      (let [valikatselmus-vastaus (valikatselmukset/hae-valikatselmuksen-tiedot-hoitovuodelle
+                                    (:db jarjestelma) +kayttaja-jvh+
+                                    {:urakkaid urakkaid :hoitovuosi hoitokauden-alkuvuosi})
+
+            _ (is (some? (:id (valitse-paatos (:paatokset valikatselmus-vastaus) :hoitovuoden-lopun-tavoite-ja-kattohinta)))
+                "Hoitovuoden lopun tavoite- ja kattohintapäätös on olemassa")
+
+            peruttava-paatos (valitse-paatos (:paatokset valikatselmus-vastaus) :hoitovuoden-lopun-tavoite-ja-kattohinta)
+            _ (is (not (nil? (:urakkaid peruttava-paatos))))
+
+            ;; Assignoi päätökselle väärä urakkaid
+            vaara-urakkaid (hae-urakan-id-nimella "POP MHU Suomussalmi 2024-2029")
+            peruttava-paatos (assoc peruttava-paatos :urakkaid vaara-urakkaid)
+
+
+            _ (is (not= vaara-urakkaid urakkaid) "Päätöksellä on väärä urakka")
+
+
+            ;; -----------------------------
+            ;; Hae kaikki kumoutuvat ja kutsu ketjupoistoa 
+            tehdyt-kumoutuvat-paatokset (kutsu-palvelua
+                                          (:http-palvelin jarjestelma)
+                                          :hae-ketjutetusti-kumoutuvat-paatokset +kayttaja-jvh+
+                                          peruttava-paatos)
+
+            poista-paatokset-vastaus (try
+                                       (kutsu-palvelua
+                                         (:http-palvelin jarjestelma)
+                                         :poista-paatokset-ketjutetusti +kayttaja-jvh+
+                                         {:urakka-id urakkaid
+                                          :paatos (assoc peruttava-paatos :luoja kayttajaid)
+                                          :tehdyt-kumoutuvat-paatokset tehdyt-kumoutuvat-paatokset})
+                                       (catch Exception e e))
+
+            ;; Pitäisi johtaa virheeseen koska assignoitiin väärä urakka 
+            _ (is
+                (true? (str/includes?
+                         poista-paatokset-vastaus
+                         (str "Yritettiin perua urakan " vaara-urakkaid " päätös, valittu urakka: " urakkaid)))
+                "Odotettu virhe heitetään, yritettiin perua väärän urakan päätös")]))))

--- a/test/clj/harja/palvelin/palvelut/valikatselmus/paatosnakyvyyskone_test.clj
+++ b/test/clj/harja/palvelin/palvelut/valikatselmus/paatosnakyvyyskone_test.clj
@@ -1,19 +1,18 @@
 (ns harja.palvelin.palvelut.valikatselmus.paatosnakyvyyskone-test
-  (:require [clojure.test :refer :all]
-            [clojure.string :as str]
-            [harja.pvm :as pvm]
-            [harja.testi :refer :all]
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
             [com.stuartsierra.component :as component]
 
-            [harja.domain.lupaus-domain :as lupaus-domain]
-
+            [harja.pvm :as pvm]
+            [harja.testi :refer :all]
+            [harja.tyokalut.yleiset :as yleiset]
             [harja.kyselyt.urakat :as urakat-kyselyt]
+            [harja.domain.lupaus-domain :as lupaus-domain]
             [harja.kyselyt.paatos-kyselyt :as paatos-kyselyt]
-
             [harja.palvelin.komponentit.tietokanta :as tietokanta]
-            [harja.palvelin.palvelut.valikatselmus.valikatselmukset :as valikatselmukset]
-            [harja.palvelin.palvelut.valikatselmus.paatosnakyvyyskone :as paatoskone]
-            [harja.palvelin.palvelut.valikatselmus.paatosnakyvyyskone :as kone]))
+            [harja.palvelin.palvelut.valikatselmus.apurit :as apurit]
+            [harja.palvelin.palvelut.valikatselmus.paatosnakyvyyskone :as kone]
+            [harja.palvelin.palvelut.valikatselmus.paatostyypit :refer [paatostyypit]]))
 
 (defn jarjestelma-fixture [testit]
   (alter-var-root #'jarjestelma
@@ -35,118 +34,118 @@
         urakan-alkuvuosi 2020
         urakan-loppuvuosi 2025
         kuluva-hoitovuosi 2024
-        tulos (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi kuluva-hoitovuosi)]
+        tulos (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi kuluva-hoitovuosi)]
     (is (not (nil? tulos)))))
 
 ;; Varmista, että mhu ja mhu+ urakat saa oikean urakkatyypin
 (deftest urakan-hoitotyyppi-test
   (let [vaativa-hoitourakka-f false
         vaativa-hoitourakka-t true]
-    (is (= "MHU" (kone/urakan-hoitotyyppi vaativa-hoitourakka-f)))
-    (is (= "MHU+" (kone/urakan-hoitotyyppi vaativa-hoitourakka-t)))))
+    (is (= "MHU" (apurit/urakan-hoitotyyppi vaativa-hoitourakka-f)))
+    (is (= "MHU+" (apurit/urakan-hoitotyyppi vaativa-hoitourakka-t)))))
 
 ;; 2023 ei ole MHU+ urakoita käynnissä ja mitään ei löydy
 (deftest mhu+-vuodelle-2023-palautaa-oikein
   (let [mhu-tyyppi "MHU+"
         urakan-alkuvuosi 2023
         urakan-loppuvuosi (+ urakan-alkuvuosi 5)]
-    (is (= 3 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2023))))
-    (is (= 3 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024))))
-    (is (= 3 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2025))))
-    (is (= 3 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2026))))
-    (is (= 3 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2027))))))
+    (is (= 3 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2023))))
+    (is (= 3 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024))))
+    (is (= 3 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2025))))
+    (is (= 3 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2026))))
+    (is (= 3 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2027))))))
 
 (deftest mhu+-vuodelle-2021-ei-saisi-palauttaa-mitaan-test
   (let [mhu-tyyppi "MHU+"
         urakan-alkuvuosi 2021
         urakan-loppuvuosi (+ urakan-alkuvuosi 5)]
-    (is (= 0 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2017))))
-    (is (= 0 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2018))))
-    (is (= 3 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2019))))
-    (is (= 3 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2020))))
-    (is (= 3 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2021))))))
+    (is (= 0 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2017))))
+    (is (= 0 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2018))))
+    (is (= 3 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2019))))
+    (is (= 3 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2020))))
+    (is (= 3 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2021))))))
 
 (deftest mhu+-vuodelle-2024-palautaa-oikein
   (let [mhu-tyyppi "MHU+"
         urakan-alkuvuosi 2024
         urakan-loppuvuosi (+ urakan-alkuvuosi 5)
-        odotettu-lista '({:hoitotyyppi #{"MHU+"} :jarjestys 2 :nakyvyys_alkaen 2024 :nakyvyys_asti 2024 :nimi "Tavoitehinnan muutokset" :paatostyyppi "tavoitehinnan-muutokset" :urakan_alkuvuosi 2024}
-                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 3 :nakyvyys_alkaen 2024 :nimi "Hoitovuoden lopun indeksikorjaus" :paatostyyppi "indeksikorjaus" :tyyppi nil :urakan_alkuvuosi 2024}
-                         {:hoitotyyppi #{"MHU+"} :jarjestys 4 :nakyvyys_alkaen 2024 :nimi "Hoitovuoden lopun tavoite- ja kattohinta" :paatostyyppi "hoitovuoden-lopun-hinta-v2" :tyyppi "B" :urakan_alkuvuosi 2024}
-                         {:hoitotyyppi #{"MHU+"} :jarjestys 5 :nakyvyys_alkaen 2024 :nimi "Tavoitehinnan alitus" :paatostyyppi "tavoitehinta" :urakan_alkuvuosi 2024}
-                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 6 :nakyvyys_alkaen 2019 :nimi "Tavoitehinnan ylitys" :paatostyyppi "tavoitehinta" :tyyppi "B" :urakan_alkuvuosi 2024}
-                         {:hoitotyyppi #{"MHU+"} :jarjestys 7 :nakyvyys_alkaen 2024 :nimi "Kattohinnan ylitys" :paatostyyppi "kattohinta" :urakan_alkuvuosi 2024}
-                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :nakyvyys_alkaen 2019 :nimi "Lupaukset" :paatostyyppi "lupaus" :tyyppi "bonus" :urakan_alkuvuosi 2019}
-                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :nakyvyys_alkaen 2019 :nimi "Lupaukset" :paatostyyppi "lupaus" :tyyppi "sanktio" :urakan_alkuvuosi 2019}
-                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :nakyvyys_alkaen 2019 :nimi "Lupaukset" :paatostyyppi "lupaus" :tyyppi "taytetty" :urakan_alkuvuosi 2019}
-                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 9 :nakyvyys_alkaen 2024 :nimi "Hoidonjohtopalkkion muutos" :paatostyyppi "hoidonjohtopalkkio" :urakan_alkuvuosi 2024}
-                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 10 :nakyvyys_alkaen 2024 :nimi "Välikatselmuspöytäkirjaan liitettävät raportit" :paatostyyppi "raportti" :urakan_alkuvuosi 2024})]
-    (is (= odotettu-lista (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024)))
-    (is (= odotettu-lista (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2025)))
-    (is (= odotettu-lista (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2026)))
-    (is (= odotettu-lista (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2027)))
-    (is (= odotettu-lista (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2028)))))
+        odotettu-lista '({:hoitotyyppi #{"MHU+"} :jarjestys 2 :nakyvyys_alkaen 2024 :nakyvyys_asti 2024 :nimi "Tavoitehinnan muutokset" :paatostyyppi "tavoitehinnan-muutokset" :urakan_alkuvuosi 2024 :avain :tavoitehinnan-muutokset :riippuu []}
+                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 3 :nakyvyys_alkaen 2024 :nimi "Hoitovuoden lopun indeksikorjaus" :paatostyyppi "indeksikorjaus" :tyyppi nil :urakan_alkuvuosi 2024 :avain :indeksikorjaus :riippuu [{:avain :tavoitehinnan-muutokset}]}
+                         {:hoitotyyppi #{"MHU+"} :jarjestys 4 :nakyvyys_alkaen 2024 :nimi "Hoitovuoden lopun tavoite- ja kattohinta" :paatostyyppi "hoitovuoden-lopun-hinta-v2" :tyyppi "B" :urakan_alkuvuosi 2024 :avain :hoitovuoden-lopun-hinta :riippuu [{:avain :tavoitehinnan-muutokset} {:avain :indeksikorjaus}]}
+                         {:hoitotyyppi #{"MHU+"} :jarjestys 5 :nakyvyys_alkaen 2024 :nimi "Tavoitehinnan alitus" :paatostyyppi "tavoitehinta" :urakan_alkuvuosi 2024 :avain :tavoitehinnan-alitus :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 6 :nakyvyys_alkaen 2019 :nimi "Tavoitehinnan ylitys" :paatostyyppi "tavoitehinta" :tyyppi "B" :urakan_alkuvuosi 2024 :avain :tavoitehinnan-ylitys :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+                         {:hoitotyyppi #{"MHU+"} :jarjestys 7 :nakyvyys_alkaen 2024 :nimi "Kattohinnan ylitys" :paatostyyppi "kattohinta" :urakan_alkuvuosi 2024 :avain :kattohinnan-ylitys :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :nakyvyys_alkaen 2019 :nimi "Lupaukset" :paatostyyppi "lupaus" :tyyppi "bonus" :urakan_alkuvuosi 2019 :avain :lupaus :riippuu [{:avain :hoitovuoden-lopun-hinta :urakan_alkuvuosi_alkaen 2025}]}
+                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :nakyvyys_alkaen 2019 :nimi "Lupaukset" :paatostyyppi "lupaus" :tyyppi "sanktio" :urakan_alkuvuosi 2019 :avain :lupaus :riippuu [{:avain :hoitovuoden-lopun-hinta :urakan_alkuvuosi_alkaen 2025}]}
+                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :nakyvyys_alkaen 2019 :nimi "Lupaukset" :paatostyyppi "lupaus" :tyyppi "taytetty" :urakan_alkuvuosi 2019 :avain :lupaus :riippuu [{:avain :hoitovuoden-lopun-hinta :urakan_alkuvuosi_alkaen 2025}]}
+                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 9 :nakyvyys_alkaen 2024 :nimi "Hoidonjohtopalkkion muutos" :paatostyyppi "hoidonjohtopalkkio" :urakan_alkuvuosi 2024 :avain :hoidonjohtopalkkio :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 10 :nakyvyys_alkaen 2024 :nimi "Välikatselmuspöytäkirjaan liitettävät raportit" :paatostyyppi "raportti" :urakan_alkuvuosi 2024 :avain :raportti :riippuu []})]
+    (is (= odotettu-lista (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024)))
+    (is (= odotettu-lista (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2025)))
+    (is (= odotettu-lista (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2026)))
+    (is (= odotettu-lista (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2027)))
+    (is (= odotettu-lista (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2028)))))
 
 (deftest mhu+-vuodelle-2025-palautaa-oikein
   (let [mhu-tyyppi "MHU+"
         urakan-alkuvuosi 2025
         urakan-loppuvuosi (+ urakan-alkuvuosi 5)
-        odotettu-lista '({:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 2 :nakyvyys_alkaen 2025 :nimi "Tavoitehinnan pysyvät muutokset" :paatostyyppi "tavoitehinnan-pysyvat-muutokset" :urakan_alkuvuosi 2025}
-                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 3 :nakyvyys_alkaen 2024 :nimi "Hoitovuoden lopun indeksikorjaus" :paatostyyppi "indeksikorjaus" :tyyppi nil :urakan_alkuvuosi 2024}
-                         {:hoitotyyppi #{"MHU+"} :jarjestys 4 :nakyvyys_alkaen 2024 :nimi "Hoitovuoden lopun tavoite- ja kattohinta" :paatostyyppi "hoitovuoden-lopun-hinta-v2" :tyyppi "B" :urakan_alkuvuosi 2024}
-                         {:hoitotyyppi #{"MHU+"} :jarjestys 5 :nakyvyys_alkaen 2024 :nimi "Tavoitehinnan alitus" :paatostyyppi "tavoitehinta" :urakan_alkuvuosi 2024}
-                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 6 :nakyvyys_alkaen 2019 :nimi "Tavoitehinnan ylitys" :paatostyyppi "tavoitehinta" :tyyppi "B" :urakan_alkuvuosi 2024}
-                         {:hoitotyyppi #{"MHU+"} :jarjestys 7 :nakyvyys_alkaen 2024 :nimi "Kattohinnan ylitys" :paatostyyppi "kattohinta" :urakan_alkuvuosi 2024}
-                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :nakyvyys_alkaen 2019 :nimi "Lupaukset" :paatostyyppi "lupaus" :tyyppi "bonus" :urakan_alkuvuosi 2019}
-                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :nakyvyys_alkaen 2019 :nimi "Lupaukset" :paatostyyppi "lupaus" :tyyppi "sanktio" :urakan_alkuvuosi 2019}
-                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :nakyvyys_alkaen 2019 :nimi "Lupaukset" :paatostyyppi "lupaus" :tyyppi "taytetty" :urakan_alkuvuosi 2019}
-                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 9 :nakyvyys_alkaen 2024 :nimi "Hoidonjohtopalkkion muutos" :paatostyyppi "hoidonjohtopalkkio" :urakan_alkuvuosi 2024}
-                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 10 :nakyvyys_alkaen 2024 :nimi "Välikatselmuspöytäkirjaan liitettävät raportit" :paatostyyppi "raportti" :urakan_alkuvuosi 2024})]
-    (is (= odotettu-lista (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2025)))
-    (is (= odotettu-lista (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2026)))
-    (is (= odotettu-lista (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2027)))
-    (is (= odotettu-lista (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2028)))
-    (is (= odotettu-lista (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2029)))))
+        odotettu-lista '({:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 2 :nakyvyys_alkaen 2025 :nimi "Tavoitehinnan pysyvät muutokset" :paatostyyppi "tavoitehinnan-pysyvat-muutokset" :urakan_alkuvuosi 2025 :avain :tavoitehinnan-muutokset :riippuu []}
+                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 3 :nakyvyys_alkaen 2024 :nimi "Hoitovuoden lopun indeksikorjaus" :paatostyyppi "indeksikorjaus" :tyyppi nil :urakan_alkuvuosi 2024 :avain :indeksikorjaus :riippuu [{:avain :tavoitehinnan-muutokset}]}
+                         {:hoitotyyppi #{"MHU+"} :jarjestys 4 :nakyvyys_alkaen 2024 :nimi "Hoitovuoden lopun tavoite- ja kattohinta" :paatostyyppi "hoitovuoden-lopun-hinta-v2" :tyyppi "B" :urakan_alkuvuosi 2024 :avain :hoitovuoden-lopun-hinta :riippuu [{:avain :tavoitehinnan-muutokset} {:avain :indeksikorjaus}]}
+                         {:hoitotyyppi #{"MHU+"} :jarjestys 5 :nakyvyys_alkaen 2024 :nimi "Tavoitehinnan alitus" :paatostyyppi "tavoitehinta" :urakan_alkuvuosi 2024 :avain :tavoitehinnan-alitus :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 6 :nakyvyys_alkaen 2019 :nimi "Tavoitehinnan ylitys" :paatostyyppi "tavoitehinta" :tyyppi "B" :urakan_alkuvuosi 2024 :avain :tavoitehinnan-ylitys :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+                         {:hoitotyyppi #{"MHU+"} :jarjestys 7 :nakyvyys_alkaen 2024 :nimi "Kattohinnan ylitys" :paatostyyppi "kattohinta" :urakan_alkuvuosi 2024 :avain :kattohinnan-ylitys :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :nakyvyys_alkaen 2019 :nimi "Lupaukset" :paatostyyppi "lupaus" :tyyppi "bonus" :urakan_alkuvuosi 2019 :avain :lupaus :riippuu [{:avain :hoitovuoden-lopun-hinta :urakan_alkuvuosi_alkaen 2025}]}
+                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :nakyvyys_alkaen 2019 :nimi "Lupaukset" :paatostyyppi "lupaus" :tyyppi "sanktio" :urakan_alkuvuosi 2019 :avain :lupaus :riippuu [{:avain :hoitovuoden-lopun-hinta :urakan_alkuvuosi_alkaen 2025}]}
+                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :nakyvyys_alkaen 2019 :nimi "Lupaukset" :paatostyyppi "lupaus" :tyyppi "taytetty" :urakan_alkuvuosi 2019 :avain :lupaus :riippuu [{:avain :hoitovuoden-lopun-hinta :urakan_alkuvuosi_alkaen 2025}]}
+                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 9 :nakyvyys_alkaen 2024 :nimi "Hoidonjohtopalkkion muutos" :paatostyyppi "hoidonjohtopalkkio" :urakan_alkuvuosi 2024 :avain :hoidonjohtopalkkio :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+                         {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 10 :nakyvyys_alkaen 2024 :nimi "Välikatselmuspöytäkirjaan liitettävät raportit" :paatostyyppi "raportti" :urakan_alkuvuosi 2024 :avain :raportti :riippuu []})]
+    (is (= odotettu-lista (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2025)))
+    (is (= odotettu-lista (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2026)))
+    (is (= odotettu-lista (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2027)))
+    (is (= odotettu-lista (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2028)))
+    (is (= odotettu-lista (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2029)))))
 
 (deftest mhu-vuodelle-2024-palautaa-oikein
   (let [mhu-tyyppi "MHU"
         urakan-alkuvuosi 2024
         urakan-loppuvuosi (+ urakan-alkuvuosi 5)]
-    (is (= 13 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024))))
-    (is (= 13 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2025))))
-    (is (= 13 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2026))))
-    (is (= 13 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2027))))
-    (is (= 13 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2028))))))
+    (is (= 13 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024))))
+    (is (= 13 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2025))))
+    (is (= 13 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2026))))
+    (is (= 13 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2027))))
+    (is (= 13 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2028))))))
 
 (deftest mhu-vuodelle-2024-toimii-kun-paallekaiset-filtteroity
   (let [mhu-tyyppi "MHU"
         urakan-alkuvuosi 2024
         urakan-loppuvuosi (+ urakan-alkuvuosi 5)
-        filtteroidyt-paatokset (kone/filtteroi-mahdolliset-paatokset (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024) nil nil nil)
+        filtteroidyt-paatokset (kone/filtteroi-mahdolliset-paatokset (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024) nil nil nil)
         lupausmaara (filter #(= "lupaus" (:paatostyyppi %)) filtteroidyt-paatokset)
         ;; Lupauksia on vain yksi
         _ (is (= 1 (count lupausmaara)))
         ;; "Hoitovuoden lopun tavoite- ja kattohinta" - päätöksiä on vain yksi
         hoitovuoden-lopun-hinta-maara (filter #(= "hoitovuoden-lopun-hinta" (:paatostyyppi %)) filtteroidyt-paatokset)
         _ (is (= 1 (count hoitovuoden-lopun-hinta-maara)))]
-    (is (= 6 (count (kone/filtteroi-mahdolliset-paatokset (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024) nil nil nil))))
-    (is (= 6 (count (kone/filtteroi-mahdolliset-paatokset (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2025) nil nil nil))))
-    (is (= 6 (count (kone/filtteroi-mahdolliset-paatokset (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2026) nil nil nil))))
-    (is (= 6 (count (kone/filtteroi-mahdolliset-paatokset (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2027) nil nil nil))))
-    (is (= 6 (count (kone/filtteroi-mahdolliset-paatokset (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2028) nil nil nil))))))
+    (is (= 6 (count (kone/filtteroi-mahdolliset-paatokset (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024) nil nil nil))))
+    (is (= 6 (count (kone/filtteroi-mahdolliset-paatokset (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2025) nil nil nil))))
+    (is (= 6 (count (kone/filtteroi-mahdolliset-paatokset (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2026) nil nil nil))))
+    (is (= 6 (count (kone/filtteroi-mahdolliset-paatokset (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2027) nil nil nil))))
+    (is (= 6 (count (kone/filtteroi-mahdolliset-paatokset (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2028) nil nil nil))))))
 
 (deftest hintapaatosten-filtterointi-toimii
   (let [mhu-tyyppi "MHU"
         urakan-alkuvuosi 2024
         urakan-loppuvuosi (+ urakan-alkuvuosi 7)
         ;; Toteutuneita kustannuksia, tavoitehintaa tai kattohintaa ei määritellä
-        filtteroidyt-paatokset (kone/filtteroi-mahdolliset-paatokset (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024) nil nil nil)
+        filtteroidyt-paatokset (kone/filtteroi-mahdolliset-paatokset (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024) nil nil nil)
         kattohintamaara1 (filter #(= "kattohinta" (:paatostyyppi %)) filtteroidyt-paatokset)
         tavoitehintamaara1 (filter #(= "tavoitehinta" (:paatostyyppi %)) filtteroidyt-paatokset)
         _ (is (= 0 (count kattohintamaara1)))
         _ (is (= 0 (count tavoitehintamaara1)))
         ;; Toteutuneet kustannukset ylittää sekä tavoite että kattohinnan
-        filtteroidyt-paatokset (kone/filtteroi-mahdolliset-paatokset (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024) 10 8 9)
+        filtteroidyt-paatokset (kone/filtteroi-mahdolliset-paatokset (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024) 10 8 9)
         kattohintamaara2 (filter #(= "kattohinta" (:paatostyyppi %)) filtteroidyt-paatokset)
         tavoitehintamaara2 (filter #(= "tavoitehinta" (:paatostyyppi %)) filtteroidyt-paatokset)
         ;; Lupauksia on vain yksi
@@ -160,74 +159,74 @@
   (let [mhu-tyyppi "MHU"
         urakan-alkuvuosi 2024
         urakan-loppuvuosi (+ urakan-alkuvuosi 6)]
-    (is (= 13 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024))))
-    (is (= 13 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2025))))
-    (is (= 13 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2026))))
-    (is (= 13 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2027))))
-    (is (= 13 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2028))))))
+    (is (= 13 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024))))
+    (is (= 13 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2025))))
+    (is (= 13 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2026))))
+    (is (= 13 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2027))))
+    (is (= 13 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2028))))))
 
 (deftest mhu-vuodelle-2025-palautaa-oikein
-  (let [odotetut-paatokset '({:hoitotyyppi #{"MHU"} :jarjestys 2 :nakyvyys_alkaen 2021 :nakyvyys_asti 2028 :nimi "Tavoitehinnan muutokset" :paatostyyppi "tavoitehinnan-muutokset" :urakan_alkuvuosi 2021}
-                             {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 2 :nakyvyys_alkaen 2025 :nimi "Tavoitehinnan pysyvät muutokset" :paatostyyppi "tavoitehinnan-pysyvat-muutokset" :urakan_alkuvuosi 2025}
-                             {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 3 :nakyvyys_alkaen 2024 :nimi "Hoitovuoden lopun indeksikorjaus" :paatostyyppi "indeksikorjaus" :tyyppi nil :urakan_alkuvuosi 2024}
-                             {:hoitotyyppi #{"MHU"} :jarjestys 4 :nakyvyys_alkaen 2025 :nimi "Hoitovuoden lopun tavoite- ja kattohinta" :paatostyyppi "hoitovuoden-lopun-hinta-v2" :tyyppi "C" :urakan_alkuvuosi 2025}
-                             {:hoitotyyppi #{"MHU"} :jarjestys 5 :nakyvyys_alkaen 2019 :nimi "Tavoitehinnan alitus" :paatostyyppi "tavoitehinta" :urakan_alkuvuosi 2019}
-                             {:hoitotyyppi #{"MHU"} :jarjestys 6 :nakyvyys_alkaen 2019 :nimi "Tavoitehinnan ylitys" :paatostyyppi "tavoitehinta" :tyyppi "A" :urakan_alkuvuosi 2019}
-                             {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 6 :nakyvyys_alkaen 2019 :nimi "Tavoitehinnan ylitys" :paatostyyppi "tavoitehinta" :tyyppi "B" :urakan_alkuvuosi 2024}
-                             {:hoitotyyppi #{"MHU"} :jarjestys 7 :nakyvyys_alkaen 2019 :nimi "Kattohinnan ylitys" :paatostyyppi "kattohinta" :urakan_alkuvuosi 2019}
-                             {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :nakyvyys_alkaen 2019 :nimi "Lupaukset" :paatostyyppi "lupaus" :tyyppi "bonus" :urakan_alkuvuosi 2019}
-                             {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :nakyvyys_alkaen 2019 :nimi "Lupaukset" :paatostyyppi "lupaus" :tyyppi "sanktio" :urakan_alkuvuosi 2019}
-                             {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :nakyvyys_alkaen 2019 :nimi "Lupaukset" :paatostyyppi "lupaus" :tyyppi "taytetty" :urakan_alkuvuosi 2019}
-                             {:hoitotyyppi #{"MHU"} :jarjestys 9 :nakyvyys_alkaen 2024 :nimi "Hoidonjohtopalkkion muutos" :paatostyyppi "hoidonjohtopalkkio" :urakan_alkuvuosi 2021}
-                             {:hoitotyyppi #{"MHU"} :jarjestys 10 :nakyvyys_alkaen 2024 :nimi "Välikatselmuspöytäkirjaan liitettävät raportit" :paatostyyppi "raportti" :urakan_alkuvuosi 2020})
+  (let [odotetut-paatokset '({:hoitotyyppi #{"MHU"} :jarjestys 2 :nakyvyys_alkaen 2021 :nakyvyys_asti 2028 :nimi "Tavoitehinnan muutokset" :paatostyyppi "tavoitehinnan-muutokset" :urakan_alkuvuosi 2021 :avain :tavoitehinnan-muutokset :riippuu []}
+                             {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 2 :nakyvyys_alkaen 2025 :nimi "Tavoitehinnan pysyvät muutokset" :paatostyyppi "tavoitehinnan-pysyvat-muutokset" :urakan_alkuvuosi 2025 :avain :tavoitehinnan-muutokset :riippuu []}
+                             {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 3 :nakyvyys_alkaen 2024 :nimi "Hoitovuoden lopun indeksikorjaus" :paatostyyppi "indeksikorjaus" :tyyppi nil :urakan_alkuvuosi 2024 :avain :indeksikorjaus :riippuu [{:avain :tavoitehinnan-muutokset}]}
+                             {:hoitotyyppi #{"MHU"} :jarjestys 4 :nakyvyys_alkaen 2025 :nimi "Hoitovuoden lopun tavoite- ja kattohinta" :paatostyyppi "hoitovuoden-lopun-hinta-v2" :tyyppi "C" :urakan_alkuvuosi 2025 :avain :hoitovuoden-lopun-hinta :riippuu [{:avain :tavoitehinnan-muutokset} {:avain :indeksikorjaus}]}
+                             {:hoitotyyppi #{"MHU"} :jarjestys 5 :nakyvyys_alkaen 2019 :nimi "Tavoitehinnan alitus" :paatostyyppi "tavoitehinta" :urakan_alkuvuosi 2019 :avain :tavoitehinnan-alitus :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+                             {:hoitotyyppi #{"MHU"} :jarjestys 6 :nakyvyys_alkaen 2019 :nimi "Tavoitehinnan ylitys" :paatostyyppi "tavoitehinta" :tyyppi "A" :urakan_alkuvuosi 2019 :avain :tavoitehinnan-ylitys :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+                             {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 6 :nakyvyys_alkaen 2019 :nimi "Tavoitehinnan ylitys" :paatostyyppi "tavoitehinta" :tyyppi "B" :urakan_alkuvuosi 2024 :avain :tavoitehinnan-ylitys :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+                             {:hoitotyyppi #{"MHU"} :jarjestys 7 :nakyvyys_alkaen 2019 :nimi "Kattohinnan ylitys" :paatostyyppi "kattohinta" :urakan_alkuvuosi 2019 :avain :kattohinnan-ylitys :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+                             {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :nakyvyys_alkaen 2019 :nimi "Lupaukset" :paatostyyppi "lupaus" :tyyppi "bonus" :urakan_alkuvuosi 2019 :avain :lupaus :riippuu [{:avain :hoitovuoden-lopun-hinta :urakan_alkuvuosi_alkaen 2025}]}
+                             {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :nakyvyys_alkaen 2019 :nimi "Lupaukset" :paatostyyppi "lupaus" :tyyppi "sanktio" :urakan_alkuvuosi 2019 :avain :lupaus :riippuu [{:avain :hoitovuoden-lopun-hinta :urakan_alkuvuosi_alkaen 2025}]}
+                             {:hoitotyyppi #{"MHU" "MHU+"} :jarjestys 8 :nakyvyys_alkaen 2019 :nimi "Lupaukset" :paatostyyppi "lupaus" :tyyppi "taytetty" :urakan_alkuvuosi 2019 :avain :lupaus :riippuu [{:avain :hoitovuoden-lopun-hinta :urakan_alkuvuosi_alkaen 2025}]}
+                             {:hoitotyyppi #{"MHU"} :jarjestys 9 :nakyvyys_alkaen 2024 :nimi "Hoidonjohtopalkkion muutos" :paatostyyppi "hoidonjohtopalkkio" :urakan_alkuvuosi 2021 :avain :hoidonjohtopalkkio :riippuu [{:avain :hoitovuoden-lopun-hinta}]}
+                             {:hoitotyyppi #{"MHU"} :jarjestys 10 :nakyvyys_alkaen 2024 :nimi "Välikatselmuspöytäkirjaan liitettävät raportit" :paatostyyppi "raportti" :urakan_alkuvuosi 2020 :avain :raportti :riippuu []})
         mhu-tyyppi "MHU"
         urakan-alkuvuosi 2025
         urakan-loppuvuosi (+ urakan-alkuvuosi 5)
-        paatokset-25 (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2025)
+        paatokset-25 (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2025)
         filtteroidyt-paatokset (kone/filtteroi-mahdolliset-paatokset paatokset-25 nil nil nil)
         hoitovuoden-lopun-hinta-maara (filter #(= "hoitovuoden-lopun-hinta-v2" (:paatostyyppi %)) filtteroidyt-paatokset)
         _ (is (= 1 (count hoitovuoden-lopun-hinta-maara)))]
-    (is (= odotetut-paatokset (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2025)))
-    (is (= odotetut-paatokset (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2026)))
-    (is (= odotetut-paatokset (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2027)))
-    (is (= odotetut-paatokset (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2028)))
-    (is (= odotetut-paatokset (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2029)))))
+    (is (= odotetut-paatokset (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2025)))
+    (is (= odotetut-paatokset (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2026)))
+    (is (= odotetut-paatokset (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2027)))
+    (is (= odotetut-paatokset (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2028)))
+    (is (= odotetut-paatokset (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2029)))))
 
 (deftest mhu-vuodelle-2019-palautaa-oikein
   (let [mhu-tyyppi "MHU"
         urakan-alkuvuosi 2019
         urakan-loppuvuosi (+ urakan-alkuvuosi 5)]
-    (is (= 7 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2019))))
-    (is (= 7 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2020))))
-    (is (= 7 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2021))))
-    (is (= 7 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2022))))
-    (is (= 7 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2023))))))
+    (is (= 7 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2019))))
+    (is (= 7 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2020))))
+    (is (= 7 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2021))))
+    (is (= 7 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2022))))
+    (is (= 7 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2023))))))
 
 (deftest mhu-vuodelle-2020-palautaa-oikein
   (let [mhu-tyyppi "MHU"
         urakan-alkuvuosi 2020
         urakan-loppuvuosi (+ urakan-alkuvuosi 5)]
-    (is (= 7 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2020))))
-    (is (= 7 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2021))))
-    (is (= 7 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2022))))
-    (is (= 7 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2023))))
-    (is (= 8 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024))))))
+    (is (= 7 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2020))))
+    (is (= 7 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2021))))
+    (is (= 7 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2022))))
+    (is (= 7 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2023))))
+    (is (= 8 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024))))))
 
 (deftest mhu-vuodelle-2021-palautaa-oikein
   (let [mhu-tyyppi "MHU"
         urakan-alkuvuosi 2021
         urakan-loppuvuosi (+ urakan-alkuvuosi 5)]
-    (is (= 7 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2021))))
-    (is (= 7 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2022))))
-    (is (= 7 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2023))))
-    (is (= 10 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024))))
-    (is (= 10 (count (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2025))))))
+    (is (= 7 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2021))))
+    (is (= 7 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2022))))
+    (is (= 7 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2023))))
+    (is (= 10 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024))))
+    (is (= 10 (count (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2025))))))
 
 (deftest mhu-2021-vuodelle-2024
   (let [mhu-tyyppi "MHU"
         urakan-alkuvuosi 2021
         urakan-loppuvuosi (+ urakan-alkuvuosi 5)
-        paatokset (kone/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024)]
+        paatokset (apurit/kaikki-mahdolliset-paatokset mhu-tyyppi urakan-alkuvuosi urakan-loppuvuosi 2024)]
     ;; Hoitovuoden lopun tavoite- ja kattohintaan tuli yksittäinen speksimuutos, niin varmistetaan sen toiminta
     (is (= 1 (count (filter
                       #(= "Hoitovuoden lopun tavoite- ja kattohinta" (:nimi %))
@@ -235,19 +234,19 @@
 
 
 (deftest paatosmaarat-mhu-tyypilla-test
-  (let [mhu-paatokset (kone/mahdolliset-paatokset-tyypilla "MHU" kone/paatostyypit)
-        mhu+-paatokset (kone/mahdolliset-paatokset-tyypilla "MHU+" kone/paatostyypit)]
+  (let [mhu-paatokset (apurit/mahdolliset-paatokset-tyypilla "MHU" paatostyypit)
+        mhu+-paatokset (apurit/mahdolliset-paatokset-tyypilla "MHU+" paatostyypit)]
     (is (= 18 (count mhu-paatokset)))
     (is (= 12 (count mhu+-paatokset)))))
 
 (deftest paatosmaarat-hoitokauden-alkuvuosilla-test
-  (let [urakan-alkuvuosi-2019-paatokset (kone/mahdolliset-paatokset-urakan-alkuvuodella 2019 kone/paatostyypit)
-        urakan-alkuvuosi-2020-paatokset (kone/mahdolliset-paatokset-urakan-alkuvuodella 2020 kone/paatostyypit)
-        urakan-alkuvuosi-2021-paatokset (kone/mahdolliset-paatokset-urakan-alkuvuodella 2021 kone/paatostyypit)
-        urakan-alkuvuosi-2022-paatokset (kone/mahdolliset-paatokset-urakan-alkuvuodella 2022 kone/paatostyypit)
-        urakan-alkuvuosi-2023-paatokset (kone/mahdolliset-paatokset-urakan-alkuvuodella 2023 kone/paatostyypit)
-        urakan-alkuvuosi-2024-paatokset (kone/mahdolliset-paatokset-urakan-alkuvuodella 2024 kone/paatostyypit)
-        urakan-alkuvuosi-2025-paatokset (kone/mahdolliset-paatokset-urakan-alkuvuodella 2025 kone/paatostyypit)]
+  (let [urakan-alkuvuosi-2019-paatokset (apurit/mahdolliset-paatokset-urakan-alkuvuodella 2019 paatostyypit)
+        urakan-alkuvuosi-2020-paatokset (apurit/mahdolliset-paatokset-urakan-alkuvuodella 2020 paatostyypit)
+        urakan-alkuvuosi-2021-paatokset (apurit/mahdolliset-paatokset-urakan-alkuvuodella 2021 paatostyypit)
+        urakan-alkuvuosi-2022-paatokset (apurit/mahdolliset-paatokset-urakan-alkuvuodella 2022 paatostyypit)
+        urakan-alkuvuosi-2023-paatokset (apurit/mahdolliset-paatokset-urakan-alkuvuodella 2023 paatostyypit)
+        urakan-alkuvuosi-2024-paatokset (apurit/mahdolliset-paatokset-urakan-alkuvuodella 2024 paatostyypit)
+        urakan-alkuvuosi-2025-paatokset (apurit/mahdolliset-paatokset-urakan-alkuvuodella 2025 paatostyypit)]
     (is (= 7 (count urakan-alkuvuosi-2019-paatokset)))
     (is (= 8 (count urakan-alkuvuosi-2020-paatokset)))
     (is (= 11 (count urakan-alkuvuosi-2021-paatokset)))
@@ -257,13 +256,13 @@
     (is (= 22 (count urakan-alkuvuosi-2025-paatokset)))))
 
 (deftest paatosmaarat-nakyvyys-asti-test
-  (let [urakan-alkuvuosi-2019-paatokset (kone/mahdolliset-paatokset-nakyvyys-asti 2019 kone/paatostyypit)
-        urakan-alkuvuosi-2020-paatokset (kone/mahdolliset-paatokset-nakyvyys-asti 2020 kone/paatostyypit)
-        urakan-alkuvuosi-2021-paatokset (kone/mahdolliset-paatokset-nakyvyys-asti 2021 kone/paatostyypit)
-        urakan-alkuvuosi-2022-paatokset (kone/mahdolliset-paatokset-nakyvyys-asti 2022 kone/paatostyypit)
-        urakan-alkuvuosi-2023-paatokset (kone/mahdolliset-paatokset-nakyvyys-asti 2023 kone/paatostyypit)
-        urakan-alkuvuosi-2024-paatokset (kone/mahdolliset-paatokset-nakyvyys-asti 2024 kone/paatostyypit)
-        urakan-alkuvuosi-2025-paatokset (kone/mahdolliset-paatokset-nakyvyys-asti 2025 kone/paatostyypit)]
+  (let [urakan-alkuvuosi-2019-paatokset (apurit/mahdolliset-paatokset-nakyvyys-asti 2019 paatostyypit)
+        urakan-alkuvuosi-2020-paatokset (apurit/mahdolliset-paatokset-nakyvyys-asti 2020 paatostyypit)
+        urakan-alkuvuosi-2021-paatokset (apurit/mahdolliset-paatokset-nakyvyys-asti 2021 paatostyypit)
+        urakan-alkuvuosi-2022-paatokset (apurit/mahdolliset-paatokset-nakyvyys-asti 2022 paatostyypit)
+        urakan-alkuvuosi-2023-paatokset (apurit/mahdolliset-paatokset-nakyvyys-asti 2023 paatostyypit)
+        urakan-alkuvuosi-2024-paatokset (apurit/mahdolliset-paatokset-nakyvyys-asti 2024 paatostyypit)
+        urakan-alkuvuosi-2025-paatokset (apurit/mahdolliset-paatokset-nakyvyys-asti 2025 paatostyypit)]
     (is (= 22 (count urakan-alkuvuosi-2019-paatokset)))
     (is (= 22 (count urakan-alkuvuosi-2020-paatokset)))
     (is (= 22 (count urakan-alkuvuosi-2021-paatokset)))
@@ -273,13 +272,13 @@
     (is (= 18 (count urakan-alkuvuosi-2025-paatokset)))))
 
 (deftest paatosmaarat-nakyvyys-vuodesta-test
-  (let [nakyvyysvuosi-2019-paatokset (kone/mahdolliset-paatokset-nakyvyys-vuodella 2019 kone/paatostyypit)
-        nakyvyysvuosi-2020-paatokset (kone/mahdolliset-paatokset-nakyvyys-vuodella 2020 kone/paatostyypit)
-        nakyvyysvuosi-2021-paatokset (kone/mahdolliset-paatokset-nakyvyys-vuodella 2021 kone/paatostyypit)
-        nakyvyysvuosi-2022-paatokset (kone/mahdolliset-paatokset-nakyvyys-vuodella 2022 kone/paatostyypit)
-        nakyvyysvuosi-2023-paatokset (kone/mahdolliset-paatokset-nakyvyys-vuodella 2023 kone/paatostyypit)
-        nakyvyysvuosi-2024-paatokset (kone/mahdolliset-paatokset-nakyvyys-vuodella 2024 kone/paatostyypit)
-        nakyvyysvuosi-2025-paatokset (kone/mahdolliset-paatokset-nakyvyys-vuodella 2025 kone/paatostyypit)]
+  (let [nakyvyysvuosi-2019-paatokset (apurit/mahdolliset-paatokset-nakyvyys-vuodella 2019 paatostyypit)
+        nakyvyysvuosi-2020-paatokset (apurit/mahdolliset-paatokset-nakyvyys-vuodella 2020 paatostyypit)
+        nakyvyysvuosi-2021-paatokset (apurit/mahdolliset-paatokset-nakyvyys-vuodella 2021 paatostyypit)
+        nakyvyysvuosi-2022-paatokset (apurit/mahdolliset-paatokset-nakyvyys-vuodella 2022 paatostyypit)
+        nakyvyysvuosi-2023-paatokset (apurit/mahdolliset-paatokset-nakyvyys-vuodella 2023 paatostyypit)
+        nakyvyysvuosi-2024-paatokset (apurit/mahdolliset-paatokset-nakyvyys-vuodella 2024 paatostyypit)
+        nakyvyysvuosi-2025-paatokset (apurit/mahdolliset-paatokset-nakyvyys-vuodella 2025 paatostyypit)]
     (is (= 8 (count nakyvyysvuosi-2019-paatokset)))
     (is (= 8 (count nakyvyysvuosi-2020-paatokset)))
     (is (= 9 (count nakyvyysvuosi-2021-paatokset)))
@@ -308,9 +307,9 @@
                       {:nimi "Kattohinnan ylitys" :tyyppi "db"}
                       {:nimi "Hoidonjohtopalkkion muutos" :tyyppi "db"}
                       {:nimi "Välikatselmuspöytäkirjaan liitettävät raportit" :tyyppi "db"}]
-        yhdistetyt-paatokset (kone/yhdista-mapit pk-paatokset db-paatokset)
+        yhdistetyt-paatokset (yleiset/yhdista-mapit pk-paatokset db-paatokset)
         yksi-db-paatos (conj [] (first db-paatokset))
-        yksi-tietokannasta (kone/yhdista-mapit pk-paatokset yksi-db-paatos)]
+        yksi-tietokannasta (yleiset/yhdista-mapit pk-paatokset yksi-db-paatos)]
     (is (= 9 (count yhdistetyt-paatokset)))
     (is (= "db" (:tyyppi (first yhdistetyt-paatokset))))
     (is (= "db" (:tyyppi (last yhdistetyt-paatokset))))
@@ -334,7 +333,7 @@
         luvatut-pisteet 10
         tarjous-tavoitehinta 100
         tavoitehinta 99
-        mahdolliset-paatokset (paatoskone/kaikki-mahdolliset-paatokset "mhu" urakan-alkuvuosi urakan-loppuvuosi valittu-hoitovuosi)
+        mahdolliset-paatokset (apurit/kaikki-mahdolliset-paatokset "mhu" urakan-alkuvuosi urakan-loppuvuosi valittu-hoitovuosi)
         tietokanta-paatokset (paatos-kyselyt/hae-paatokset db mahdolliset-paatokset urakkaid valittu-hoitovuosi)
         paatokset-ei-kumpikaan (kone/valmistele-lupauspaatokset (:db jarjestelma) false valittu-hoitovuosi urakkaid paatokset
                                  toteutuneet-pisteet luvatut-pisteet tavoitehinta tarjous-tavoitehinta indeksi
@@ -376,13 +375,13 @@
           luvatut-pisteet 10
           tarjous-tavoitehinta 100000M ;; 100 000 €
           tavoitehinta 99000M
-          mahdolliset-paatokset (paatoskone/kaikki-mahdolliset-paatokset "mhu" urakan-alkuvuosi urakan-loppuvuosi valittu-hoitovuosi)
+          mahdolliset-paatokset (apurit/kaikki-mahdolliset-paatokset "mhu" urakan-alkuvuosi urakan-loppuvuosi valittu-hoitovuosi)
           tietokanta-paatokset (paatos-kyselyt/hae-paatokset db mahdolliset-paatokset urakkaid valittu-hoitovuosi)
           ;; Haetaan urakan parametrit bonus/sanktioprosenteille
           urakan-parametrit (first (urakat-kyselyt/hae-urakan-parametrit (:db jarjestelma) {:urakkaid urakkaid}))
           bonusprosentti (:lupauspaatoksen_bonusprosentti urakan-parametrit)
           sanktioprosentti (:lupauspaatoksen_sanktioprosentti urakan-parametrit)
-          
+
           ;; Lasketaan odotettu bonussumma yhteisellä funktiolla
           yhteinen-tulos (lupaus-domain/laske-lupauspaatos-bonus-tai-sanktio
                            {:toteutuneet-pisteet toteutuneet-pisteet
@@ -391,18 +390,18 @@
                             :sanktioprosentti sanktioprosentti
                             :bonusprosentti bonusprosentti})
           odotettu-bonus (:lupausbonus yhteinen-tulos)
-          
+
           ;; Valmistele lupauspaatos
-          valmistellut-paatokset (kone/valmistele-lupauspaatokset 
-                                   (:db jarjestelma) false valittu-hoitovuosi urakkaid paatokset 
+          valmistellut-paatokset (kone/valmistele-lupauspaatokset
+                                   (:db jarjestelma) false valittu-hoitovuosi urakkaid paatokset
                                    toteutuneet-pisteet luvatut-pisteet tavoitehinta tarjous-tavoitehinta indeksi
                                    tietokanta-paatokset urakan-alkuvuosi)
           lupauspaatos (first valmistellut-paatokset)]
-      
+
       (is (= 1 (count valmistellut-paatokset)) "Vain yksi päätös palautetaan")
       (is (= "bonus" (:tyyppi lupauspaatos)) "Päätös on bonuspäätös")
       (is (= odotettu-bonus (:lupausbonus lupauspaatos))
-          "Lupausbonus vastaa yhteistä laskentaa"))))
+        "Lupausbonus vastaa yhteistä laskentaa"))))
 
 (deftest valmistele-lupauspaatokset-sanktio-laskenta-yhdenmukaisuus-test
   (testing "Varmistetaan, että lupaussanktio lasketaan yhteisen domain-funktion mukaisesti"
@@ -423,7 +422,7 @@
           urakan-parametrit (first (urakat-kyselyt/hae-urakan-parametrit (:db jarjestelma) {:urakkaid urakkaid}))
           bonusprosentti (:lupauspaatoksen_bonusprosentti urakan-parametrit)
           sanktioprosentti (:lupauspaatoksen_sanktioprosentti urakan-parametrit)
-          
+
           ;; Lasketaan odotettu sanktiosumma yhteisellä funktiolla
           yhteinen-tulos (lupaus-domain/laske-lupauspaatos-bonus-tai-sanktio
                            {:toteutuneet-pisteet toteutuneet-pisteet
@@ -432,20 +431,20 @@
                             :sanktioprosentti sanktioprosentti
                             :bonusprosentti bonusprosentti})
           odotettu-sanktio (:lupaussanktio yhteinen-tulos)
-          
+
           ;; Valmistele lupauspaatos
-          mahdolliset-paatokset (paatoskone/kaikki-mahdolliset-paatokset "mhu" urakan-alkuvuosi urakan-loppuvuosi valittu-hoitovuosi)
+          mahdolliset-paatokset (apurit/kaikki-mahdolliset-paatokset "mhu" urakan-alkuvuosi urakan-loppuvuosi valittu-hoitovuosi)
           tietokanta-paatokset (paatos-kyselyt/hae-paatokset db mahdolliset-paatokset urakkaid valittu-hoitovuosi)
           valmistellut-paatokset (kone/valmistele-lupauspaatokset
-                                   (:db jarjestelma) false valittu-hoitovuosi urakkaid paatokset 
+                                   (:db jarjestelma) false valittu-hoitovuosi urakkaid paatokset
                                    toteutuneet-pisteet luvatut-pisteet tavoitehinta tarjous-tavoitehinta indeksi
                                    tietokanta-paatokset urakan-alkuvuosi)
           lupauspaatos (first valmistellut-paatokset)]
-      
+
       (is (= 1 (count valmistellut-paatokset)) "Vain yksi päätös palautetaan")
       (is (= "sanktio" (:tyyppi lupauspaatos)) "Päätös on sanktioon johtava päätös")
-      (is (= odotettu-sanktio (:lupaussanktio lupauspaatos)) 
-          "Lupaussanktio vastaa yhteistä laskentaa"))))
+      (is (= odotettu-sanktio (:lupaussanktio lupauspaatos))
+        "Lupaussanktio vastaa yhteistä laskentaa"))))
 
 
 (deftest valmistele-lupauspaatokset-puuttuvat-prosentit-test
@@ -463,23 +462,22 @@
           luvatut-pisteet 10
           tarjous-tavoitehinta 100000M
           tavoitehinta 99000M
-          mahdolliset-paatokset (paatoskone/kaikki-mahdolliset-paatokset "mhu" urakan-alkuvuosi urakan-loppuvuosi valittu-hoitovuosi)
+          mahdolliset-paatokset (apurit/kaikki-mahdolliset-paatokset "mhu" urakan-alkuvuosi urakan-loppuvuosi valittu-hoitovuosi)
           tietokanta-paatokset (paatos-kyselyt/hae-paatokset db mahdolliset-paatokset urakkaid valittu-hoitovuosi)]
-      
+
       ;; Stubataan urakan parametrit niin että bonus- ja sanktioprosentit puuttuvat (nil)
-      (with-redefs [urakat-kyselyt/hae-urakan-parametrit 
-                    (fn [db params] 
+      (with-redefs [urakat-kyselyt/hae-urakan-parametrit
+                    (fn [_db _params]
                       [{:lupauspaatoksen_bonusprosentti nil
                         :lupauspaatoksen_sanktioprosentti nil}])]
-        (let [valmistellut-paatokset (kone/valmistele-lupauspaatokset 
-                                       (:db jarjestelma) false valittu-hoitovuosi urakkaid paatokset 
+        (let [valmistellut-paatokset (kone/valmistele-lupauspaatokset
+                                       (:db jarjestelma) false valittu-hoitovuosi urakkaid paatokset
                                        toteutuneet-pisteet luvatut-pisteet tavoitehinta tarjous-tavoitehinta indeksi
                                        tietokanta-paatokset urakan-alkuvuosi)
               lupauspaatos (first valmistellut-paatokset)]
-          
+
           (is (= 1 (count valmistellut-paatokset)) "Vain yksi päätös palautetaan")
           (is (= "Lupaukset" (:nimi lupauspaatos)) "Päätöksen nimi on Lupaukset")
           (is (some? (:virheet lupauspaatos)) "Päätöksessä on virhe")
           (is (str/includes? (:virheet lupauspaatos) "prosentit")
-              "Virheviesti mainitsee puuttuvat prosentit"))))))
-
+            "Virheviesti mainitsee puuttuvat prosentit"))))))

--- a/test/clj/harja/palvelin/palvelut/valikatselmus/paatosnakyvyyskone_test.clj
+++ b/test/clj/harja/palvelin/palvelut/valikatselmus/paatosnakyvyyskone_test.clj
@@ -307,9 +307,9 @@
                       {:nimi "Kattohinnan ylitys" :tyyppi "db"}
                       {:nimi "Hoidonjohtopalkkion muutos" :tyyppi "db"}
                       {:nimi "Välikatselmuspöytäkirjaan liitettävät raportit" :tyyppi "db"}]
-        yhdistetyt-paatokset (yleiset/yhdista-mapit pk-paatokset db-paatokset)
+        yhdistetyt-paatokset (yleiset/yhdista-mapit :nimi pk-paatokset db-paatokset)
         yksi-db-paatos (conj [] (first db-paatokset))
-        yksi-tietokannasta (yleiset/yhdista-mapit pk-paatokset yksi-db-paatos)]
+        yksi-tietokannasta (yleiset/yhdista-mapit :nimi pk-paatokset yksi-db-paatos)]
     (is (= 9 (count yhdistetyt-paatokset)))
     (is (= "db" (:tyyppi (first yhdistetyt-paatokset))))
     (is (= "db" (:tyyppi (last yhdistetyt-paatokset))))


### PR DESCRIPTION
## Mitä muutettiin
Välikatselmuksen päätösten logiikkaa. 
Tietty päätös voi kumota siitä riippuvaiset päätökset.

## Miksi
Uusi loogisempi speksi

## Testaustapa
Hieman työlästä. Ota välikatselmusvalidointi pois hallinnasta, ja mene tekemään urakalle välikatselmukseen päätöksiä, sekä peru niitä. 

Tiketillä on linkki sääntöihin. Päätöskomponentin "Riippuvuudet"  tarkoittaa, jos riippuvan päätöksen kumoaa, kyseinen päätös kumoutuu myös.
<img width="382" height="286" alt="image" src="https://github.com/user-attachments/assets/163d054c-5e53-4243-a24e-dd3b50ff59ae" />
