### PR TITLE
HARJA-2418 Paikkauskohteiden muut kustannukset

### DIFF
--- a/dev-resources/less/pages/paallystys_ja_paikkaus.less
+++ b/dev-resources/less/pages/paallystys_ja_paikkaus.less
@@ -445,7 +445,7 @@ div.yllapitokohteet {
 }
 
 .paallystyskustannusten-toiminnot-container {
-    height: @valistys-32;
+    height: @valistys-48;
 }
 
 .paallystyskustannusten-toiminnot {

--- a/src/clj/harja/kyselyt/yllapito_muut_toteumat.clj
+++ b/src/clj/harja/kyselyt/yllapito_muut_toteumat.clj
@@ -1,5 +1,10 @@
 (ns harja.kyselyt.yllapito-muut-toteumat
   (:require [jeesql.core :refer [defqueries]]))
 
+(declare luo-uusi-urakan_laskentakohde<! hae-urakan-laskentakohteet tiemerkinnan-yksikkohintaisen-toteuman-urakka
+  muun-toteuman-urakka hae-muut-tyot hae-muu-tyo paivita-muu-tyo<! luo-uusi-muu-tyo<!
+  luo-tiemerkintaurakan-yksikkohintainen-tyo<! hae-tiemerkintaurakan-yksikkohintaiset-tyot
+  paivita-tiemerkintaurakan-yksikkohintainen-tyo<!)
+
 (defqueries "harja/kyselyt/yllapito_toteumat.sql"
   {:positional? true})

--- a/src/clj/harja/palvelin/palvelut/yllapito_toteumat.clj
+++ b/src/clj/harja/palvelin/palvelut/yllapito_toteumat.clj
@@ -65,7 +65,7 @@
                  (q/hae-muu-tyo db {:urakka urakka
                                     :id id})))))
 
-(defn hae-laskentakohteet [db user {:keys [urakka] :as tiedot}]
+(defn hae-laskentakohteet [db user {:keys [urakka]}]
   (oikeudet/vaadi-lukuoikeus oikeudet/urakat-toteutus-muutkustannukset user urakka)
   (log/debug "Hae laskentakohteet urakalle: " (pr-str urakka))
   (jdbc/with-db-transaction [db db]
@@ -76,7 +76,7 @@
   (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-toteutus-muutkustannukset user urakka-id)
 
   (jdbc/with-db-transaction [db db]
-    (doseq [{:keys [id] :as toteuma} toteumat]
+    (doseq [{:keys [id]} toteumat]
       (vaadi-toteuma-kuuluu-urakkaan db id urakka-id))
 
     (doseq [toteuma toteumat]
@@ -132,14 +132,14 @@
   [db user {:keys [urakka-id vuosi toteumat]}]
   (oikeudet/vaadi-kirjoitusoikeus oikeudet/urakat-toteutus-yksikkohintaisettyot user urakka-id)
   (jdbc/with-db-transaction [db db]
-    (doseq [{:keys [id yllapitokohde-id] :as kohde} toteumat]
+    (doseq [{:keys [id yllapitokohde-id]} toteumat]
       (vaadi-yksikkohintainen-toteuma-kuuluu-urakkaan db id urakka-id)
       (when yllapitokohde-id (yy/vaadi-yllapitokohde-osoitettu-tiemerkintaurakkaan db urakka-id yllapitokohde-id)))
 
     (log/debug "Tallennetaan yksikköhintaiset työt tiemerkintäurakalle: " urakka-id)
 
     (doseq [{:keys [hinta hintatyyppi paivamaara id yllapitokohde-id poistettu
-                    selite tr-numero yllapitoluokka pituus hinta-kohteelle] :as kohde} toteumat]
+                    selite tr-numero yllapitoluokka pituus hinta-kohteelle]} toteumat]
       (let [sql-parametrit {:yllapitokohde yllapitokohde-id
                             :hinta hinta
                             :hintatyyppi (when hintatyyppi (name hintatyyppi))

--- a/src/cljc/harja/domain/oikeudet.cljc
+++ b/src/cljc/harja/domain/oikeudet.cljc
@@ -53,6 +53,8 @@
   urakat-toteumat-muutos-ja-lisatyot
   urakat-toteumat-vesivaylaerilliskustannukset
   urakat-toteumat-varusteet
+  urakat-toteutus-muutkustannukset
+  urakat-toteutus-yksikkohintaisettyot
   urakat-tyomaapaivakirja
   urakat-kohdeluettelo-paikkauskohteet
   hallinta-indeksit

--- a/src/cljs/harja/tiedot/urakka/paallystys_muut_kustannukset.cljs
+++ b/src/cljs/harja/tiedot/urakka/paallystys_muut_kustannukset.cljs
@@ -62,6 +62,7 @@
                      (if (:bonus ks)
                        {:hinta (-> ks :summa)
                         :pvm (-> ks :perintapvm)
+                        :tyyppi :bonus
                         :selite (str (sanktio-domain/bonuslaji->teksti (-> ks :laji)) kohdetiedot)
                         :id (-> ks :id)}
 
@@ -69,6 +70,7 @@
                       {:hinta (-> ks :summa) ;; käännetään sanktioiden etumerkki ladattaessa (näitä ei tallenneta, ovat read-only gridissä)
                        :pvm (-> ks :laatupoikkeama :aika)
                        :selite (str (-> ks :tyyppi :nimi) kohdetiedot)
+                       :tyyppi :sanktio
                        :id (-> ks :id)})))]
     (concat
       (map #(assoc % :muokattava true :id (mk-id %)) muut-kustannukset-tiedot)

--- a/src/cljs/harja/ui/grid/perus.cljs
+++ b/src/cljs/harja/ui/grid/perus.cljs
@@ -363,10 +363,8 @@
               (if (:colspan rivi)
                 (filter #(contains? (:colspan rivi) (:nimi %)) skeema)
                 skeema)))
-     (when (or nayta-toimintosarake?
-             (and (not piilota-toiminnot?)
-               tallenna))
-       [:th.toiminnot {:width "40px"} " "])]))
+     (when (and nayta-toimintosarake? (not piilota-toiminnot?))
+       [:td.toiminnot {:width "40px"} " "])]))
 
 
 (def renderoi-rivia-kerralla 100)
@@ -550,7 +548,14 @@
     :default ; ei näytetä ikonia jos kentällä ei parhaillaan lajitella
     nil))
 
-(defn- otsikkorivi [{:keys [opts skeema nayta-toimintosarake? piilota-toiminnot? tallenna esta-tiivis-grid?]}]
+(defn- toimintosarake-nakyvissa? [{:keys [muokataan
+                                      nayta-toimintosarake?
+                                      piilota-toiminnot?]}]
+  (and (not piilota-toiminnot?)
+    (or muokataan
+      nayta-toimintosarake?)))
+
+(defn- otsikkorivi [{:keys [opts skeema muokataan nayta-toimintosarake? piilota-toiminnot? esta-tiivis-grid?]}]
   (let [otsikkorivi-klikattu (:otsikkorivi-klikattu opts)]
     [:thead
      (when-let [rivi-ennen (:rivi-ennen opts)]
@@ -563,7 +568,12 @@
                   :class (y/luokat luokka
                            (y/tasaus-luokka tasaa))}
              [:div teksti]])
-          rivi-ennen)])
+          rivi-ennen)
+        (when (toimintosarake-nakyvissa?
+                {:muokataan muokataan
+                 :nayta-toimintosarake? nayta-toimintosarake?
+                 :piilota-toiminnot? piilota-toiminnot?})
+          [:th.toiminnot {:scope "col" :colSpan 1} " "])])
      (when-not (:piilota-otsikot? opts)
        [:tr
         (map-indexed
@@ -584,9 +594,9 @@
                  [:div.sort-nuoli
                   [:span.klikattava {:on-click (:fn sarake-sort)}
                    otsikko " " (sort-ikoni (:suunta sarake-sort)) " "]]))]) skeema)
-        (when (or nayta-toimintosarake?
-                (and (not piilota-toiminnot?)
-                  tallenna))
+        (when (toimintosarake-nakyvissa? {:muokataan muokataan
+                                         :nayta-toimintosarake? nayta-toimintosarake?
+                                         :piilota-toiminnot? piilota-toiminnot?})
           [:th.toiminnot {:width "40px"} " "])])]))
 
 (defn- aseta-leijuvan-otsikkorivin-sarakkeet! [leijuva-otsikkorivi oikea-taulu leveys-atomi scroll
@@ -627,7 +637,7 @@
         EventType/SCROLL aseta-taulukon-scroll!)
       {:component-did-update aseta-leijuvan-otsikkorivin-sarakkeet!}
 
-      (fnc [_ _ _ opts skeema nayta-toimintosarake? piilota-toiminnot? tallenna esta-tiivis-grid?
+      (fnc [_ _ _ opts skeema muokataan nayta-toimintosarake? piilota-toiminnot? tallenna esta-tiivis-grid?
             avattavat-rivit-auki]
         @avattavat-rivit-auki
         [:table.grid
@@ -636,7 +646,7 @@
                   :top 0
                   :z-index 100
                   :transform (str "translateX(-" @taulukon-scroll "px)")}}
-         [otsikkorivi {:opts opts :skeema skeema
+         [otsikkorivi {:opts opts :skeema skeema :muokataan muokataan
                        :nayta-toimintosarake? nayta-toimintosarake? :piilota-toiminnot? piilota-toiminnot?
                        :tallenna tallenna :esta-tiivis-grid? esta-tiivis-grid?}]]))))
 
@@ -786,9 +796,10 @@
 
                   (when-not (rivi-piilotetun-otsikon-alla? i (vec rivit-jarjestetty) @piilotetut-valiotsikot)
                     (let [id (tunniste rivi)
-                          vetolaatikko-colspan (if (or piilota-toiminnot? (nil? tallenna))
-                                                 (count skeema)
-                                                 (inc (count skeema)))]
+                          vetolaatikko-colspan (if (and nayta-toimintosarake?
+                                                     (not piilota-toiminnot?))
+                                                 (inc (count skeema))
+                                                 (count skeema))]
                       [^{:key id}
                        [nayttorivi {:ohjaus ohjaus
                                     :vetolaatikot vetolaatikot
@@ -1302,10 +1313,13 @@
               muuta-gridia-muokataan? (and
                                         (>= (count @muokkauksessa-olevat-gridit) 1)
                                         (not (@muokkauksessa-olevat-gridit komponentti-id)))
-              colspan (if (or piilota-toiminnot? (nil? tallenna))
-                        (count skeema)
-                        (inc (count skeema)))
               muokataan (some? @muokatut)
+              colspan (if (toimintosarake-nakyvissa?
+                            {:muokataan muokataan
+                             :nayta-toimintosarake? nayta-toimintosarake?
+                             :piilota-toiminnot? piilota-toiminnot?})
+                        (inc (count skeema))
+                        (count skeema))
               tiedot (if max-rivimaara
                        (take max-rivimaara alkup-tiedot)
                        alkup-tiedot)
@@ -1358,14 +1372,14 @@
             (when @kiinnita-otsikkorivi?
               ^{:key "kiinnitettyotsikko"}
               (if sivuttain-rullattava?
-                [leijuva-otsikkorivi taulukon-ref taulukon-rootin-ref ensimmainen-sarake-sticky? opts skeema nayta-toimintosarake?
-                 piilota-toiminnot? tallenna esta-tiivis-grid? avattavat-rivit-auki]
+                [leijuva-otsikkorivi taulukon-ref taulukon-rootin-ref ensimmainen-sarake-sticky? opts skeema muokataan
+                 nayta-toimintosarake? piilota-toiminnot? tallenna esta-tiivis-grid? avattavat-rivit-auki]
                 [:table.grid
                  {:style {:position "fixed"
                           :top 0
                           :width @kiinnitetyn-otsikkorivin-leveys
                           :z-index 200}}
-                 [otsikkorivi {:opts opts :skeema skeema
+                 [otsikkorivi {:opts opts :skeema skeema :muokataan muokataan
                                :nayta-toimintosarake? nayta-toimintosarake? :piilota-toiminnot? piilota-toiminnot?
                                :tallenna tallenna}]]))
             (if (nil? tiedot)
@@ -1373,7 +1387,7 @@
               ^{:key "taulukkodata"}
               [:table.grid
                {:ref #(when % (reset! taulukon-ref %))}
-               [otsikkorivi {:opts opts :skeema skeema
+               [otsikkorivi {:opts opts :skeema skeema :muokataan muokataan
                              :nayta-toimintosarake? nayta-toimintosarake? :piilota-toiminnot? piilota-toiminnot?
                              :tallenna tallenna :esta-tiivis-grid? esta-tiivis-grid?}]
                [:tbody

--- a/src/cljs/harja/ui/kentat.cljs
+++ b/src/cljs/harja/ui/kentat.cljs
@@ -1219,7 +1219,7 @@
                                           :aria-label "päiväys"
                                           :id elementin-id}]]
            (swap! vanha-data assoc :data nykyinen-pvm :muokattu-tassa? false)
-           [:span.pvm-kentta
+           [:span.pvm-kentta.input-default
             {:on-click #(do (.stopPropagation %)
                           (.preventDefault %)
                           (reset! auki true) nil)}

--- a/src/cljs/harja/views/urakka/paallystys_muut_kustannukset.cljs
+++ b/src/cljs/harja/views/urakka/paallystys_muut_kustannukset.cljs
@@ -1,10 +1,13 @@
 (ns harja.views.urakka.paallystys-muut-kustannukset
-  (:require [reagent.core :refer [atom] :as r]
-            [harja.ui.yleiset :refer [ajax-loader]]
+  (:require [harja.tiedot.urakka.siirtymat :as siirtymat]
+            [reagent.core :refer [atom] :as r]
+            [harja.ui.yleiset :as yleiset :refer [ajax-loader]]
             [harja.ui.grid :as grid]
             [harja.loki :refer [log logt tarkkaile!]]
             [harja.ui.komponentti :as komp]
             [harja.tiedot.urakka.paallystys-muut-kustannukset :as tiedot]
+            [harja.tiedot.urakka.urakka :as tila]
+            [harja.tiedot.navigaatio :as nav]
             [harja.ui.valinnat :as valinnat]
             [harja.ui.validointi :as validointi]
             [cljs-time.core :as t]
@@ -14,15 +17,28 @@
                    [cljs.core.async.macros :refer [go]]))
 
 ;; Ylläpitokohteiden sarakkeiden leveydet
-(def kustannus-selite-leveys 5)
-(def kustannus-hinta-leveys 3)
-(def kustannus-pvm-leveys 3)
+(def kustannus-selite-leveys "auto")
+(def kustannus-hinta-leveys "144px")
+(def kustannus-pvm-leveys "144px")
 
 (defn- rivi-poistettavissa? [m]
   (log "rivi-poistettavissa? " (pr-str m))
   (or (-> m :muokattava) (-> m :id neg?)))
 
-(def grid-opts {:otsikko "Urakan muut kustannukset"
+(defn otsikkopaneeli []
+  [:div
+   [:h6 "Urakan muut kustannukset"]
+   [:div.body-text {:style {:max-width "900px" :padding-top "16px"}} "Sopimuksen mukaiset sanktiot ja bonukset tulee syöttää"
+    [:a.klikattava.alleviivaa {:href (str "/#urakat/laadunseuranta/sanktiot?&hy=" @nav/valittu-hallintayksikko-id "&u=" (-> @tila/yleiset :urakka :id))
+                               :on-click #(siirtymat/siirry-annettuun-valilehteen
+                                            @nav/valittu-hallintayksikko-id (-> @tila/yleiset :urakka :id)
+                                            {:taso1 :urakat
+                                             :taso2 :laadunseuranta
+                                             :taso3 :sanktiot})}
+     "Sanktiot ja bonukset"]
+    "-osiossa. Laatupoikkeamat- tai “Sanktiot ja bonukset”-osion kautta syötetyt sanktiot ja bonukset tulevat näkyville urakan muihin kustannuksiin lisäyksen jälkeen."]])
+
+(def grid-opts {:otsikko [otsikkopaneeli]
                 :voi-lisata? true
                 :voi-muokata-rivia? :muokattava
                 :esta-poistaminen? (complement rivi-poistettavissa?)
@@ -31,14 +47,28 @@
 
 
 (def grid-skeema
-  [{:otsikko "Pvm" :nimi :pvm :fmt pvm/pvm-opt
+  [{:otsikko "Pvm"
+    :nimi :pvm
+    :fmt pvm/pvm-opt
     :validoi [[:ei-tyhja "Anna päivämäärä"]]
-    :tyyppi :pvm :leveys kustannus-pvm-leveys}
+    :tyyppi :pvm
+    :vayla-tyyli? true
+    :leveys kustannus-pvm-leveys}
+   {:otsikko "Laji"
+    :tyyppi :string
+    :muokattava? (constantly false)
+    :nimi :tyyppi
+    :fmt (fn [tyyppi]
+           (cond
+             (= tyyppi :muu) "Muu"
+             (= tyyppi :sanktio) "Sanktio"
+             (= tyyppi :bonus) "Bonus"
+             :else "Muu"))}
    {:otsikko "Kustannuksen kuvaus" :nimi :selite
     :validoi [[:ei-tyhja "Anna kuvaus"]]
     :tyyppi :string :leveys kustannus-selite-leveys}
-   {:otsikko "Summa" :nimi :hinta :fmt fmt/euro-opt
-    :tyyppi :numero :leveys kustannus-hinta-leveys
+   {:otsikko "Summa (€)" :nimi :hinta :fmt #(fmt/euro-opt false %)
+    :tyyppi :numero :leveys kustannus-hinta-leveys :tasaa :oikea
     :validoi [[:ei-tyhja "Anna hinta"]]}])
 
 (defn muut-kustannukset [urakka]

--- a/src/cljs/harja/views/urakka/paallystys_muut_kustannukset.cljs
+++ b/src/cljs/harja/views/urakka/paallystys_muut_kustannukset.cljs
@@ -20,6 +20,7 @@
 (def kustannus-selite-leveys "auto")
 (def kustannus-hinta-leveys "144px")
 (def kustannus-pvm-leveys "144px")
+(def kustannus-laji-leveys "75px")
 
 (defn- rivi-poistettavissa? [m]
   (log "rivi-poistettavissa? " (pr-str m))
@@ -63,7 +64,8 @@
              (= tyyppi :muu) "Muu"
              (= tyyppi :sanktio) "Sanktio"
              (= tyyppi :bonus) "Bonus"
-             :else "Muu"))}
+             :else "Muu"))
+    :leveys kustannus-laji-leveys}
    {:otsikko "Kustannuksen kuvaus" :nimi :selite
     :validoi [[:ei-tyhja "Anna kuvaus"]]
     :tyyppi :string :leveys kustannus-selite-leveys}

--- a/src/cljs/harja/views/urakka/yllapitokohteet.cljs
+++ b/src/cljs/harja/views/urakka/yllapitokohteet.cljs
@@ -968,7 +968,7 @@
                              (if piilota-arvonmuutos-ja-sanktiot? 15 17))
     :luokka "paallystys-tausta"}
    {:teksti "Hintamuutokset" :sarakkeita 3 :luokka "paallystys-tausta-tumma"}
-   {:teksti "" :sarakkeita 2 :luokka "paallystys-tausta"}])
+   {:teksti "" :sarakkeita 1 :luokka "paallystys-tausta"}])
 
 (defn yllapitokohteet
   "Ottaa urakan, kohteet atomin ja optiot ja luo taulukon, jossa on listattu kohteen tiedot.
@@ -1190,7 +1190,7 @@
               :kohdistamattomat-sanktiot kohdistamattomat-sanktiot-yhteensa}]))]
 
     [grid/grid
-     {:nayta-toimintosarake? true
+     {:nayta-toimintosarake? false
       :otsikko "Yhteensä"
       :rivi-ennen (taulukon-ryhmittely-header :yhteensa (yllapitokohteet-domain/piilota-arvonmuutos-ja-sanktio? (:valittu-vuosi optiot)))
       :tyhja (if (nil? {}) [ajax-loader "Lasketaan..."] "")}


### PR DESCRIPTION
## Mitä muutettiin
1. Lisättiin "Laji" kolumni Muut Kustannukset taulukkoon ja pakotettiin sen leveydeksi 75px, jotta näkyy asiallisesti kapeammallakin näytöllä
2. Korjattiin Excel-nappuloiden meneminen "Muokkaa" nappulan esteeksi sivun yläreunassa
3. Muokattiin grid/perus  -komponenttia niin, että viimeinen "toiminto" -sarake ei ole näkyvissä ja viemässä turhaa tilaa, jos muokkaus-tila ei ole päällä.

## Miksi
UI parannuksia

## Testaustapa
Avaa Päällystykset/Päällystyskohteet ja tarkista kolmas taulukko, jonka nimi on "Muut kustannukset" ja sen toiminta.

## Huomioita
Grid -muutokset saattavat hajottaa muuallakin asioita. Yritin testata niitä taulukoita mitä tuli vastaan ja en löytänyt ongelmia. Se ei tarkoita, etteikö jossain voisi olla piilossa joku taulukko, joka ei toimi oikein.
